### PR TITLE
feat: servo position readback + calibration bench binary

### DIFF
--- a/crates/scservo/src/lib.rs
+++ b/crates/scservo/src/lib.rs
@@ -71,6 +71,23 @@ pub const ADDR_GOAL_POSITION: u8 = 42;
 /// SCSCL memory-table address of the torque-enable byte.
 pub const ADDR_TORQUE_ENABLE: u8 = 40;
 
+/// SCSCL memory-table address of the present-position low byte. A
+/// 2-byte big-endian read here yields the current servo position in
+/// the same 0..=1023 count space as [`ADDR_GOAL_POSITION`].
+pub const ADDR_PRESENT_POSITION: u8 = 56;
+
+/// SCSCL memory-table address of the present-voltage byte. Units: 0.1 V
+/// per count (e.g. 74 = 7.4 V).
+pub const ADDR_PRESENT_VOLTAGE: u8 = 62;
+
+/// SCSCL memory-table address of the present-temperature byte. Units:
+/// °C (direct, no scaling).
+pub const ADDR_PRESENT_TEMPERATURE: u8 = 63;
+
+/// SCSCL memory-table address of the moving-flag byte. 0 = settled,
+/// non-zero = actively tracking toward goal position.
+pub const ADDR_MOVING: u8 = 66;
+
 /// Protocol instruction codes (from `INST.h` in the Feetech reference
 /// library).
 #[repr(u8)]
@@ -333,6 +350,150 @@ impl<U: Read + Write> Scservo<U> {
         // dedicated status read later.
         Ok(())
     }
+
+    /// Low-level [`Instruction::Read`] that fills `buf` with `buf.len()`
+    /// bytes read starting at `mem_addr` on servo `id`.
+    ///
+    /// Outbound packet layout:
+    ///
+    /// ```text
+    /// | 0xFF | 0xFF | ID | 0x04 | 0x02 | MemAddr | Len | ~Checksum |
+    /// ```
+    ///
+    /// Response layout:
+    ///
+    /// ```text
+    /// | 0xFF | 0xFF | ID | Len+2 | Error | Data[0..Len] | ~Checksum |
+    /// ```
+    ///
+    /// Same timeout responsibility as [`Scservo::ping`] — wrap with
+    /// `embassy_time::with_timeout` for bounded waits.
+    ///
+    /// # Errors
+    /// - [`Error::PayloadTooLarge`] if `buf.len() > MAX_DATA_BYTES`.
+    /// - [`Error::Uart`] on transport failure.
+    /// - [`Error::NoResponse`] / [`Error::MalformedResponse`] /
+    ///   [`Error::ChecksumMismatch`] on bad responses.
+    pub async fn read_memory(
+        &mut self,
+        id: u8,
+        mem_addr: u8,
+        buf: &mut [u8],
+    ) -> Result<(), Error<U::Error>> {
+        if buf.len() > MAX_DATA_BYTES {
+            return Err(Error::PayloadTooLarge);
+        }
+        // data.len() is ≤ MAX_DATA_BYTES (6), so fits u8 trivially.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "len() ≤ MAX_DATA_BYTES (6), fits u8"
+        )]
+        let read_len = buf.len() as u8;
+
+        // Outbound: FF FF ID 04 02 ADDR LEN ~checksum (8 bytes).
+        // Checksum = ~(ID + 4 + Read + mem_addr + len).
+        let sum = id
+            .wrapping_add(0x04)
+            .wrapping_add(Instruction::Read as u8)
+            .wrapping_add(mem_addr)
+            .wrapping_add(read_len);
+        let outbound = [
+            HEADER_BYTE,
+            HEADER_BYTE,
+            id,
+            0x04,
+            Instruction::Read as u8,
+            mem_addr,
+            read_len,
+            !sum,
+        ];
+        self.uart.write_all(&outbound).await?;
+
+        // Response: 2 header + 1 id + 1 len-field + 1 error + N data + 1 checksum.
+        let response_total = 6 + buf.len();
+        let mut response = [0u8; MAX_PACKET_BYTES];
+        self.uart
+            .read_exact(&mut response[..response_total])
+            .await?;
+
+        if response[0] != HEADER_BYTE || response[1] != HEADER_BYTE {
+            return Err(Error::MalformedResponse);
+        }
+        if response[2] != id {
+            return Err(Error::MalformedResponse);
+        }
+        // msgLen for a READ response is `data_len + 2` (error + checksum).
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "buf.len() ≤ MAX_DATA_BYTES; the +2 stays well under u8::MAX"
+        )]
+        let expected_msg_len = (buf.len() + 2) as u8;
+        if response[3] != expected_msg_len {
+            return Err(Error::MalformedResponse);
+        }
+
+        // Checksum covers ID..=last data byte (excludes the checksum byte
+        // itself).
+        let mut check_sum: u8 = 0;
+        for &b in &response[2..response_total - 1] {
+            check_sum = check_sum.wrapping_add(b);
+        }
+        if response[response_total - 1] != !check_sum {
+            return Err(Error::ChecksumMismatch);
+        }
+
+        // Data bytes start at index 5; skip the 2 header + 1 id + 1 msgLen +
+        // 1 error bytes before them.
+        buf.copy_from_slice(&response[5..5 + buf.len()]);
+        Ok(())
+    }
+
+    /// Read the current position of servo `id` — the live encoder
+    /// reading, in the same 0..=1023 count space as the goal position.
+    /// Big-endian 2-byte field at [`ADDR_PRESENT_POSITION`].
+    ///
+    /// # Errors
+    /// Same as [`Scservo::read_memory`].
+    pub async fn read_position(&mut self, id: u8) -> Result<u16, Error<U::Error>> {
+        let mut buf = [0u8; 2];
+        self.read_memory(id, ADDR_PRESENT_POSITION, &mut buf)
+            .await?;
+        Ok(u16::from_be_bytes(buf))
+    }
+
+    /// Read the current supply voltage of servo `id`. Units: 0.1 V per
+    /// count (e.g. 74 → 7.4 V).
+    ///
+    /// # Errors
+    /// Same as [`Scservo::read_memory`].
+    pub async fn read_voltage(&mut self, id: u8) -> Result<u8, Error<U::Error>> {
+        let mut buf = [0u8; 1];
+        self.read_memory(id, ADDR_PRESENT_VOLTAGE, &mut buf).await?;
+        Ok(buf[0])
+    }
+
+    /// Read the current internal temperature of servo `id`, in °C.
+    ///
+    /// # Errors
+    /// Same as [`Scservo::read_memory`].
+    pub async fn read_temperature(&mut self, id: u8) -> Result<u8, Error<U::Error>> {
+        let mut buf = [0u8; 1];
+        self.read_memory(id, ADDR_PRESENT_TEMPERATURE, &mut buf)
+            .await?;
+        Ok(buf[0])
+    }
+
+    /// Read the moving flag of servo `id` — true while the servo is
+    /// actively tracking toward its goal position, false once settled.
+    /// Useful for "wait until move completes" loops during calibration.
+    ///
+    /// # Errors
+    /// Same as [`Scservo::read_memory`].
+    pub async fn read_moving(&mut self, id: u8) -> Result<bool, Error<U::Error>> {
+        let mut buf = [0u8; 1];
+        self.read_memory(id, ADDR_MOVING, &mut buf).await?;
+        Ok(buf[0] != 0)
+    }
 }
 
 #[cfg(test)]
