### PR TITLE
feat: FT6336U tap-to-cycle emotion + shared I²C0 bus

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,6 +3,7 @@
   "crates/stackchan-sim": "0.2.0",
   "crates/axp2101": "0.1.0",
   "crates/aw9523": "0.2.0",
+  "crates/ft6336u": "0.1.0",
   "crates/scservo": "0.2.0",
   "crates/stackchan-firmware": "0.2.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
 dependencies = [
+ "defmt 1.0.1",
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-sync 0.7.2",
@@ -944,6 +945,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "ft6336u"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal-async",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1460,7 @@ dependencies = [
  "axp2101",
  "critical-section",
  "defmt 1.0.1",
+ "embassy-embedded-hal",
  "embassy-executor",
  "embassy-sync 0.7.2",
  "embassy-time",
@@ -1465,6 +1474,7 @@ dependencies = [
  "esp-hal",
  "esp-println",
  "esp-rtos",
+ "ft6336u",
  "mipidsi",
  "scservo",
  "stackchan-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/stackchan-sim",
     "crates/axp2101",
     "crates/aw9523",
+    "crates/ft6336u",
     "crates/scservo",
     "crates/stackchan-firmware",
 ]
@@ -13,6 +14,7 @@ default-members = [
     "crates/stackchan-sim",
     "crates/axp2101",
     "crates/aw9523",
+    "crates/ft6336u",
     "crates/scservo",
 ]
 

--- a/crates/ft6336u/Cargo.toml
+++ b/crates/ft6336u/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ft6336u"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Minimal async driver for the FocalTech FT6336U capacitive touch controller. Single-touch point reads over I²C; used on the M5Stack CoreS3 behind the ILI9342C LCD."
+
+[lints]
+workspace = true
+
+[dependencies]
+embedded-hal-async = { workspace = true }

--- a/crates/ft6336u/src/lib.rs
+++ b/crates/ft6336u/src/lib.rs
@@ -1,0 +1,288 @@
+//! # ft6336u
+//!
+//! `no_std` async driver for the `FocalTech` FT6336U capacitive touch
+//! controller. Supports the single-touch subset of the chip's
+//! functionality — one `read_touch()` returns the current finger
+//! count + first touch coordinates. Multi-touch, native gesture
+//! registers, and power-saving modes are intentionally out of scope
+//! for the MVP; they can be added in place without changing the
+//! `Ft6336u` type surface.
+//!
+//! The driver is generic over any [`embedded_hal_async::i2c::I2c`] so
+//! it plugs into either a directly-owned bus or a shared-bus wrapper
+//! (e.g. `embassy-embedded-hal`'s `I2cDevice`).
+//!
+//! ## CoreS3 wiring
+//!
+//! The FT6336U sits on the internal I²C0 (SCL = GPIO11, SDA = GPIO12)
+//! at address [`CORES3_ADDRESS`]. Reset is handled by the AW9523 IO
+//! expander as part of the LCD bring-up, so this driver assumes the
+//! chip is already out of reset by the time [`Ft6336u::new`] runs.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # use embedded_hal_async::i2c::I2c;
+//! # async fn demo<B: I2c>(bus: B) -> Result<(), ft6336u::Error<B::Error>> {
+//! let mut touch = ft6336u::Ft6336u::new(bus);
+//! let vendor = touch.read_vendor_id().await?;
+//! assert_eq!(vendor, ft6336u::VENDOR_ID_FOCALTECH);
+//!
+//! if let Some(report) = touch.read_touch().await?.point() {
+//!     let (x, y) = report;
+//!     // ... do something with the touch position ...
+//!     let _ = (x, y);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+#![no_std]
+#![deny(unsafe_code)]
+
+use embedded_hal_async::i2c::I2c;
+
+/// 7-bit I²C address of the FT6336U on CoreS3.
+pub const CORES3_ADDRESS: u8 = 0x38;
+
+/// Vendor ID value read back from register `0xA8` for genuine
+/// `FocalTech` FT6336 family parts. Used as a cheap presence / identity
+/// check at boot.
+pub const VENDOR_ID_FOCALTECH: u8 = 0x11;
+
+/// Device operating mode register. Reset value: `0x00`
+/// (interrupt-on-change mode). Not written by this driver; included so
+/// a single bulk read from `REG_G_MODE` covers the status + first
+/// touch-point in one transaction.
+const REG_G_MODE: u8 = 0x00;
+
+/// Vendor-ID register. Reads back [`VENDOR_ID_FOCALTECH`] on genuine
+/// parts.
+const REG_VENDOR_ID: u8 = 0xA8;
+
+/// Width of the bulk touch-status read in bytes:
+///
+/// | Offset | Register    | Contents                              |
+/// |--------|-------------|---------------------------------------|
+/// | 0      | `G_MODE`    | Operating mode (unused here)          |
+/// | 1      | `GESTURE`   | HW-detected gesture code (unused)     |
+/// | 2      | `TD_STATUS` | Low nibble = touch count              |
+/// | 3      | `P1_XH`     | `[7:6]` event flag, `[3:0]` x\[11:8\] |
+/// | 4      | `P1_XL`     | x\[7:0\]                              |
+/// | 5      | `P1_YH`     | `[7:4]` touch id, `[3:0]` y\[11:8\]   |
+/// | 6      | `P1_YL`     | y\[7:0\]                              |
+const TOUCH_READ_LEN: usize = 7;
+
+/// Offset of `TD_STATUS` inside the [`TOUCH_READ_LEN`]-byte window.
+const OFFSET_TD_STATUS: usize = 2;
+/// Offset of `P1_XH` (first touch point, high nibble of X).
+const OFFSET_P1_XH: usize = 3;
+/// Offset of `P1_XL` (first touch point, low byte of X).
+const OFFSET_P1_XL: usize = 4;
+/// Offset of `P1_YH` (first touch point, high nibble of Y).
+const OFFSET_P1_YH: usize = 5;
+/// Offset of `P1_YL` (first touch point, low byte of Y).
+const OFFSET_P1_YL: usize = 6;
+
+/// Mask used to extract the 12-bit X / Y coordinate's high nibble from
+/// `P1_XH` / `P1_YH`. The top two bits of `P1_XH` carry the event flag
+/// and the top nibble of `P1_YH` carries the touch ID; both are
+/// ignored in the MVP.
+const COORD_HIGH_MASK: u8 = 0x0F;
+
+/// Mask used to extract the touch-point count from `TD_STATUS`.
+const TD_STATUS_COUNT_MASK: u8 = 0x0F;
+
+/// Driver error type.
+///
+/// Single variant today; kept as a `non_exhaustive` enum so future
+/// additions (e.g. a dedicated `ChipIdMismatch` variant) won't be
+/// breaking.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error<E> {
+    /// Transport error from the underlying I²C bus.
+    I2c(E),
+}
+
+impl<E> From<E> for Error<E> {
+    fn from(e: E) -> Self {
+        Self::I2c(e)
+    }
+}
+
+/// One decoded FT6336U touch status snapshot.
+///
+/// The datasheet reports 0, 1, or 2 simultaneous fingers in the low
+/// nibble of `TD_STATUS`. This driver only exposes the first point;
+/// `fingers` is still reported verbatim so callers can distinguish
+/// "one finger" from "two fingers" without us needing to grow the
+/// API surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TouchReport {
+    /// Number of fingers currently in contact with the panel
+    /// (0..=2 on FT6336U).
+    pub fingers: u8,
+    /// Coordinates of the first touch point, or `None` if no fingers
+    /// are down. X/Y are in the panel's native 12-bit coordinate
+    /// space; depending on panel orientation, callers may need to
+    /// swap or invert axes to match the framebuffer.
+    pub first: Option<(u16, u16)>,
+}
+
+impl TouchReport {
+    /// Convenience: `true` iff one or more fingers are currently down.
+    #[must_use]
+    pub const fn is_touched(&self) -> bool {
+        self.fingers > 0
+    }
+
+    /// Coordinates of the first touch point, if any. Equivalent to
+    /// [`TouchReport::first`] — named for ergonomics at call sites.
+    #[must_use]
+    pub const fn point(&self) -> Option<(u16, u16)> {
+        self.first
+    }
+}
+
+/// FT6336U driver.
+///
+/// Generic over any async I²C bus that implements
+/// [`embedded_hal_async::i2c::I2c`]. Does not cache any state — every
+/// call hits the bus, so the chip's internal timing (polling rate
+/// ≤ 60 Hz for controller-limited reasons) is the only thing bounding
+/// caller cadence.
+pub struct Ft6336u<B> {
+    /// The I²C bus the chip is addressed on.
+    bus: B,
+}
+
+impl<B: I2c> Ft6336u<B> {
+    /// Wrap an I²C bus already configured for the FT6336U's 400 kHz
+    /// max rate (100 kHz is also fine, as the driver does nothing
+    /// rate-sensitive).
+    #[must_use]
+    pub const fn new(bus: B) -> Self {
+        Self { bus }
+    }
+
+    /// Read the vendor-ID register. Returns [`VENDOR_ID_FOCALTECH`]
+    /// (`0x11`) on genuine FT6336 family parts. Useful as a presence
+    /// check at boot.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error encountered during the register
+    /// read.
+    pub async fn read_vendor_id(&mut self) -> Result<u8, Error<B::Error>> {
+        let mut buf = [0u8];
+        self.bus
+            .write_read(CORES3_ADDRESS, &[REG_VENDOR_ID], &mut buf)
+            .await?;
+        Ok(buf[0])
+    }
+
+    /// Poll the touch-status registers and return a decoded snapshot.
+    ///
+    /// Always issues a single 7-byte read starting at register `0x00`
+    /// (`G_MODE`). Empty panels (zero fingers) still cost one
+    /// transaction — no short-circuit is possible without losing
+    /// touch-release detection.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error. A chip that returns all-ones
+    /// bytes (common failure mode for unpowered parts) decodes as
+    /// `fingers = 15`, which callers can filter as a sanity check if
+    /// desired.
+    pub async fn read_touch(&mut self) -> Result<TouchReport, Error<B::Error>> {
+        let mut buf = [0u8; TOUCH_READ_LEN];
+        self.bus
+            .write_read(CORES3_ADDRESS, &[REG_G_MODE], &mut buf)
+            .await?;
+        Ok(decode_touch(buf))
+    }
+
+    /// Drop the driver, returning the wrapped bus so the caller can
+    /// share it with another device (or explicitly release it).
+    #[must_use]
+    pub fn into_inner(self) -> B {
+        self.bus
+    }
+}
+
+/// Decode the 7-byte bulk read into a [`TouchReport`]. Separated so
+/// unit tests can exercise the bit-twiddling without a real bus.
+///
+/// Takes the buffer by value: clippy prefers this for arrays ≤ 8 bytes
+/// since the copy is cheaper than indirecting through a reference.
+fn decode_touch(buf: [u8; TOUCH_READ_LEN]) -> TouchReport {
+    let fingers = buf[OFFSET_TD_STATUS] & TD_STATUS_COUNT_MASK;
+    let first = if fingers == 0 {
+        None
+    } else {
+        let xh = u16::from(buf[OFFSET_P1_XH] & COORD_HIGH_MASK);
+        let xl = u16::from(buf[OFFSET_P1_XL]);
+        let yh = u16::from(buf[OFFSET_P1_YH] & COORD_HIGH_MASK);
+        let yl = u16::from(buf[OFFSET_P1_YL]);
+        Some(((xh << 8) | xl, (yh << 8) | yl))
+    };
+    TouchReport { fingers, first }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_touch_decodes_to_empty_report() {
+        let buf = [0u8; TOUCH_READ_LEN];
+        let report = decode_touch(buf);
+        assert_eq!(report.fingers, 0);
+        assert!(report.first.is_none());
+        assert!(!report.is_touched());
+    }
+
+    #[test]
+    fn single_touch_decodes_coordinates() {
+        // One finger at (0x123, 0x045). Event flag bits in P1_XH and
+        // touch-id bits in P1_YH are set to nonzero to prove the
+        // masks strip them.
+        let mut buf = [0u8; TOUCH_READ_LEN];
+        buf[OFFSET_TD_STATUS] = 0x01;
+        buf[OFFSET_P1_XH] = 0b1100_0001; // event=11, x_high=0x1
+        buf[OFFSET_P1_XL] = 0x23;
+        buf[OFFSET_P1_YH] = 0b0101_0000; // touch_id=0x5, y_high=0x0
+        buf[OFFSET_P1_YL] = 0x45;
+        let report = decode_touch(buf);
+        assert_eq!(report.fingers, 1);
+        assert_eq!(report.first, Some((0x0123, 0x0045)));
+        assert!(report.is_touched());
+    }
+
+    #[test]
+    fn two_fingers_report_count_but_only_first_coords() {
+        let mut buf = [0u8; TOUCH_READ_LEN];
+        buf[OFFSET_TD_STATUS] = 0x02;
+        buf[OFFSET_P1_XH] = 0x00;
+        buf[OFFSET_P1_XL] = 0x10;
+        buf[OFFSET_P1_YH] = 0x00;
+        buf[OFFSET_P1_YL] = 0x20;
+        let report = decode_touch(buf);
+        assert_eq!(report.fingers, 2);
+        assert_eq!(report.first, Some((0x0010, 0x0020)));
+    }
+
+    #[test]
+    fn td_status_high_nibble_is_ignored() {
+        let mut buf = [0u8; TOUCH_READ_LEN];
+        // Datasheet leaves high nibble reserved; don't misread a
+        // reserved bit as "many fingers."
+        buf[OFFSET_TD_STATUS] = 0xF1;
+        buf[OFFSET_P1_XL] = 0x05;
+        buf[OFFSET_P1_YL] = 0x07;
+        let report = decode_touch(buf);
+        assert_eq!(report.fingers, 1);
+        assert_eq!(report.first, Some((0x0005, 0x0007)));
+    }
+}

