### PR TITLE
feat(dx): boot PING health check + boot-nod gesture + justfile

### DIFF
--- a/crates/scservo/src/lib.rs
+++ b/crates/scservo/src/lib.rs
@@ -3,9 +3,18 @@
 //! `no_std` driver for the Feetech `SCServo` (`SCSCL` / `SCS0009`) family of
 //! smart serial servos. The servos share a half-duplex TTL bus at 1 Mbaud
 //! (default), each addressed by a 1-byte ID. This crate speaks the
-//! Feetech packet protocol over any [`embedded_io_async::Write`] — for
-//! v1, writes only (position and torque commands); reads and feedback
-//! may arrive in a later release.
+//! Feetech packet protocol over any [`embedded_io_async::Write`] (for
+//! position / torque commands) and optionally [`embedded_io_async::Read`]
+//! (for [`Scservo::ping`], the boot-time health check).
+//!
+//! ## Timeouts
+//!
+//! Neither write nor [`Scservo::ping`] implement timeouts themselves —
+//! UART reads block until the full response arrives, so a disconnected
+//! or unpowered servo hangs forever. Callers are expected to wrap
+//! `ping(id)` with their runtime's timeout primitive (e.g.
+//! `embassy_time::with_timeout(Duration::from_millis(10), bus.ping(1))`).
+//! 10 ms is generous — a round-trip at 1 Mbaud is <200 µs.
 //!
 //! ## Packet format
 //!
@@ -44,7 +53,7 @@
 #![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
 
-use embedded_io_async::Write;
+use embedded_io_async::{Read, ReadExactError, Write};
 
 /// Broadcast ID — all servos on the bus act on the packet, no response.
 pub const BROADCAST_ID: u8 = 0xFE;
@@ -104,9 +113,29 @@ pub enum Error<E> {
     /// Transport error from the underlying UART.
     Uart(E),
     /// Caller passed more than [`MAX_DATA_BYTES`] bytes of data. The
-    /// v1 surface (`WritePos`, `WriteTorque`) never reaches this; the arm
-    /// exists so arbitrary-length writers added later stay bounded.
+    /// v1 write surface (`WritePos`, `WriteTorque`) never reaches
+    /// this; the arm exists so arbitrary-length writers added later
+    /// stay bounded.
     PayloadTooLarge,
+    /// `read_exact` returned `UnexpectedEof` — the UART closed before
+    /// a full response arrived. On open-ended serial links this rarely
+    /// fires in practice; a hung slave produces a timeout (caller's
+    /// responsibility) rather than EOF.
+    NoResponse,
+    /// Response packet didn't parse: wrong header bytes or the
+    /// responding ID doesn't match what we asked.
+    MalformedResponse,
+    /// Response packet arrived but its checksum didn't verify.
+    ChecksumMismatch,
+}
+
+impl<E> From<ReadExactError<E>> for Error<E> {
+    fn from(e: ReadExactError<E>) -> Self {
+        match e {
+            ReadExactError::UnexpectedEof => Self::NoResponse,
+            ReadExactError::Other(e) => Self::Uart(e),
+        }
+    }
 }
 
 impl<E> From<E> for Error<E> {
@@ -229,6 +258,83 @@ impl<W: Write> Scservo<W> {
     }
 }
 