@@ -525,5 +686,98 @@ mod tests {
         let mut bus = Scservo::new(MockUart::new());
         let err = block_on(bus.ping(1));
         assert!(matches!(err, Err(Error::NoResponse)));
+    }
+
+    // ----- READ instruction ------------------------------------------
+
+    #[test]
+    fn read_position_sends_correct_outbound_packet() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Pre-queue a valid 2-byte position response so read_exact doesn't hang.
+        // Response: FF FF 01 04 00 02 00 checksum. sum = 1+4+0+2+0 = 7, !7 = 0xF8.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x04, 0x00, 0x02, 0x00, 0xF8]);
+        let _ = block_on(bus.read_position(1));
+        // Expected outbound: FF FF 01 04 02 38 02 ~(1+4+2+56+2) = ~65 = 0xBE.
+        let expected: &[u8] = &[0xFF, 0xFF, 0x01, 0x04, 0x02, 0x38, 0x02, 0xBE];
+        assert_eq!(bus.uart.written.borrow().as_slice(), expected);
+    }
+
+    #[test]
+    fn read_position_decodes_big_endian_response() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Position = 0x0200 = 512 (center). Data bytes: [0x02, 0x00].
+        // Full response: FF FF 01 04 00 02 00 checksum.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x04, 0x00, 0x02, 0x00, 0xF8]);
+        let pos = block_on(bus.read_position(1)).unwrap();
+        assert_eq!(pos, 512);
+    }
+
+    #[test]
+    fn read_voltage_decodes_single_byte() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Voltage = 74 (= 7.4 V). msgLen = 3. sum = 1+3+0+74 = 78, !78 = 0xB1.
+        bus.uart.queue_rx(&[0xFF, 0xFF, 0x01, 0x03, 0x00, 74, 0xB1]);
+        let v = block_on(bus.read_voltage(1)).unwrap();
+        assert_eq!(v, 74);
+    }
+
+    #[test]
+    fn read_temperature_decodes_single_byte() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Temp = 32°C. sum = 1+3+0+32 = 36, !36 = 0xDB.
+        bus.uart.queue_rx(&[0xFF, 0xFF, 0x01, 0x03, 0x00, 32, 0xDB]);
+        let t = block_on(bus.read_temperature(1)).unwrap();
+        assert_eq!(t, 32);
+    }
+
+    #[test]
+    fn read_moving_decodes_bool() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Moving = 1 (true). sum = 1+3+0+1 = 5, !5 = 0xFA.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x03, 0x00, 0x01, 0xFA]);
+        let moving = block_on(bus.read_moving(1)).unwrap();
+        assert!(moving);
+    }
+
+    #[test]
+    fn read_moving_false_on_zero_byte() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Moving = 0 (false). sum = 1+3+0+0 = 4, !4 = 0xFB.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x03, 0x00, 0x00, 0xFB]);
+        let moving = block_on(bus.read_moving(1)).unwrap();
+        assert!(!moving);
+    }
+
+    #[test]
+    fn read_memory_rejects_oversized_buf() {
+        let mut bus = Scservo::new(MockUart::new());
+        let mut buf = [0u8; MAX_DATA_BYTES + 1];
+        let err = block_on(bus.read_memory(1, 0, &mut buf));
+        assert!(matches!(err, Err(Error::PayloadTooLarge)));
+    }
+
+    #[test]
+    fn read_memory_rejects_wrong_length_field() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Response claims msgLen = 5 but we asked for 2 data bytes → expect 4.
+        // Even with a matching checksum the header check fails first.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x05, 0x00, 0x02, 0x00, 0xF7]);
+        let err = block_on(bus.read_position(1));
+        assert!(matches!(err, Err(Error::MalformedResponse)));
+    }
+
+    #[test]
+    fn read_memory_rejects_bad_checksum() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Valid structure but checksum byte corrupted.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x04, 0x00, 0x02, 0x00, 0x00]);
+        let err = block_on(bus.read_position(1));
+        assert!(matches!(err, Err(Error::ChecksumMismatch)));
     }
 }