--- a/crates/stackchan-core/src/avatar.rs
+++ b/crates/stackchan-core/src/avatar.rs
@@ -21,7 +21,15 @@
 //! on hardware, the LCD moves with the head, so the face stays centered
 //! on screen. Use [`Avatar::frame_eq`] (not `==`) for render-loop dirty
 //! checks so pose updates don't force redundant LCD blits.
+//!
+//! ## Input / autonomy fields
+//!
+//! `manual_until` is a deadline: while `Some(t)` and the clock is below
+//! `t`, autonomous drivers like `EmotionCycle` stand down so the user's
+//! explicit input (e.g. a touch-triggered emotion via `EmotionTouch`)
+//! sticks. `EmotionTouch::update` clears the field when it expires.
 
+use crate::clock::Instant;
 use crate::emotion::Emotion;
 use crate::head::Pose;
 
@@ -168,6 +176,15 @@ pub struct Avatar {
     /// this to point the eyes toward the direction the head is
     /// *actually* facing, decoupled from the command pipeline.
     pub head_pose_actual: Pose,
+    /// Deadline until which autonomous emotion drivers should defer to
+    /// explicit user input. `None` = autonomy active (default). `Some(t)`
+    /// = a user interaction has pinned the current emotion until `t`;
+    /// [`super::modifiers::EmotionCycle`] skips advancement while the
+    /// deadline is in the future, and
+    /// [`super::modifiers::EmotionTouch`] clears the field once it
+    /// expires. Excluded from [`Avatar::frame_eq`] — this field only
+    /// gates modifier behaviour, not pixels.
+    pub manual_until: Option<Instant>,
 }
 
 impl Avatar {
@@ -235,6 +252,7 @@ impl Default for Avatar {
             breath_depth_scale: SCALE_DEFAULT,
             head_pose: Pose::NEUTRAL,
             head_pose_actual: Pose::NEUTRAL,
+            manual_until: None,
         }
     }
 }