+impl<U: Read + Write> Scservo<U> {
+    /// Probe servo `id` with a [`Instruction::Ping`] and wait for the
+    /// 6-byte status response. Returns `Ok(())` iff a well-formed
+    /// response with matching ID and valid checksum arrives.
+    ///
+    /// Does **not** enforce a timeout internally — a hung or absent
+    /// slave leaves this future pending forever. Callers wrap with
+    /// their runtime's timeout primitive, e.g.
+    ///
+    /// ```no_run
+    /// # use embedded_io_async::{Read, Write};
+    /// # async fn demo<U: Read + Write>(uart: U) {
+    /// # let mut bus = scservo::Scservo::new(uart);
+    /// # let timeout_fut = core::future::pending::<()>();
+    /// // Pseudocode — use embassy_time::with_timeout or equivalent.
+    /// let _ = bus.ping(1).await;
+    /// # }
+    /// ```
+    ///
+    /// Echo-on-bus note: if the physical half-duplex converter echoes
+    /// outgoing TX back into RX, this read may see the 6-byte outgoing
+    /// PING packet before the 6-byte response. On CoreS3 with the
+    /// standard Stack-chan base this has not been observed; if it
+    /// becomes a problem, switch to `Instruction::Read` (different
+    /// packet size, distinguishable from its own echo).
+    ///
+    /// # Errors
+    /// - [`Error::Uart`] on transport failure.
+    /// - [`Error::NoResponse`] if the UART closes before a full
+    ///   response arrives.
+    /// - [`Error::MalformedResponse`] if the header or responding ID
+    ///   don't match expectations.
+    /// - [`Error::ChecksumMismatch`] if the response checksum is
+    ///   invalid.
+    pub async fn ping(&mut self, id: u8) -> Result<(), Error<U::Error>> {
+        // PING outbound: FF FF ID 02 01 ~(ID+2+1).
+        let checksum = !id.wrapping_add(0x02).wrapping_add(Instruction::Ping as u8);
+        let outbound = [
+            HEADER_BYTE,
+            HEADER_BYTE,
+            id,
+            0x02,
+            Instruction::Ping as u8,
+            checksum,
+        ];
+        self.uart.write_all(&outbound).await?;
+
+        // Expected response layout: FF FF ID 02 Error ~checksum (6 bytes).
+        let mut response = [0u8; 6];
+        self.uart.read_exact(&mut response).await?;
+
+        if response[0] != HEADER_BYTE || response[1] != HEADER_BYTE {
+            return Err(Error::MalformedResponse);
+        }
+        if response[2] != id {
+            return Err(Error::MalformedResponse);
+        }
+        // msgLen for a PING response is 2 (error + checksum).
+        if response[3] != 0x02 {
+            return Err(Error::MalformedResponse);
+        }
+        // Checksum covers ID..=error byte.
+        let sum = response[2]
+            .wrapping_add(response[3])
+            .wrapping_add(response[4]);
+        if response[5] != !sum {
+            return Err(Error::ChecksumMismatch);
+        }
+        // response[4] is the servo's error byte — non-zero signals
+        // voltage / overload / angle-limit faults, but the servo is
+        // still "present". PING cares about presence, not fault-free;
+        // return Ok. Callers that need the error byte can use a
+        // dedicated status read later.
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -240,16 +346,27 @@ mod tests {
     use core::cell::RefCell;
 
     /// Host-side UART mock that records every write into a Vec for
-    /// byte-level packet assertions.
+    /// byte-level packet assertions, and returns pre-loaded bytes on
+    /// reads (for ping-response testing).
     struct MockUart {
-        buf: RefCell<Vec<u8>>,
+        /// Bytes the driver has written to us.
+        written: RefCell<Vec<u8>>,
+        /// Bytes we'll hand back, in order, to driver reads. Tests
+        /// pre-load this with the response packet they expect the
+        /// driver to consume.
+        rx_queue: RefCell<Vec<u8>>,
     }
 
     impl MockUart {
         fn new() -> Self {
             Self {
-                buf: RefCell::new(Vec::new()),
+                written: RefCell::new(Vec::new()),
+                rx_queue: RefCell::new(Vec::new()),
             }
+        }
+
+        fn queue_rx(&self, bytes: &[u8]) {
+            self.rx_queue.borrow_mut().extend_from_slice(bytes);
         }
     }
 
@@ -259,12 +376,24 @@ mod tests {
 
     impl embedded_io_async::Write for MockUart {
         async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-            self.buf.borrow_mut().extend_from_slice(buf);
+            self.written.borrow_mut().extend_from_slice(buf);
             Ok(buf.len())
         }
 
         async fn flush(&mut self) -> Result<(), Self::Error> {
             Ok(())
+        }
+    }
+
+    impl embedded_io_async::Read for MockUart {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+            // Pop up to buf.len() bytes from the head of rx_queue.
+            let mut q = self.rx_queue.borrow_mut();
+            let take = buf.len().min(q.len());
+            for (dst, src) in buf.iter_mut().zip(q.drain(..take)) {
+                *dst = src;
+            }
+            Ok(take)
         }
     }
 
@@ -294,14 +423,14 @@ mod tests {
         let expected: &[u8] = &[
             0xFF, 0xFF, 0x01, 0x09, 0x03, 0x2A, 0x02, 0x00, 0x00, 0x14, 0x00, 0x00, 0xB2,
         ];
-        assert_eq!(bus.uart.buf.borrow().as_slice(), expected);
+        assert_eq!(bus.uart.written.borrow().as_slice(), expected);
     }
 
     #[test]
     fn write_position_broadcast_id_uses_0xfe() {
         let mut bus = Scservo::new(MockUart::new());
         block_on(bus.write_position(BROADCAST_ID, 0, 0, 0)).unwrap();
-        assert_eq!(bus.uart.buf.borrow()[2], 0xFE);
+        assert_eq!(bus.uart.written.borrow()[2], 0xFE);
     }
 
     #[test]
@@ -310,14 +439,14 @@ mod tests {
         block_on(bus.write_torque_enable(1, true)).unwrap();
         // FF FF 01 04 03 28 01 CE
         let expected: &[u8] = &[0xFF, 0xFF, 0x01, 0x04, 0x03, 0x28, 0x01, 0xCE];
-        assert_eq!(bus.uart.buf.borrow().as_slice(), expected);
+        assert_eq!(bus.uart.written.borrow().as_slice(), expected);
     }
 
     #[test]
     fn checksum_is_bitwise_not_of_field_sum() {
         let mut bus = Scservo::new(MockUart::new());
         block_on(bus.write_position(2, 700, 30, 100)).unwrap();
-        let buf = bus.uart.buf.borrow();
+        let buf = bus.uart.written.borrow();
         let expected_sum = buf[2..12].iter().fold(0u8, |a, b| a.wrapping_add(*b));
         assert_eq!(buf[12], !expected_sum);
     }
@@ -328,5 +457,73 @@ mod tests {
         let oversize = [0u8; MAX_DATA_BYTES + 1];
         let err = block_on(bus.write_memory(1, 0, &oversize));
         assert!(matches!(err, Err(Error::PayloadTooLarge)));
+    }
+
+    #[test]
+    fn ping_sends_correct_outbound_packet() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Pre-queue a valid response so the read doesn't hang. We
+        // don't assert on its value here; this test checks the outbound.
+        bus.uart.queue_rx(&[0xFF, 0xFF, 0x01, 0x02, 0x00, 0xFC]);
+        block_on(bus.ping(1)).unwrap();
+        // Expected outbound: FF FF 01 02 01 ~(1+2+1) = ~4 = FB.
+        let expected: &[u8] = &[0xFF, 0xFF, 0x01, 0x02, 0x01, 0xFB];
+        assert_eq!(bus.uart.written.borrow().as_slice(), expected);
+    }
+
+    #[test]
+    fn ping_succeeds_on_valid_response() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Response: FF FF 01 02 Error=0 ~(1+2+0) = ~3 = FC.
+        bus.uart.queue_rx(&[0xFF, 0xFF, 0x01, 0x02, 0x00, 0xFC]);
+        assert!(block_on(bus.ping(1)).is_ok());
+    }
+
+    #[test]
+    fn ping_succeeds_when_error_byte_nonzero() {
+        // Non-zero error byte signals fault (overload, voltage, etc.),
+        // but the servo is still present — ping returns Ok.
+        let mut bus = Scservo::new(MockUart::new());
+        let err_byte = 0x20;
+        let checksum = !(1u8.wrapping_add(2).wrapping_add(err_byte));
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x02, err_byte, checksum]);
+        assert!(block_on(bus.ping(1)).is_ok());
+    }
+
+    #[test]
+    fn ping_rejects_bad_header() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Header byte 0 corrupted.
+        bus.uart.queue_rx(&[0x00, 0xFF, 0x01, 0x02, 0x00, 0xFC]);
+        let err = block_on(bus.ping(1));
+        assert!(matches!(err, Err(Error::MalformedResponse)));
+    }
+
+    #[test]
+    fn ping_rejects_wrong_id_in_response() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Response from ID=2 when we asked for ID=1.
+        bus.uart.queue_rx(&[0xFF, 0xFF, 0x02, 0x02, 0x00, 0xFB]);
+        let err = block_on(bus.ping(1));
+        assert!(matches!(err, Err(Error::MalformedResponse)));
+    }
+
+    #[test]
+    fn ping_rejects_bad_checksum() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Valid structure but checksum byte corrupted.
+        bus.uart.queue_rx(&[0xFF, 0xFF, 0x01, 0x02, 0x00, 0xFF]);
+        let err = block_on(bus.ping(1));
+        assert!(matches!(err, Err(Error::ChecksumMismatch)));
+    }
+
+    #[test]
+    fn ping_no_response_maps_to_typed_error() {
+        // Empty rx queue -> read_exact returns UnexpectedEof (the mock
+        // returns 0 bytes on read, which read_exact treats as EOF).
+        let mut bus = Scservo::new(MockUart::new());
+        let err = block_on(bus.ping(1));
+        assert!(matches!(err, Err(Error::NoResponse)));
     }
 }

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -6,10 +6,11 @@
 //! physical assembly is pre-wired by M5Stack's base, so this is a
 //! solderless plug-in for standard Stack-chan units.
 //!