--- a/crates/stackchan-core/src/avatar.rs
+++ b/crates/stackchan-core/src/avatar.rs
@@ -158,6 +158,16 @@ pub struct Avatar {
     /// `IdleSway`); consumed by firmware's head-update task, not the
     /// pixel renderer. Excluded from [`Avatar::frame_eq`].
     pub head_pose: Pose,
+    /// Observed head pan/tilt pose in degrees — the servos' reported
+    /// actual position, not the commanded one. Written by the firmware
+    /// head-update task after reading `read_position` from each servo
+    /// (at ~1 Hz). Defaults to [`Pose::NEUTRAL`] and stays there until
+    /// the first successful readback. Excluded from
+    /// [`Avatar::frame_eq`] like [`Avatar::head_pose`] — the LCD
+    /// doesn't render against it. A future `EyeGaze` modifier can read
+    /// this to point the eyes toward the direction the head is
+    /// *actually* facing, decoupled from the command pipeline.
+    pub head_pose_actual: Pose,
 }
 
 impl Avatar {
@@ -224,6 +234,7 @@ impl Default for Avatar {
             blink_rate_scale: SCALE_DEFAULT,
             breath_depth_scale: SCALE_DEFAULT,
             head_pose: Pose::NEUTRAL,
+            head_pose_actual: Pose::NEUTRAL,
         }
     }
 }

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -63,6 +63,14 @@ esp-println = { version = "0.17.0", default-features = false, features = [
 critical-section = "1.2.0"
 static_cell = "2.1.1"
 
+[lib]
+name = "stackchan_firmware"
+path = "src/lib.rs"
+
 [[bin]]
 name = "stackchan-firmware"
 path = "src/main.rs"
+
+[[example]]
+name = "bench"
+path = "examples/bench.rs"

--- a/crates/stackchan-firmware/examples/bench.rs
+++ b/crates/stackchan-firmware/examples/bench.rs
@@ -1,0 +1,207 @@
+//! Servo calibration bench.
+//!
+//! Standalone firmware binary that sweeps each axis through a fixed
+//! pattern, reads the live servo position at each stop, and logs a
+//! one-line-per-step CSV-ish row via defmt so the operator can grep
+//! out a trim table. Designed for flashing via `just bench` — when
+//! the sweep finishes the binary centres the servos, logs
+//! `bench complete`, and halts forever.
+//!
+//! Sweep (conservative, matches the defaults in the parent PR):
+//!
+//! - Pan: -30 → -20 → -10 → 0 → +10 → +20 → +30 (7 steps)
+//! - Tilt: -20 → -10 → 0 → +10 → +20 (5 steps)
+//! - 300 ms dwell per step — enough for the servo's internal
+//!   interpolation to complete before the readback.
+//!
+//! Output per step:
+//!
+//! ```text
+//! bench pan:  cmd=-30.00 raw_pos=547 actual_deg=+14.37 delta=+44.37
+//! ```
+//!
+//! `delta = actual - cmd`. The expected value is 0 after proper trim
+//! calibration; systematic offsets suggest a trim value; changes in
+//! sign across the range suggest flipping `*_DIRECTION`.
+
+#![no_std]
+#![no_main]
+// Example binary inherits the same ESP-IDF app-descriptor requirement
+// as the main firmware, so the same app-desc anchor + unsafe allowance
+// is needed here. Otherwise `lto = "fat"` strips the descriptor and
+// espflash refuses to flash the image.
+#![allow(unsafe_code)]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+// Single-core executor; `Send`-bounded futures aren't meaningful here.
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Timer};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use stackchan_core::{Clock, HeadDriver, Pose};
+use stackchan_firmware::{board, clock::HalClock};
+
+// esp-println registers the global defmt logger via USB-Serial-JTAG.
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// `#[used]`-anchor newtype for `ESP_APP_DESC`. See `main.rs` for the
+/// full rationale — short version: `lto = "fat"` strips the
+/// bootloader-readable descriptor unless a `#[used]` static holds a
+/// reference to it.
+#[repr(transparent)]
+struct AppDescAnchor(*const esp_bootloader_esp_idf::EspAppDesc);
+// SAFETY: the raw pointer is never dereferenced at runtime; the
+// newtype only exists so `#[used]` on the static below holds a symbol
+// reference for the linker.
+unsafe impl Sync for AppDescAnchor {}
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped.
+#[used]
+static APP_DESC_ANCHOR: AppDescAnchor = AppDescAnchor(core::ptr::addr_of!(ESP_APP_DESC));
+
+/// Panic handler for the bench binary. Halts the core; the trace has
+/// already been emitted via defmt before we arrive here.
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Smaller heap than main (no framebuffer), but the embassy task arena
+/// and defmt buffers still need SRAM. 32 KiB is comfortable.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Dwell per sweep step before reading the actual position.
+const DWELL_MS: u64 = 300;
+
+/// Timeout for each `read_position` call.
+const READ_TIMEOUT_MS: u64 = 10;
+
+/// Main entry point. Runs a single imperative sweep in the embassy
+/// executor and halts. The `_spawner` argument is required by the
+/// `esp_rtos::main` macro signature but we never spawn background
+/// tasks — bench is intentionally single-threaded.
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "the esp_rtos::main macro requires the `spawner` arg; bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-bench v{} — CoreS3 boot, will sweep + log deltas",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let mut driver = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    // Pan sweep: -30 .. +30 in 10° steps.
+    for cmd in [-30.0_f32, -20.0, -10.0, 0.0, 10.0, 20.0, 30.0] {
+        run_step("pan", &mut driver, Pose::new(cmd, 0.0), cmd, true).await;
+    }
+
+    // Tilt sweep: -20 .. +20 in 10° steps. Return pan to 0 first so
+    // the tilt readings aren't entangled with an off-axis pan target.
+    for cmd in [-20.0_f32, -10.0, 0.0, 10.0, 20.0] {
+        run_step("tilt", &mut driver, Pose::new(0.0, cmd), cmd, false).await;
+    }
+
+    // Centre, log completion, halt.
+    if let Err(e) = driver.set_pose(Pose::NEUTRAL, HalClock.now()).await {
+        defmt::warn!("bench: centre command failed: {}", defmt::Debug2Format(&e));
+    }
+    Timer::after(Duration::from_millis(DWELL_MS)).await;
+    defmt::info!("bench complete — re-flash main firmware with `just flash` to resume normal boot");
+    loop {
+        Timer::after(Duration::from_secs(5)).await;
+    }
+}
+
+/// Command a single pose, wait for the servo to settle, read back its
+/// live position, and log one line with `cmd_deg`, `raw_pos`,
+/// `actual_deg`, `delta_deg`. `axis` picks which servo to read; `is_pan`
+/// true = yaw servo, false = pitch servo.
+async fn run_step(
+    label: &str,
+    driver: &mut board::HeadDriverImpl,
+    pose: Pose,
+    cmd_deg: f32,
+    is_pan: bool,
+) {
+    if let Err(e) = driver.set_pose(pose, HalClock.now()).await {
+        defmt::warn!(
+            "bench {}: set_pose failed: {}",
+            label,
+            defmt::Debug2Format(&e)
+        );
+        return;
+    }
+    Timer::after(Duration::from_millis(DWELL_MS)).await;
+
+    let id = if is_pan {
+        stackchan_firmware::head::YAW_SERVO_ID
+    } else {
+        stackchan_firmware::head::PITCH_SERVO_ID
+    };
+    let bus = driver.bus_mut();
+    let raw = match embassy_time::with_timeout(
+        Duration::from_millis(READ_TIMEOUT_MS),
+        bus.read_position(id),
+    )
+    .await
+    {
+        Ok(Ok(p)) => p,
+        Ok(Err(e)) => {
+            defmt::warn!(
+                "bench {}: read_position err at cmd={=f32}: {}",
+                label,
+                cmd_deg,
+                defmt::Debug2Format(&e)
+            );
+            return;
+        }
+        Err(_) => {
+            defmt::warn!(
+                "bench {}: read_position timed out at cmd={=f32}",
+                label,
+                cmd_deg
+            );
+            return;
+        }
+    };
+
+    // Inverse mapping: actual_deg = (raw - 512) / POSITION_PER_DEGREE,
+    // assuming direction = +1 and trim = 0 (bench's job is to discover
+    // the actual trim, so don't apply one here).
+    let actual_deg =
+        (f32::from(raw) - f32::from(scservo::POSITION_CENTER)) / scservo::POSITION_PER_DEGREE;
+    let delta = actual_deg - cmd_deg;
+    defmt::info!(
+        "bench {}: cmd={=f32} raw_pos={=u16} actual_deg={=f32} delta={=f32}",
+        label,
+        cmd_deg,
+        raw,
+        actual_deg,
+        delta,
+    );
+}

