### PR TITLE
chore: inline crate versions so release-please can parse them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+# Per-crate `version` is declared literally in each member crate's
+# Cargo.toml — not via `version.workspace = true` — because
+# release-please's `cargo-workspace` plugin at v4 can't parse
+# workspace-inherited version fields and errors with
+# `has an invalid [package.version]`. All six crates stay in
+# lockstep; release-please bumps them together.
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/andymai/stackchan-rs"

--- a/crates/aw9523/Cargo.toml
+++ b/crates/aw9523/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aw9523"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/axp2101/Cargo.toml
+++ b/crates/axp2101/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axp2101"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/scservo/Cargo.toml
+++ b/crates/scservo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scservo"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-core/Cargo.toml
+++ b/crates/stackchan-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-core"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-firmware"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-sim/Cargo.toml
+++ b/crates/stackchan-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-sim"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Fixes the release-please workflow that's been failing on every main push since PR #5 merged.

**Root cause:** release-please v4's `cargo-workspace` plugin can't parse `version.workspace = true` in per-crate `Cargo.toml` files. It bails with:

```
package manifest at crates/stackchan-core/Cargo.toml has an invalid [package.version]
```

**Fix:** inline `version = \"0.1.0\"` in each of the six crates (stackchan-core, stackchan-sim, axp2101, aw9523, scservo, stackchan-firmware), and remove `version` from `[workspace.package]`. Other workspace inheritances (edition, license, repository, rust-version) are untouched — only the version field needs to be literal.

## Trade-off

Six versions to keep in sync instead of one. Release-please keeps them in lockstep on every release PR (`cargo-workspace` plugin with `merge: true`), so drift only happens on hand-edits, which the existing Cargo.lock drift guard in the pre-commit hook catches.

## Test plan

- [x] `just check` / full host test suite — 63+ passing
- [x] `cargo check --workspace` — clean
- [ ] CI — should go green, including release-please this time

## References

- [release-please issue #1920](https://github.com/googleapis/release-please/issues/1920) — tracking workspace inheritance support
- [Chat of PR #5 failure](https://github.com/andymai/stackchan-rs/actions/runs/24879105461) — where this surfaced