-//! This module owns the servo driver + per-axis servo math + a boot-time
-//! slow-ramp + the inter-task [`Signal`] used to hand poses from the
-//! render task (which runs the Modifier pipeline) to the 50 Hz head
-//! task.
+//! This module owns the servo driver + per-axis servo math + the
+//! inter-task [`Signal`] used to hand poses from the render task (which
+//! runs the Modifier pipeline) to the 50 Hz head task. Smooth start-up
+//! is handled by the firmware's boot-nod gesture in `main` rather than
+//! an implicit ramp here — the gesture is the gentle-first-move.
 //!
 //! ## Wiring
 //!
@@ -53,11 +54,6 @@ const PAN_TRIM_DEG: f32 = 0.0;
 /// Per-unit tilt trim, in degrees. Positive = head aims up at NEUTRAL.
 const TILT_TRIM_DEG: f32 = 0.0;
 
-/// Boot-time slow-ramp window: how long to linearly lerp the commanded
-/// pose from NEUTRAL to the first requested pose. Keeps the servos
-/// from snapping on power-up.
-pub const BOOT_RAMP_MS: u64 = 500;
-
 /// Move-time sent with every `WritePos`. `SCServo` servos interpolate
 /// internally over this many milliseconds, smoothing out the 50 Hz
 /// step commands we send.