@@ -282,6 +300,27 @@ mod tests {
 
         eye.weight = 0;
         assert_eq!(eye.height(), 0);
+    }
+
+    #[test]
+    fn default_has_no_manual_override() {
+        let a = Avatar::default();
+        assert!(
+            a.manual_until.is_none(),
+            "boot defaults must leave autonomy active"
+        );
+    }
+
+    #[test]
+    fn frame_eq_ignores_manual_until() {
+        let a = Avatar::default();
+        let mut b = a;
+        b.manual_until = Some(Instant::from_millis(1_000));
+        assert!(
+            a.frame_eq(&b),
+            "manual_until is non-visual; frame_eq must skip it"
+        );
+        assert_ne!(a, b, "PartialEq still sees the difference");
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/emotion_cycle.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_cycle.rs
@@ -87,6 +87,17 @@ impl Modifier for EmotionCycle {
             return;
         }
 
+        // Manual-override active: user input (e.g. `EmotionTouch`) has
+        // pinned the emotion until a deadline. Re-anchor `started_at` so
+        // the cycle resumes cleanly when the hold expires instead of
+        // snap-advancing by however many dwell windows passed.
+        if let Some(until) = avatar.manual_until
+            && now < until
+        {
+            self.started_at = Some(now);
+            return;
+        }
+
         let Some(start) = self.started_at else {
             // First tick: anchor to now and apply index 0 immediately.
             self.started_at = Some(now);
@@ -184,6 +195,61 @@ mod tests {
         // Jump forward 2.5 s -- should land on index 2 (Sad), not index 1.
         cycle.update(&mut avatar, Instant::from_millis(2_500));
         assert_eq!(avatar.emotion, Emotion::Sad);
+    }
+
+    #[test]
+    fn manual_until_suppresses_advancement() {
+        let mut avatar = Avatar::default();
+        let mut cycle =
+            EmotionCycle::with_params(&[Emotion::Neutral, Emotion::Happy, Emotion::Sad], 1_000);
+
+        // Establish the baseline.
+        cycle.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+
+        // User taps at t=500: the touch modifier would set Happy + hold
+        // until t=30_500. Simulate that here.
+        avatar.emotion = Emotion::Happy;
+        avatar.manual_until = Some(Instant::from_millis(30_500));
+
+        // 29 s later (still inside the hold): EmotionCycle must NOT
+        // advance, and must not overwrite the manually-set emotion.
+        cycle.update(&mut avatar, Instant::from_millis(29_500));
+        assert_eq!(avatar.emotion, Emotion::Happy);
+    }
+
+    #[test]
+    fn cycle_resumes_cleanly_after_manual_hold() {
+        let mut avatar = Avatar::default();
+        let mut cycle =
+            EmotionCycle::with_params(&[Emotion::Neutral, Emotion::Happy, Emotion::Sad], 1_000);
+
+        cycle.update(&mut avatar, Instant::from_millis(0));
+
+        // Manual hold from t=500 to t=30_500.
+        avatar.emotion = Emotion::Happy;
+        avatar.manual_until = Some(Instant::from_millis(30_500));
+        cycle.update(&mut avatar, Instant::from_millis(15_000));
+        cycle.update(&mut avatar, Instant::from_millis(29_000));
+
+        // Hold expires; someone (EmotionTouch in real code) clears it.
+        avatar.manual_until = None;
+
+        // One dwell window after the hold ends the cycle advances by
+        // exactly one step — not by the 30 windows that passed while
+        // paused.
+        cycle.update(&mut avatar, Instant::from_millis(29_000 + 1_000));
+        assert_eq!(
+            avatar.emotion,
+            Emotion::Happy,
+            "first post-hold tick carries the user's emotion forward"
+        );
+        cycle.update(&mut avatar, Instant::from_millis(29_000 + 2_000));
+        assert_eq!(
+            avatar.emotion,
+            Emotion::Sad,
+            "second post-hold dwell advances by exactly one step"
+        );
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/emotion_touch.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_touch.rs
@@ -1,0 +1,239 @@
+//! `EmotionTouch`: advances `Avatar::emotion` on explicit user input
+//! and pins the chosen emotion for a configurable hold window.
+//!
+//! ## Coordination with `EmotionCycle`
+//!
+//! A "tap" (in the hardware sense: a FT6336U rising-edge) translates
+//! into a single [`EmotionTouch::tap`] call. The next [`Modifier::update`]
+//! tick then:
+//!
+//! 1. advances `Avatar::emotion` to the next variant in
+//!    [`EMOTION_ORDER`];
+//! 2. sets `Avatar::manual_until` to `now + MANUAL_HOLD_MS` (see
+//!    [`MANUAL_HOLD_MS`]) so [`super::EmotionCycle`] stands down;
+//! 3. clears an expired `manual_until` on any later tick, handing
+//!    autonomy back to `EmotionCycle`.
+//!
+//! The tap event itself is *not* stored with a timestamp — the modifier
+//! just remembers "a tap is pending." The hardware polling task can
+//! signal a tap at any time between render ticks; the avatar state only
+//! changes when the render loop picks it up on the next `update` call.
+//!
+//! ## Sim-testability
+//!
+//! Because `tap()` is an ordinary method (not a signal/channel), sim
+//! tests drive the modifier the same way firmware does: call `tap()`,
+//! then call `update(avatar, now)` and assert on the resulting
+//! `avatar.emotion` + `avatar.manual_until`.
+
+use super::Modifier;
+use crate::avatar::Avatar;
+use crate::clock::Instant;
+use crate::emotion::Emotion;
+
+/// How long a tap pins the chosen emotion, in milliseconds.
+///
+/// 30 s feels intentional without being permanent: long enough for the
+/// eased `EmotionStyle` transition to read visually + for the user to
+/// notice their tap stuck, short enough that Stack-chan resumes its
+/// autonomous cycle before it seems "frozen."
+pub const MANUAL_HOLD_MS: u64 = 30_000;
+
+/// Order in which [`EmotionTouch`] cycles through emotions on each tap.
+///
+/// Defined independently of [`super::EmotionCycle::DEFAULT_SEQUENCE`] so
+/// touch cycling can use a different ordering from autonomous cycling
+/// if a future tune-up wants it. Currently identical to the autonomy
+/// order for consistency.
+pub const EMOTION_ORDER: [Emotion; 5] = [
+    Emotion::Neutral,
+    Emotion::Happy,
+    Emotion::Sleepy,
+    Emotion::Surprised,
+    Emotion::Sad,
+];
+
+/// Modifier that advances `Avatar::emotion` on each queued tap and
+/// gates `EmotionCycle` by writing `Avatar::manual_until`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EmotionTouch {
+    /// `true` after [`Self::tap`] was called and before the next
+    /// `update` consumed it. The modifier is edge-triggered: a held
+    /// finger doesn't re-fire as long as the hardware task only
+    /// publishes rising edges.
+    pending_tap: bool,
+}
+
+impl EmotionTouch {
+    /// Construct a modifier with no pending tap and no in-flight hold.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { pending_tap: false }
+    }
+
+    /// Queue a tap to be applied on the next `update` tick. Idempotent
+    /// within a single render frame: multiple `tap()` calls between
+    /// consecutive `update`s collapse to a single emotion advance.
+    pub const fn tap(&mut self) {
+        self.pending_tap = true;
+    }
+}
+
+/// Next emotion in the touch-cycle order.
+///
+/// Pattern-matches on every [`Emotion`] variant explicitly. `Emotion`
+/// is `#[non_exhaustive]`, but within the defining crate exhaustiveness
+/// is still enforced, so adding a new variant produces a compile
+/// error here — a deliberate hint to slot the new variant into the
+/// cycle.
+const fn next_emotion(current: Emotion) -> Emotion {
+    match current {
+        Emotion::Neutral => Emotion::Happy,
+        Emotion::Happy => Emotion::Sleepy,
+        Emotion::Sleepy => Emotion::Surprised,
+        Emotion::Surprised => Emotion::Sad,
+        Emotion::Sad => Emotion::Neutral,
+    }
+}
+
+impl Modifier for EmotionTouch {
+    fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        if self.pending_tap {
+            self.pending_tap = false;
+            avatar.emotion = next_emotion(avatar.emotion);
+            avatar.manual_until = Some(now + MANUAL_HOLD_MS);
+            return;
+        }
+
+        // Clear an expired hold so autonomous drivers know the user's
+        // done. Running *every* tick (not just on taps) ensures the
+        // handoff happens even if no new touch events arrive.
+        if let Some(until) = avatar.manual_until
+            && now >= until
+        {
+            avatar.manual_until = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_tap_advances_emotion_and_sets_hold() {
+        let mut avatar = Avatar::default();
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+
+        let mut touch = EmotionTouch::new();
+        touch.tap();
+        touch.update(&mut avatar, Instant::from_millis(1_000));
+
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(1_000 + MANUAL_HOLD_MS)),
+        );
+    }
+
+    #[test]
+    fn repeated_taps_cycle_through_order() {
+        let mut avatar = Avatar::default();
+        let mut touch = EmotionTouch::new();
+
+        for (i, expected) in [
+            Emotion::Happy,
+            Emotion::Sleepy,
+            Emotion::Surprised,
+            Emotion::Sad,
+            Emotion::Neutral,
+            Emotion::Happy,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            touch.tap();
+            touch.update(&mut avatar, Instant::from_millis((i as u64) * 10));
+            assert_eq!(avatar.emotion, expected, "step {i}");
+        }
+    }
+
+    #[test]
+    fn update_without_tap_is_a_noop_on_emotion() {
+        let mut avatar = Avatar {
+            emotion: Emotion::Happy,
+            ..Avatar::default()
+        };
+        let mut touch = EmotionTouch::new();
+
+        for step in 0..10 {
+            touch.update(&mut avatar, Instant::from_millis(step * 100));
+        }
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn held_finger_does_not_re_fire() {
+        // The firmware task only publishes rising-edge taps, so from
+        // EmotionTouch's perspective a held finger is just one tap.
+        let mut avatar = Avatar::default();
+        let mut touch = EmotionTouch::new();
+
+        touch.tap();
+        touch.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(avatar.emotion, Emotion::Happy);
+
+        // Simulate 500 ms of ticks without another tap signal — emotion
+        // must stay pinned.
+        for step in 1..=30 {
+            touch.update(&mut avatar, Instant::from_millis(step * 16));
+        }
+        assert_eq!(avatar.emotion, Emotion::Happy);
+    }
+
+    #[test]
+    fn expired_hold_is_cleared() {
+        let mut avatar = Avatar::default();
+        let mut touch = EmotionTouch::new();
+
+        touch.tap();
+        touch.update(&mut avatar, Instant::from_millis(1_000));
+        let hold_ends = 1_000 + MANUAL_HOLD_MS;
+        assert_eq!(avatar.manual_until, Some(Instant::from_millis(hold_ends)));
+
+        // Still inside the hold window.
+        touch.update(&mut avatar, Instant::from_millis(hold_ends - 1));
+        assert!(avatar.manual_until.is_some(), "hold must still be active");
+
+        // At the deadline.
+        touch.update(&mut avatar, Instant::from_millis(hold_ends));
+        assert!(
+            avatar.manual_until.is_none(),
+            "hold ends exactly at `now >= until`",
+        );
+    }
+
+    #[test]
+    fn tap_during_active_hold_extends_it() {
+        let mut avatar = Avatar::default();
+        let mut touch = EmotionTouch::new();
+
+        touch.tap();
+        touch.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(MANUAL_HOLD_MS))
+        );
+
+        // Second tap 5 s later: emotion advances again and the hold
+        // deadline moves forward to 5_000 + MANUAL_HOLD_MS.
+        touch.tap();
+        touch.update(&mut avatar, Instant::from_millis(5_000));
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(5_000 + MANUAL_HOLD_MS)),
+        );
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -6,18 +6,23 @@
 //!
 //! The canonical stack, outermost-first, is:
 //!
