### PR TITLE
ci: drop redundant build/check + paths-ignore docs-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    # Skip CI for changes that can't affect build output (pure docs,
+    # licenses, hook scripts). Any touch to `.yml` / `.toml` / `.rs`
+    # still triggers, so the "I forgot my change is actually code"
+    # footgun is bounded.
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE-*'
+      - '.githooks/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE-*'
+      - '.githooks/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,8 +44,8 @@ jobs:
       - name: Test (host crates)
         run: cargo test --workspace --exclude stackchan-firmware --all-features
 
-      - name: Build (host crates)
-        run: cargo build --workspace --exclude stackchan-firmware
+      # `cargo build` is redundant with `cargo test` above — the test
+      # pass builds every target. Dropping it saves ~6 s of Host runtime.
 
       - name: Doc check (host crates)
         run: cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features
@@ -72,9 +84,9 @@ jobs:
         working-directory: crates/stackchan-firmware
         run: cargo clippy --all-features -- -D warnings
 
-      - name: Check (firmware)
-        working-directory: crates/stackchan-firmware
-        run: cargo check --all-features
+      # `cargo check` is redundant with `cargo clippy` above — clippy
+      # runs a full type-check as part of its lint pass. Dropping it
+      # cuts ~45 s off the 2 m 22 s firmware job (the longest in CI).
 
   msrv:
     name: MSRV (host crates)


### PR DESCRIPTION
## Summary

Three small, independent CI wins that target the slowest jobs.

### 1. Firmware job — drop redundant `cargo check` step

`Clippy (firmware)` runs a full type-check pass with \`-D warnings\`. Running \`cargo check\` right after runs the same compile again, just with fewer lints. Expected saving: **~45 s** off the 2 m 22 s firmware job (the CI critical path).

### 2. Host job — drop redundant `cargo build` step

\`cargo test\` above it builds every target via test binaries. The separate \`cargo build\` is wasted compile. Expected saving: **~6 s**.

### 3. \`paths-ignore\` for docs-only changes

Skip the entire workflow when only \`**.md\` / \`LICENSE-*\` / \`.githooks/**\` change. Pure changelog / README commits no longer burn ~3 minutes of runner time. Conservative — \`*.toml\`, \`*.yml\`, \`*.rs\` still trigger full CI.

## Safety

Both dropped steps were running the same compile as the step immediately before. No coverage lost; the workflow still gates on clippy pedantic + strict warnings. Firmware strict clippy covers what \`cargo check\` would have caught.

## Test plan

- [x] Local: `just check` + `just clippy-firmware` still green
- [ ] CI on this PR — should itself complete ~50 s faster than prior PR's main branch
- [ ] Measured against a future PR (e.g. PR #6 rebase) — confirm savings

## Follow-ups (not in this PR)

- Release-please workflow is still failing on main with a different error (`Cannot read properties of undefined (reading 'pullRequest')`) after the manifest fix in PR #7 got past the parse stage. That's a config problem, not a speed problem — separate PR.
- Caching: `Swatinem/rust-cache@v2` is already in each job. Warm cache should reduce the firmware job further on subsequent runs; if it's not, that's worth investigating.