--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -1,0 +1,235 @@
+//! CoreS3 board bring-up — power + servo bus init shared between the
+//! main firmware binary and `examples/bench.rs`.
+//!
+//! [`bringup`] owns the full sequence:
+//!
+//! 1. Internal I²C0 on GPIO11/12 → AXP2101 → AW9523 → PY32 (enable
+//!    servo power pin, 200 ms settle).
+//! 2. External UART1 on GPIO6/7 at 1 Mbaud for the `SCServo` bus.
+//! 3. `SCServo::ping` each configured servo ID, log presence.
+//! 4. Run the boot-nod gesture so the head visibly exercises both
+//!    axes before the main control pipeline takes over.
+//!
+//! The function returns the fully-initialised [`HeadDriverImpl`] ready
+//! to be handed to the firmware's head task (or driven directly in the
+//! bench example). It does **not** touch the LCD peripherals — that
+//! stays in the caller so the bench binary can skip it.
+//!
+//! ## Philosophy
+//!
+//! Errors at each step are handled in place: a failing sub-step logs
+//! `warn` or `error` via defmt and carries on. A missing PY32 or
+//! disconnected servos should never blank the face. The only step
+//! that panics on failure is AXP2101 init, and only because no
+//! forward progress is possible without the LDOs.
+
+use embassy_time::{Delay, Duration, Timer};
+use esp_hal::{
+    i2c::master::{Config as I2cConfig, I2c},
+    peripherals::{GPIO6, GPIO7, GPIO11, GPIO12, I2C0, UART1},
+    time::Rate,
+    uart::{Config as UartConfig, Uart},
+};
+use scservo::Scservo;
+use stackchan_core::{Clock, HeadDriver, Pose};
+
+use crate::clock::HalClock;
+use crate::head;
+
+/// Concrete type of the `SCServo`-backed head driver, needed so
+/// `#[embassy_executor::task]` (which forbids generic tasks) can accept
+/// it as an argument.
+pub type HeadDriverImpl = head::ScsHead<Uart<'static, esp_hal::Async>>;
+
+/// 7-bit I²C address of the CoreS3 PY32 IO expander.
+const PY32_ADDRESS: u8 = 0x6F;
+
+/// Milliseconds to wait after raising the servo-power pin on the PY32.
+/// Matches the 200 ms delay in `hal_io_expander.cpp`.
+const SERVO_POWER_SETTLE_MS: u64 = 200;
+
+/// Retry delay between failed AXP2101 init attempts. Covers transient
+/// I²C glitches during cold boot.
+const PMIC_RETRY_MS: u64 = 500;
+
+/// `SCServo` UART baud rate. Feetech `SCSCL` family default is 1 Mbaud.
+const SERVO_UART_BAUD: u32 = 1_000_000;
+
+/// PING timeout per servo, in ms. 10 ms is well past the ~200 µs
+/// round-trip of a 1 Mbaud PING packet.
+const PING_TIMEOUT_MS: u64 = 10;
+
+/// Wall-clock pace between boot-nod steps. Matches the servos'
+/// single-leg move budget (`MOVE_TIME_MS` in `head.rs`).
+const BOOT_NOD_STEP_MS: u64 = 170;
+
+/// Full CoreS3 bring-up for the servo subsystem.
+///
+/// Consumes the I²C / UART peripherals + their GPIOs, returns a
+/// ready-to-drive [`HeadDriverImpl`] with both servos `PINGed` and the
+/// boot-nod gesture already executed. Caller keeps ownership of
+/// unrelated peripherals (SPI2, LCD GPIOs, etc.) for further init.
+///
+/// # Panics
+///
+/// Panics if AXP2101 init can't eventually succeed — the LDOs feed
+/// the rest of the board, so halting here surfaces a wiring failure
+/// loudly rather than silently limping.
+pub async fn bringup(
+    i2c_periph: I2C0<'static>,
+    uart_periph: UART1<'static>,
+    sda: GPIO12<'static>,
+    scl: GPIO11<'static>,
+    uart_tx: GPIO6<'static>,
+    uart_rx: GPIO7<'static>,
+    delay: &mut Delay,
+) -> HeadDriverImpl {
+    // Internal I²C0: 100 kHz standard-mode rate — works from cold boot
+    // before PLLs are fully settled. AXP2101 / AW9523 / PY32 all share
+    // this bus.
+    let i2c_cfg = I2cConfig::default().with_frequency(Rate::from_khz(100));
+    let i2c = match I2c::new(i2c_periph, i2c_cfg) {
+        Ok(bus) => bus.with_sda(sda).with_scl(scl).into_async(),
+        Err(e) => defmt::panic!("I2C0 config rejected: {}", defmt::Debug2Format(&e)),
+    };
+    defmt::debug!("I2C0 ready on GPIO12/11 @ 100 kHz");
+
+    let mut pmic = axp2101::Axp2101::new(i2c);
+    loop {
+        match pmic.init_cores3().await {
+            Ok(()) => {
+                defmt::info!(
+                    "AXP2101: CoreS3 power defaults applied — LCD rails + power-key timing set"
+                );
+                break;
+            }
+            Err(e) => {
+                defmt::error!(
+                    "AXP2101 init failed (retrying in {=u64} ms): {}",
+                    PMIC_RETRY_MS,
+                    defmt::Debug2Format(&e)
+                );
+                Timer::after(Duration::from_millis(PMIC_RETRY_MS)).await;
+            }
+        }
+    }
+
+    let mut i2c = pmic.into_inner();
+    match aw9523::init_cores3(&mut i2c, delay).await {
+        Ok(()) => defmt::info!("AW9523: CoreS3 defaults applied, LCD reset pulsed (P1_1)"),
+        Err(e) => defmt::panic!("AW9523 init failed: {}", defmt::Debug2Format(&e)),
+    }
+
+    enable_servo_power(&mut i2c).await;
+    Timer::after(Duration::from_millis(SERVO_POWER_SETTLE_MS)).await;
+
+    // I²C0 is done — drop it so later code can't accidentally share the bus.
+    drop(i2c);
+
+    // External UART1 for the SCServo bus.
+    let uart_cfg = UartConfig::default().with_baudrate(SERVO_UART_BAUD);
+    let servo_uart = match Uart::new(uart_periph, uart_cfg) {
+        Ok(uart) => uart.with_tx(uart_tx).with_rx(uart_rx).into_async(),
+        Err(e) => defmt::panic!("UART1 config rejected: {}", defmt::Debug2Format(&e)),
+    };
+    defmt::info!(
+        "SCServo bus ready on UART1 (TX=GPIO6, RX=GPIO7) @ {=u32} baud",
+        SERVO_UART_BAUD
+    );
+    let mut scs_head = head::ScsHead::new(Scservo::new(servo_uart));
+
+    // Servo presence check. UART writes don't NACK on missing slaves,
+    // so without this probe we can't tell the bus is alive.
+    ping_servo(&mut scs_head, head::YAW_SERVO_ID).await;
+    ping_servo(&mut scs_head, head::PITCH_SERVO_ID).await;
+
+    // Visible proof of life: deliberate pan-then-tilt gesture before
+    // the main control pipeline takes over.
+    boot_nod(&mut scs_head).await;
+
+    scs_head
+}
+
+/// Drive pin 0 of the PY32 IO expander HIGH to enable the servo power
+/// rail. Three register writes with values that match the PY32's
+/// reset-state of all zeros (no read-modify-write yet — future RGB-LED
+/// work will need that). Logs at `warn` on any I²C failure and keeps
+/// going.
+async fn enable_servo_power(i2c: &mut I2c<'_, esp_hal::Async>) {
+    use embedded_hal_async::i2c::I2c as AsyncI2c;
+    /// Write `[reg, value]` to the PY32; log + return Err on transport failure.
+    async fn write_py32(i2c: &mut I2c<'_, esp_hal::Async>, reg: u8, value: u8) -> Result<(), ()> {
+        // Fully-qualified `AsyncI2c::write` — `esp_hal::i2c::master::I2c`
+        // has an inherent `write` that's blocking; we want the trait
+        // version for its `async fn`.
+        match AsyncI2c::write(i2c, PY32_ADDRESS, &[reg, value]).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                defmt::warn!(
+                    "PY32 0x{=u8:02X} ← 0x{=u8:02X} failed: {}",
+                    reg,
+                    value,
+                    defmt::Debug2Format(&e)
+                );
+                Err(())
+            }
+        }
+    }
+    // Pin 0: direction = output, pull-up = enabled, level = HIGH.
+    if write_py32(i2c, 0x03, 0x01).await.is_err()
+        || write_py32(i2c, 0x09, 0x01).await.is_err()
+        || write_py32(i2c, 0x05, 0x01).await.is_err()
+    {
+        defmt::warn!("PY32: servo-power enable incomplete — servos may stay unpowered");
+        return;
+    }
+    defmt::info!("PY32: servo power enabled (pin 0 HIGH)");
+}
+
+/// Probe one `SCServo` ID and log the outcome. 10 ms is well past the
+/// ~200 µs round-trip of a 1 Mbaud PING packet, so a miss here is a
+/// real "servo not responding" signal.
+async fn ping_servo(driver: &mut HeadDriverImpl, id: u8) {
+    let bus = driver.bus_mut();
+    match embassy_time::with_timeout(
+        embassy_time::Duration::from_millis(PING_TIMEOUT_MS),
+        bus.ping(id),
+    )
+    .await
+    {
+        Ok(Ok(())) => defmt::info!("SCServo[{=u8}]: present", id),
+        Ok(Err(e)) => defmt::warn!(
+            "SCServo[{=u8}]: malformed response: {}",
+            id,
+            defmt::Debug2Format(&e)
+        ),
+        Err(_) => defmt::warn!(
+            "SCServo[{=u8}]: no response within {=u64} ms (disconnected or unpowered?)",
+            id,
+            PING_TIMEOUT_MS
+        ),
+    }
+}
+
+/// Boot-time "hello" gesture: pan +15 → pan -15 → pan 0 → tilt +10
+/// → tilt -10 → tilt 0 over ~1 s. Each step waits
+/// [`BOOT_NOD_STEP_MS`] for the servo's internal interpolation to
+/// complete before commanding the next. Write errors log + continue.
+async fn boot_nod(driver: &mut HeadDriverImpl) {
+    let clock = HalClock;
+    defmt::info!("boot-nod: hello gesture start");
+    for (pan, tilt, label) in [
+        (15.0, 0.0, "pan+15"),
+        (-15.0, 0.0, "pan-15"),
+        (0.0, 0.0, "pan 0"),
+        (0.0, 10.0, "tilt+10"),
+        (0.0, -10.0, "tilt-10"),
+        (0.0, 0.0, "tilt 0"),
+    ] {
+        if let Err(e) = driver.set_pose(Pose::new(pan, tilt), clock.now()).await {
+            defmt::warn!("boot-nod step {}: {}", label, defmt::Debug2Format(&e));
+        }
+        Timer::after(Duration::from_millis(BOOT_NOD_STEP_MS)).await;
+    }
+    defmt::info!("boot-nod: complete");
+}