-//! 1. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`.
-//! 2. [`EmotionStyle`] — translates emotion into style fields, with a
+//! 1. [`EmotionTouch`] — consumes queued taps, advances
+//!    `Avatar::emotion`, and writes `Avatar::manual_until`. Runs first
+//!    so the same tick that produced the tap also clears any expired
+//!    override before `EmotionCycle` checks it.
+//! 2. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
+//!    when `manual_until` is unset or expired.
+//! 3. [`EmotionStyle`] — translates emotion into style fields, with a
 //!    linear ease over the transition window.
-//! 3. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
+//! 4. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
 //!    `blink_rate_scale` from the avatar.
-//! 4. [`Breath`] — vertical drift on all features, scaled by
+//! 5. [`Breath`] — vertical drift on all features, scaled by
 //!    `breath_depth_scale`.
-//! 5. [`IdleDrift`] — occasional eye-center jitter.
-//! 6. [`IdleSway`] — slow pan/tilt head wander written to
+//! 6. [`IdleDrift`] — occasional eye-center jitter.
+//! 7. [`IdleSway`] — slow pan/tilt head wander written to
 //!    `Avatar::head_pose`. Non-visual; drives the firmware's head-update
 //!    task, not the pixel pipeline.
-//! 7. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
+//! 8. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
 //!    sway. Runs **after** `IdleSway` so bias composes additively rather
 //!    than fighting for absolute control of the pose.
 //!
