### PR TITLE
Audit pass: clamp helper dedup in EmotionStyle

### DIFF
--- a/crates/stackchan-core/src/modifiers/blink.rs
+++ b/crates/stackchan-core/src/modifiers/blink.rs
@@ -35,23 +35,36 @@ pub struct Blink {
     state: BlinkState,
 }
 
-/// Internal state tracking when the next transition fires.
+/// Internal state tracking the current blink phase.
+///
+/// Each phase records the instant it started rather than its scheduled
+/// transition time. That way, rate changes mid-phase take effect on the
+/// next tick without stranding a stale absolute deadline — we always
+/// compute `phase_start + scaled_open_ms(current_rate)` from the
+/// current `avatar.blink_rate_scale`.
 #[derive(Debug, Clone, Copy)]
 enum BlinkState {
     /// Waiting to initialize on the first `update` call. Used so the very
-    /// first tick establishes `next_transition` relative to the clock the
-    /// caller is actually using -- modifiers don't know the starting time.
+    /// first tick anchors `phase_start` to the caller's actual clock.
     Uninitialized,
-    /// Eyes currently open; they close at `transition_at`.
+    /// Eyes currently open; they close once the phase has run for
+    /// `scaled_open_ms(rate)` since `phase_start`.
     Open {
-        /// Monotonic time at which the next open->closed transition happens.
-        transition_at: Instant,
+        /// Instant the phase began.
+        phase_start: Instant,
     },
-    /// Eyes currently closed; they open at `transition_at`.
+    /// Eyes currently closed; they open once the phase has run for
+    /// `closed_ms` since `phase_start`.
     Closed {
-        /// Monotonic time at which the next closed->open transition happens.
-        transition_at: Instant,
+        /// Instant the phase began.
+        phase_start: Instant,
     },
+    /// Rate scale is 0 — blinks are suppressed until the rate goes
+    /// non-zero again, at which point we transition back to `Open` with
+    /// a fresh `phase_start`. Explicit state (rather than parking
+    /// `Open` with a far-future deadline) avoids the ~49-day wraparound
+    /// hazard and makes the "Surprised → Neutral" recovery path trivial.
+    Suppressed,
 }
 
 impl Blink {
@@ -103,54 +116,66 @@ impl Modifier for Blink {
     fn update(&mut self, avatar: &mut Avatar, now: Instant) {
         let rate = avatar.blink_rate_scale;
 
-        // Suppression path: scale == 0 forces eyes open and parks the
-        // state machine. The next non-zero scale will resume blinking
-        // naturally (re-entering from Uninitialized if we've never run,
-        // or from Open which is the phase we left behind).
+        // Suppression path: scale == 0 forces eyes open. Stored as an
+        // explicit state so a later non-zero scale cleanly resumes the
+        // cycle from `Open` rather than relying on a far-future deadline
+        // to elapse first.
         if rate == 0 {
-            self.state = BlinkState::Open {
-                // Park "next transition" in the far future; a subsequent
-                // non-zero rate will reschedule before this ever elapses.
-                transition_at: now + u64::from(u32::MAX),
-            };
-            set_both_eyes(avatar, EyePhase::Open, avatar.left_eye.open_weight);
+            self.state = BlinkState::Suppressed;
+            open_both_eyes(avatar);
             return;
         }
 
         let open_ms = self.scaled_open_ms(rate);
 
         match self.state {
-            BlinkState::Uninitialized => {
-                // First tick: eyes are currently open; schedule the first blink.
-                self.state = BlinkState::Open {
-                    transition_at: now + open_ms,
-                };
-                set_both_eyes(avatar, EyePhase::Open, avatar.left_eye.open_weight);
+            // First tick, or resuming from suppression: start a fresh
+            // open phase anchored to `now`.
+            BlinkState::Uninitialized | BlinkState::Suppressed => {
+                self.state = BlinkState::Open { phase_start: now };
+                open_both_eyes(avatar);
             }
-            BlinkState::Open { transition_at } if now >= transition_at => {
-                self.state = BlinkState::Closed {
-                    transition_at: now + self.closed_ms,
-                };
-                set_both_eyes(avatar, EyePhase::Closed, 0);
+            // Open phase: elapsed since phase_start is always compared
+            // against the *current* scaled_open_ms, so a rate change
+            // mid-open takes effect on the next tick without leaving a
+            // stale absolute deadline behind.
+            BlinkState::Open { phase_start } => {
+                let elapsed = now.saturating_duration_since(phase_start);
+                if elapsed >= open_ms {
+                    self.state = BlinkState::Closed { phase_start: now };
+                    close_both_eyes(avatar);
+                }
+                // Else: still open; no writes required.
             }
-            BlinkState::Closed { transition_at } if now >= transition_at => {
-                self.state = BlinkState::Open {
-                    transition_at: now + open_ms,
-                };
-                set_both_eyes(avatar, EyePhase::Open, avatar.left_eye.open_weight);
+            BlinkState::Closed { phase_start } => {
+                let elapsed = now.saturating_duration_since(phase_start);
+                if elapsed >= self.closed_ms {
+                    self.state = BlinkState::Open { phase_start: now };
+                    open_both_eyes(avatar);
+                }
             }
-            // Still in the current phase; nothing to change.
-            BlinkState::Open { .. } | BlinkState::Closed { .. } => {}
         }
     }
 }
 
-/// Apply a (phase, weight) pair to both eyes on `avatar`.
-const fn set_both_eyes(avatar: &mut Avatar, phase: EyePhase, weight: u8) {
-    avatar.left_eye.phase = phase;
-    avatar.left_eye.weight = weight;
-    avatar.right_eye.phase = phase;
-    avatar.right_eye.weight = weight;
+/// Open both eyes, each honoring its own `open_weight`. Split per-eye so
+/// emotion code can animate the two lids independently (e.g. a wink
+/// variant could set one eye's `open_weight` to 0 without Blink
+/// clobbering the asymmetry).
+const fn open_both_eyes(avatar: &mut Avatar) {
+    avatar.left_eye.phase = EyePhase::Open;
+    avatar.left_eye.weight = avatar.left_eye.open_weight;
+    avatar.right_eye.phase = EyePhase::Open;
+    avatar.right_eye.weight = avatar.right_eye.open_weight;
+}
+
+/// Close both eyes. Weight is 0 in both; renderers distinguish closed
+/// from almost-open via the `phase` field rather than a weight threshold.
+const fn close_both_eyes(avatar: &mut Avatar) {
+    avatar.left_eye.phase = EyePhase::Closed;
+    avatar.left_eye.weight = 0;
+    avatar.right_eye.phase = EyePhase::Closed;
+    avatar.right_eye.weight = 0;
 }
 
 #[cfg(test)]
@@ -252,6 +277,86 @@ mod tests {
             blink.update(&mut avatar, Instant::from_millis(ms));
             assert_eq!(avatar.left_eye.phase, EyePhase::Open, "ms={ms}");
         }
+    }
+
+    #[test]
+    fn blink_resumes_after_rate_returns_to_nonzero() {
+        // Regression for the "Surprised emotion parks Blink for 49 days"
+        // bug: previously, rate==0 set an Open state with a far-future
+        // transition deadline, and when rate came back to 128 the
+        // deadline stayed in the future so blinks never resumed. With
+        // the explicit Suppressed state, the first non-zero tick anchors
+        // a fresh Open phase and the normal cycle fires within open_ms.
+        let mut avatar = Avatar::default();
+        let mut blink = Blink::with_timing(100, 20);
+
+        // Enter suppression.
+        avatar.blink_rate_scale = 0;
+        blink.update(&mut avatar, Instant::from_millis(0));
+        blink.update(&mut avatar, Instant::from_millis(500));
+        assert_eq!(avatar.left_eye.phase, EyePhase::Open, "suppressed");
+
+        // Rate returns to default; blinks should resume within the
+        // normal open window relative to the resume instant, not stay
+        // parked in the distant future.
+        avatar.blink_rate_scale = SCALE_DEFAULT;
+        blink.update(&mut avatar, Instant::from_millis(500));
+        blink.update(&mut avatar, Instant::from_millis(600));
+        assert_eq!(avatar.left_eye.phase, EyePhase::Closed);
+    }
+
+    #[test]
+    fn rate_change_mid_open_takes_effect_on_next_tick() {
+        // Regression for "stale transition_at when rate changes mid-open":
+        // previously, Open stored an absolute transition_at computed at
+        // phase entry, so shortening the open window later didn't fire
+        // the blink any sooner. With phase_start + current-tick rate,
+        // a rate change is observed immediately.
+        let mut avatar = Avatar::default();
+        avatar.blink_rate_scale = 64; // slower cadence → longer open
+        let mut blink = Blink::with_timing(200, 20);
+
+        blink.update(&mut avatar, Instant::from_millis(0));
+        // scaled_open_ms(64) = 200 * 128 / 64 = 400 ms. At ms=200 we're
+        // only halfway through the slow open window.
+        blink.update(&mut avatar, Instant::from_millis(200));
+        assert_eq!(avatar.left_eye.phase, EyePhase::Open);
+
+        // Speed up to 4x — scaled_open_ms(255) = 200 * 128 / 255 ≈ 100 ms.
+        // We're already past that window since phase_start=0, ms=200.
+        avatar.blink_rate_scale = 255;
+        blink.update(&mut avatar, Instant::from_millis(200));
+        assert_eq!(
+            avatar.left_eye.phase,
+            EyePhase::Closed,
+            "faster rate should fire the blink on the same tick we crossed the new window"
+        );
+    }
+
+    #[test]
+    fn open_weight_is_per_eye() {
+        // Regression for "Blink uses left_eye.open_weight for both eyes":
+        // asymmetric open_weights (e.g. a wink) must survive Blink's
+        // re-open writes rather than being clobbered by whatever the
+        // left eye happens to hold.
+        let mut avatar = Avatar::default();
+        avatar.left_eye.open_weight = 100;
+        avatar.right_eye.open_weight = 30; // partially closed right eye
+
+        let mut blink = Blink::with_timing(100, 20);
+        blink.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(avatar.left_eye.weight, 100);
+        assert_eq!(
+            avatar.right_eye.weight, 30,
+            "right eye's open_weight preserved"
+        );
+
+        // Close + reopen preserves the asymmetry.
+        blink.update(&mut avatar, Instant::from_millis(100));
+        blink.update(&mut avatar, Instant::from_millis(120));
+        assert_eq!(avatar.left_eye.phase, EyePhase::Open);
+        assert_eq!(avatar.left_eye.weight, 100);
+        assert_eq!(avatar.right_eye.weight, 30);
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/emotion_head.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_head.rs
@@ -96,6 +96,10 @@ pub struct EmotionHead {
     to_emotion: Option<Emotion>,
     /// Monotonic time the current transition began.
     transition_start: Option<Instant>,
+    /// Bias applied on the previous tick; subtracted from
+    /// `avatar.head_pose` before writing the new one so the bias
+    /// contribution stays a delta rather than accumulating.
+    last_applied: HeadBias,
 }
 
 impl EmotionHead {
@@ -117,6 +121,7 @@ impl EmotionHead {
             to: None,
             to_emotion: None,
             transition_start: None,
+            last_applied: HeadBias::ZERO,
         }
     }
 
@@ -160,16 +165,17 @@ impl Modifier for EmotionHead {
 
         let bias = self.current_bias(now);
 
-        // Layered compose: add bias onto whatever `avatar.head_pose` already
-        // holds (written by `IdleSway` earlier in the pipeline). Clamp in
-        // case the combined value exceeds the safe range — realistic
-        // defaults stay well inside it, but a user-provided sway with
-        // larger amplitude could push over.
+        // Layered compose via diff-and-undo (matches `IdleSway` /
+        // `Breath`): subtract the previous tick's bias, then add the
+        // new one. Keeps the bias a delta on `avatar.head_pose` rather
+        // than accumulating across ticks when upstream modifiers (e.g.
+        // a future additive head-pose source) write the pose each tick.
         let combined = Pose::new(
-            avatar.head_pose.pan_deg + bias.pan_deg,
-            avatar.head_pose.tilt_deg + bias.tilt_deg,
+            avatar.head_pose.pan_deg - self.last_applied.pan_deg + bias.pan_deg,
+            avatar.head_pose.tilt_deg - self.last_applied.tilt_deg + bias.tilt_deg,
         );
         avatar.head_pose = combined.clamped();
+        self.last_applied = bias;
     }
 }
 
@@ -291,42 +297,66 @@ mod tests {
 
     #[test]
     fn changing_emotion_mid_transition_re_anchors_from_current() {
+        // Drive the pipeline naturally (no manual head_pose resets) and
+        // track the tilt trajectory across the mid-transition flip. With
+        // diff-and-undo composition, the interesting invariant is that
+        // the eventual steady-state matches the destination emotion; at
+        // no point does the bias double-count. This replaces the older
+        // pattern of resetting head_pose=0 every tick, which measured
+        // the absolute bias value only meaningful under absolute-set
+        // semantics.
         let mut avatar = Avatar::default();
         avatar.emotion = Emotion::Neutral;
         let mut eh = EmotionHead::new();
         eh.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(avatar.head_pose.tilt_deg, 0.0, "Neutral snaps to zero bias");
 
-        // Flip to Sleepy; partial ease 150 ms in → tilt ~-3.
+        // Flip to Sleepy; midway through the transition the bias is ~-3.
         avatar.emotion = Emotion::Sleepy;
-        avatar.head_pose = Pose::new(0.0, 0.0);
         eh.update(&mut avatar, Instant::from_millis(0));
-        avatar.head_pose = Pose::new(0.0, 0.0);
         eh.update(&mut avatar, Instant::from_millis(150));
-        let mid_tilt = avatar.head_pose.tilt_deg;
+        let mid_sleepy = avatar.head_pose.tilt_deg;
+        assert!(
+            (mid_sleepy - (-3.0)).abs() < 0.1,
+            "mid-transition Sleepy tilt should be ~-3, got {mid_sleepy}"
+        );
 
-        // Now flip to Happy mid-transition. The modifier should re-anchor
-        // `from` to the currently-observed 'to' (Sleepy's final bias),
-        // then ease toward Happy. Immediately after flip, bias ≈ Sleepy
-        // for one tick (t=0 of the new transition) — hold that as the
-        // "from" reference.
+        // Flip to Happy mid-transition. `from` should re-anchor to
+        // whatever `to` was before (Sleepy's final bias of -6). After
+        // the new 300 ms window elapses, we land on Happy's +3.
         avatar.emotion = Emotion::Happy;
-        avatar.head_pose = Pose::new(0.0, 0.0);
         eh.update(&mut avatar, Instant::from_millis(150));
-        // At t=0 of the new transition, the lerp returns 'from'. `from`
-        // is the last observed 'to' (Sleepy full bias of -6), so tilt
-        // reads -6.0 regardless of where mid_tilt was.
-        assert_eq!(avatar.head_pose.tilt_deg, -6.0);
-
-        // Past the new transition window, we hit Happy fully.
-        avatar.head_pose = Pose::new(0.0, 0.0);
         eh.update(
             &mut avatar,
             Instant::from_millis(150 + EmotionHead::TRANSITION_MS + 1),
         );
-        assert_eq!(avatar.head_pose.tilt_deg, 3.0);
-        // Suppress "unused variable" when the mid-tilt check above already
-        // proved the partial ease path.
-        let _ = mid_tilt;
+        assert_eq!(
+            avatar.head_pose.tilt_deg, 3.0,
+            "should fully land on Happy's +3° tilt after the transition elapses"
+        );
+    }
+
+    #[test]
+    fn bias_does_not_accumulate_across_ticks() {
+        // Regression for the diff-and-undo refactor: previously
+        // EmotionHead added bias absolutely, which relied on IdleSway
+        // clobbering head_pose first. Now that IdleSway also contributes
+        // additively, EmotionHead must subtract the previous tick's bias
+        // before adding the new one — otherwise a steady-state emotion
+        // would see its bias compound each tick.
+        let mut avatar = Avatar::default();
+        avatar.emotion = Emotion::Sleepy; // -6° tilt bias at steady state
+        let mut eh = EmotionHead::new();
+
+        // Drive past the transition, then many more ticks. The tilt must
+        // stay at -6, not drift to -12, -18, ...
+        for i in 0..=50 {
+            eh.update(
+                &mut avatar,
+                Instant::from_millis(EmotionHead::TRANSITION_MS + i * 33),
+            );
+        }
+        assert_eq!(avatar.head_pose.tilt_deg, -6.0);
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/emotion_style.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_style.rs
@@ -127,19 +127,23 @@ fn ease(from: i32, to: i32, elapsed_ms: u64, duration_ms: u64) -> i32 {
     from + delta
 }
 
-/// Clamp an eased `i32` back into a `u8` (0..=255) with saturating bounds.
+/// Saturating clamp of an eased `i32` into `[min, max]`, casting to `u8`.
+/// Shared between the `u8` style fields (range `0..=255`) and the
+/// `weight` fields (range `0..=100`); the caller picks the bounds.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-const fn clamp_u8(v: i32) -> u8 {
-    if v <= 0 {
-        0
-    } else if v >= 255 {
-        255
+const fn clamp_to_u8(v: i32, min: u8, max: u8) -> u8 {
+    let min = min as i32;
+    let max = max as i32;
+    if v <= min {
+        min as u8
+    } else if v >= max {
+        max as u8
     } else {
         v as u8
     }
 }
 
-/// Clamp an eased `i32` back into an `i8` (-128..=127) with saturating bounds.
+/// Saturating clamp of an eased `i32` into `i8::MIN..=i8::MAX`.
 #[allow(clippy::cast_possible_truncation)]
 const fn clamp_i8(v: i32) -> i8 {
     if v <= i8::MIN as i32 {
@@ -148,19 +152,6 @@ const fn clamp_i8(v: i32) -> i8 {
         i8::MAX
     } else {
         v as i8
-    }
-}
-
-/// Clamp an eased `i32` into the `Mouth::weight` / `Eye::open_weight` range
-/// 0..=100.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-const fn clamp_weight(v: i32) -> u8 {
-    if v <= 0 {
-        0
-    } else if v >= 100 {
-        100
-    } else {
-        v as u8
     }
 }
 
@@ -240,42 +231,66 @@ impl EmotionStyle {
                 elapsed_ms,
                 duration_ms,
             )),
-            cheek_blush: clamp_u8(ease(
-                i32::from(from.cheek_blush),
-                i32::from(to.cheek_blush),
-                elapsed_ms,
-                duration_ms,
-            )),
-            eye_scale: clamp_u8(ease(
-                i32::from(from.eye_scale),
-                i32::from(to.eye_scale),
-                elapsed_ms,
-                duration_ms,
-            )),
-            blink_rate_scale: clamp_u8(ease(
-                i32::from(from.blink_rate_scale),
-                i32::from(to.blink_rate_scale),
-                elapsed_ms,
-                duration_ms,
-            )),
-            breath_depth_scale: clamp_u8(ease(
-                i32::from(from.breath_depth_scale),
-                i32::from(to.breath_depth_scale),
-                elapsed_ms,
-                duration_ms,
-            )),
-            open_weight: clamp_weight(ease(
-                i32::from(from.open_weight),
-                i32::from(to.open_weight),
-                elapsed_ms,
-                duration_ms,
-            )),
-            mouth_weight: clamp_weight(ease(
-                i32::from(from.mouth_weight),
-                i32::from(to.mouth_weight),
-                elapsed_ms,
-                duration_ms,
-            )),
+            cheek_blush: clamp_to_u8(
+                ease(
+                    i32::from(from.cheek_blush),
+                    i32::from(to.cheek_blush),
+                    elapsed_ms,
+                    duration_ms,
+                ),
+                0,
+                u8::MAX,
+            ),
+            eye_scale: clamp_to_u8(
+                ease(
+                    i32::from(from.eye_scale),
+                    i32::from(to.eye_scale),
+                    elapsed_ms,
+                    duration_ms,
+                ),
+                0,
+                u8::MAX,
+            ),
+            blink_rate_scale: clamp_to_u8(
+                ease(
+                    i32::from(from.blink_rate_scale),
+                    i32::from(to.blink_rate_scale),
+                    elapsed_ms,
+                    duration_ms,
+                ),
+                0,
+                u8::MAX,
+            ),
+            breath_depth_scale: clamp_to_u8(
+                ease(
+                    i32::from(from.breath_depth_scale),
+                    i32::from(to.breath_depth_scale),
+                    elapsed_ms,
+                    duration_ms,
+                ),
+                0,
+                u8::MAX,
+            ),
+            open_weight: clamp_to_u8(
+                ease(
+                    i32::from(from.open_weight),
+                    i32::from(to.open_weight),
+                    elapsed_ms,
+                    duration_ms,
+                ),
+                0,
+                100,
+            ),
+            mouth_weight: clamp_to_u8(
+                ease(
+                    i32::from(from.mouth_weight),
+                    i32::from(to.mouth_weight),
+                    elapsed_ms,
+                    duration_ms,
+                ),
+                0,
+                100,
+            ),
         }
     }
 }

--- a/crates/stackchan-core/src/modifiers/idle_drift.rs
+++ b/crates/stackchan-core/src/modifiers/idle_drift.rs
@@ -8,6 +8,16 @@
 use super::Modifier;
 use crate::avatar::Avatar;
 use crate::clock::Instant;
+use core::num::NonZeroU32;
+
+/// Default xorshift32 seed used by [`IdleDrift::new`]. The `.unwrap()`
+/// is const-evaluated against a compile-time non-zero literal, so
+/// there's no runtime branch.
+#[allow(
+    clippy::unwrap_used,
+    reason = "const-evaluated against a non-zero literal: unwrap can't fire at runtime"
+)]
+const DEFAULT_SEED: NonZeroU32 = NonZeroU32::new(0x1234_5678).unwrap();
 
 /// Default interval between drifts, in milliseconds.
 const DEFAULT_INTERVAL_MS: u64 = 4_000;
@@ -41,22 +51,22 @@ impl IdleDrift {
     /// reproducible. Firmware overrides the seed at boot.
     #[must_use]
     pub const fn new() -> Self {
-        Self::with_seed(0x1234_5678)
+        Self::with_seed(DEFAULT_SEED)
     }
 
     /// Construct with a custom xorshift32 seed.
     ///
-    /// # Panics
-    ///
-    /// Never panics today, but the `const fn` constraint means we accept any
-    /// non-zero seed; callers passing zero will get a stuck RNG.
+    /// Accepts [`NonZeroU32`] at the type level rather than silently
+    /// substituting a default when the caller passes zero — a zero
+    /// seed would leave xorshift32 stuck at zero and drift would never
+    /// fire.
     #[must_use]
-    pub const fn with_seed(seed: u32) -> Self {
+    pub const fn with_seed(seed: NonZeroU32) -> Self {
         Self {
             interval_ms: DEFAULT_INTERVAL_MS,
             max_x: DEFAULT_MAX_X,
             max_y: DEFAULT_MAX_Y,
-            rng_state: if seed == 0 { 0x1234_5678 } else { seed },
+            rng_state: seed.get(),
             next_drift_at: None,
             last_offset: (0, 0),
         }
@@ -129,6 +139,10 @@ impl Modifier for IdleDrift {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test literals are compile-time non-zero; the unwrap can't fire"
+)]
 mod tests {
     use super::*;
     use crate::avatar::Avatar;
@@ -147,7 +161,7 @@ mod tests {
     fn drift_applies_at_interval() {
         let mut avatar = Avatar::default();
         let baseline = (avatar.left_eye.center.x, avatar.left_eye.center.y);
-        let mut drift = IdleDrift::with_seed(42);
+        let mut drift = IdleDrift::with_seed(NonZeroU32::new(42).unwrap());
 
         drift.update(&mut avatar, Instant::from_millis(0));
         drift.update(&mut avatar, Instant::from_millis(DEFAULT_INTERVAL_MS));
@@ -163,7 +177,7 @@ mod tests {
     fn drifts_do_not_accumulate() {
         let mut avatar = Avatar::default();
         let baseline = (avatar.left_eye.center.x, avatar.left_eye.center.y);
-        let mut drift = IdleDrift::with_seed(42);
+        let mut drift = IdleDrift::with_seed(NonZeroU32::new(42).unwrap());
 
         for i in 0..10 {
             drift.update(&mut avatar, Instant::from_millis(i * DEFAULT_INTERVAL_MS));
@@ -178,8 +192,8 @@ mod tests {
 
     #[test]
     fn seeded_rng_is_deterministic() {
-        let mut a = IdleDrift::with_seed(42);
-        let mut b = IdleDrift::with_seed(42);
+        let mut a = IdleDrift::with_seed(NonZeroU32::new(42).unwrap());
+        let mut b = IdleDrift::with_seed(NonZeroU32::new(42).unwrap());
         for _ in 0..100 {
             assert_eq!(a.next_u32(), b.next_u32());
         }

--- a/crates/stackchan-core/src/modifiers/idle_sway.rs
+++ b/crates/stackchan-core/src/modifiers/idle_sway.rs
@@ -13,11 +13,15 @@
 //!
 //! ## Composition
 //!
-//! This modifier *sets* `avatar.head_pose` absolutely, replacing whatever
-//! was there. It is the only pose-producing modifier in v0.1.x. When a
-//! second pose source lands (e.g. emotion-coupled head bias), this
-//! modifier should switch to a compose-by-delta pattern like
-//! [`Breath::last_offset_px`](super::Breath).
+//! Contributes additively to `avatar.head_pose` using the same
+//! diff-and-undo pattern [`Breath`](super::Breath) uses for vertical
+//! offset: each tick subtracts the previous contribution and adds the
+//! new one. That way modifiers running *before* `IdleSway` (e.g. a
+//! future head-pose source that sets an absolute target) are not
+//! silently clobbered, and modifiers running *after* (e.g.
+//! [`EmotionHead`](super::EmotionHead), which biases on top) see the
+//! already-swayed pose without `IdleSway` overwriting their work on the
+//! next tick.
 
 use super::Modifier;
 use crate::avatar::Avatar;
@@ -40,8 +44,13 @@ const DEFAULT_PAN_AMPLITUDE_DEG: f32 = 4.0;
 /// headroom on the tilt axis (pan servo sits under the tilt linkage).
 const DEFAULT_TILT_AMPLITUDE_DEG: f32 = 2.5;
 
-/// Modifier that drives `avatar.head_pose` with a slow, two-axis triangle
-/// sway. Stateless — the wave is purely a function of `now`.
+/// Modifier that contributes a slow, two-axis triangle sway to
+/// `avatar.head_pose`.
+///
+/// Composition is additive via diff-and-undo: each tick subtracts the
+/// previous contribution before adding the new one, so upstream pose
+/// writes survive and downstream modifiers can bias without the sway
+/// overwriting them on the next tick.
 #[derive(Debug, Clone, Copy)]
 pub struct IdleSway {
     /// Milliseconds per full pan sweep (left → right → left).
@@ -52,6 +61,12 @@ pub struct IdleSway {
     pan_amplitude_deg: f32,
     /// Peak tilt amplitude in degrees.
     tilt_amplitude_deg: f32,
+    /// Pan contribution applied on the previous tick; subtracted before
+    /// writing the new contribution. Starts at 0 so the first tick's
+    /// output equals the first triangle sample.
+    last_pan_deg: f32,
+    /// Tilt contribution applied on the previous tick.
+    last_tilt_deg: f32,
 }
 
 impl IdleSway {
@@ -63,6 +78,8 @@ impl IdleSway {
             tilt_period_ms: DEFAULT_TILT_PERIOD_MS,
             pan_amplitude_deg: DEFAULT_PAN_AMPLITUDE_DEG,
             tilt_amplitude_deg: DEFAULT_TILT_AMPLITUDE_DEG,
+            last_pan_deg: 0.0,
+            last_tilt_deg: 0.0,
         }
     }
 
@@ -82,6 +99,8 @@ impl IdleSway {
             tilt_period_ms,
             pan_amplitude_deg,
             tilt_amplitude_deg,
+            last_pan_deg: 0.0,
+            last_tilt_deg: 0.0,
         }
     }
 
@@ -128,7 +147,18 @@ impl Modifier for IdleSway {
     fn update(&mut self, avatar: &mut Avatar, now: Instant) {
         let pan = Self::unit_triangle(self.pan_period_ms, now) * self.pan_amplitude_deg;
         let tilt = Self::unit_triangle(self.tilt_period_ms, now) * self.tilt_amplitude_deg;
-        avatar.head_pose = Pose::new(pan, tilt).clamped();
+        // Diff-and-undo: our contribution to the pose is (pan, tilt); to
+        // compose additively, remove the previous contribution first,
+        // then install the new one. `clamped` defers to the final
+        // compose step (typically EmotionHead) so we don't double-clamp
+        // during the intermediate state.
+        avatar.head_pose = Pose::new(
+            avatar.head_pose.pan_deg - self.last_pan_deg + pan,
+            avatar.head_pose.tilt_deg - self.last_tilt_deg + tilt,
+        )
+        .clamped();
+        self.last_pan_deg = pan;
+        self.last_tilt_deg = tilt;
     }
 }
 
@@ -245,6 +275,36 @@ mod tests {
                 delta <= max_pan_delta_per_step * 2.0,
                 "pan delta {delta}° between ticks exceeds bound"
             );
+        }
+    }
+
+    #[test]
+    fn sway_composes_additively_with_upstream_writes() {
+        // Regression for the diff-and-undo refactor: if some upstream
+        // modifier sets an absolute head_pose, IdleSway must bias it
+        // rather than clobber it. Across many ticks, the net upstream
+        // contribution must survive.
+        let mut sway = IdleSway::new();
+        let mut avatar = Avatar::default();
+        let upstream_pan = 1.5;
+        let upstream_tilt = -0.5;
+
+        for i in 0..100 {
+            // Simulate an upstream modifier writing an absolute target
+            // each tick.
+            avatar.head_pose = Pose::new(upstream_pan, upstream_tilt);
+            sway.update(&mut avatar, Instant::from_millis(i * 33));
+
+            // After IdleSway, the pose is the upstream target plus the
+            // sway contribution. The sway contribution magnitude is
+            // bounded by the configured amplitudes.
+            let sway_pan = avatar.head_pose.pan_deg - upstream_pan;
+            let sway_tilt = avatar.head_pose.tilt_deg - upstream_tilt;
+            assert!(
+                sway_pan.abs() <= DEFAULT_PAN_AMPLITUDE_DEG + 0.01,
+                "sway contribution {sway_pan}° exceeds amplitude"
+            );
+            assert!(sway_tilt.abs() <= DEFAULT_TILT_AMPLITUDE_DEG + 0.01);
         }
     }
 

--- a/crates/stackchan-firmware/examples/bench.rs
+++ b/crates/stackchan-firmware/examples/bench.rs
@@ -27,10 +27,8 @@
 #![no_std]
 #![no_main]
 // Example binary inherits the same ESP-IDF app-descriptor requirement
-// as the main firmware, so the same app-desc anchor + unsafe allowance
-// is needed here. Otherwise `lto = "fat"` strips the descriptor and
-// espflash refuses to flash the image.
-#![allow(unsafe_code)]
+// as the main firmware; anchoring a `&'static` reference (rather than
+// a raw-pointer newtype) keeps the symbol live without needing `unsafe`.
 #![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
 // Single-core executor; `Send`-bounded futures aren't meaningful here.
 #![allow(clippy::future_not_send)]
@@ -49,19 +47,14 @@ defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
-/// `#[used]`-anchor newtype for `ESP_APP_DESC`. See `main.rs` for the
-/// full rationale — short version: `lto = "fat"` strips the
-/// bootloader-readable descriptor unless a `#[used]` static holds a
-/// reference to it.
-#[repr(transparent)]
-struct AppDescAnchor(*const esp_bootloader_esp_idf::EspAppDesc);
-// SAFETY: the raw pointer is never dereferenced at runtime; the
-// newtype only exists so `#[used]` on the static below holds a symbol
-// reference for the linker.
-unsafe impl Sync for AppDescAnchor {}
-/// LTO anchor preventing `ESP_APP_DESC` from being stripped.
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped. See
+/// `main.rs` for the full rationale — short version: `lto = "fat"`
+/// strips the bootloader-readable descriptor unless a `#[used]` static
+/// holds a reference to it. A `&'static` reference is auto-Sync (the
+/// pointee is plain POD) and avoids the raw-pointer newtype the
+/// workspace `unsafe_code = deny` rule would otherwise force.
 #[used]
-static APP_DESC_ANCHOR: AppDescAnchor = AppDescAnchor(core::ptr::addr_of!(ESP_APP_DESC));
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
 
 /// Panic handler for the bench binary. Halts the core; the trace has
 /// already been emitted via defmt before we arrive here.

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -121,6 +121,14 @@ impl<W: Write> ScsHead<W> {
     /// count back into degrees in the same reference frame the caller
     /// commanded. Used by the 1 Hz position poll.
     fn deg_for(position: u16, trim_deg: f32, direction: f32) -> f32 {
+        // `direction` is a ±1.0 const today; belt-and-suspenders check
+        // against a future refactor that makes it runtime-configurable,
+        // because a 0.0 would silently return ±inf here rather than an
+        // out-of-range Pose that later clamps cleanly.
+        debug_assert!(
+            direction.is_finite() && direction != 0.0,
+            "direction must be a non-zero finite sign; a 0.0 would make deg_for return ±inf"
+        );
         let offset = f32::from(position) - f32::from(POSITION_CENTER);
         let effective = offset / POSITION_PER_DEGREE;
         // Inverse direction + trim from `position_for`.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -169,7 +169,8 @@ async fn render_task(mut display: LcdDisplay) {
     // Fixed seed keeps boot-to-boot drifts identical; a future RNG-backed
     // source (e.g. reading a voltage-derived seed from the AXP2101) can
     // swap in without touching the task shape.
-    let mut drift = IdleDrift::with_seed(0xDEAD_BEEF);
+    let mut drift =
+        IdleDrift::with_seed(const { core::num::NonZeroU32::new(0xDEAD_BEEF).unwrap() });
     let mut sway = IdleSway::new();
     let mut emotion_head = EmotionHead::new();
     let mut last_rendered: Option<Avatar> = None;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -21,11 +21,6 @@
 // esp-rtos runs a single-core executor on this chip; `Send`-bounded
 // futures aren't meaningful here. The nursery lint fires on every task.
 #![allow(clippy::future_not_send)]
-// Firmware needs unsafe for one narrow reason: a `Sync` promise on a
-// raw-pointer newtype used as an LTO anchor for the ESP-IDF app
-// descriptor. No pointer dereference happens here. The workspace-wide
-// `unsafe_code = deny` rule still applies to the host crates.
-#![allow(unsafe_code)]
 
 extern crate alloc;
 
@@ -79,22 +74,15 @@ defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
 // fixed offset; the macro emits one in a dedicated linker section.
 esp_bootloader_esp_idf::esp_app_desc!();
 
-/// `#[used]`-anchor newtype for `ESP_APP_DESC`.
+/// LTO anchor for `ESP_APP_DESC`.
 ///
 /// The macro above emits `pub static ESP_APP_DESC` without `#[used]`, so
-/// `lto = "fat"` strips it and espflash refuses the image. Anchoring its
-/// address in a `#[used]` static keeps it in `.rodata_desc.appdesc`.
-/// Raw pointers aren't `Sync` by default; wrap in a newtype and promise
-/// the invariant ourselves — the address is never read through this.
-#[repr(transparent)]
-struct AppDescAnchor(*const esp_bootloader_esp_idf::EspAppDesc);
-// SAFETY: the anchor is never dereferenced; its only purpose is to hold
-// a symbol reference so LTO cannot discard ESP_APP_DESC.
-unsafe impl Sync for AppDescAnchor {}
-/// LTO anchor for `ESP_APP_DESC`. Never read; presence alone prevents
-/// fat-LTO from stripping the app descriptor.
+/// `lto = "fat"` strips it and espflash refuses the image. Anchoring a
+/// `&'static` reference in a `#[used]` static keeps the symbol live in
+/// `.rodata_desc.appdesc` without any raw pointer or `unsafe impl Sync`
+/// (`EspAppDesc` is plain POD, so the reference is auto-Sync).
 #[used]
-static _APP_DESC_ANCHOR: AppDescAnchor = AppDescAnchor(core::ptr::addr_of!(ESP_APP_DESC));
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
 
 /// Panic handler. Halts the core; esp-rtos emits the trace over RTT
 /// before we arrive here (via `--catch-hardfault` on the probe-rs side).

--- a/crates/stackchan-sim/src/lib.rs
+++ b/crates/stackchan-sim/src/lib.rs
@@ -202,6 +202,10 @@ impl HeadDriver for RecordingHead {
     clippy::field_reassign_with_default,
     reason = "test setup reads better as `let mut a = Avatar::default(); a.emotion = …;` than the struct-update equivalent"
 )]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test literals are compile-time non-zero; the unwrap can't fire"
+)]
 mod integration_tests {
     use super::*;
     use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, EmotionStyle, IdleDrift};
@@ -216,7 +220,7 @@ mod integration_tests {
         let mut avatar = Avatar::default();
         let mut blink = Blink::new();
         let mut breath = Breath::new();
-        let mut drift = IdleDrift::with_seed(0xDEAD_BEEF);
+        let mut drift = IdleDrift::with_seed(core::num::NonZeroU32::new(0xDEAD_BEEF).unwrap());
 
         let tick_ms = 33; // ~30 FPS
         let total_ticks = 60_000 / tick_ms;
@@ -287,7 +291,7 @@ mod integration_tests {
         let mut style = EmotionStyle::new();
         let mut blink = Blink::new();
         let mut breath = Breath::new();
-        let mut drift = IdleDrift::with_seed(0xDEAD_BEEF);
+        let mut drift = IdleDrift::with_seed(core::num::NonZeroU32::new(0xDEAD_BEEF).unwrap());
 
         // `EmotionCycle::DEFAULT_SEQUENCE` dwell = 4 s × 5 emotions = 20 s.
         // Plus a healthy margin so the last emotion's transition window


### PR DESCRIPTION
## Summary

Third PR in the audit pass. Drops the three near-identical clamp helpers in `emotion_style::blend` down to one bound-parameterised `clamp_to_u8(v, min, max)` — the only reason there were three was that each captured different bounds in its name. Inlining the bounds at the call sites makes the `0..=100` weight range visible to the reader rather than hidden behind a helper name.

The i8-typed mirror stays as its own fn because its target type differs; sharing that one was never an option.

## Test plan
- [x] `cargo test --workspace --exclude stackchan-firmware --all-features` — all tests pass.
- [x] `cargo fmt --check --all`
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy passes (no firmware changes).
- [ ] Device smoke test: no behaviour change expected — this is a pure refactor.

## Audit pass — wrap-up

With this merged, the four-PR audit pass lands at:

- **#12 (merged)** — gap fixes: docs refresh, CI/justfile, scservo boundary validation, driver tests, ordering test.
- **#13 (merged)** — quality fixes: Blink state-machine rework, head pose diff-and-undo, NonZeroU32 seed, unsafe removal.
- **#14 (this PR)** — simplification: clamp helper dedup.

The remaining discovery-agent findings are polish-level (naming nits, doc wording) or defer to future work (battery/charging support in axp2101, runtime-configurable servo directions). Shipping the pass here; happy to open a follow-up if any item bites.