### PR TITLE
ci: run firmware cross-check from inside the firmware crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,19 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
 
+      # Run from inside the firmware crate so cargo picks up
+      # crates/stackchan-firmware/.cargo/config.toml, which sets
+      # `unstable.build-std = ["alloc", "core"]` — required because
+      # `core` isn't precompiled for xtensa-esp32s3-none-elf. The
+      # previous workspace-root invocation bypassed this config and
+      # failed with `error[E0463]: can't find crate for 'core'`.
       - name: Clippy (firmware)
-        run: cargo clippy -p stackchan-firmware --target xtensa-esp32s3-none-elf --all-features -- -D warnings
+        working-directory: crates/stackchan-firmware
+        run: cargo clippy --all-features -- -D warnings
 
       - name: Check (firmware)
-        run: cargo check -p stackchan-firmware --target xtensa-esp32s3-none-elf --all-features
+        working-directory: crates/stackchan-firmware
+        run: cargo check --all-features
 
   msrv:
     name: MSRV (host crates)


### PR DESCRIPTION
## Summary

Fixes the firmware cross-check CI job, which has been red on every run since the initial scaffold.

- Cargo discovers `.cargo/config.toml` files only on the path from the invocation directory upward, so invoking `cargo clippy -p stackchan-firmware` from the workspace root never read `crates/stackchan-firmware/.cargo/config.toml`.
- That file pins the xtensa target and sets `unstable.build-std = ["alloc", "core"]`, which is mandatory on `xtensa-esp32s3-none-elf` — the target has no precompiled `core`.
- Result on CI: `error[E0463]: can't find crate for 'core'`.

Fix is two-line: add `working-directory: crates/stackchan-firmware` to each firmware step. The esp-rs/xtensa-toolchain action already sets the esp toolchain as default, so `cargo clippy` / `cargo check` naturally pick up the right rustc and the per-crate config contributes target + build-std flags.

Verified locally: `cd crates/stackchan-firmware && cargo +esp clippy --all-features -- -D warnings` passes clean on the current main.

## Test plan

- [x] Local: `cd crates/stackchan-firmware && cargo +esp clippy --all-features -- -D warnings` — passes
- [x] Local: `cd crates/stackchan-firmware && cargo +esp check --all-features` — passes
- [ ] CI: watch this PR — the firmware cross-check job should go green for the first time.