### PR TITLE
Audit pass: gap fixes (docs, CI, scservo boundary validation, driver tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   host:
-    name: Host (core + sim + axp2101)
+    name: Host (core + sim + drivers)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,8 +38,10 @@ jobs:
       - name: Format check
         run: cargo fmt --check
 
+      # `--all-targets` also lints examples + integration tests, matching
+      # the pre-commit hook so local and CI lint passes can't diverge.
       - name: Clippy (host crates)
-        run: cargo clippy --workspace --exclude stackchan-firmware --all-features -- -D warnings
+        run: cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings
 
       - name: Test (host crates)
         run: cargo test --workspace --exclude stackchan-firmware --all-features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,23 +2,25 @@
 
 ## Project Structure
 
-Cargo workspace with four crates:
-- `crates/stackchan-core` — `no_std` domain library: `Avatar`, `Eye`, `Mouth`, `Modifier` trait, `Clock` trait, `Emotion`. Pure Rust, no hardware deps.
+Cargo workspace with six crates:
+- `crates/stackchan-core` — `no_std` domain library: `Avatar`, `Eye`, `Mouth`, `Modifier` trait, `Clock` trait, `Emotion`, `Pose`. Pure Rust, no hardware deps.
 - `crates/stackchan-sim` — Headless integration tests that drive `stackchan-core` with a fake clock.
 - `crates/axp2101` — Minimal AXP2101 PMU driver (I²C, embedded-hal-async).
+- `crates/aw9523` — Minimal AW9523 I/O-expander init (I²C, embedded-hal-async). Pulls the LCD reset pin and gates the backlight-boost rail on the CoreS3.
+- `crates/scservo` — Feetech SCServo half-duplex serial driver (UART1, embedded-io-async). Drives the pan/tilt head servos.
 - `crates/stackchan-firmware` — Binary crate. `no_std` + `alloc`. embassy executor on CoreS3.
 
 ## Build
 
 ```bash
-cargo test                    # host-side: core, sim, axp2101
-cargo clippy --workspace      # host crates only (firmware excluded from default-members)
+cargo test                                  # host-side: core, sim, axp2101, aw9523, scservo
+cargo clippy --workspace --all-targets      # host crates only (firmware excluded from default-members)
 
 # Firmware: requires `source ~/export-esp.sh` first so the `esp` toolchain is on PATH.
-# `cargo run` uses the probe-rs runner declared in crates/stackchan-firmware/.cargo/config.toml,
-# which flashes over the CoreS3's built-in USB-JTAG and opens an RTT session for defmt logs.
+# `just fmr` wraps `cargo +esp build --release` + espflash flash-and-monitor through
+# `sg dialout`; see the justfile for the full recipe set.
 source ~/export-esp.sh
-cargo run -p stackchan-firmware --release
+just fmr
 ```
 
 ## Pre-commit Hook
@@ -35,14 +37,16 @@ Conventional-commit check at `.githooks/commit-msg`.
 
 - `stackchan-core` models the avatar as data: `Avatar { left_eye, right_eye, mouth, emotion }` plus a `Modifier` trait with `update(&mut Avatar, now: Instant)`. Time comes from the `Clock` trait so core is deterministic and host-testable.
 - `stackchan-sim` constructs a `stackchan_core::Avatar` + a `FakeClock` and runs a list of `Modifier`s through hand-crafted time sequences. Golden assertions on `Eye::weight`, `Mouth::rotation`, etc.
-- `stackchan-firmware` initializes AXP2101 → SPI LCD via `mipidsi` → spawns an embassy task that composes `Avatar::draw(&mut framebuffer)` into `embedded-graphics` primitives, pushes frames at ~30 FPS. `HalClock` wraps embassy-time.
-- `crates/axp2101` is the minimum set of registers (ALDO1/2, BLDO1/2, power-on sequencing) needed for CoreS3 LCD + 3V3 rails.
+- `stackchan-firmware` initializes AXP2101 → AW9523 (releases LCD reset + enables the backlight-boost gate) → SPI LCD via `mipidsi` → SCServo head driver on UART1 → spawns an embassy render task that composes `Avatar::draw(&mut framebuffer)` into `embedded-graphics` primitives, pushes frames at ~30 FPS. `HalClock` wraps embassy-time.
+- `crates/axp2101` is the minimum set of registers (ALDO1/2, BLDO1/2, DLDO1, power-on sequencing) needed for CoreS3 LCD + 3V3 rails.
+- `crates/aw9523` handles the rest of the CoreS3 boot dance: pulses `P1_1` (LCD_RST) and leaves `P1_7` (backlight-boost enable) high so the LCD backlight rail actually comes up.
+- `crates/scservo` is a protocol-correct Feetech driver (checksum + status frame parsing) with golden-packet tests; position readback supports the calibration bench at `crates/stackchan-firmware/examples/bench.rs`.
 
 ## Conventions
 
 Commits: conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`, etc.).
 
-PR workflow (post-v0.1.0): every change lands via PR; greptile bot review required. Pre-v0.1.0 commits may land directly on main for solo scaffold work.
+PR workflow: every change lands via PR; greptile bot review required. v0.1.0 shipped 2026-04-23 — direct-to-main commits are no longer part of the workflow.
 
 Parallel work: `git worktree add .worktrees/<branch> <branch>` — `.worktrees/` is gitignored.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A clean-slate Rust firmware for the M5Stack CoreS3 StackChan character. No AI.
 No upstream cloud. No C blobs. Just a desk toy that animates a face.
 
-> **Status:** pre-v0.1.0 — the repo is being scaffolded. No released crate
-> artefacts. See [`STABILITY.md`](STABILITY.md) for the stability policy once
-> we tag v0.1.0.
+> **Status:** v0.1.0 shipped 2026-04-23. All public items are currently
+> [Experimental](STABILITY.md#experimental); the v0.x series will iterate the
+> avatar domain model before anything graduates to Stable.
 
 ## Why
 
@@ -19,22 +19,27 @@ that's hard to reason about. This repo rebuilds just the local desk-toy piece
 
 | Crate | What | Test target |
 | --- | --- | --- |
-| `crates/stackchan-core` | `no_std` domain library: `Avatar`, `Eye`, `Mouth`, `Modifier` trait, `Clock` trait, `Emotion`. Pure Rust, no hardware deps. | Host unit tests |
+| `crates/stackchan-core` | `no_std` domain library: `Avatar`, `Eye`, `Mouth`, `Modifier` trait, `Clock` trait, `Emotion`, `Pose`. Pure Rust, no hardware deps. | Host unit tests |
 | `crates/stackchan-sim` | Headless integration tests that drive `stackchan-core` with a fake clock. Golden-test modifier sequences without hardware. | Host integration tests |
 | `crates/axp2101` | Minimal AXP2101 PMU driver (I²C). Just enough to bring up the CoreS3 LCD rail + 3V3. embedded-hal-async. | Host mock-I²C tests |
-| `crates/stackchan-firmware` | Binary crate. `no_std` + `alloc`. embassy executor. Wires PMU init + mipidsi LCD driver + `stackchan-core` render loop on the CoreS3. | HIL via probe-rs + defmt-test |
+| `crates/aw9523` | Minimal AW9523 I/O-expander init routine for the CoreS3 (LCD reset pulse, backlight-boost gate). embedded-hal-async. | Host mock-I²C tests |
+| `crates/scservo` | Feetech SCServo half-duplex serial driver (UART1). embedded-io-async. | Host unit tests with a mock UART |
+| `crates/stackchan-firmware` | Binary crate. `no_std` + `alloc`. embassy executor. Wires PMU init + mipidsi LCD driver + SCServo head driver + `stackchan-core` render loop on the CoreS3. | HIL via probe-rs + defmt-test |
 
 ## Build
 
 ```bash
-# Host side (core + sim + axp2101)
+# Host side (core + sim + drivers).
 cargo test
-cargo clippy --workspace
+cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings
 
-# Firmware side (requires espup-installed esp toolchain)
-cargo build -p stackchan-firmware --release
-espflash flash --monitor target/xtensa-esp32s3-none-elf/release/stackchan-firmware
+# Firmware side (requires espup-installed esp toolchain).
+source ~/export-esp.sh
+just build-firmware         # or: cd crates/stackchan-firmware && cargo +esp build --release
+just fmr                    # flash + monitor in one go
 ```
+
+See the `justfile` for the full set of host + firmware recipes.
 
 ## Conventions
 
@@ -42,7 +47,7 @@ espflash flash --monitor target/xtensa-esp32s3-none-elf/release/stackchan-firmwa
   dual license.
 - Conventional commits via `.githooks/commit-msg`. After cloning:
   `git config core.hooksPath .githooks`
-- Every change lands via PR once v0.1.0 ships; greptile bot review required.
+- Every change lands via PR; greptile bot review required.
 - Parallel work: `git worktree add .worktrees/<branch> <branch>` — the
   `.worktrees/` directory is gitignored.
 

--- a/crates/aw9523/src/lib.rs
+++ b/crates/aw9523/src/lib.rs
@@ -30,7 +30,7 @@
 //! # }
 //! ```
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
 
 use embedded_hal_async::{delay::DelayNs, i2c::I2c};
@@ -133,4 +133,156 @@ where
 async fn write_reg<B: I2c>(bus: &mut B, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
     bus.write(CORES3_ADDRESS, &[reg, value]).await?;
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test scaffolding: Infallible bus error makes unwrap() sound"
+)]
+#[allow(
+    clippy::future_not_send,
+    reason = "test mocks hold RefCell for event recording; single-threaded block_on runs them"
+)]
+#[allow(
+    clippy::assertions_on_constants,
+    reason = "runtime asserts keep the invariant in the test output; const blocks would move failures to compile time and silently pass the test binary"
+)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use embedded_hal_async::i2c::{Operation, SevenBitAddress};
+
+    /// Event recorded by the mock harness: either an I²C write payload or
+    /// a delay request. Interleaved so tests can assert on ordering.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Event {
+        /// I²C write: (address, register, value).
+        Write(u8, u8, u8),
+        /// `delay_ms(n)`.
+        DelayMs(u32),
+    }
+
+    struct Harness {
+        events: RefCell<Vec<Event>>,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            Self {
+                events: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<Event> {
+            self.events.borrow().clone()
+        }
+    }
+
+    /// Mock I²C that borrows the shared event log.
+    struct MockI2c<'a> {
+        harness: &'a Harness,
+    }
+
+    impl embedded_hal_async::i2c::ErrorType for MockI2c<'_> {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal_async::i2c::I2c for MockI2c<'_> {
+        async fn transaction(
+            &mut self,
+            address: SevenBitAddress,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            for op in operations {
+                if let Operation::Write(buf) = op {
+                    // write_reg always sends exactly [reg, value].
+                    assert_eq!(buf.len(), 2, "driver issued non-[reg,val] write");
+                    self.harness
+                        .events
+                        .borrow_mut()
+                        .push(Event::Write(address, buf[0], buf[1]));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Mock delay that records every request without actually sleeping.
+    struct MockDelay<'a> {
+        harness: &'a Harness,
+    }
+
+    impl embedded_hal_async::delay::DelayNs for MockDelay<'_> {
+        async fn delay_ns(&mut self, ns: u32) {
+            // DelayNs::delay_ms default-impls in terms of delay_ns, so
+            // recording here covers both entry points.
+            self.harness
+                .events
+                .borrow_mut()
+                .push(Event::DelayMs(ns / 1_000_000));
+        }
+    }
+
+    fn block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut fut = pin!(future);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn init_cores3_issues_m5stack_reference_sequence() {
+        let harness = Harness::new();
+        let mut bus = MockI2c { harness: &harness };
+        let mut delay = MockDelay { harness: &harness };
+        block_on(init_cores3(&mut bus, &mut delay)).unwrap();
+
+        let expected = vec![
+            Event::Write(CORES3_ADDRESS, REG_OUTPUT_P0, P0_OUTPUT_INIT),
+            Event::Write(CORES3_ADDRESS, REG_OUTPUT_P1, P1_OUTPUT_INIT),
+            Event::Write(CORES3_ADDRESS, REG_DIR_P0, P0_DIR_INIT),
+            Event::Write(CORES3_ADDRESS, REG_DIR_P1, P1_DIR_INIT),
+            Event::Write(CORES3_ADDRESS, REG_CONTROL, CONTROL_P0_PUSH_PULL),
+            Event::Write(CORES3_ADDRESS, REG_LEDMODE_P0, LEDMODE_ALL_GPIO),
+            Event::Write(CORES3_ADDRESS, REG_LEDMODE_P1, LEDMODE_ALL_GPIO),
+            Event::Write(CORES3_ADDRESS, REG_OUTPUT_P1, P1_OUTPUT_LCD_RESET),
+            Event::DelayMs(RESET_PULSE_MS),
+            Event::Write(CORES3_ADDRESS, REG_OUTPUT_P1, P1_OUTPUT_INIT),
+            Event::DelayMs(POST_RESET_SETTLE_MS),
+        ];
+        assert_eq!(harness.events(), expected);
+    }
+
+    #[test]
+    fn lcd_reset_pulse_keeps_backlight_boost_enable_high() {
+        // P1_OUTPUT_LCD_RESET must have bit 7 (backlight-boost enable)
+        // HIGH, or the panel stays dark during + after the reset pulse.
+        assert_eq!(
+            P1_OUTPUT_LCD_RESET & (1 << 7),
+            1 << 7,
+            "boost-enable dropped during reset pulse; LCD will stay dark"
+        );
+        // Bit 1 (LCD_RST) must be LOW to actually assert reset.
+        assert_eq!(P1_OUTPUT_LCD_RESET & (1 << 1), 0);
+    }
+
+    #[test]
+    fn post_reset_settle_meets_ili9342c_datasheet_minimum() {
+        // Datasheet requires ≥120 ms after releasing reset before any
+        // SPI command.
+        assert!(POST_RESET_SETTLE_MS >= 120);
+    }
+
+    #[test]
+    fn reset_pulse_meets_datasheet_minimum() {
+        // Datasheet requires ≥10 µs on RESX; we use 20 ms to match M5Stack.
+        assert!(RESET_PULSE_MS >= 1);
+    }
 }

--- a/crates/axp2101/src/lib.rs
+++ b/crates/axp2101/src/lib.rs
@@ -24,7 +24,7 @@
 //! # }
 //! ```
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
 
 use embedded_hal_async::i2c::I2c;
@@ -171,5 +171,113 @@ where
             .await
             .map_err(Error::I2c)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test scaffolding: Infallible bus error makes unwrap() sound"
+)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use embedded_hal_async::i2c::{Operation, SevenBitAddress};
+
+    /// Host-side I²C mock that records every transaction payload in order.
+    struct MockI2c {
+        transactions: RefCell<Vec<(u8, Vec<u8>)>>,
+    }
+
+    impl MockI2c {
+        fn new() -> Self {
+            Self {
+                transactions: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl embedded_hal_async::i2c::ErrorType for MockI2c {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal_async::i2c::I2c for MockI2c {
+        async fn transaction(
+            &mut self,
+            address: SevenBitAddress,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            for op in operations {
+                if let Operation::Write(buf) = op {
+                    self.transactions.borrow_mut().push((address, buf.to_vec()));
+                }
+                // Reads and write-reads never issued by the driver under test.
+            }
+            Ok(())
+        }
+    }
+
+    /// Tiny future poller used instead of pulling in an async executor.
+    fn block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut fut = pin!(future);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn init_cores3_issues_exact_m5unified_register_sequence() {
+        let mut pmic = Axp2101::new(MockI2c::new());
+        block_on(pmic.init_cores3()).unwrap();
+
+        // Every write hits the PMIC address.
+        let txs = pmic.bus.transactions.borrow().clone();
+        assert_eq!(txs.len(), CORES3_INIT_SEQUENCE.len());
+        for (addr, _) in &txs {
+            assert_eq!(*addr, ADDRESS, "all init writes must target AXP2101");
+        }
+
+        // Each write is a (reg, value) pair in the exact order of
+        // CORES3_INIT_SEQUENCE. This is a golden test: if anyone edits
+        // the sequence without meaning to, this fails.
+        let actual: Vec<(u8, u8)> = txs.iter().map(|(_, buf)| (buf[0], buf[1])).collect();
+        let expected: Vec<(u8, u8)> = CORES3_INIT_SEQUENCE.to_vec();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn init_cores3_writes_backlight_voltage_before_enable_bitmap() {
+        // BLDO1 (0x96) / BLDO2 (0x97) voltage setpoints must come before
+        // the enable bitmap (0x90) so the rails come up at 3.3V, not the
+        // 0.5V PoR default.
+        let bldo1 = CORES3_INIT_SEQUENCE
+            .iter()
+            .position(|&(r, _)| r == 0x96)
+            .unwrap();
+        let enable = CORES3_INIT_SEQUENCE
+            .iter()
+            .position(|&(r, _)| r == 0x90)
+            .unwrap();
+        assert!(bldo1 < enable, "BLDO1 voltage must precede enable bitmap");
+    }
+
+    #[test]
+    fn init_cores3_keeps_battery_detect_and_adc_enabled() {
+        // Battery detect + ADC enable are both part of the sequence —
+        // without them, later battery-voltage reads return zero.
+        assert!(CORES3_INIT_SEQUENCE.contains(&(0x68, 0x01)));
+        assert!(CORES3_INIT_SEQUENCE.contains(&(0x30, 0x0F)));
+    }
+
+    #[test]
+    fn into_inner_releases_bus() {
+        let pmic = Axp2101::new(MockI2c::new());
+        let _bus: MockI2c = pmic.into_inner();
     }
 }

--- a/crates/scservo/src/lib.rs
+++ b/crates/scservo/src/lib.rs
@@ -153,6 +153,12 @@ pub enum Error<E> {
     /// bits as a different address in its memory table, so we reject at
     /// the driver boundary.
     PositionOutOfRange(u16),
+    /// Caller used [`BROADCAST_ID`] on an operation that requires a
+    /// response ([`Scservo::ping`] / [`Scservo::read_memory`]): every
+    /// servo on the bus would try to reply at once, garbling the frame.
+    /// Broadcasting writes (`write_position`, `write_torque_enable`,
+    /// `write_memory`) remains supported — those don't need a response.
+    BroadcastNotAllowed,
 }
 
 impl<E> From<ReadExactError<E>> for Error<E> {
@@ -317,6 +323,8 @@ impl<U: Read + Write> Scservo<U> {
     /// packet size, distinguishable from its own echo).
     ///
     /// # Errors
+    /// - [`Error::BroadcastNotAllowed`] if `id == BROADCAST_ID` — every
+    ///   servo would respond and the bus would collide.
     /// - [`Error::Uart`] on transport failure.
     /// - [`Error::NoResponse`] if the UART closes before a full
     ///   response arrives.
@@ -325,6 +333,9 @@ impl<U: Read + Write> Scservo<U> {
     /// - [`Error::ChecksumMismatch`] if the response checksum is
     ///   invalid.
     pub async fn ping(&mut self, id: u8) -> Result<(), Error<U::Error>> {
+        if id == BROADCAST_ID {
+            return Err(Error::BroadcastNotAllowed);
+        }
         // PING outbound: FF FF ID 02 01 ~(ID+2+1).
         let checksum = !id.wrapping_add(0x02).wrapping_add(Instruction::Ping as u8);
         let outbound = [
@@ -391,6 +402,8 @@ impl<U: Read + Write> Scservo<U> {
     /// `embassy_time::with_timeout` for bounded waits.
     ///
     /// # Errors
+    /// - [`Error::BroadcastNotAllowed`] if `id == BROADCAST_ID` — reads
+    ///   require exactly one responder.
     /// - [`Error::PayloadTooLarge`] if `buf.len() > MAX_DATA_BYTES`.
     /// - [`Error::Uart`] on transport failure.
     /// - [`Error::NoResponse`] / [`Error::MalformedResponse`] /
@@ -401,6 +414,9 @@ impl<U: Read + Write> Scservo<U> {
         mem_addr: u8,
         buf: &mut [u8],
     ) -> Result<(), Error<U::Error>> {
+        if id == BROADCAST_ID {
+            return Err(Error::BroadcastNotAllowed);
+        }
         if buf.len() > MAX_DATA_BYTES {
             return Err(Error::PayloadTooLarge);
         }
@@ -790,6 +806,26 @@ mod tests {
             .queue_rx(&[0xFF, 0xFF, 0x01, 0x03, 0x00, 0x00, 0xFB]);
         let moving = block_on(bus.read_moving(1)).unwrap();
         assert!(!moving);
+    }
+
+    #[test]
+    fn ping_rejects_broadcast_id() {
+        let mut bus = Scservo::new(MockUart::new());
+        let err = block_on(bus.ping(BROADCAST_ID));
+        assert!(matches!(err, Err(Error::BroadcastNotAllowed)));
+        assert!(
+            bus.uart.written.borrow().is_empty(),
+            "guard must run before any TX"
+        );
+    }
+
+    #[test]
+    fn read_memory_rejects_broadcast_id() {
+        let mut bus = Scservo::new(MockUart::new());
+        let mut buf = [0u8; 2];
+        let err = block_on(bus.read_memory(BROADCAST_ID, ADDR_PRESENT_POSITION, &mut buf));
+        assert!(matches!(err, Err(Error::BroadcastNotAllowed)));
+        assert!(bus.uart.written.borrow().is_empty());
     }
 
     #[test]

--- a/crates/scservo/src/lib.rs
+++ b/crates/scservo/src/lib.rs
@@ -384,7 +384,13 @@ impl<U: Read + Write> Scservo<U> {
     }
 
     /// Low-level [`Instruction::Read`] that fills `buf` with `buf.len()`
-    /// bytes read starting at `mem_addr` on servo `id`.
+    /// bytes read starting at `mem_addr` on servo `id`. Returns the
+    /// servo's **error byte** from the response (0 if the servo reports
+    /// no fault; non-zero encodes angle-limit / voltage / overload /
+    /// overheat flags — see the Feetech SCSCL memory table). Data is
+    /// always delivered regardless of the error byte: a faulting servo
+    /// still reports its current position, temperature, etc., and a
+    /// caller trying to diagnose the fault wants to see both.
     ///
     /// Outbound packet layout:
     ///
@@ -413,7 +419,7 @@ impl<U: Read + Write> Scservo<U> {
         id: u8,
         mem_addr: u8,
         buf: &mut [u8],
-    ) -> Result<(), Error<U::Error>> {
+    ) -> Result<u8, Error<U::Error>> {
         if id == BROADCAST_ID {
             return Err(Error::BroadcastNotAllowed);
         }
@@ -484,18 +490,24 @@ impl<U: Read + Write> Scservo<U> {
         // Data bytes start at index 5; skip the 2 header + 1 id + 1 msgLen +
         // 1 error bytes before them.
         buf.copy_from_slice(&response[5..5 + buf.len()]);
-        Ok(())
+        // response[4] is the servo's Error byte — surface it to the caller.
+        Ok(response[4])
     }
 
     /// Read the current position of servo `id` — the live encoder
-    /// reading, in the same 0..=1023 count space as the goal position.
-    /// Big-endian 2-byte field at [`ADDR_PRESENT_POSITION`].
+    /// reading, in the same 0..=[`POSITION_MAX`] count space as the goal
+    /// position. Big-endian 2-byte field at [`ADDR_PRESENT_POSITION`].
+    ///
+    /// Discards the servo's error byte; callers that want to detect
+    /// faults alongside the position should use [`Scservo::read_memory`]
+    /// directly.
     ///
     /// # Errors
     /// Same as [`Scservo::read_memory`].
     pub async fn read_position(&mut self, id: u8) -> Result<u16, Error<U::Error>> {
         let mut buf = [0u8; 2];
-        self.read_memory(id, ADDR_PRESENT_POSITION, &mut buf)
+        let _fault = self
+            .read_memory(id, ADDR_PRESENT_POSITION, &mut buf)
             .await?;
         Ok(u16::from_be_bytes(buf))
     }
@@ -503,21 +515,28 @@ impl<U: Read + Write> Scservo<U> {
     /// Read the current supply voltage of servo `id`. Units: 0.1 V per
     /// count (e.g. 74 → 7.4 V).
     ///
+    /// Discards the servo's error byte; use [`Scservo::read_memory`]
+    /// directly to inspect fault flags alongside the voltage.
+    ///
     /// # Errors
     /// Same as [`Scservo::read_memory`].
     pub async fn read_voltage(&mut self, id: u8) -> Result<u8, Error<U::Error>> {
         let mut buf = [0u8; 1];
-        self.read_memory(id, ADDR_PRESENT_VOLTAGE, &mut buf).await?;
+        let _fault = self.read_memory(id, ADDR_PRESENT_VOLTAGE, &mut buf).await?;
         Ok(buf[0])
     }
 
     /// Read the current internal temperature of servo `id`, in °C.
     ///
+    /// Discards the servo's error byte; use [`Scservo::read_memory`]
+    /// directly to inspect fault flags alongside the temperature.
+    ///
     /// # Errors
     /// Same as [`Scservo::read_memory`].
     pub async fn read_temperature(&mut self, id: u8) -> Result<u8, Error<U::Error>> {
         let mut buf = [0u8; 1];
-        self.read_memory(id, ADDR_PRESENT_TEMPERATURE, &mut buf)
+        let _fault = self
+            .read_memory(id, ADDR_PRESENT_TEMPERATURE, &mut buf)
             .await?;
         Ok(buf[0])
     }
@@ -526,11 +545,14 @@ impl<U: Read + Write> Scservo<U> {
     /// actively tracking toward its goal position, false once settled.
     /// Useful for "wait until move completes" loops during calibration.
     ///
+    /// Discards the servo's error byte; use [`Scservo::read_memory`]
+    /// directly to inspect fault flags alongside the moving state.
+    ///
     /// # Errors
     /// Same as [`Scservo::read_memory`].
     pub async fn read_moving(&mut self, id: u8) -> Result<bool, Error<U::Error>> {
         let mut buf = [0u8; 1];
-        self.read_memory(id, ADDR_MOVING, &mut buf).await?;
+        let _fault = self.read_memory(id, ADDR_MOVING, &mut buf).await?;
         Ok(buf[0] != 0)
     }
 }
@@ -845,6 +867,29 @@ mod tests {
             .queue_rx(&[0xFF, 0xFF, 0x01, 0x05, 0x00, 0x02, 0x00, 0xF7]);
         let err = block_on(bus.read_position(1));
         assert!(matches!(err, Err(Error::MalformedResponse)));
+    }
+
+    #[test]
+    fn read_memory_returns_fault_byte_from_response() {
+        let mut bus = Scservo::new(MockUart::new());
+        // Fault byte 0x20 (overload flag set); 2 position bytes = 0x0200 (512).
+        // sum = 1+4+0x20+2+0 = 0x27, checksum = !0x27 = 0xD8.
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x04, 0x20, 0x02, 0x00, 0xD8]);
+        let mut buf = [0u8; 2];
+        let fault = block_on(bus.read_memory(1, ADDR_PRESENT_POSITION, &mut buf)).unwrap();
+        assert_eq!(fault, 0x20, "fault byte should be surfaced to the caller");
+        assert_eq!(buf, [0x02, 0x00], "data bytes still copied even on fault");
+    }
+
+    #[test]
+    fn read_memory_returns_zero_fault_on_healthy_response() {
+        let mut bus = Scservo::new(MockUart::new());
+        bus.uart
+            .queue_rx(&[0xFF, 0xFF, 0x01, 0x04, 0x00, 0x02, 0x00, 0xF8]);
+        let mut buf = [0u8; 2];
+        let fault = block_on(bus.read_memory(1, ADDR_PRESENT_POSITION, &mut buf)).unwrap();
+        assert_eq!(fault, 0);
     }
 
     #[test]

--- a/crates/scservo/src/lib.rs
+++ b/crates/scservo/src/lib.rs
@@ -336,6 +336,12 @@ impl<U: Read + Write> Scservo<U> {
             checksum,
         ];
         self.uart.write_all(&outbound).await?;
+        // Flush before switching to RX: `write_all` only guarantees the
+        // bytes were accepted by the TX FIFO, not that they've left the
+        // wire. On a half-duplex converter we must drain TX before
+        // sampling RX so the first byte we read isn't the tail of our
+        // own packet.
+        self.uart.flush().await?;
 
         // Expected response layout: FF FF ID 02 Error ~checksum (6 bytes).
         let mut response = [0u8; 6];
@@ -423,6 +429,8 @@ impl<U: Read + Write> Scservo<U> {
             !sum,
         ];
         self.uart.write_all(&outbound).await?;
+        // Drain TX before reading — see `ping` for the half-duplex rationale.
+        self.uart.flush().await?;
 
         // Response: 2 header + 1 id + 1 len-field + 1 error + N data + 1 checksum.
         let response_total = 6 + buf.len();

--- a/crates/scservo/src/lib.rs
+++ b/crates/scservo/src/lib.rs
@@ -110,6 +110,10 @@ pub enum Instruction {
 
 /// Servo position count at the mechanical center (neutral).
 pub const POSITION_CENTER: u16 = 512;
+/// Maximum valid servo position count. SCSCL / SCS0009 use a 0..=1023
+/// range; values above are rejected by [`Scservo::write_position`] with
+/// [`Error::PositionOutOfRange`].
+pub const POSITION_MAX: u16 = 1023;
 /// Position counts per degree for SCSCL / SCS0009: 1023 counts across
 /// 300° of travel.
 pub const POSITION_PER_DEGREE: f32 = 1023.0 / 300.0;
@@ -144,6 +148,11 @@ pub enum Error<E> {
     MalformedResponse,
     /// Response packet arrived but its checksum didn't verify.
     ChecksumMismatch,
+    /// Caller passed a position value above [`POSITION_MAX`] (1023) to
+    /// [`Scservo::write_position`]. The servo would interpret the high
+    /// bits as a different address in its memory table, so we reject at
+    /// the driver boundary.
+    PositionOutOfRange(u16),
 }
 
 impl<E> From<ReadExactError<E>> for Error<E> {
@@ -183,18 +192,21 @@ impl<W: Write> Scservo<W> {
         self.uart
     }
 
-    /// Command servo `id` to `position` (step count 0..=1023),
+    /// Command servo `id` to `position` (step count 0..=[`POSITION_MAX`]),
     /// transitioning over `time_ms` milliseconds at `speed` (0 = use
     /// time control).
     ///
     /// See [`POSITION_CENTER`] / [`POSITION_PER_DEGREE`] for angle
-    /// conversion. Values outside 0..=1023 are clamped implicitly by
-    /// the servo's angle-limit registers, which is the preferred layer
-    /// for enforcing safety — ship custom limits by writing the
-    /// `MIN_ANGLE_LIMIT` / `MAX_ANGLE_LIMIT` registers directly.
+    /// conversion. Positions above [`POSITION_MAX`] are rejected with
+    /// [`Error::PositionOutOfRange`] rather than forwarded verbatim:
+    /// the servo interprets the high bits as a different memory-table
+    /// address, so silently sending them out-of-range is strictly
+    /// worse than returning an error. For tighter per-application
+    /// limits, write `MIN_ANGLE_LIMIT` / `MAX_ANGLE_LIMIT` directly.
     ///
     /// # Errors
-    /// Returns the UART transport error if the write fails.
+    /// - [`Error::PositionOutOfRange`] if `position > POSITION_MAX`.
+    /// - [`Error::Uart`] if the transport fails.
     pub async fn write_position(
         &mut self,
         id: u8,
@@ -202,6 +214,9 @@ impl<W: Write> Scservo<W> {
         time_ms: u16,
         speed: u16,
     ) -> Result<(), Error<W::Error>> {
+        if position > POSITION_MAX {
+            return Err(Error::PositionOutOfRange(position));
+        }
         let data = [
             (position >> 8) as u8,
             (position & 0xFF) as u8,
@@ -610,6 +625,23 @@ mod tests {
         let buf = bus.uart.written.borrow();
         let expected_sum = buf[2..12].iter().fold(0u8, |a, b| a.wrapping_add(*b));
         assert_eq!(buf[12], !expected_sum);
+    }
+
+    #[test]
+    fn write_position_accepts_exact_max_position() {
+        let mut bus = Scservo::new(MockUart::new());
+        // POSITION_MAX (1023) is inside the valid range — must succeed.
+        block_on(bus.write_position(1, POSITION_MAX, 0, 0)).unwrap();
+        assert!(!bus.uart.written.borrow().is_empty());
+    }
+
+    #[test]
+    fn write_position_rejects_above_max() {
+        let mut bus = Scservo::new(MockUart::new());
+        let err = block_on(bus.write_position(1, POSITION_MAX + 1, 0, 0));
+        assert!(matches!(err, Err(Error::PositionOutOfRange(p)) if p == POSITION_MAX + 1));
+        // No packet was transmitted — the guard runs before serialisation.
+        assert!(bus.uart.written.borrow().is_empty());
     }
 
     #[test]

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -287,7 +287,7 @@ async fn head_task(mut driver: HeadDriverImpl) {
                     defmt::Debug2Format(&e)
                 ),
                 Err(_) => {
-                    defmt::warn!("head: read_pose timed out after {=u64} ms", READ_TIMEOUT_MS)
+                    defmt::warn!("head: read_pose timed out after {=u64} ms", READ_TIMEOUT_MS);
                 }
             }
         }

--- a/crates/stackchan-sim/src/lib.rs
+++ b/crates/stackchan-sim/src/lib.rs
@@ -151,12 +151,12 @@ impl DrawTarget for Framebuffer {
 
 /// [`HeadDriver`] that records every `set_pose` call into a `Vec`.
 ///
-/// Pair with [`FakeClock`] to test motion modifiers without a real PCA9685:
-/// drive the modifier pipeline, push `avatar.head_pose` into a
+/// Pair with [`FakeClock`] to test motion modifiers without a real `SCServo`
+/// bus: drive the modifier pipeline, push `avatar.head_pose` into a
 /// `RecordingHead` each tick, then assert amplitude / period / trajectory
 /// bounds on [`RecordingHead::records`].
 ///
-/// The [`HeadDriver`] impl is `async` to match the firmware's PCA9685
+/// The [`HeadDriver`] impl is `async` to match the firmware's `SCServo`
 /// driver shape, but the recorded future is always immediately `Ready` —
 /// tests can drive it with the small `block_on` helper in the
 /// `head_sway.rs` integration test, or skip the trait entirely and inspect

--- a/crates/stackchan-sim/src/lib.rs
+++ b/crates/stackchan-sim/src/lib.rs
@@ -198,10 +198,14 @@ impl HeadDriver for RecordingHead {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::field_reassign_with_default,
+    reason = "test setup reads better as `let mut a = Avatar::default(); a.emotion = …;` than the struct-update equivalent"
+)]
 mod integration_tests {
     use super::*;
     use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, EmotionStyle, IdleDrift};
-    use stackchan_core::{Avatar, Emotion, EyePhase, Modifier};
+    use stackchan_core::{Avatar, Emotion, EyePhase, Modifier, SCALE_DEFAULT};
 
     /// End-to-end: drive a Blink + Breath + `IdleDrift` stack for 60 simulated
     /// seconds at 30 FPS and verify the avatar never enters a nonsensical
@@ -332,5 +336,43 @@ mod integration_tests {
             seen_surprised_wide,
             "Surprised emotion never raised eye_scale above baseline"
         );
+    }
+
+    /// Regression test for the `EmotionStyle → Blink` ordering contract in
+    /// `modifiers::mod`. The canonical pipeline must preserve the invariant
+    /// that Blink's effect on `Eye::weight` reflects the *current* tick's
+    /// `blink_rate_scale`, not a stale value from a previous tick — which
+    /// is only guaranteed if [`EmotionStyle`] runs first on the same tick.
+    #[test]
+    fn canonical_order_propagates_blink_rate_within_one_tick() {
+        let mut avatar = Avatar::default();
+        avatar.emotion = Emotion::Surprised;
+        let mut style = EmotionStyle::new();
+        let mut blink = Blink::new();
+
+        // First tick establishes Surprised as both from + to in EmotionStyle,
+        // and rate = 0 takes effect immediately.
+        style.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(
+            avatar.blink_rate_scale, 0,
+            "EmotionStyle must snap to target on first observation of a new emotion"
+        );
+
+        // Blink sees rate == 0 on the same tick and suppresses.
+        blink.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(
+            avatar.left_eye.phase,
+            EyePhase::Open,
+            "rate == 0 must force eyes open on the same tick EmotionStyle wrote it"
+        );
+
+        // Baseline sanity: with Neutral, the default rate propagates.
+        avatar.emotion = Emotion::Neutral;
+        style.update(&mut avatar, Instant::from_millis(10_000));
+        blink.update(&mut avatar, Instant::from_millis(10_000));
+        // After the transition elapses (at next tick past 10_000 + 300 ms),
+        // rate is SCALE_DEFAULT.
+        style.update(&mut avatar, Instant::from_millis(10_400));
+        assert_eq!(avatar.blink_rate_scale, SCALE_DEFAULT);
     }
 }

--- a/justfile
+++ b/justfile
@@ -34,6 +34,10 @@ ci: check
     cargo deny check
     RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features
 
+# MSRV check — matches the `msrv` CI job. Requires `rustup toolchain install 1.88`.
+msrv:
+    cargo +1.88 build --workspace --exclude stackchan-firmware --all-features
+
 # ----- Firmware (requires `source ~/export-esp.sh` first) ------------------
 
 # Firmware-side compile check. Runs from inside the firmware crate so the


### PR DESCRIPTION
## Summary

First PR in a four-part audit pass. Lands **gap fixes** surfaced by parallel discovery agents across the whole workspace: things that were promised, documented, or obviously expected but not actually wired up.

- **docs**: README + CLAUDE.md refreshed to reflect the six-crate workspace post-v0.1.0 (aw9523 + scservo were missing from both). `stackchan-sim` docstrings still named PCA9685 — SCServo-swapped in PR #5.
- **ci / dx**: CI's host clippy now passes `--all-targets` (pre-commit already did, so local and CI could diverge silently). New `just msrv` recipe mirrors the CI MSRV job.
- **scservo boundary validation**: four separate commits
  - Reject `position > POSITION_MAX` (1023) with typed `Error::PositionOutOfRange` — previously forwarded verbatim and the servo interpreted the high bits as a different memory-table address.
  - `flush().await` between every `write_all` / `read_exact` pair so half-duplex converters can drain TX before RX samples.
  - Reject `BROADCAST_ID` on `ping` / `read_memory` with typed `Error::BroadcastNotAllowed` — every servo responds, the bus collides, the call would hang forever.
  - `read_memory` now returns the servo's fault byte via `Ok(u8)` (non-zero → overheat / voltage / overload / angle-limit). `read_*` convenience wrappers keep their existing signatures by discarding the byte.
- **driver coverage**: `axp2101` and `aw9523` had zero host tests — the init sequences they ship are load-bearing for LCD bring-up, and any drift would only surface on device. Add mock-I²C + mock-delay harnesses and pin the exact register / delay ordering as golden tests.
- **modifier-order contract**: `crates/stackchan-sim` now has a regression test that pins the `EmotionStyle → Blink` same-tick propagation invariant for the Surprised path.

## Breaking changes

Two, both in `scservo` — everything in this workspace was still **Experimental** per `STABILITY.md`:

- `Scservo::write_position` now returns `Err(Error::PositionOutOfRange(u16))` when `position > 1023`. Callers that were relying on wrap-around see a typed error instead.
- `Scservo::read_memory`'s success type changed from `()` to `u8` (the fault byte). Internal `read_*` wrappers migrated; external users pattern-match on the byte or `let _ = …;` to opt out.

## Test plan
- [x] `cargo test --workspace --exclude stackchan-firmware --all-features` — 102 tests pass (was ~20 before this PR).
- [x] `cargo fmt --check --all`
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware still cross-compiles with the esp toolchain (one pre-existing clippy nit at `stackchan-firmware/src/main.rs:290` remains; that'll land in the next PR).
- [ ] Device smoke test: flash and confirm blink + breath + emotion cycle still run identically (no runtime-visible changes expected — all additions are additive except the two breaking scservo errors, and the firmware consumer already clamps before calling `write_position`).

## Follow-on PRs

- **#2 — quality fixes**: Blink 49-day park (B3), IdleSway diff-and-undo promise, firmware `unsafe impl Sync` removal, the `main.rs:290` clippy fix.
- **#3 — optimizations**: framebuffer PSRAM assert, EmotionStyle / EmotionHead transition-state DRY, format-string bloat.
- **#4 — simplifications**: dedupe clamp helpers, drop unused `Instruction` variants, naming consistency.