@@ -28,6 +33,7 @@ mod breath;
 mod emotion_cycle;
 mod emotion_head;
 mod emotion_style;
+mod emotion_touch;
 mod idle_drift;
 mod idle_sway;
 
@@ -36,6 +42,7 @@ pub use breath::Breath;
 pub use emotion_cycle::EmotionCycle;
 pub use emotion_head::EmotionHead;
 pub use emotion_style::EmotionStyle;
+pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 stackchan-core = { path = "../stackchan-core" }
 axp2101 = { path = "../axp2101" }
 aw9523 = { path = "../aw9523" }
+ft6336u = { path = "../ft6336u" }
 scservo = { path = "../scservo" }
 embedded-graphics = { workspace = true }
 embedded-hal = { workspace = true }
@@ -47,6 +48,15 @@ embassy-time = { version = "0.5.0", features = ["defmt"] }
 # task. 0.7 matches the embassy-executor 0.9 / embassy-time 0.5 triple
 # per the embassy-sync release matrix.
 embassy-sync = { version = "0.7", features = ["defmt"] }
+# `embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice` wraps an
+# `embassy-sync` `Mutex<NoopRawMutex, I2c>` so multiple tasks (touch,
+# future RTC / IMU) can all hold `embedded-hal-async` I²C handles onto
+# the single internal I²C0 bus without stepping on each other. Pinned
+# to 0.5 to share the version esp-hal 1.0 already pulls transitively
+# (on embassy-sync 0.7); 0.6 would drag in a second embassy-sync 0.8,
+# and our `NoopRawMutex` would then resolve to the 0.7 type the 0.6
+# crate can't consume.
+embassy-embedded-hal = { version = "0.5", features = ["defmt"] }
 
 defmt = "1.0.1"
 # Log transport: defmt-encoded bytes over the ESP32-S3 USB-Serial-JTAG
@@ -74,3 +84,7 @@ path = "src/main.rs"
 [[example]]
 name = "bench"
 path = "examples/bench.rs"
+
+[[example]]
+name = "touch_bench"
+path = "examples/touch_bench.rs"

--- a/crates/stackchan-firmware/examples/bench.rs
+++ b/crates/stackchan-firmware/examples/bench.rs
@@ -106,7 +106,8 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
         peripherals.GPIO7,
         &mut delay,
     )