@@ -76,12 +72,9 @@ const MOVE_SPEED: u16 = 0;
 pub static POSE_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Signal::new();
 
 /// Feetech SCServo-backed head driver.
-pub struct ScsHead<W: Write> {
+pub struct ScsHead<W> {
     /// Underlying `SCServo` protocol driver on the UART bus.
     bus: Scservo<W>,
-    /// Timestamp of the very first `set_pose` call. Used by the boot
-    /// ramp. `None` until the first call anchors it.
-    first_call_at: Option<Instant>,
 }
 
 impl<W: Write> ScsHead<W> {
@@ -89,10 +82,14 @@ impl<W: Write> ScsHead<W> {
     /// configuring the UART baud rate (1 Mbaud for SCS defaults).
     #[must_use]
     pub const fn new(bus: Scservo<W>) -> Self {
-        Self {
-            bus,
-            first_call_at: None,
-        }
+        Self { bus }
+    }
+
+    /// Borrow the wrapped bus mutably. Needed by firmware `main` to
+    /// issue `ping` + boot-nod commands before handing the driver to
+    /// the head task.
+    pub const fn bus_mut(&mut self) -> &mut Scservo<W> {
+        &mut self.bus
     }
 
     /// Convert one axis angle (deg) into a servo step count, applying
@@ -110,35 +107,14 @@ impl<W: Write> ScsHead<W> {
         let pos = clamped as u16;
         pos
     }
-
-    /// Produce the effective pose to command, applying the boot ramp.
-    ///
-    /// The first call captures `now` as the ramp start; subsequent
-    /// calls linearly interpolate from `NEUTRAL` toward `target` over
-    /// [`BOOT_RAMP_MS`]. After the window elapses, `target` passes
-    /// through unchanged.
-    fn ramped_pose(&mut self, target: Pose, now: Instant) -> Pose {
-        let start = *self.first_call_at.get_or_insert(now);
-        let elapsed = now.saturating_duration_since(start);
-        if elapsed >= BOOT_RAMP_MS {
-            return target;
-        }
-        #[allow(
-            clippy::cast_precision_loss,
-            reason = "elapsed + BOOT_RAMP_MS are < 2^32, well under the mantissa limit"
-        )]
-        let t = elapsed as f32 / BOOT_RAMP_MS as f32;
-        Pose::new(target.pan_deg * t, target.tilt_deg * t)
-    }
 }
 
 impl<W: Write> HeadDriver for ScsHead<W> {
     type Error = scservo::Error<W::Error>;
 
-    async fn set_pose(&mut self, pose: Pose, now: Instant) -> Result<(), Self::Error> {
-        let effective = self.ramped_pose(pose, now);
-        let pan_pos = Self::position_for(effective.pan_deg, PAN_TRIM_DEG, PAN_DIRECTION);
-        let tilt_pos = Self::position_for(effective.tilt_deg, TILT_TRIM_DEG, TILT_DIRECTION);
+    async fn set_pose(&mut self, pose: Pose, _now: Instant) -> Result<(), Self::Error> {
+        let pan_pos = Self::position_for(pose.pan_deg, PAN_TRIM_DEG, PAN_DIRECTION);
+        let tilt_pos = Self::position_for(pose.tilt_deg, TILT_TRIM_DEG, TILT_DIRECTION);
         self.bus
             .write_position(YAW_SERVO_ID, pan_pos, MOVE_TIME_MS, MOVE_SPEED)
             .await?;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -312,6 +312,79 @@ async fn enable_servo_power(i2c: &mut I2c<'_, esp_hal::Async>) {
     defmt::info!("PY32: servo power enabled (pin 0 HIGH)");
 }
 
+/// Probe one `SCServo` ID and log the outcome. 10 ms is well past the
+/// ~200 µs round-trip of a 1 Mbaud PING packet, so a miss here is a
+/// real "servo not responding" signal. Errors are informational only —
+/// head task spawns regardless, so a servo reconnected later starts
+/// working without a reboot.
+async fn ping_servo(driver: &mut HeadDriverImpl, id: u8) {
+    const PING_TIMEOUT_MS: u64 = 10;
+    let bus = driver.bus_mut();
+    match embassy_time::with_timeout(
+        embassy_time::Duration::from_millis(PING_TIMEOUT_MS),
+        bus.ping(id),
+    )
+    .await
+    {
+        Ok(Ok(())) => defmt::info!("SCServo[{=u8}]: present", id),
+        Ok(Err(e)) => defmt::warn!(
+            "SCServo[{=u8}]: malformed response: {}",
+            id,
+            defmt::Debug2Format(&e)
+        ),
+        Err(_) => defmt::warn!(
+            "SCServo[{=u8}]: no response within {=u64} ms (disconnected or unpowered?)",
+            id,
+            PING_TIMEOUT_MS
+        ),
+    }
+}
+
+/// Boot-time "hello" gesture: visible, deliberate, unambiguous.
+///
+/// Sequence (each step holds for `STEP_MS` to let the servo's internal
+/// interpolation complete before the next command):
+///
+/// 1. pan +15° — "I'm alive, here's my range"
+/// 2. pan -15°
+/// 3. pan 0°
+/// 4. tilt +10° — "both axes work"
+/// 5. tilt -10°
+/// 6. tilt 0°
+///
+/// Total ≈ 1 s. Per-step `move_time` inside each `WritePos` is short
+/// (smooth steps), but we pace the SEQUENCE with `STEP_MS` so each
+/// motion visibly completes before the next begins.
+///
+/// Write errors are logged and swallowed — a partial nod is better
+/// than a panic, and subsequent head-task writes will keep retrying
+/// if the bus recovers.
+async fn boot_nod(driver: &mut HeadDriverImpl) {
+    /// Wall-clock pace between nod steps (ms). Matches the servos'
+    /// single-leg move budget.
+    const STEP_MS: u64 = 170;
+
+    let clock = HalClock;
+    defmt::info!("boot-nod: hello gesture start");
+    for (pan, tilt, label) in [
+        (15.0, 0.0, "pan+15"),
+        (-15.0, 0.0, "pan-15"),
+        (0.0, 0.0, "pan 0"),
+        (0.0, 10.0, "tilt+10"),
+        (0.0, -10.0, "tilt-10"),
+        (0.0, 0.0, "tilt 0"),
+    ] {
+        if let Err(e) = driver
+            .set_pose(stackchan_core::Pose::new(pan, tilt), clock.now())
+            .await
+        {
+            defmt::warn!("boot-nod step {}: {}", label, defmt::Debug2Format(&e));
+        }
+        Timer::after(Duration::from_millis(STEP_MS)).await;
+    }
+    defmt::info!("boot-nod: complete");
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
@@ -406,10 +479,6 @@ async fn main(spawner: Spawner) -> ! {
     // old C++ firmware's `_scs_bus.begin(UART_NUM_1, 1000000, 6, 7)` call.
     // Two smart servos (yaw=1, pitch=2) share this half-duplex bus; the
     // base board handles direction switching externally.
-    //
-    // UART writes don't NACK like I²C, so we can't detect a missing bus
-    // at init time — the head task will blast packets regardless. If no
-    // servos are wired, nothing moves; firmware stays healthy.
     let uart_cfg = UartConfig::default().with_baudrate(SERVO_UART_BAUD);
     let servo_uart = match Uart::new(peripherals.UART1, uart_cfg) {
         Ok(uart) => uart
@@ -422,7 +491,20 @@ async fn main(spawner: Spawner) -> ! {
         "SCServo bus ready on UART1 (TX=GPIO6, RX=GPIO7) @ {=u32} baud",
         SERVO_UART_BAUD
     );
-    let scs_head = head::ScsHead::new(Scservo::new(servo_uart));
+    let mut scs_head = head::ScsHead::new(Scservo::new(servo_uart));
+
+    // Health check: PING each servo ID with a 10 ms timeout. UART writes
+    // don't NACK on missing slaves, so without this probe we can't tell
+    // the bus is alive until we observe physical motion. Log per-ID
+    // success/failure but keep booting either way — a missing servo is
+    // not fatal.
+    ping_servo(&mut scs_head, head::YAW_SERVO_ID).await;
+    ping_servo(&mut scs_head, head::PITCH_SERVO_ID).await;
+
+    // Visible proof of life: a deliberate pan-then-tilt gesture before
+    // the idle modifier pipeline takes over. Also serves as the
+    // gentle-first-move the old boot ramp used to provide.
+    boot_nod(&mut scs_head).await;
 
     // CoreS3 LCD (ILI9342C) on SPI2.
     //   SCK  = GPIO36

--- a/justfile
+++ b/justfile
@@ -5,36 +5,67 @@
 #   cargo install espup
 #   espup install
 #   source $HOME/export-esp.sh
+#
+# PORT defaults to /dev/ttyACM1 (Andy's CoreS3 USB-Serial-JTAG). Override
+# with `just PORT=/dev/ttyACM0 flash` if your device enumerates differently.
 
 set shell := ["bash", "-cu"]
+
+# Path to the release firmware ELF. Used by `flash`, `monitor`, `fmr`.
+firmware_elf := "target/xtensa-esp32s3-none-elf/release/stackchan-firmware"
+
+# Default port for CoreS3 USB-Serial-JTAG. Override by prefixing `just PORT=/dev/ttyACM0 …`.
+PORT := "/dev/ttyACM1"
 
 # Default: list available recipes.
 default:
     @just --list
 
-# Host-side checks (core + sim + axp2101). Fast.
+# ----- Host-side -----------------------------------------------------------
+
+# Fast host checks — the same gates the pre-commit hook runs.
 check:
     cargo fmt --check
-    cargo clippy --workspace --exclude stackchan-firmware --all-features -- -D warnings
+    cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings
     cargo test --workspace --exclude stackchan-firmware --all-features
 
-# Firmware-side compile check (requires esp toolchain sourced).
-check-firmware:
-    cargo check -p stackchan-firmware --target xtensa-esp32s3-none-elf
-
-# Full build of the firmware binary.
-build-firmware:
-    cargo build -p stackchan-firmware --release --target xtensa-esp32s3-none-elf
-
-# Flash the firmware to a connected CoreS3 at $PORT (defaults to /dev/ttyACM1).
-flash PORT='/dev/ttyACM1':
-    cargo run -p stackchan-firmware --release --target xtensa-esp32s3-none-elf -- --port {{PORT}}
-
-# Monitor defmt-rtt logs from a connected CoreS3.
-monitor PORT='/dev/ttyACM1':
-    espflash monitor --port {{PORT}}
-
-# Run everything CI runs (host side).
+# Everything the CI host job runs (adds doc-lint + cargo-deny).
 ci: check
     cargo deny check
-    cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features
+
+# ----- Firmware (requires `source ~/export-esp.sh` first) ------------------
+
+# Firmware-side compile check. Runs from inside the firmware crate so the
+# per-crate `.cargo/config.toml` (target + `build-std`) actually applies —
+# `-p stackchan-firmware` from workspace root silently misses that.
+check-firmware:
+    cd crates/stackchan-firmware && cargo +esp check
+
+# Firmware strict clippy (matches the CI firmware job).
+clippy-firmware:
+    cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings
+
+# Full release build of the firmware binary.
+build-firmware:
+    cd crates/stackchan-firmware && cargo +esp build --release
+
+# ----- Flash + monitor (requires `sg dialout` on this distrobox) -----------
+#
+# probe-rs is blocked by SELinux on Andy's Aurora-distrobox setup, so these
+# recipes go through espflash over the serial-JTAG port. The `sg dialout`
+# wrapper is required until dialout group membership is active in the
+# interactive shell's supplementary groups.
+
+# Flash the latest release build. Rebuilds first.
+flash: build-firmware
+    sg dialout -c "espflash flash --port {{PORT}} {{firmware_elf}}"
+
+# Monitor defmt logs from a running device (no reflash). Exits on Ctrl+C.
+monitor:
+    sg dialout -c "espflash monitor --port {{PORT}} --log-format defmt --elf {{firmware_elf}}"
+
+# Flash + monitor in one recipe. `fmr` = flash-monitor-reload, the
+# default inner-loop verb. Build first, then flash, then stream logs.
+fmr: build-firmware
+    sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{firmware_elf}}"


### PR DESCRIPTION
## Summary

Three related DX wins for building with StackChan. All grew out of "it's not moving" debugging today.

1. **`crates/scservo`: `Scservo::ping(id)`** — bidirectional now. New `impl<U: Read + Write>` block adds a PING round-trip that sends 6 bytes, reads 6 bytes, validates header/ID/checksum. No timeout in the crate (caller wraps with `embassy_time::with_timeout` — matches the runtime-agnostic design). New typed errors: `NoResponse` / `MalformedResponse` / `ChecksumMismatch`. 7 new unit tests including byte-exact outbound assertion + rejection paths for bad header, wrong ID, bad checksum, and empty response. 12 scservo tests total (was 5).

2. **Firmware: boot PING + imperative boot-nod gesture** — at boot, PING yaw (ID 1) and pitch (ID 2) with a 10 ms timeout each; log `present` or `no response`. Turns "silent no motion" into a loud log line. Then run a deliberate `pan +15 → -15 → 0 → tilt +10 → -10 → 0` sequence over ~1 s — unambiguous proof-of-life on every boot. Removed the old 500 ms `BOOT_RAMP_MS` / `first_call_at` state from `ScsHead`; the nod is now the gentle-first-move.

3. **`justfile`: solderless inner loop** — rewrote the recipes so they work on the real setup (probe-rs blocked by SELinux, needs `sg dialout` for serial, firmware commands need to run from inside the crate to pick up `.cargo/config.toml`).
   - `just flash` — build + flash via espflash.
   - `just monitor` — defmt log stream from a running device.
   - `just fmr` — flash-monitor-reload, the default inner-loop verb.
   - `just check` / `just check-firmware` / `just clippy-firmware` / `just ci` — mirror the pre-commit + CI gates.

## Architectural notes

- `ScsHead` gained `bus_mut()` so firmware `main` can borrow the underlying `Scservo<W>` for PING + nod commands before handing the driver to `head_task`.
- The old implicit 500 ms boot ramp is gone. An explicit gesture is a better UX (visible, debuggable, predictable) than a hidden animation baked into the driver.
- The crate's doc warns about half-duplex echo-on-bus. Didn't materialize on this unit — both PINGs came back clean. Left the warning in place for future units where the wiring might differ.

## Test plan

- [x] `just check` (host clippy + tests + fmt): 63+ tests passing across core / sim / scservo / axp2101 / aw9523
- [x] `just clippy-firmware`: clean
- [x] `just build-firmware`: clean
- [x] **HIL flash-test on CoreS3** via `just fmr`:
  ```
  509 ms [INFO ] SCServo[1]: present
  509 ms [INFO ] SCServo[2]: present
  509 ms [INFO ] boot-nod: hello gesture start
  1530 ms [INFO ] boot-nod: complete
  1795 ms [INFO ] head task: 20 ms tick, ... IDs 1 (yaw) / 2 (pitch)
  1795 ms [INFO ] boot complete — idle heartbeat
  ```
  Both servos responded to PING. Boot-nod completed in ~1 s. IdleSway + EmotionHead took over cleanly after handoff.

## Follow-ups

- `Scservo::read_memory` for position / voltage / temperature feedback now that the Read path is proven.
- `SyncWrite` to bundle yaw + pitch commands into one packet (halve UART utilisation).
- Move `PAN_TRIM_DEG` / `TILT_TRIM_DEG` / direction signs into a RON config in a flash partition — "calibrate without a rebuild", the second big DX win from the earlier recommendations.