--- a/crates/stackchan-firmware/src/framebuffer.rs
+++ b/crates/stackchan-firmware/src/framebuffer.rs
@@ -27,6 +27,7 @@ pub const WIDTH: u32 = 320;
 pub const HEIGHT: u32 = 240;
 
 /// `Rgb565` framebuffer with the same row-major layout the ILI9342C expects.
+///
 /// Implements [`DrawTarget`] with `Infallible` errors; out-of-bounds pixel
 /// writes are silently dropped, matching embedded-graphics' `OriginDimensions`
 /// clipping contract.

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -31,7 +31,7 @@
 //! physical trim.
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-use embedded_io_async::Write;
+use embedded_io_async::{Read, Write};
 use scservo::{POSITION_CENTER, POSITION_PER_DEGREE, Scservo};
 use stackchan_core::{HeadDriver, Instant, Pose};
 
@@ -63,13 +63,22 @@ const MOVE_TIME_MS: u16 = 20;
 /// control" (see [`MOVE_TIME_MS`]).
 const MOVE_SPEED: u16 = 0;
 
-/// Single-producer / single-consumer latest-pose signal.
+/// Commanded-pose signal: render task → head task.
 ///
 /// The render task calls [`Signal::signal`] with the latest
 /// `avatar.head_pose` after each modifier pass; the head task drains
 /// it via [`Signal::try_take`] on every tick (and holds the prior pose
 /// if nothing new is pending).
 pub static POSE_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Signal::new();
+
+/// Observed-pose signal: head task → render task.
+///
+/// The head task reads the servos' live position at ~1 Hz and signals
+/// the result back here; the render task consumes via `try_take` and
+/// writes to `avatar.head_pose_actual`. Used for feedback logging +
+/// future gaze-compensation work. Signal semantics: latest wins, no
+/// backlog.
+pub static HEAD_POSE_ACTUAL_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Signal::new();
 
 /// Feetech SCServo-backed head driver.
 pub struct ScsHead<W> {
@@ -106,6 +115,34 @@ impl<W: Write> ScsHead<W> {
         )]
         let pos = clamped as u16;
         pos
+    }
+
+    /// Inverse of [`Self::position_for`]: convert a live servo step
+    /// count back into degrees in the same reference frame the caller
+    /// commanded. Used by the 1 Hz position poll.
+    fn deg_for(position: u16, trim_deg: f32, direction: f32) -> f32 {
+        let offset = f32::from(position) - f32::from(POSITION_CENTER);
+        let effective = offset / POSITION_PER_DEGREE;
+        // Inverse direction + trim from `position_for`.
+        (effective / direction) - trim_deg
+    }
+}
+
+impl<U: Read + Write> ScsHead<U> {
+    /// Read the live position of both servos, return a `Pose` in the
+    /// same commanded-reference-frame as `set_pose` inputs. Useful for
+    /// feedback logging + the future `EyeGaze` modifier.
+    ///
+    /// # Errors
+    /// Returns the transport error on the first failing read; the
+    /// caller typically logs + continues rather than treating this as
+    /// fatal.
+    pub async fn read_pose(&mut self) -> Result<Pose, scservo::Error<U::Error>> {
+        let pan_pos = self.bus.read_position(YAW_SERVO_ID).await?;
+        let tilt_pos = self.bus.read_position(PITCH_SERVO_ID).await?;
+        let pan_deg = Self::deg_for(pan_pos, PAN_TRIM_DEG, PAN_DIRECTION);
+        let tilt_deg = Self::deg_for(tilt_pos, TILT_TRIM_DEG, TILT_DIRECTION);
+        Ok(Pose::new(pan_deg, tilt_deg))
     }
 }
 

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -1,0 +1,23 @@
+//! Shared library surface of the StackChan firmware — modules that the
+//! main binary (`src/main.rs`) and any `examples/*.rs` binary both use.
+//!
+//! Each binary still carries its own `#[panic_handler]`, app-descriptor
+//! anchor, heap init, and `#[esp_rtos::main]` entry point; this crate
+//! only hosts the reusable device-driver + task-infrastructure modules.
+//!
+//! Unsafe code is isolated inside specific binary files (the app-desc
+//! anchor — see `main.rs` / `examples/bench.rs`). The library surface
+//! itself is `#![deny(unsafe_code)]`.
+
+#![no_std]
+#![deny(unsafe_code)]
+// esp-rtos runs a single-core executor on this chip; `Send`-bounded
+// futures aren't meaningful here. The nursery lint fires on every task.
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+pub mod board;
+pub mod clock;
+pub mod framebuffer;
+pub mod head;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -29,11 +29,9 @@
 
 extern crate alloc;
 
-mod clock;
-mod framebuffer;
-mod head;
+use stackchan_firmware::{board, clock, framebuffer, head};
 
-use axp2101::Axp2101;
+use board::HeadDriverImpl;
 use clock::HalClock;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Ticker, Timer};