-    .await;
+    .await
+    .head;
 
     // Pan sweep: -30 .. +30 in 10° steps.
     for cmd in [-30.0_f32, -20.0, -10.0, 0.0, 10.0, 20.0, 30.0] {

--- a/crates/stackchan-firmware/examples/touch_bench.rs
+++ b/crates/stackchan-firmware/examples/touch_bench.rs
@@ -1,0 +1,152 @@
+//! Touch-controller bench.
+//!
+//! Standalone firmware binary that brings up only the pieces of the
+//! CoreS3 needed to reach the FT6336U — AXP2101 → AW9523 → shared
+//! I²C0 — and then enters a tight polling loop logging each touch
+//! report via defmt. Intentionally skips the LCD init (no `mipidsi`)
+//! so the bench binary is small and fast to flash.
+//!
+//! Output per touch tick:
+//!
+//! ```text
+//! touch-bench: fingers=1 x=134 y=98
+//! ```
+//!
+//! `fingers=0` ticks are suppressed — the log would drown otherwise —
+//! but the *first* no-touch tick after a release is logged so you can
+//! see the release edge. A bus error is logged once per occurrence.
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Ticker};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use ft6336u::{Ft6336u, VENDOR_ID_FOCALTECH};
+use stackchan_firmware::board;
+
+// esp-println registers the global defmt logger via USB-Serial-JTAG.
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped. See
+/// `main.rs` for the full rationale — short version: `lto = "fat"`
+/// strips the bootloader-readable descriptor unless a `#[used]` static
+/// holds a reference to it. A `&'static` reference is auto-Sync (the
+/// pointee is plain POD) and avoids the raw-pointer newtype the
+/// workspace `unsafe_code = deny` rule would otherwise force.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+/// Panic handler for the bench binary. Halts the core; the trace has
+/// already been emitted via defmt before we arrive here.
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("touch-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Smaller heap than main (no framebuffer). 32 KiB comfortably covers
+/// the embassy task arena + defmt buffers.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Poll cadence. 60 Hz matches the FT6336U's native sample rate —
+/// reading faster returns duplicates of the same internal sample.
+const POLL_PERIOD_MS: u64 = 16;
+
+/// Main entry. Runs the shared CoreS3 bringup (servos + shared I²C),
+/// constructs a `Ft6336u`, reads the vendor ID once, then polls
+/// forever.
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "the esp_rtos::main macro requires the `spawner` arg; touch-bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-touch-bench v{} — CoreS3 boot, will poll FT6336U over I²C0",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let mut touch = Ft6336u::new(board_io.i2c);
+
+    match touch.read_vendor_id().await {
+        Ok(id) if id == VENDOR_ID_FOCALTECH => {
+            defmt::info!("FT6336U: vendor ID 0x{=u8:02X} (FocalTech, expected)", id);
+        }
+        Ok(id) => defmt::warn!(
+            "FT6336U: unexpected vendor ID 0x{=u8:02X} (expected 0x{=u8:02X})",
+            id,
+            VENDOR_ID_FOCALTECH,
+        ),
+        Err(e) => defmt::error!(
+            "FT6336U: vendor-ID read failed — touch-bench will still poll, but chip may be absent: {}",
+            defmt::Debug2Format(&e),
+        ),
+    }
+
+    defmt::info!(
+        "touch-bench: polling @ {=u64} ms tick — touch the screen to stream reports",
+        POLL_PERIOD_MS
+    );
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    let mut was_touched = false;
+    loop {
+        match touch.read_touch().await {
+            Ok(report) => {
+                if report.is_touched() {
+                    if let Some((x, y)) = report.first {
+                        defmt::info!(
+                            "touch-bench: fingers={=u8} x={=u16} y={=u16}",
+                            report.fingers,
+                            x,
+                            y,
+                        );
+                    } else {
+                        defmt::warn!(
+                            "touch-bench: fingers={=u8} but no first-point data",
+                            report.fingers,
+                        );
+                    }
+                    was_touched = true;
+                } else if was_touched {
+                    // First idle tick after a release — useful to
+                    // confirm we're seeing release edges too.
+                    defmt::info!("touch-bench: release");
+                    was_touched = false;
+                }
+            }
+            Err(e) => defmt::warn!(
+                "touch-bench: read_touch failed: {}",
+                defmt::Debug2Format(&e)
+            ),
+        }
+        ticker.next().await;
+    }
+}

--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -1,5 +1,5 @@
 //! CoreS3 board bring-up — power + servo bus init shared between the
-//! main firmware binary and `examples/bench.rs`.
+//! main firmware binary and the `examples/` binaries.
 //!
 //! [`bringup`] owns the full sequence:
 //!
@@ -9,11 +9,13 @@
 //! 3. `SCServo::ping` each configured servo ID, log presence.
 //! 4. Run the boot-nod gesture so the head visibly exercises both
 //!    axes before the main control pipeline takes over.
+//! 5. Park the I²C0 bus in a shared-bus wrapper so post-boot consumers
+//!    (touch, future RTC / IMU) can hold handles to it concurrently.
 //!
-//! The function returns the fully-initialised [`HeadDriverImpl`] ready
-//! to be handed to the firmware's head task (or driven directly in the
-//! bench example). It does **not** touch the LCD peripherals — that
-//! stays in the caller so the bench binary can skip it.
+//! The function returns a [`BoardIo`] with both the fully-initialised
+//! [`HeadDriverImpl`] **and** a [`SharedI2c`] handle on the internal
+//! bus. It does **not** touch the LCD peripherals — that stays in the
+//! caller so the bench examples can skip the SPI init.
 //!
 //! ## Philosophy
 //!
@@ -23,6 +25,8 @@
 //! that panics on failure is AXP2101 init, and only because no
 //! forward progress is possible without the LDOs.
 
+use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 use embassy_time::{Delay, Duration, Timer};
 use esp_hal::{
     i2c::master::{Config as I2cConfig, I2c},
@@ -32,6 +36,7 @@ use esp_hal::{
 };
 use scservo::Scservo;
 use stackchan_core::{Clock, HeadDriver, Pose};
+use static_cell::StaticCell;
 
 use crate::clock::HalClock;
 use crate::head;
@@ -40,6 +45,41 @@ use crate::head;
 /// `#[embassy_executor::task]` (which forbids generic tasks) can accept
 /// it as an argument.
 pub type HeadDriverImpl = head::ScsHead<Uart<'static, esp_hal::Async>>;
+
+/// Internal I²C0 bus wrapped in an async [`Mutex`].
+///
+/// Consumers never name this directly; they hold [`SharedI2c`] handles
+/// instead. The `NoopRawMutex` is correct here because the esp-rtos
+/// executor on this chip is single-threaded — cross-core / cross-
+/// executor safety is not meaningful.
+pub type SharedI2cBus = Mutex<NoopRawMutex, I2c<'static, esp_hal::Async>>;
+
+/// Cloneable handle onto [`SharedI2cBus`].
+///
+/// Every I²C consumer (touch task, future RTC / IMU tasks) receives
+/// its own `SharedI2c` and uses it exactly like a directly-owned bus:
+/// the [`I2cDevice`] wrapper transparently locks the mutex around
+/// each transaction.
+pub type SharedI2c = I2cDevice<'static, NoopRawMutex, I2c<'static, esp_hal::Async>>;
+
+/// Values [`bringup`] hands back to the caller.
+///
+/// Contains the servo bus driver + a shared-handle onto the internal
+/// I²C0 bus. Further handles onto the same bus can be cloned by
+/// calling [`I2cDevice::new`] on the [`SharedI2cBus`] reference
+/// returned via [`BoardIo::i2c_bus`].
+pub struct BoardIo {
+    /// The initialised servo-bus driver, already `PINGed` and
+    /// post-boot-nod.
+    pub head: HeadDriverImpl,
+    /// One shared-bus handle onto internal I²C0, ready to be consumed
+    /// by the first I²C task (typically the touch poll task).
+    pub i2c: SharedI2c,
+    /// Reference to the underlying shared-bus mutex so callers can
+    /// spawn additional [`I2cDevice`] handles for further peripherals
+    /// (future RTC / IMU / sensors).
+    pub i2c_bus: &'static SharedI2cBus,
+}
 
 /// 7-bit I²C address of the CoreS3 PY32 IO expander.
 const PY32_ADDRESS: u8 = 0x6F;
@@ -83,7 +123,7 @@ pub async fn bringup(
     uart_tx: GPIO6<'static>,
     uart_rx: GPIO7<'static>,
     delay: &mut Delay,
-) -> HeadDriverImpl {
+) -> BoardIo {
     // Internal I²C0: 100 kHz standard-mode rate — works from cold boot
     // before PLLs are fully settled. AXP2101 / AW9523 / PY32 all share
     // this bus.
@@ -123,8 +163,20 @@ pub async fn bringup(
     enable_servo_power(&mut i2c).await;
     Timer::after(Duration::from_millis(SERVO_POWER_SETTLE_MS)).await;
 
-    // I²C0 is done — drop it so later code can't accidentally share the bus.
-    drop(i2c);
+    // Park the I²C0 bus in a shared-bus mutex. Any post-boot consumer
+    // (touch, future RTC / IMU) gets its own cheap-to-create
+    // `I2cDevice` handle by calling `I2cDevice::new(i2c_bus)`.
+    //
+    // The `StaticCell` lives for the entire binary, so its
+    // `Mutex<...>` reference is `'static` — which every `I2cDevice<'_,
+    // ...>` handle also needs to be to cross a task boundary. Each
+    // firmware binary calls `bringup` exactly once; double-init
+    // `StaticCell::init` is defensively caught by the runtime.
+    #[allow(clippy::items_after_statements)]
+    static I2C_BUS: StaticCell<SharedI2cBus> = StaticCell::new();
+    let i2c_bus: &'static SharedI2cBus = I2C_BUS.init(Mutex::new(i2c));
+    let shared_i2c = I2cDevice::new(i2c_bus);
+    defmt::debug!("I2C0 shared-bus wrapper ready (post-boot consumers may now attach)");
 
     // External UART1 for the SCServo bus.
     let uart_cfg = UartConfig::default().with_baudrate(SERVO_UART_BAUD);
@@ -147,7 +199,11 @@ pub async fn bringup(
     // the main control pipeline takes over.
     boot_nod(&mut scs_head).await;
 
-    scs_head
+    BoardIo {
+        head: scs_head,
+        i2c: shared_i2c,
+        i2c_bus,
+    }
 }
 
 /// Drive pin 0 of the PY32 IO expander HIGH to enable the servo power

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -21,3 +21,4 @@ pub mod board;
 pub mod clock;
 pub mod framebuffer;
 pub mod head;
+pub mod touch;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -24,9 +24,9 @@
 
 extern crate alloc;
 
-use stackchan_firmware::{board, clock, framebuffer, head};
+use stackchan_firmware::{board, clock, framebuffer, head, touch};
 
-use board::HeadDriverImpl;
+use board::{HeadDriverImpl, SharedI2c};
 use clock::HalClock;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Ticker, Timer};
@@ -56,7 +56,9 @@ use mipidsi::{
 };
 use stackchan_core::{
     Avatar, Clock, HeadDriver, Modifier,
-    modifiers::{Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, IdleDrift, IdleSway},
+    modifiers::{
+        Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch, IdleDrift, IdleSway,
+    },
 };
 use static_cell::StaticCell;
 
@@ -131,8 +133,10 @@ type LcdDisplay = mipidsi::Display<
 /// complete frame, so the white-clear flicker from direct-draw is gone.
 ///
 /// Modifier order is the canonical stackchan-core stack:
-/// `EmotionCycle` → `EmotionStyle` → `Blink` → `Breath` → `IdleDrift` →
-/// `IdleSway` → `EmotionHead`. The first five mutate pixel state;
+/// `EmotionTouch` → `EmotionCycle` → `EmotionStyle` → `Blink` →
+/// `Breath` → `IdleDrift` → `IdleSway` → `EmotionHead`. `EmotionTouch`
+/// runs first so a tap queued from the touch task becomes the active
+/// emotion before `EmotionCycle` checks the `manual_until` gate.
 /// `IdleSway` writes the base `avatar.head_pose` (slow wander);
 /// `EmotionHead` adds an emotion-keyed bias on top (layered compose).
 /// The final pose is published to the 50 Hz head task via
@@ -150,6 +154,7 @@ async fn render_task(mut display: LcdDisplay) {
         FB_HEIGHT
     );
     let mut avatar = Avatar::default();
+    let mut emotion_touch = EmotionTouch::new();
     let mut cycle = EmotionCycle::new();
     let mut style = EmotionStyle::new();
     let mut blink = Blink::new();
@@ -168,12 +173,21 @@ async fn render_task(mut display: LcdDisplay) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead",
+        "render task: {=u64} ms tick, EmotionTouch + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead",
         FRAME_PERIOD_MS
     );
 
     loop {
         let now = clock.now();
+
+        // Drain any tap edges the touch task published since last
+        // frame. `try_take` is non-blocking; a missing signal is the
+        // common case and means `EmotionTouch::update` only does the
+        // expired-hold cleanup work this tick.
+        if touch::TAP_SIGNAL.try_take().is_some() {
+            emotion_touch.tap();
+        }
+        emotion_touch.update(&mut avatar, now);
         cycle.update(&mut avatar, now);
         style.update(&mut avatar, now);
         blink.update(&mut avatar, now);
@@ -284,6 +298,17 @@ async fn head_task(mut driver: HeadDriverImpl) {
     }
 }
 
+/// FT6336U polling task. Wraps the shared I²C bus in a [`Ft6336u`]
+/// driver and delegates to [`touch::run_touch_loop`], which reads the
+/// vendor ID once at startup and then publishes rising-edge taps on
+/// [`touch::TAP_SIGNAL`]. The render task drains the signal and feeds
+/// it into the [`EmotionTouch`] modifier.
+#[embassy_executor::task]
+async fn touch_task(shared_i2c: SharedI2c) -> ! {
+    let touch = ft6336u::Ft6336u::new(shared_i2c);
+    touch::run_touch_loop(touch).await
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
@@ -305,7 +330,7 @@ async fn main(spawner: Spawner) -> ! {
     );
 
     let mut delay = Delay;
-    let scs_head = board::bringup(
+    let board_io = board::bringup(
         peripherals.I2C0,
         peripherals.UART1,
         peripherals.GPIO12,
@@ -367,8 +392,11 @@ async fn main(spawner: Spawner) -> ! {
     if let Err(e) = spawner.spawn(render_task(display)) {
         defmt::panic!("spawn render_task failed: {}", defmt::Debug2Format(&e));
     }
-    if let Err(e) = spawner.spawn(head_task(scs_head)) {
+    if let Err(e) = spawner.spawn(head_task(board_io.head)) {
         defmt::panic!("spawn head_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(touch_task(board_io.i2c)) {
+        defmt::panic!("spawn touch_task failed: {}", defmt::Debug2Format(&e));
     }
 
     defmt::info!("boot complete — idle heartbeat");

--- a/crates/stackchan-firmware/src/touch.rs
+++ b/crates/stackchan-firmware/src/touch.rs
@@ -1,0 +1,105 @@
+//! FT6336U touch-polling task + rising-edge tap signal.
+//!
+//! Polls the capacitive touch controller over the shared I²C0 bus at
+//! ~60 Hz (matching the FT6336U's native sample rate), detects the
+//! 0→1 finger-count rising edge, and publishes a pulse on
+//! [`TAP_SIGNAL`]. The render task consumes the signal on each tick
+//! and feeds it into [`stackchan_core::modifiers::EmotionTouch`].
+//!
+//! ## Why signal and not a richer event?
+//!
+//! The MVP treats every tap as equivalent: the `EmotionTouch` modifier
+//! only cares that *a* tap happened, not where on the screen. Sending
+//! `Signal<_, ()>` keeps this decoupling explicit — if we ever want
+//! zone-aware behaviour, growing the signal to `TouchEvent { x, y }`
+//! is a local change and the render-side consumer is still a single
+//! `try_take` on the signal.
+//!
+//! ## Boot probe
+//!
+//! On startup the task reads the FT6336U vendor ID once and logs the
+//! result. A miswired bus or missing part surfaces as a warn-level
+//! line here, but the task keeps running — the rest of the firmware
+//! (render, head) doesn't depend on touch, so silent degradation is
+//! acceptable.
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker};
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+use ft6336u::{Ft6336u, VENDOR_ID_FOCALTECH};
+
+/// Rising-edge tap signal: touch task → render task.
+///
+/// The touch task calls [`Signal::signal`] once per detected
+/// 0→1 finger-count transition. The render task consumes via
+/// [`Signal::try_take`] on each render tick. Signal semantics (latest
+/// wins, no backlog) mean multiple taps between render ticks collapse
+/// into a single `tap()` call — fine for tap-to-cycle UX; a future
+/// queue could replace the signal if buffering is needed.
+pub static TAP_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+/// Poll cadence for the touch task. 60 Hz matches the controller's
+/// native sample rate; polling faster buys no latency (reads would
+/// just return the same value twice) and wastes bus time that the
+/// future RTC / IMU tasks will need.
+const POLL_PERIOD_MS: u64 = 16;
+
+/// Drive the FT6336U touch-polling loop.
+///
+/// Takes an owned I²C device (a shared-bus [`I2cDevice`](embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice)
+/// handle is fine), not a borrow, so the task outlives any stack frame
+/// in `main`. Runs the boot probe, then loops forever publishing tap
+/// edges.
+///
+/// Bus errors at poll time log at `warn` and are skipped — a single
+/// dropped I²C transaction must not blank the face.
+pub async fn run_touch_loop<I: AsyncI2c>(mut touch: Ft6336u<I>) -> ! {
+    match touch.read_vendor_id().await {
+        Ok(id) if id == VENDOR_ID_FOCALTECH => {
+            defmt::info!("FT6336U: vendor ID 0x{=u8:02X} (FocalTech, expected)", id);
+        }
+        Ok(id) => defmt::warn!(
+            "FT6336U: unexpected vendor ID 0x{=u8:02X} (expected 0x{=u8:02X}); taps may misbehave",
+            id,
+            VENDOR_ID_FOCALTECH,
+        ),
+        Err(e) => defmt::warn!(
+            "FT6336U: vendor-ID read failed (is the chip present?): {}",
+            defmt::Debug2Format(&e),
+        ),
+    }
+
+    defmt::info!(
+        "touch task: {=u64} ms tick, publishing rising-edge taps to TAP_SIGNAL",
+        POLL_PERIOD_MS,
+    );
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    let mut previous_fingers: u8 = 0;
+    loop {
+        match touch.read_touch().await {
+            Ok(report) => {
+                // Rising edge: previous tick had no finger down, this
+                // tick has ≥1. Held fingers stay at `fingers >= 1` and
+                // don't re-fire; release-and-retouch counts as a new
+                // rising edge.
+                if previous_fingers == 0 && report.fingers > 0 {
+                    TAP_SIGNAL.signal(());
+                    if let Some((x, y)) = report.first {
+                        defmt::debug!("touch: tap at ({=u16}, {=u16})", x, y);
+                    } else {
+                        defmt::debug!("touch: tap (no coord in report)");
+                    }
+                }
+                previous_fingers = report.fingers;
+            }
+            Err(e) => {
+                defmt::warn!("touch: read_touch failed: {}", defmt::Debug2Format(&e));
+                // Don't latch a transient bus error as "finger still
+                // down" — that would swallow the next real release.
+                previous_fingers = 0;
+            }
+        }
+        ticker.next().await;
+    }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,9 @@
     "crates/aw9523": {
       "package-name": "aw9523"
     },
+    "crates/ft6336u": {
+      "package-name": "ft6336u"
+    },
     "crates/scservo": {
       "package-name": "scservo"
     },


### PR DESCRIPTION
## Summary
- New `ft6336u` driver crate + firmware `touch` module poll the capacitive touch controller at 60 Hz and publish rising-edge taps via `Signal<_, ()>`.
- New `EmotionTouch` modifier in `stackchan-core` advances `Avatar::emotion` on each tap and pins it for 30 s via a new `Avatar::manual_until` field; `EmotionCycle` respects the hold and re-anchors its timer so no snap-advance on resume.
- `board::bringup` lifts internal I²C0 into an `embassy-embedded-hal` `NoopRawMutex` shared bus (`BoardIo { head, i2c, i2c_bus }`), ready for future BM8563/BMI270 tasks to attach their own handles without re-plumbing.
- New `examples/touch_bench.rs` — standalone diagnostic binary that streams raw FT6336U coordinates over defmt.

## Test plan
- [x] `cargo test --workspace --exclude stackchan-firmware`: 107 pass (up from 68), including new tests for `manual_until` suppression, tap cycle order, held-finger de-dup, hold expiry, and release-after-bus-error behavior.
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings`: clean.
- [x] `cargo +esp clippy --all-features --examples -- -D warnings` (firmware): clean.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware`: clean.
- [ ] Hardware flash test on CoreS3 (follow-up): confirm boot log shows `FT6336U: vendor ID 0x11 (FocalTech, expected)`, tapping cycles emotions, cycle resumes ~30 s after last tap.
- [ ] `cargo run --example touch_bench -p stackchan-firmware --release` (follow-up): stream raw tap coords under a finger-drag to sanity-check axis orientation.