@@ -47,14 +45,12 @@ use esp_hal::{
     Blocking,
     clock::CpuClock,
     gpio::{Level, Output, OutputConfig},
-    i2c::master::{Config as I2cConfig, I2c},
     spi::{
         Mode as SpiMode,
         master::{Config as SpiConfig, Spi},
     },
     time::Rate,
     timer::timg::TimerGroup,
-    uart::{Config as UartConfig, Uart},
 };
 use framebuffer::{Framebuffer, HEIGHT as FB_HEIGHT, WIDTH as FB_WIDTH};
 use mipidsi::{
@@ -63,7 +59,6 @@ use mipidsi::{
     models::ILI9342CRgb565,
     options::{ColorInversion, ColorOrder},
 };
-use scservo::Scservo;
 use stackchan_core::{
     Avatar, Clock, HeadDriver, Modifier,
     modifiers::{Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, IdleDrift, IdleSway},
@@ -115,11 +110,6 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 /// the esp-generate default and leaves ample margin for `esp-rtos` state.
 const HEAP_SIZE: usize = 72 * 1024;
 
-/// Retry delay between failed AXP2101 init attempts. Covers transient
-/// I²C glitches during cold boot — no forward progress is possible
-/// without the LDOs, so halting here is the wrong answer.
-const PMIC_RETRY_MS: u64 = 500;
-
 /// Render cadence. 33 ms ≈ 30 FPS; `Ticker` corrects drift automatically
 /// if a single frame's `Avatar::draw` runs long (e.g. during a blink
 /// transition where every pixel changes).
@@ -130,16 +120,6 @@ const FRAME_PERIOD_MS: u64 = 33;
 /// internal interpolation smooths between commands — and keeps the
 /// UART bus utilisation below 2% even with two servos per tick.
 const HEAD_PERIOD_MS: u64 = 20;
-
-/// `SCServo` UART baud rate. Feetech `SCSCL` family default is 1 Mbaud.
-const SERVO_UART_BAUD: u32 = 1_000_000;
-
-/// 7-bit I²C address of the CoreS3 PY32 IO expander.
-const PY32_ADDRESS: u8 = 0x6F;
-
-/// Milliseconds to wait after raising the servo-power pin on the PY32.
-/// Matches the 200 ms delay in `hal_io_expander.cpp`.
-const SERVO_POWER_SETTLE_MS: u64 = 200;
 
 /// Concrete type of the assembled LCD display. Spelled out once here so the
 /// render task (which the `#[embassy_executor::task]` macro requires to be
@@ -154,11 +134,6 @@ type LcdDisplay = mipidsi::Display<
     ILI9342CRgb565,
     NoResetPin,
 >;
-
-/// Concrete type of the `SCServo`-backed head driver, needed so
-/// `#[embassy_executor::task]` (which forbids generic tasks) can accept
-/// it as an argument.
-type HeadDriverImpl = head::ScsHead<Uart<'static, esp_hal::Async>>;
 
 /// 30 FPS render task. Double-buffered via a PSRAM-backed [`Framebuffer`]:
 /// each frame we run the modifier stack, draw the avatar into the off-screen
@@ -224,6 +199,13 @@ async fn render_task(mut display: LcdDisplay) {
         // recent pose.
         head::POSE_SIGNAL.signal(avatar.head_pose);
 
+        // Drain the latest observed pose from the head task. Updated at
+        // ~1 Hz over there, so most render ticks see nothing new and
+        // hold the previous value — which is exactly what we want.
+        if let Some(actual) = head::HEAD_POSE_ACTUAL_SIGNAL.try_take() {
+            avatar.head_pose_actual = actual;
+        }
+
         // `frame_eq` intentionally skips `head_pose` — the LCD is mounted
         // rigidly to the head, so pan/tilt updates never change pixels.
         // `IdleSway` mutates `avatar.head_pose` every tick; using `==`
@@ -250,20 +232,30 @@ async fn render_task(mut display: LcdDisplay) {
 /// hold their position via internal torque, so a slow render task
 /// never leaves the head wobbling.
 ///
-/// UART write failures log at `warn` and continue: a transient bus
-/// glitch shouldn't blank the face or reboot the binary. UART writes
-/// don't NACK on missing slaves, so in a "no servos attached" state
-/// this path is silent — the face still renders.
+/// Every `POSITION_POLL_EVERY` ticks (= 1 Hz at 50 Hz command cadence),
+/// the task also reads back each servo's live position and publishes it
+/// via [`head::HEAD_POSE_ACTUAL_SIGNAL`] for the render task to write
+/// onto `avatar.head_pose_actual` + logs a `cmd vs actual` line.
+///
+/// UART write/read failures log at `warn` and continue: a transient
+/// bus glitch shouldn't blank the face or reboot the binary.
 #[embassy_executor::task]
 async fn head_task(mut driver: HeadDriverImpl) {
+    /// Poll position every N command ticks. `HEAD_PERIOD_MS` × N = 1 s.
+    const POSITION_POLL_EVERY: u32 = 50;
+    /// Per-read timeout for the `read_position` calls.
+    const READ_TIMEOUT_MS: u64 = 10;
+
     let clock = HalClock;
     let mut ticker = Ticker::every(Duration::from_millis(HEAD_PERIOD_MS));
     let mut current = stackchan_core::Pose::NEUTRAL;
+    let mut tick_count: u32 = 0;
     defmt::info!(
-        "head task: {=u64} ms tick, consumes POSE_SIGNAL for SCServo IDs {=u8} (yaw) / {=u8} (pitch)",
+        "head task: {=u64} ms tick, consumes POSE_SIGNAL for SCServo IDs {=u8} (yaw) / {=u8} (pitch), reads actual @ {=u64} ms",
         HEAD_PERIOD_MS,
         head::YAW_SERVO_ID,
         head::PITCH_SERVO_ID,
+        HEAD_PERIOD_MS.saturating_mul(u64::from(POSITION_POLL_EVERY)),
     );
     loop {
         if let Some(next) = head::POSE_SIGNAL.try_take() {
@@ -272,117 +264,35 @@ async fn head_task(mut driver: HeadDriverImpl) {
         if let Err(e) = driver.set_pose(current, clock.now()).await {
             defmt::warn!("head: SCServo write failed: {}", defmt::Debug2Format(&e));
         }
-        ticker.next().await;
-    }
-}
-
-/// Drive pin 0 of the PY32 IO expander HIGH to enable the servo power
-/// rail. Three register writes with values that match the PY32's
-/// reset-state of all zeros (no read-modify-write yet — future RGB-LED
-/// work will need that). Logs at `warn` on any I²C failure and keeps
-/// going; the firmware stays healthy even if the expander is missing.
-async fn enable_servo_power(i2c: &mut I2c<'_, esp_hal::Async>) {
-    use embedded_hal_async::i2c::I2c as AsyncI2c;
-    /// Write `[reg, value]` to the PY32; log + return Err on transport failure.
-    async fn write_py32(i2c: &mut I2c<'_, esp_hal::Async>, reg: u8, value: u8) -> Result<(), ()> {
-        // Fully-qualified `AsyncI2c::write` — `esp_hal::i2c::master::I2c`
-        // has an inherent `write` that's blocking; we want the trait
-        // version for its `async fn`.
-        match AsyncI2c::write(i2c, PY32_ADDRESS, &[reg, value]).await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                defmt::warn!(
-                    "PY32 0x{=u8:02X} ← 0x{=u8:02X} failed: {}",
-                    reg,
-                    value,
+        tick_count = tick_count.wrapping_add(1);
+        if tick_count.is_multiple_of(POSITION_POLL_EVERY) {
+            match embassy_time::with_timeout(
+                Duration::from_millis(READ_TIMEOUT_MS),
+                driver.read_pose(),
+            )
+            .await
+            {
+                Ok(Ok(actual)) => {
+                    head::HEAD_POSE_ACTUAL_SIGNAL.signal(actual);
+                    defmt::info!(
+                        "head: cmd=({=f32}, {=f32}) actual=({=f32}, {=f32})",
+                        current.pan_deg,
+                        current.tilt_deg,
+                        actual.pan_deg,
+                        actual.tilt_deg,
+                    );
+                }
+                Ok(Err(e)) => defmt::warn!(
+                    "head: read_pose response error: {}",
                     defmt::Debug2Format(&e)
-                );
-                Err(())
+                ),
+                Err(_) => {
+                    defmt::warn!("head: read_pose timed out after {=u64} ms", READ_TIMEOUT_MS)
+                }
             }
         }
+        ticker.next().await;
     }
-    // Pin 0: direction = output, pull-up = enabled, level = HIGH.
-    if write_py32(i2c, 0x03, 0x01).await.is_err()
-        || write_py32(i2c, 0x09, 0x01).await.is_err()
-        || write_py32(i2c, 0x05, 0x01).await.is_err()
-    {
-        defmt::warn!("PY32: servo-power enable incomplete — servos may stay unpowered");
-        return;
-    }
-    defmt::info!("PY32: servo power enabled (pin 0 HIGH)");
-}
-
-/// Probe one `SCServo` ID and log the outcome. 10 ms is well past the
-/// ~200 µs round-trip of a 1 Mbaud PING packet, so a miss here is a
-/// real "servo not responding" signal. Errors are informational only —
-/// head task spawns regardless, so a servo reconnected later starts
-/// working without a reboot.
-async fn ping_servo(driver: &mut HeadDriverImpl, id: u8) {
-    const PING_TIMEOUT_MS: u64 = 10;
-    let bus = driver.bus_mut();
-    match embassy_time::with_timeout(
-        embassy_time::Duration::from_millis(PING_TIMEOUT_MS),
-        bus.ping(id),
-    )
-    .await
-    {
-        Ok(Ok(())) => defmt::info!("SCServo[{=u8}]: present", id),
-        Ok(Err(e)) => defmt::warn!(
-            "SCServo[{=u8}]: malformed response: {}",
-            id,
-            defmt::Debug2Format(&e)
-        ),
-        Err(_) => defmt::warn!(
-            "SCServo[{=u8}]: no response within {=u64} ms (disconnected or unpowered?)",
-            id,
-            PING_TIMEOUT_MS
-        ),
-    }
-}
-
-/// Boot-time "hello" gesture: visible, deliberate, unambiguous.
-///
-/// Sequence (each step holds for `STEP_MS` to let the servo's internal
-/// interpolation complete before the next command):
-///
-/// 1. pan +15° — "I'm alive, here's my range"
-/// 2. pan -15°
-/// 3. pan 0°
-/// 4. tilt +10° — "both axes work"
-/// 5. tilt -10°
-/// 6. tilt 0°
-///
-/// Total ≈ 1 s. Per-step `move_time` inside each `WritePos` is short
-/// (smooth steps), but we pace the SEQUENCE with `STEP_MS` so each
-/// motion visibly completes before the next begins.
-///
-/// Write errors are logged and swallowed — a partial nod is better
-/// than a panic, and subsequent head-task writes will keep retrying
-/// if the bus recovers.
-async fn boot_nod(driver: &mut HeadDriverImpl) {
-    /// Wall-clock pace between nod steps (ms). Matches the servos'
-    /// single-leg move budget.
-    const STEP_MS: u64 = 170;
-
-    let clock = HalClock;
-    defmt::info!("boot-nod: hello gesture start");
-    for (pan, tilt, label) in [
-        (15.0, 0.0, "pan+15"),
-        (-15.0, 0.0, "pan-15"),
-        (0.0, 0.0, "pan 0"),
-        (0.0, 10.0, "tilt+10"),
-        (0.0, -10.0, "tilt-10"),
-        (0.0, 0.0, "tilt 0"),
-    ] {
-        if let Err(e) = driver
-            .set_pose(stackchan_core::Pose::new(pan, tilt), clock.now())
-            .await
-        {
-            defmt::warn!("boot-nod step {}: {}", label, defmt::Debug2Format(&e));
-        }
-        Timer::after(Duration::from_millis(STEP_MS)).await;
-    }
-    defmt::info!("boot-nod: complete");
 }
 
 #[esp_rtos::main]
@@ -405,106 +315,17 @@ async fn main(spawner: Spawner) -> ! {
         env!("CARGO_PKG_VERSION")
     );
 
-    // CoreS3 internal I²C bus: GPIO11 = SCL, GPIO12 = SDA.
-    // (Confirmed against M5Unified source: `In SCL, SDA = GPIO_NUM_11, GPIO_NUM_12`.)
-    // AXP2101 (0x34), AW9523 IO expander, and the touch controller all
-    // sit on this bus. 100 kHz is the conservative standard-mode rate
-    // that works from cold boot before PLLs are fully settled.
-    let i2c_cfg = I2cConfig::default().with_frequency(Rate::from_khz(100));
-    let i2c = match I2c::new(peripherals.I2C0, i2c_cfg) {
-        Ok(bus) => bus
-            .with_sda(peripherals.GPIO12)
-            .with_scl(peripherals.GPIO11)
-            .into_async(),
-        Err(e) => defmt::panic!("I2C0 config rejected: {}", defmt::Debug2Format(&e)),
-    };
-    defmt::debug!("I2C0 ready on GPIO12/11 @ 100 kHz");
-
-    let mut pmic = Axp2101::new(i2c);
-
-    loop {
-        match pmic.init_cores3().await {
-            Ok(()) => {
-                defmt::info!(
-                    "AXP2101: CoreS3 power defaults applied — LCD rails + power-key timing set"
-                );
-                break;
-            }
-            Err(e) => {
-                defmt::error!(
-                    "AXP2101 init failed (retrying in {=u64} ms): {}",
-                    PMIC_RETRY_MS,
-                    defmt::Debug2Format(&e)
-                );
-                Timer::after(Duration::from_millis(PMIC_RETRY_MS)).await;
-            }
-        }
-    }
-
-    // Reclaim the I²C bus from the PMIC driver; the AW9523 is the next (and
-    // only other) I²C consumer in this PR, so a sequential hand-off avoids
-    // pulling in embedded-hal-bus shared-bus machinery.
-    let mut i2c = pmic.into_inner();
-    // `embassy_time::Delay` impls `embedded_hal_async::delay::DelayNs`. The
-    // driver takes `&mut D: DelayNs`, so bind an instance rather than taking
-    // a reference to the zero-sized type itself.
     let mut delay = Delay;
-    match aw9523::init_cores3(&mut i2c, &mut delay).await {
-        Ok(()) => defmt::info!("AW9523: CoreS3 defaults applied, LCD reset pulsed (P1_1)"),
-        Err(e) => defmt::panic!("AW9523 init failed: {}", defmt::Debug2Format(&e)),
-    }
-
-    // Enable servo power via the PY32 IO expander (I²C addr 0x6F). Without
-    // this the SCServo rail is unpowered — the UART writes will go out
-    // cleanly but nothing moves. The PY32 resets all bits to 0, so writing
-    // `0x01` (pin 0 only) is safe — if we later drive RGB LEDs on pin 13
-    // we'll need read-modify-write via a dedicated driver.
-    //
-    // Register map (from `PY32IOExpander_Class.cpp` in the old C++ firmware):
-    //   0x03  GPIO direction-low  (1 = output)
-    //   0x05  GPIO output-low     (the actual pin level)
-    //   0x09  GPIO pull-up-low    (pull-up enable)
-    //
-    // Sequence matches `hal_io_expander.cpp`: direction → pull-up →
-    // level HIGH → 200 ms for the rail to stabilise.
-    enable_servo_power(&mut i2c).await;
-    Timer::after(Duration::from_millis(SERVO_POWER_SETTLE_MS)).await;
-
-    // Internal I²C (I2C0) is done for this boot — drop it so the compiler
-    // catches any accidental later uses (touch / battery drivers come in
-    // future PRs).
-    drop(i2c);
-
-    // CoreS3 SCServo bus: UART1 TX=GPIO6, RX=GPIO7 @ 1 Mbaud. Matches the
-    // old C++ firmware's `_scs_bus.begin(UART_NUM_1, 1000000, 6, 7)` call.
-    // Two smart servos (yaw=1, pitch=2) share this half-duplex bus; the
-    // base board handles direction switching externally.
-    let uart_cfg = UartConfig::default().with_baudrate(SERVO_UART_BAUD);
-    let servo_uart = match Uart::new(peripherals.UART1, uart_cfg) {
-        Ok(uart) => uart
-            .with_tx(peripherals.GPIO6)
-            .with_rx(peripherals.GPIO7)
-            .into_async(),
-        Err(e) => defmt::panic!("UART1 config rejected: {}", defmt::Debug2Format(&e)),
-    };
-    defmt::info!(
-        "SCServo bus ready on UART1 (TX=GPIO6, RX=GPIO7) @ {=u32} baud",
-        SERVO_UART_BAUD
-    );
-    let mut scs_head = head::ScsHead::new(Scservo::new(servo_uart));
-
-    // Health check: PING each servo ID with a 10 ms timeout. UART writes
-    // don't NACK on missing slaves, so without this probe we can't tell
-    // the bus is alive until we observe physical motion. Log per-ID
-    // success/failure but keep booting either way — a missing servo is
-    // not fatal.
-    ping_servo(&mut scs_head, head::YAW_SERVO_ID).await;
-    ping_servo(&mut scs_head, head::PITCH_SERVO_ID).await;
-
-    // Visible proof of life: a deliberate pan-then-tilt gesture before
-    // the idle modifier pipeline takes over. Also serves as the
-    // gentle-first-move the old boot ramp used to provide.
-    boot_nod(&mut scs_head).await;
+    let scs_head = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
 
     // CoreS3 LCD (ILI9342C) on SPI2.
     //   SCK  = GPIO36

--- a/justfile
+++ b/justfile
@@ -69,3 +69,13 @@ monitor:
 # default inner-loop verb. Build first, then flash, then stream logs.
 fmr: build-firmware
     sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{firmware_elf}}"
+
+# Path to the release bench example ELF.
+bench_elf := "target/xtensa-esp32s3-none-elf/release/examples/bench"
+
+# Calibration bench: flashes the sweep-and-print example + streams its
+# defmt output. The bench binary halts after one full sweep; re-flash
+# the main firmware with `just flash` or `just fmr` when done.
+bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example bench
+    sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{bench_elf}}"


### PR DESCRIPTION
## Summary

Ships the Read half of the `SCServo` driver plus firmware plumbing + an `examples/bench.rs` calibration binary. Unblocks per-unit trim discovery (`PAN_TRIM_DEG` / `TILT_TRIM_DEG` / direction signs) without hand-guessing.

This is **PR A** of the three-PR stack from the earlier DX elicitation. PR B (USB-OTG swap) and PR C (interactive Bench task via CDC) are deferred.

### crates/scservo — Read API

- `read_memory(id, addr, &mut buf)` — generic READ instruction, same error surface as `ping` (NoResponse / MalformedResponse / ChecksumMismatch).
- `read_position(id) -> u16`, `read_voltage(id) -> u8`, `read_temperature(id) -> u8`, `read_moving(id) -> bool` — convenience wrappers.
- `pub const ADDR_PRESENT_POSITION/_VOLTAGE/_TEMPERATURE/_MOVING` — the SCSCL memory-map constants we use.
- 9 new unit tests including byte-exact outbound packet assertion + rejection paths. **21 scservo tests total (was 12).**

### stackchan-core — Avatar.head_pose_actual

New Pose field alongside `head_pose`. Excluded from `frame_eq` (same reasoning as `head_pose` — kinematic, not pixel). Populated by the render task from a reverse signal.

### firmware

- **Refactor:** extracted `src/board.rs::bringup()` — AXP2101 → AW9523 → PY32 → UART1 → SCServo + ping + boot-nod all in one place. Converts firmware crate to lib+bin so `examples/bench.rs` can share the same init. main.rs shrinks ~100 lines.
- **1 Hz position poll:** head task counts ticks; every 50th it calls `ScsHead::read_pose`, logs `cmd=(…) actual=(…)`, publishes to new `HEAD_POSE_ACTUAL_SIGNAL`. Render task consumes + writes to `avatar.head_pose_actual`. Read failures log warn + hold last-good.
- **examples/bench.rs:** sweep binary that pans -30° → +30° in 10° steps, then tilts -20° → +20° in 10° steps, 300 ms dwell per stop, logs `bench pan: cmd=… raw_pos=… actual_deg=… delta=…` per step. Centers + halts at the end. Re-flash main with \`just flash\` when done.
- **\`just bench\`:** builds + flashes + streams the bench example's defmt output.

## Test status

- \`just check\` / host suite: **82 tests** passing across core + sim + drivers (was 73)
- \`just clippy-firmware\` (strict): green for both main binary + bench example
- \`just build-firmware\` + \`cargo +esp build --example bench\`: clean
- **⚠️ HIL flash test: PENDING.** The CoreS3 dropped off USB mid-session. Physical recovery needed (unplug → hold power button 10 s → replug → short-press power) before flash-verification can happen. Code compiles + all host tests pass, but nothing has been run against real servo hardware yet.

## Follow-up to merge checklist

After the unit is physically recovered, run:

\`\`\`bash
just flash   # re-flash main firmware with new poll + logs
just bench   # run the sweep, observe the delta table
\`\`\`

Confirm main firmware shows \`head: cmd=(...) actual=(...)\` lines at 1 Hz. Confirm bench prints per-step delta rows and halts with "bench complete".

## Related

- PR #6 shipped the boot-nod + PING groundwork this builds on.
- PR #9 fixed release-please config.