### PR TITLE
feat: BM8563 wall-clock + LTR-553 AmbientSleepy modifier

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,8 +3,10 @@
   "crates/stackchan-sim": "0.2.0",
   "crates/axp2101": "0.1.0",
   "crates/aw9523": "0.2.0",
+  "crates/bm8563": "0.1.0",
   "crates/bmi270": "0.1.0",
   "crates/ft6336u": "0.1.0",
+  "crates/ltr553": "0.1.0",
   "crates/scservo": "0.2.0",
   "crates/stackchan-firmware": "0.2.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bm8563"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal-async",
+]
+
+[[package]]
 name = "bmi270"
 version = "0.1.0"
 dependencies = [
@@ -1147,6 +1154,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "ltr553"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal-async",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1479,7 @@ version = "0.2.0"
 dependencies = [
  "aw9523",
  "axp2101",
+ "bm8563",
  "bmi270",
  "critical-section",
  "defmt 1.0.1",
@@ -1483,6 +1498,7 @@ dependencies = [
  "esp-println",
  "esp-rtos",
  "ft6336u",
+ "ltr553",
  "mipidsi",
  "scservo",
  "stackchan-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ members = [
     "crates/stackchan-sim",
     "crates/axp2101",
     "crates/aw9523",
+    "crates/bm8563",
     "crates/bmi270",
     "crates/ft6336u",
+    "crates/ltr553",
     "crates/scservo",
     "crates/stackchan-firmware",
 ]
@@ -15,8 +17,10 @@ default-members = [
     "crates/stackchan-sim",
     "crates/axp2101",
     "crates/aw9523",
+    "crates/bm8563",
     "crates/bmi270",
     "crates/ft6336u",
+    "crates/ltr553",
     "crates/scservo",
 ]
 

--- a/crates/bm8563/Cargo.toml
+++ b/crates/bm8563/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bm8563"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Minimal async driver for the NXP BM8563 / PCF8563 real-time clock over I²C. no_std; embedded-hal-async 1.0; no chrono dep."
+
+[lints]
+workspace = true
+
+[dependencies]
+embedded-hal-async = { workspace = true }

--- a/crates/bm8563/src/lib.rs
+++ b/crates/bm8563/src/lib.rs
@@ -1,0 +1,378 @@
+//! # bm8563
+//!
+//! `no_std` async driver for the NXP BM8563 real-time clock (a
+//! pin-compatible clone of the PCF8563) over I²C. Scope: set / read
+//! the date-time registers. Alarm, timer, and CLKOUT features are
+//! deliberately out of scope for this driver.
+//!
+//! ## Why a bespoke `DateTime` instead of `chrono`?
+//!
+//! `chrono` requires `alloc` and drags in a surprising amount of
+//! date-arithmetic code. All we need from the RTC is "hour/minute/
+//! second + calendar date" in a shape the firmware can format into a
+//! log line; callers that actually need date arithmetic can convert
+//! our [`DateTime`] into their calendar library of choice.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # use embedded_hal_async::i2c::I2c;
+//! # async fn demo<B: I2c>(bus: B) -> Result<(), bm8563::Error<B::Error>> {
+//! let mut rtc = bm8563::Bm8563::new(bus);
+//! rtc.init().await?;
+//! let now = rtc.read_datetime().await?;
+//! let _ = now.hours;
+//! # Ok(())
+//! # }
+//! ```
+
+#![no_std]
+#![deny(unsafe_code)]
+
+use embedded_hal_async::i2c::I2c;
+
+/// Fixed 7-bit I²C address of the BM8563 / PCF8563.
+pub const ADDRESS: u8 = 0x51;
+
+/// `Control_1` register. Top bit `STOP`: `0` = RTC running, `1` = stopped.
+const REG_CONTROL_1: u8 = 0x00;
+/// `Control_2` register. Holds alarm / timer interrupt flags; we zero
+/// it at init to disable them.
+const REG_CONTROL_2: u8 = 0x01;
+/// First byte of the date-time block (seconds, then minutes, hours,
+/// days, weekdays, months+century, years). Seven consecutive
+/// registers read in one burst.
+const REG_VL_SECONDS: u8 = 0x02;
+
+/// Mask used to strip the "voltage low" flag from the seconds byte.
+const VL_SECONDS_MASK: u8 = 0x7F;
+/// Mask for the two-digit BCD fields (all calendar values except year).
+const BCD_TWO_DIGIT_MASK: u8 = 0x7F;
+/// Mask for the day register (bits 5-0; bit 7 is undefined).
+const DAYS_MASK: u8 = 0x3F;
+/// Mask for the weekday register (bits 2-0).
+const WEEKDAYS_MASK: u8 = 0x07;
+/// Bit 7 of the months+century register: `1` = 20th century (years
+/// 1900-1999), `0` = 21st (years 2000-2099).
+const CENTURY_FLAG: u8 = 0x80;
+
+/// Driver error type.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error<E> {
+    /// I²C transport error.
+    I2c(E),
+    /// The RTC's `VL` (voltage low) flag was set, signalling that the
+    /// on-chip battery backup dropped and the current time is
+    /// unreliable. Read the time anyway if you like, but treat it as
+    /// "unset."
+    VoltageLow,
+}
+
+impl<E> From<E> for Error<E> {
+    fn from(e: E) -> Self {
+        Self::I2c(e)
+    }
+}
+
+/// A calendar date + wall-clock time, matching the layout the BM8563
+/// stores. No timezone — the RTC is timezone-agnostic; assume UTC
+/// unless you set it to something else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DateTime {
+    /// Four-digit Gregorian year (1900..=2099). The RTC's two-digit
+    /// "year" register is expanded using its `CENTURY` flag.
+    pub year: u16,
+    /// 1..=12
+    pub month: u8,
+    /// 1..=31
+    pub day: u8,
+    /// 0..=6; 0 = Sunday (convention matches many C libraries and the
+    /// Linux kernel; the BM8563 itself doesn't care which weekday is
+    /// "zero").
+    pub weekday: u8,
+    /// 0..=23
+    pub hours: u8,
+    /// 0..=59
+    pub minutes: u8,
+    /// 0..=59
+    pub seconds: u8,
+}
+
+/// BM8563 driver.
+pub struct Bm8563<B> {
+    /// I²C bus.
+    bus: B,
+}
+
+impl<B: I2c> Bm8563<B> {
+    /// Wrap an I²C bus.
+    #[must_use]
+    pub const fn new(bus: B) -> Self {
+        Self { bus }
+    }
+
+    /// Zero `Control_1` and `Control_2`: clears the STOP flag (so the
+    /// RTC runs) and disables any lingering alarm/timer interrupts.
+    ///
+    /// Does **not** set the time — that's a separate operation (see
+    /// [`Bm8563::write_datetime`]). A freshly-powered RTC will have
+    /// the `VL` flag set and the date-time fields at arbitrary values.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn init(&mut self) -> Result<(), Error<B::Error>> {
+        self.write_register(REG_CONTROL_1, 0x00).await?;
+        self.write_register(REG_CONTROL_2, 0x00).await?;
+        Ok(())
+    }
+
+    /// Read the current date-time.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::VoltageLow`] if the RTC's `VL` flag is set, meaning
+    ///   the current time is unreliable. The caller can choose to
+    ///   retry, re-set the time, or treat the returned value as a
+    ///   best-effort reading.
+    /// - [`Error::I2c`] on any bus failure.
+    pub async fn read_datetime(&mut self) -> Result<DateTime, Error<B::Error>> {
+        let mut buf = [0u8; 7];
+        self.bus
+            .write_read(ADDRESS, &[REG_VL_SECONDS], &mut buf)
+            .await?;
+        if buf[0] & !VL_SECONDS_MASK != 0 {
+            return Err(Error::VoltageLow);
+        }
+        Ok(decode_datetime(buf))
+    }
+
+    /// Set the RTC's date-time. Does **not** clear the `VL` flag
+    /// automatically; the next read that succeeds will clear it
+    /// (writing a valid seconds byte implicitly acknowledges `VL`).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error. No validation — callers are
+    /// responsible for passing sensible values (hour ≤ 23 etc.).
+    pub async fn write_datetime(&mut self, dt: DateTime) -> Result<(), Error<B::Error>> {
+        let mut buf = [0u8; 8];
+        buf[0] = REG_VL_SECONDS;
+        buf[1..].copy_from_slice(&encode_datetime(dt));
+        self.bus.write(ADDRESS, &buf).await?;
+        Ok(())
+    }
+
+    /// Single-register write helper.
+    async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
+        self.bus.write(ADDRESS, &[reg, value]).await?;
+        Ok(())
+    }
+}
+
+/// Convert a BCD-encoded byte back to its u8 value.
+///
+/// Takes the mask of "valid bits" — the BM8563 reuses upper bits of
+/// several registers for flags that must be stripped before decoding.
+const fn bcd_to_u8(bcd: u8, mask: u8) -> u8 {
+    let masked = bcd & mask;
+    ((masked >> 4) * 10) + (masked & 0x0F)
+}
+
+/// Encode a u8 as two-digit BCD. Saturates above 99.
+const fn u8_to_bcd(value: u8) -> u8 {
+    let clamped = if value > 99 { 99 } else { value };
+    ((clamped / 10) << 4) | (clamped % 10)
+}
+
+/// Decode the 7-byte date-time burst into a [`DateTime`].
+fn decode_datetime(buf: [u8; 7]) -> DateTime {
+    let seconds = bcd_to_u8(buf[0], VL_SECONDS_MASK);
+    let minutes = bcd_to_u8(buf[1], BCD_TWO_DIGIT_MASK);
+    let hours = bcd_to_u8(buf[2], 0x3F);
+    let day = bcd_to_u8(buf[3], DAYS_MASK);
+    let weekday = buf[4] & WEEKDAYS_MASK;
+    let month_century = buf[5];
+    let month = bcd_to_u8(month_century, 0x1F);
+    let year_two_digit = u16::from(bcd_to_u8(buf[6], 0xFF));
+    // `CENTURY` bit = 1 means 20th century (1900-1999).
+    let century_base: u16 = if month_century & CENTURY_FLAG != 0 {
+        1900
+    } else {
+        2000
+    };
+    DateTime {
+        year: century_base + year_two_digit,
+        month,
+        day,
+        weekday,
+        hours,
+        minutes,
+        seconds,
+    }
+}
+
+/// Format a [`DateTime`] into `YYYY-MM-DD HH:MM:SS` (19 ASCII bytes)
+/// in the caller's buffer.
+///
+/// Returns the formatted slice as a `&str`, which is always valid
+/// UTF-8 because every byte is ASCII. Useful for writing one-off
+/// wall-clock strings into log lines without pulling in `alloc`.
+///
+/// Values that exceed the normal calendar range (e.g. a glitched
+/// sensor read producing `month = 99`) are clamped to two digits
+/// via saturation, so the output length is always exactly 19 bytes.
+pub fn format_datetime(dt: DateTime, out: &mut [u8; 19]) -> &str {
+    // ASCII '0' = 0x30.
+    let y = dt.year;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "year / 1000 and intermediates fit in 0..=9 after `% 10`"
+    )]
+    {
+        out[0] = b'0' + (y / 1000) as u8;
+        out[1] = b'0' + ((y / 100) % 10) as u8;
+        out[2] = b'0' + ((y / 10) % 10) as u8;
+        out[3] = b'0' + (y % 10) as u8;
+    }
+    out[4] = b'-';
+    write_two_digits(&mut out[5..=6], dt.month);
+    out[7] = b'-';
+    write_two_digits(&mut out[8..=9], dt.day);
+    out[10] = b' ';
+    write_two_digits(&mut out[11..=12], dt.hours);
+    out[13] = b':';
+    write_two_digits(&mut out[14..=15], dt.minutes);
+    out[16] = b':';
+    write_two_digits(&mut out[17..=18], dt.seconds);
+    // All 19 bytes are ASCII; conversion is infallible.
+    core::str::from_utf8(out).unwrap_or("")
+}
+
+/// Write a two-digit decimal (0..=99) into a 2-byte slot as ASCII.
+/// Values > 99 saturate to "99".
+fn write_two_digits(slot: &mut [u8], value: u8) {
+    let v = if value > 99 { 99 } else { value };
+    slot[0] = b'0' + (v / 10);
+    slot[1] = b'0' + (v % 10);
+}
+
+/// Encode a [`DateTime`] as the 7-byte register block the BM8563
+/// writes to.
+const fn encode_datetime(dt: DateTime) -> [u8; 7] {
+    // Century: 1 if year in 1900s, 0 for 2000s+.
+    let (century_bit, year_two_digit) = if dt.year < 2000 {
+        (CENTURY_FLAG, dt.year.saturating_sub(1900))
+    } else {
+        (0, dt.year.saturating_sub(2000))
+    };
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "year_two_digit was computed from a two-digit-range subtraction; fits in u8"
+    )]
+    let year_byte = u8_to_bcd(year_two_digit as u8);
+    [
+        u8_to_bcd(dt.seconds),
+        u8_to_bcd(dt.minutes),
+        u8_to_bcd(dt.hours),
+        u8_to_bcd(dt.day),
+        dt.weekday & WEEKDAYS_MASK,
+        u8_to_bcd(dt.month) | century_bit,
+        year_byte,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bcd_roundtrip_common_values() {
+        for v in [0_u8, 1, 9, 10, 29, 59, 99] {
+            assert_eq!(bcd_to_u8(u8_to_bcd(v), 0xFF), v);
+        }
+    }
+
+    #[test]
+    fn bcd_saturates_above_99() {
+        assert_eq!(u8_to_bcd(200), u8_to_bcd(99));
+    }
+
+    #[test]
+    fn decode_2026_04_24_13_37_00_round_trips() {
+        // Friday 2026-04-24 13:37:00.
+        let dt = DateTime {
+            year: 2026,
+            month: 4,
+            day: 24,
+            weekday: 5, // Friday in "Sunday=0" convention
+            hours: 13,
+            minutes: 37,
+            seconds: 0,
+        };
+        let bytes = encode_datetime(dt);
+        let decoded = decode_datetime(bytes);
+        assert_eq!(decoded, dt);
+    }
+
+    #[test]
+    fn decode_century_flag_uses_20th_century() {
+        // Century bit set → 1900s.
+        let mut bytes = encode_datetime(DateTime {
+            year: 1999,
+            month: 12,
+            day: 31,
+            weekday: 5,
+            hours: 23,
+            minutes: 59,
+            seconds: 59,
+        });
+        // Re-check the century bit survives the round-trip.
+        assert!(bytes[5] & CENTURY_FLAG != 0);
+        // Poke the month byte to simulate a raw register read.
+        let _ = &mut bytes;
+        assert_eq!(decode_datetime(bytes).year, 1999);
+    }
+
+    #[test]
+    fn format_datetime_round_trips_example() {
+        let dt = DateTime {
+            year: 2026,
+            month: 4,
+            day: 24,
+            weekday: 5,
+            hours: 13,
+            minutes: 37,
+            seconds: 5,
+        };
+        let mut buf = [0u8; 19];
+        let s = format_datetime(dt, &mut buf);
+        assert_eq!(s, "2026-04-24 13:37:05");
+    }
+
+    #[test]
+    fn format_datetime_saturates_pathological_input() {
+        let dt = DateTime {
+            year: 2099,
+            month: 99,
+            day: 99,
+            weekday: 7,
+            hours: 99,
+            minutes: 99,
+            seconds: 99,
+        };
+        let mut buf = [0u8; 19];
+        let s = format_datetime(dt, &mut buf);
+        assert_eq!(s, "2099-99-99 99:99:99");
+    }
+
+    #[test]
+    fn vl_flag_stripped_from_seconds() {
+        // Seconds register with VL bit set: raw bytes have the bit,
+        // but the decoded value shouldn't. Manual wire-level check.
+        let bytes = [0x80 | u8_to_bcd(42), 0, 0, 1, 0, u8_to_bcd(1), 0];
+        let decoded = decode_datetime(bytes);
+        assert_eq!(decoded.seconds, 42);
+    }
+}

--- a/crates/ltr553/Cargo.toml
+++ b/crates/ltr553/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ltr553"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Minimal async driver for the Lite-On LTR-553ALS ambient light + proximity sensor over I²C. no_std; embedded-hal-async 1.0."
+
+[lints]
+workspace = true
+
+[dependencies]
+embedded-hal-async = { workspace = true }

--- a/crates/ltr553/src/lib.rs
+++ b/crates/ltr553/src/lib.rs
@@ -1,0 +1,279 @@
+//! # ltr553
+//!
+//! `no_std` async driver for the Lite-On LTR-553ALS ambient-light +
+//! proximity sensor over I²C. Keeps the register surface minimal: one
+//! init call, then two polling accessors (`read_ambient`,
+//! `read_proximity`). Configures the chip for default gain /
+//! integration so the lux math matches Lite-On's app-note piecewise
+//! formula at unit scale.
+//!
+//! ## Addressing
+//!
+//! The LTR-553 lives at fixed I²C address `0x23` on CoreS3. No strap
+//! pin, so [`ADDRESS`] is a single constant.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # use embedded_hal_async::i2c::I2c;
+//! # async fn demo<B: I2c>(bus: B) -> Result<(), ltr553::Error<B::Error>> {
+//! let mut als = ltr553::Ltr553::new(bus);
+//! als.init().await?;
+//! let reading = als.read_ambient().await?;
+//! let _ = reading.lux;
+//! # Ok(())
+//! # }
+//! ```
+
+#![no_std]
+#![deny(unsafe_code)]
+
+use embedded_hal_async::i2c::I2c;
+
+/// Fixed 7-bit I²C address of the LTR-553 on CoreS3.
+pub const ADDRESS: u8 = 0x23;
+
+/// Expected value of the `PART_ID` register for the LTR-553. The
+/// low nibble is the revision ID; only the upper nibble (`0x9`)
+/// identifies the part family.
+pub const PART_ID_UPPER: u8 = 0x90;
+
+/// `ALS_CONTR` register. Controls ambient-light sensor mode + gain.
+const REG_ALS_CONTR: u8 = 0x80;
+/// `PS_CONTR` register. Controls proximity sensor mode + gain.
+const REG_PS_CONTR: u8 = 0x81;
+/// `PART_ID` register (read-only). Upper nibble `0x9` for LTR-553.
+const REG_PART_ID: u8 = 0x86;
+/// First byte of the ambient data burst. Registers 0x88..=0x8B hold
+/// the two channel pairs: `CH1_LSB`, `CH1_MSB`, `CH0_LSB`, `CH0_MSB`.
+const REG_ALS_DATA_START: u8 = 0x88;
+/// `ALS_PS_STATUS` register. Bit 2 = `ALS_DATA_STATUS` (new data
+/// ready since last read), bit 0 = `PS_DATA_STATUS`.
+const REG_ALS_PS_STATUS: u8 = 0x8C;
+/// First byte of the proximity data pair. Registers 0x8D..=0x8E hold
+/// the 11-bit PS value; bit 15 of the MSB is a saturation flag.
+const REG_PS_DATA_START: u8 = 0x8D;
+
+/// `ALS_CONTR` value: bit 1 = `ALS_MODE = active`, gain = 1× (default).
+const ALS_CONTR_ACTIVE_1X: u8 = 0b0000_0010;
+/// `PS_CONTR` value: bits 1-0 = `PS_MODE = active` (`0b11`), default
+/// gain.
+const PS_CONTR_ACTIVE: u8 = 0b0000_0011;
+
+/// Driver error type.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error<E> {
+    /// I²C transport error.
+    I2c(E),
+    /// `PART_ID` upper nibble didn't match [`PART_ID_UPPER`]. Carries
+    /// the byte that was read. Common causes: wrong device at the
+    /// I²C address, or a related Lite-On part with a different lux
+    /// formula.
+    BadPartId(u8),
+}
+
+impl<E> From<E> for Error<E> {
+    fn from(e: E) -> Self {
+        Self::I2c(e)
+    }
+}
+
+/// One decoded ambient-light reading.
+///
+/// `ch0` is the visible + IR channel; `ch1` is IR-only. `lux` is the
+/// piecewise-formula estimate at default gain / integration, which is
+/// what [`Ltr553::init`] configures. Callers that change gain /
+/// integration need to post-scale or reach for a more complete driver.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct AmbientReading {
+    /// Visible + IR channel raw count.
+    pub ch0: u16,
+    /// IR-only channel raw count.
+    pub ch1: u16,
+    /// Estimated lux. `0.0` for all-IR sources (e.g. an incandescent
+    /// bulb seen through filters), positive for anything with visible
+    /// content.
+    pub lux: f32,
+}
+
+/// LTR-553 driver.
+pub struct Ltr553<B> {
+    /// The I²C bus the chip is addressed on.
+    bus: B,
+}
+
+impl<B: I2c> Ltr553<B> {
+    /// Wrap an I²C bus.
+    #[must_use]
+    pub const fn new(bus: B) -> Self {
+        Self { bus }
+    }
+
+    /// Read the `PART_ID` register. Upper nibble `0x9` identifies an
+    /// LTR-553 family part; lower nibble is silicon revision.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn read_part_id(&mut self) -> Result<u8, Error<B::Error>> {
+        let mut buf = [0u8];
+        self.bus
+            .write_read(ADDRESS, &[REG_PART_ID], &mut buf)
+            .await?;
+        Ok(buf[0])
+    }
+
+    /// Validate the `PART_ID`, then enable ALS + PS at default gain /
+    /// integration.
+    ///
+    /// Default ALS config: gain 1×, integration 100 ms, measurement
+    /// rate 500 ms. Default PS config: gain 16×, active.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::BadPartId`] if the upper nibble of `PART_ID` isn't
+    ///   `0x9`.
+    /// - [`Error::I2c`] on any bus failure.
+    pub async fn init(&mut self) -> Result<(), Error<B::Error>> {
+        let id = self.read_part_id().await?;
+        if (id & 0xF0) != PART_ID_UPPER {
+            return Err(Error::BadPartId(id));
+        }
+        self.write_register(REG_ALS_CONTR, ALS_CONTR_ACTIVE_1X)
+            .await?;
+        self.write_register(REG_PS_CONTR, PS_CONTR_ACTIVE).await?;
+        Ok(())
+    }
+
+    /// Read the ambient channels + compute estimated lux.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn read_ambient(&mut self) -> Result<AmbientReading, Error<B::Error>> {
+        let mut buf = [0u8; 4];
+        self.bus
+            .write_read(ADDRESS, &[REG_ALS_DATA_START], &mut buf)
+            .await?;
+        // Datasheet order: CH1_LSB, CH1_MSB, CH0_LSB, CH0_MSB.
+        let ch1 = u16::from_le_bytes([buf[0], buf[1]]);
+        let ch0 = u16::from_le_bytes([buf[2], buf[3]]);
+        Ok(AmbientReading {
+            ch0,
+            ch1,
+            lux: lux_from_channels(ch0, ch1),
+        })
+    }
+
+    /// Read the 11-bit proximity count. Raw units; larger = closer.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn read_proximity(&mut self) -> Result<u16, Error<B::Error>> {
+        let mut buf = [0u8; 2];
+        self.bus
+            .write_read(ADDRESS, &[REG_PS_DATA_START], &mut buf)
+            .await?;
+        // PS_DATA_1 bits 0..=2 are the high 3 bits of the 11-bit
+        // value; bit 7 is the saturation flag, which we ignore.
+        let high = u16::from(buf[1] & 0x07);
+        let low = u16::from(buf[0]);
+        Ok((high << 8) | low)
+    }
+
+    /// Read the `ALS_PS_STATUS` register.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn read_status(&mut self) -> Result<u8, Error<B::Error>> {
+        let mut buf = [0u8];
+        self.bus
+            .write_read(ADDRESS, &[REG_ALS_PS_STATUS], &mut buf)
+            .await?;
+        Ok(buf[0])
+    }
+
+    /// Single-register write helper.
+    async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
+        self.bus.write(ADDRESS, &[reg, value]).await?;
+        Ok(())
+    }
+}
+
+/// Compute estimated lux from the two raw channels at the driver's
+/// default gain / integration settings.
+///
+/// Implements the Lite-On LTR-55x app-note piecewise formula keyed on
+/// `ratio = ch1 / (ch0 + ch1)`. Returns `0.0` when both channels read
+/// zero or when the ratio lands in the "all IR" range (ratio ≥ 0.85).
+///
+/// The driver always configures gain = 1× and integration = 100 ms,
+/// which makes the denominator `gain * integration = 1.0` — i.e. the
+/// raw weighted sum is the lux estimate directly.
+fn lux_from_channels(ch0: u16, ch1: u16) -> f32 {
+    let sum = u32::from(ch0) + u32::from(ch1);
+    if sum == 0 {
+        return 0.0;
+    }
+    let ch0 = f32::from(ch0);
+    let ch1 = f32::from(ch1);
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "sum fits in u17; f32 precision is ample for lux comparisons"
+    )]
+    let sum_f = sum as f32;
+    let ratio = ch1 / sum_f;
+    // Piecewise formula (Lite-On LTR-55x app note).
+    #[allow(
+        clippy::suboptimal_flops,
+        reason = "f32::mul_add needs libm; stay consistent with workspace"
+    )]
+    if ratio < 0.45 {
+        1.7743 * ch0 + 1.1059 * ch1
+    } else if ratio < 0.64 {
+        4.2785 * ch0 - 1.9548 * ch1
+    } else if ratio < 0.85 {
+        0.5926 * ch0 + 0.1185 * ch1
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_channels_gives_zero_lux() {
+        assert!(lux_from_channels(0, 0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn visible_dominant_uses_first_formula() {
+        // Low-ratio (mostly visible) input: ratio ≈ 0.2.
+        let ch0 = 200;
+        let ch1 = 50;
+        let expected = 1.7743 * f32::from(ch0) + 1.1059 * f32::from(ch1);
+        let got = lux_from_channels(ch0, ch1);
+        assert!((got - expected).abs() < 0.001);
+    }
+
+    #[test]
+    fn all_ir_returns_zero() {
+        // Fabricate a ratio just above the final branch (0.85): ch1
+        // much larger than ch0.
+        let lux = lux_from_channels(10, 100);
+        assert!(lux.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn part_id_mask_accepts_rev_variants() {
+        // The driver accepts any silicon revision: mask is `0xF0`.
+        assert_eq!(0x92 & 0xF0, PART_ID_UPPER);
+        assert_eq!(0x9A & 0xF0, PART_ID_UPPER);
+        assert_ne!(0x82 & 0xF0, PART_ID_UPPER); // not LTR-553
+    }
+}

--- a/crates/stackchan-core/src/avatar.rs
+++ b/crates/stackchan-core/src/avatar.rs
@@ -37,6 +37,13 @@
 //! so they are excluded from [`Avatar::frame_eq`] just like
 //! [`Avatar::head_pose`]. Defaults match the resting state of a
 //! face-up CoreS3: gravity (`+1 g`) on the Z axis, zero angular rate.
+//!
+//! ## Ambient light
+//!
+//! `ambient_lux` is `Some(lux)` after the first successful LTR-553
+//! read; `None` beforehand. Consumed by
+//! [`super::modifiers::AmbientSleepy`]. Excluded from
+//! [`Avatar::frame_eq`].
 
 use crate::clock::Instant;
 use crate::emotion::Emotion;
@@ -205,6 +212,14 @@ pub struct Avatar {
     /// the firmware IMU task; consumed by future rotation-reactive
     /// modifiers. Zero at rest. Excluded from [`Avatar::frame_eq`].
     pub gyro_dps: (f32, f32, f32),
+    /// Ambient light level in lux, or `None` before the first
+    /// successful read. Written by the firmware ambient-light task
+    /// (LTR-553); consumed by
+    /// [`super::modifiers::AmbientSleepy`]. Excluded from
+    /// [`Avatar::frame_eq`] — a dimming room doesn't change pixels
+    /// directly; modifiers translate lux into visible state via
+    /// `Avatar::emotion`.
+    pub ambient_lux: Option<f32>,
 }
 
 impl Avatar {
@@ -276,6 +291,8 @@ impl Default for Avatar {
             // Resting face-up: gravity is +1 g along Z, no rotation.
             accel_g: (0.0, 0.0, 1.0),
             gyro_dps: (0.0, 0.0, 0.0),
+            // No ambient reading until the LTR-553 task publishes one.
+            ambient_lux: None,
         }
     }
 }
@@ -366,6 +383,25 @@ mod tests {
         assert!(
             a.frame_eq(&b),
             "IMU readings are non-visual; frame_eq must skip them",
+        );
+    }
+
+    #[test]
+    fn default_has_no_ambient_reading() {
+        assert!(
+            Avatar::default().ambient_lux.is_none(),
+            "ambient starts unknown until the LTR-553 task publishes",
+        );
+    }
+
+    #[test]
+    fn frame_eq_ignores_ambient_lux() {
+        let a = Avatar::default();
+        let mut b = a;
+        b.ambient_lux = Some(15.0);
+        assert!(
+            a.frame_eq(&b),
+            "ambient reading is non-visual; modifiers translate it, not the renderer",
         );
     }
 

--- a/crates/stackchan-core/src/modifiers/ambient_sleepy.rs
+++ b/crates/stackchan-core/src/modifiers/ambient_sleepy.rs
@@ -1,0 +1,277 @@
+//! `AmbientSleepy`: ambient-light-reactive modifier that flips
+//! `Avatar::emotion` to `Sleepy` when the room gets dark and wakes
+//! when the light comes back on.
+//!
+//! ## Detection shape
+//!
+//! Reads `avatar.ambient_lux` each tick. The trigger uses hysteresis
+//! to absorb sensor noise + natural light variation:
+//!
+//! - **Enter Sleepy:** `lux` below [`SLEEPY_ENTER_LUX`] while not
+//!   already asleep.
+//! - **Wake:** `lux` above [`SLEEPY_EXIT_LUX`] while asleep. Clears
+//!   this modifier's own hold so autonomy resumes.
+//! - Between the two thresholds, the modifier holds its current state.
+//!
+//! Unknown ambient (`ambient_lux = None`, i.e. the LTR-553 task hasn't
+//! produced a reading yet) is treated as "no information" and never
+//! triggers either transition.
+//!
+//! ## Coordination with the other emotion modifiers
+//!
+//! Like [`super::PickupReaction`], this modifier respects an existing
+//! [`Avatar::manual_until`] hold — if touch, a pickup, or any other
+//! explicit input has already claimed the emotion, we stand down.
+//! Ambient sleep is *background state*: it shouldn't override a user's
+//! deliberate interaction.
+//!
+//! The hold set on a sleep-trigger is short
+//! ([`AMBIENT_HOLD_MS`], ~5 s) rather than 30 s: we *want* it to
+//! un-stick quickly once the room gets bright again, and the modifier
+//! itself re-affirms the hold on every dark tick so Sleepy sticks as
+//! long as the room stays dim.
+
+use super::Modifier;
+use crate::avatar::Avatar;
+use crate::clock::Instant;
+use crate::emotion::Emotion;
+
+/// Ambient lux below which Sleepy triggers.
+///
+/// 20 lux ≈ "room with overhead light off, only glow from a nearby
+/// monitor." Roughly the boundary where you'd naturally reach for a
+/// lamp.
+pub const SLEEPY_ENTER_LUX: f32 = 20.0;
+
+/// Ambient lux above which the avatar wakes up again.
+///
+/// 50 lux ≈ "desk lamp on at arm's length." Comfortably above the
+/// noise floor of room lighting variations (shadows, cloud passes)
+/// but well below daylight.
+pub const SLEEPY_EXIT_LUX: f32 = 50.0;
+
+/// How long the ambient-triggered hold pins Sleepy once set, in ms.
+///
+/// Short (5 s) by design: the modifier re-sets the hold on every dark
+/// tick, so the effective behavior is "Sleepy while dark, resume
+/// within 5 s of the room brightening." Keeps this modifier cheap to
+/// reason about vs. touch's 30 s explicit hold.
+pub const AMBIENT_HOLD_MS: u64 = 5_000;
+
+/// Modifier that watches [`Avatar::ambient_lux`] and toggles Sleepy
+/// with hysteresis.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AmbientSleepy {
+    /// `true` while this modifier believes the avatar should currently
+    /// be asleep. Driven by the two-threshold hysteresis; a fresh
+    /// instance starts `false` regardless of the first ambient
+    /// reading so the avatar wakes visibly at boot even in a dark
+    /// room (the hysteresis flips it to Sleepy a tick later).
+    is_asleep: bool,
+}
+
+impl AmbientSleepy {
+    /// Construct a modifier in the awake state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { is_asleep: false }
+    }
+
+    /// Exposed for tests: whether this modifier currently believes the
+    /// avatar should be asleep.
+    #[cfg(test)]
+    const fn is_asleep(self) -> bool {
+        self.is_asleep
+    }
+}
+
+impl Modifier for AmbientSleepy {
+    fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        let Some(lux) = avatar.ambient_lux else {
+            // No reading yet — nothing to do.
+            return;
+        };
+
+        // Hysteresis: update our internal "is_asleep" belief.
+        if !self.is_asleep && lux < SLEEPY_ENTER_LUX {
+            self.is_asleep = true;
+        } else if self.is_asleep && lux > SLEEPY_EXIT_LUX {
+            self.is_asleep = false;
+        }
+
+        // Another modifier (touch, pickup) has already claimed the
+        // emotion. Stand down — ambient is background state, explicit
+        // input wins.
+        if let Some(until) = avatar.manual_until
+            && now < until
+        {
+            return;
+        }
+
+        if self.is_asleep {
+            avatar.emotion = Emotion::Sleepy;
+            // Re-affirm the hold every dark tick so Sleepy persists
+            // as long as the room stays dim.
+            avatar.manual_until = Some(now + AMBIENT_HOLD_MS);
+        }
+        // When `is_asleep == false` and no hold is active we do
+        // nothing — `EmotionCycle` takes over on the next tick and
+        // drives autonomy forward. No need to explicitly clear
+        // `manual_until` here; `EmotionTouch::update` handles
+        // expiry cleanup on every tick.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: make a bright-ambient avatar (well above the exit
+    /// threshold).
+    fn bright() -> Avatar {
+        Avatar {
+            ambient_lux: Some(200.0),
+            ..Avatar::default()
+        }
+    }
+
+    /// Helper: make a dark-ambient avatar (well below enter threshold).
+    fn dark() -> Avatar {
+        Avatar {
+            ambient_lux: Some(5.0),
+            ..Avatar::default()
+        }
+    }
+
+    #[test]
+    fn no_reading_does_nothing() {
+        let mut avatar = Avatar::default(); // ambient_lux = None
+        let mut sleepy = AmbientSleepy::new();
+        for t in (0..1_000).step_by(50) {
+            sleepy.update(&mut avatar, Instant::from_millis(t));
+        }
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn dark_room_triggers_sleepy() {
+        let mut avatar = dark();
+        let mut sleepy = AmbientSleepy::new();
+        sleepy.update(&mut avatar, Instant::from_millis(100));
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+        assert!(sleepy.is_asleep());
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(100 + AMBIENT_HOLD_MS)),
+        );
+    }
+
+    #[test]
+    fn bright_room_does_not_trigger() {
+        let mut avatar = bright();
+        let mut sleepy = AmbientSleepy::new();
+        sleepy.update(&mut avatar, Instant::from_millis(100));
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert!(!sleepy.is_asleep());
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn hysteresis_holds_sleep_between_thresholds() {
+        let mut avatar = dark();
+        let mut sleepy = AmbientSleepy::new();
+
+        // Enter sleep at 5 lux.
+        sleepy.update(&mut avatar, Instant::from_millis(0));
+        assert!(sleepy.is_asleep());
+
+        // Dim bulb lights up — 30 lux is between ENTER (20) and EXIT
+        // (50) thresholds. Must stay asleep.
+        avatar.ambient_lux = Some(30.0);
+        sleepy.update(&mut avatar, Instant::from_millis(100));
+        assert!(sleepy.is_asleep(), "30 lux is inside the hysteresis band");
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+    }
+
+    #[test]
+    fn bright_room_wakes_from_sleep() {
+        let mut avatar = dark();
+        let mut sleepy = AmbientSleepy::new();
+        sleepy.update(&mut avatar, Instant::from_millis(0));
+
+        avatar.ambient_lux = Some(200.0);
+        sleepy.update(&mut avatar, Instant::from_millis(100));
+        assert!(!sleepy.is_asleep());
+        // Prior-frame hold remains (the modifier re-affirms but
+        // doesn't actively clear); EmotionTouch::update clears
+        // expired holds in the normal pipeline.
+    }
+
+    #[test]
+    fn asymmetric_thresholds_prevent_flicker() {
+        // Simulate ambient hovering around a single mid-point: if we
+        // used one threshold at 35 lux the output would flicker. With
+        // hysteresis (20 / 50), a hover in the 25–45 band never
+        // toggles state.
+        let mut avatar = dark();
+        let mut sleepy = AmbientSleepy::new();
+        sleepy.update(&mut avatar, Instant::from_millis(0));
+        assert!(sleepy.is_asleep());
+
+        for (i, lux) in [25.0_f32, 45.0, 30.0, 40.0, 35.0].into_iter().enumerate() {
+            avatar.ambient_lux = Some(lux);
+            sleepy.update(&mut avatar, Instant::from_millis(100 + (i as u64) * 100));
+            assert!(
+                sleepy.is_asleep(),
+                "lux {lux} in hysteresis band should hold prior state",
+            );
+        }
+    }
+
+    #[test]
+    fn touch_hold_blocks_ambient_sleepy() {
+        let mut avatar = dark();
+        // Touch just set emotion=Happy + 30 s hold.
+        avatar.emotion = Emotion::Happy;
+        avatar.manual_until = Some(Instant::from_millis(30_000));
+        let mut sleepy = AmbientSleepy::new();
+
+        sleepy.update(&mut avatar, Instant::from_millis(100));
+        assert_eq!(
+            avatar.emotion,
+            Emotion::Happy,
+            "touch-set emotion must survive concurrent darkness",
+        );
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(30_000)),
+            "touch-set hold deadline must be preserved",
+        );
+    }
+
+    #[test]
+    fn ambient_hold_is_renewed_every_dark_tick() {
+        let mut avatar = dark();
+        let mut sleepy = AmbientSleepy::new();
+
+        // First dark tick.
+        sleepy.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(AMBIENT_HOLD_MS))
+        );
+
+        // Simulate clearing by EmotionTouch::update when the hold
+        // expires (3 s later, still dark — modifier stack would see
+        // the clear before AmbientSleepy runs in the same frame).
+        avatar.manual_until = None;
+
+        sleepy.update(&mut avatar, Instant::from_millis(3_000));
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(3_000 + AMBIENT_HOLD_MS)),
+            "still-dark ticks must re-arm the hold",
+        );
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -14,24 +14,30 @@
 //!    `Surprised` with a `manual_until` hold when a pickup / drop is
 //!    detected. Stands down when `manual_until` is already set (so
 //!    explicit touch wins).
-//! 3. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
+//! 3. [`AmbientSleepy`] — reads `Avatar::ambient_lux`, flips emotion
+//!    to `Sleepy` with a short `manual_until` hold in dark rooms
+//!    (hysteresis 20/50 lux). Runs after `PickupReaction` so a
+//!    pickup-in-the-dark still surfaces as Surprised rather than
+//!    Sleepy.
+//! 4. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
 //!    when `manual_until` is unset or expired.
-//! 4. [`EmotionStyle`] — translates emotion into style fields, with a
+//! 5. [`EmotionStyle`] — translates emotion into style fields, with a
 //!    linear ease over the transition window.
-//! 5. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
+//! 6. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
 //!    `blink_rate_scale` from the avatar.
-//! 6. [`Breath`] — vertical drift on all features, scaled by
+//! 7. [`Breath`] — vertical drift on all features, scaled by
 //!    `breath_depth_scale`.
-//! 7. [`IdleDrift`] — occasional eye-center jitter.
-//! 8. [`IdleSway`] — slow pan/tilt head wander written to
+//! 8. [`IdleDrift`] — occasional eye-center jitter.
+//! 9. [`IdleSway`] — slow pan/tilt head wander written to
 //!    `Avatar::head_pose`. Non-visual; drives the firmware's head-update
 //!    task, not the pixel pipeline.
-//! 9. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
-//!    sway. Runs **after** `IdleSway` so bias composes additively rather
-//!    than fighting for absolute control of the pose.
+//! 10. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
+//!     sway. Runs **after** `IdleSway` so bias composes additively rather
+//!     than fighting for absolute control of the pose.
 //!
 //! [`Avatar`]: crate::avatar::Avatar
 
+mod ambient_sleepy;
 mod blink;
 mod breath;
 mod emotion_cycle;
@@ -42,6 +48,7 @@ mod idle_drift;
 mod idle_sway;
 mod pickup_reaction;
 
+pub use ambient_sleepy::{AMBIENT_HOLD_MS, AmbientSleepy, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX};
 pub use blink::Blink;
 pub use breath::Breath;
 pub use emotion_cycle::EmotionCycle;

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -15,8 +15,10 @@ workspace = true
 stackchan-core = { path = "../stackchan-core" }
 axp2101 = { path = "../axp2101" }
 aw9523 = { path = "../aw9523" }
+bm8563 = { path = "../bm8563" }
 bmi270 = { path = "../bmi270" }
 ft6336u = { path = "../ft6336u" }
+ltr553 = { path = "../ltr553" }
 scservo = { path = "../scservo" }
 embedded-graphics = { workspace = true }
 embedded-hal = { workspace = true }
@@ -93,3 +95,7 @@ path = "examples/touch_bench.rs"
 [[example]]
 name = "imu_bench"
 path = "examples/imu_bench.rs"
+
+[[example]]
+name = "ambient_bench"
+path = "examples/ambient_bench.rs"

--- a/crates/stackchan-firmware/examples/ambient_bench.rs
+++ b/crates/stackchan-firmware/examples/ambient_bench.rs
@@ -1,0 +1,105 @@
+//! Ambient-light bench: brings up shared I²C, runs LTR-553 init,
+//! streams raw channel values + estimated lux at 5 Hz via defmt.
+//!
+//! Used to calibrate the 20 / 50 lux thresholds in
+//! `stackchan_core::modifiers::AmbientSleepy`. Move the device under
+//! various lighting conditions and grep the log for matching lux
+//! values.
+//!
+//! Output per tick:
+//!
+//! ```text
+//! ambient-bench: ch0=1234 ch1=123 lux=1234.56 status=0b0100
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Ticker};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use ltr553::Ltr553;
+use stackchan_firmware::board;
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped. See
+/// `main.rs` for the full rationale.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+/// Panic handler for the bench binary.
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("ambient-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Heap size: no framebuffer, small driver, embassy task arena.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Poll cadence. 200 ms = 5 Hz; slow enough to read comfortably, fast
+/// enough to see real-time lux changes as a lamp switches.
+const POLL_PERIOD_MS: u64 = 200;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "the esp_rtos::main macro requires the `spawner` arg; ambient-bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-ambient-bench v{} — CoreS3 boot, streaming LTR-553 readings",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let mut als = Ltr553::new(board_io.i2c);
+    match als.read_part_id().await {
+        Ok(id) => defmt::info!("LTR-553 part_id=0x{=u8:02X}", id),
+        Err(e) => defmt::warn!("LTR-553 part_id read failed: {}", defmt::Debug2Format(&e)),
+    }
+    if let Err(e) = als.init().await {
+        defmt::panic!("LTR-553 init failed: {}", defmt::Debug2Format(&e));
+    }
+    defmt::info!("ambient-bench: streaming @ {=u64} ms tick", POLL_PERIOD_MS,);
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    loop {
+        match als.read_ambient().await {
+            Ok(r) => defmt::info!(
+                "ambient-bench: ch0={=u16} ch1={=u16} lux={=f32}",
+                r.ch0,
+                r.ch1,
+                r.lux,
+            ),
+            Err(e) => defmt::warn!("ambient-bench: read failed: {}", defmt::Debug2Format(&e)),
+        }
+        ticker.next().await;
+    }
+}

--- a/crates/stackchan-firmware/src/ambient.rs
+++ b/crates/stackchan-firmware/src/ambient.rs
@@ -1,0 +1,74 @@
+//! LTR-553 ambient-light polling task.
+//!
+//! Polls the chip at 2 Hz (plenty for ambient — the human eye doesn't
+//! adapt fast enough to care about higher rates) and publishes the
+//! latest lux estimate on [`AMBIENT_LUX_SIGNAL`]. The render task
+//! drains the signal, writes `avatar.ambient_lux`, and runs
+//! [`stackchan_core::modifiers::AmbientSleepy`].
+//!
+//! ## Boot probe
+//!
+//! Reads `PART_ID` once at startup and logs the outcome. An unexpected
+//! part identifier logs at `warn`; I²C transport failures log at
+//! `error` and drop the task into an idle loop. The rest of the
+//! firmware keeps running — ambient-driven behavior silently
+//! degrades into "never sleepy" without affecting touch, pickup, or
+//! the render stack.
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker, Timer};
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+use ltr553::Ltr553;
+
+/// Latest ambient-light reading: ambient task → render task. Lux only
+/// — the render-side consumer doesn't care about raw channels (those
+/// are available via `examples/ambient_bench.rs` for calibration).
+pub static AMBIENT_LUX_SIGNAL: Signal<CriticalSectionRawMutex, f32> = Signal::new();
+
+/// Poll cadence. 500 ms matches the LTR-553's default measurement
+/// rate (the chip updates its internal channels every 500 ms), so
+/// reading faster just returns duplicates.
+const POLL_PERIOD_MS: u64 = 500;
+
+/// Run the LTR-553 init sequence then loop forever publishing lux
+/// values.
+pub async fn run_ambient_loop<I: AsyncI2c>(bus: I) -> ! {
+    let mut als = Ltr553::new(bus);
+
+    if let Err(e) = als.init().await {
+        defmt::error!(
+            "LTR-553: init failed ({}); ambient-driven behaviors disabled",
+            defmt::Debug2Format(&e),
+        );
+        park().await;
+    }
+    defmt::info!(
+        "LTR-553: init complete — polling @ {=u64} ms tick",
+        POLL_PERIOD_MS,
+    );
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    loop {
+        match als.read_ambient().await {
+            Ok(reading) => {
+                AMBIENT_LUX_SIGNAL.signal(reading.lux);
+                defmt::debug!(
+                    "LTR-553: ch0={=u16} ch1={=u16} lux={=f32}",
+                    reading.ch0,
+                    reading.ch1,
+                    reading.lux,
+                );
+            }
+            Err(e) => defmt::warn!("LTR-553: read failed: {}", defmt::Debug2Format(&e),),
+        }
+        ticker.next().await;
+    }
+}
+
+/// Idle loop for the post-failure path. Keeps the task alive without
+/// further bus traffic.
+async fn park() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(60)).await;
+    }
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -17,9 +17,11 @@
 
 extern crate alloc;
 
+pub mod ambient;
 pub mod board;
 pub mod clock;
 pub mod framebuffer;
 pub mod head;
 pub mod imu;
 pub mod touch;
+pub mod wallclock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -24,7 +24,7 @@
 
 extern crate alloc;
 
-use stackchan_firmware::{board, clock, framebuffer, head, imu, touch};
+use stackchan_firmware::{ambient, board, clock, framebuffer, head, imu, touch, wallclock};
 
 use board::{HeadDriverImpl, SharedI2c};
 use clock::HalClock;
@@ -58,8 +58,8 @@ use mipidsi::{
 use stackchan_core::{
     Avatar, Clock, HeadDriver, Modifier,
     modifiers::{
-        Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch, IdleDrift, IdleSway,
-        PickupReaction,
+        AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
+        IdleDrift, IdleSway, PickupReaction,
     },
 };
 use static_cell::StaticCell;
@@ -158,6 +158,7 @@ async fn render_task(mut display: LcdDisplay) {
     let mut avatar = Avatar::default();
     let mut emotion_touch = EmotionTouch::new();
     let mut pickup = PickupReaction::new();
+    let mut ambient_sleepy = AmbientSleepy::new();
     let mut cycle = EmotionCycle::new();
     let mut style = EmotionStyle::new();
     let mut blink = Blink::new();
@@ -176,7 +177,7 @@ async fn render_task(mut display: LcdDisplay) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + PickupReaction + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead",
+        "render task: {=u64} ms tick, EmotionTouch + PickupReaction + AmbientSleepy + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead",
         FRAME_PERIOD_MS
     );
 
@@ -198,8 +199,15 @@ async fn render_task(mut display: LcdDisplay) {
             avatar.accel_g = m.accel_g;
             avatar.gyro_dps = m.gyro_dps;
         }
+        // Drain the latest ambient reading. 2 Hz publish rate, so most
+        // render ticks see nothing new — last-known lux stays on the
+        // avatar so `AmbientSleepy` has coherent input.
+        if let Some(lux) = ambient::AMBIENT_LUX_SIGNAL.try_take() {
+            avatar.ambient_lux = Some(lux);
+        }
         emotion_touch.update(&mut avatar, now);
         pickup.update(&mut avatar, now);
+        ambient_sleepy.update(&mut avatar, now);
         cycle.update(&mut avatar, now);
         style.update(&mut avatar, now);
         blink.update(&mut avatar, now);
@@ -330,6 +338,13 @@ async fn imu_task(shared_i2c: SharedI2c) -> ! {
     imu::run_imu_loop(shared_i2c).await
 }
 
+/// LTR-553 ambient-light polling task. Third consumer of the shared
+/// I²C0 bus. Publishes lux estimates on [`ambient::AMBIENT_LUX_SIGNAL`].
+#[embassy_executor::task]
+async fn ambient_task(shared_i2c: SharedI2c) -> ! {
+    ambient::run_ambient_loop(shared_i2c).await
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
@@ -419,11 +434,22 @@ async fn main(spawner: Spawner) -> ! {
     if let Err(e) = spawner.spawn(touch_task(board_io.i2c)) {
         defmt::panic!("spawn touch_task failed: {}", defmt::Debug2Format(&e));
     }
-    // Second shared-bus handle onto the same I²C0 for the IMU task.
-    // The `I2cDevice` wrapper serialises concurrent access so the
-    // touch task and IMU task can each own a handle.
+    // Three more shared-bus handles onto the same I²C0. The
+    // `I2cDevice` wrapper serialises concurrent access so each task
+    // can own a handle without contention bookkeeping.
     if let Err(e) = spawner.spawn(imu_task(I2cDevice::new(board_io.i2c_bus))) {
         defmt::panic!("spawn imu_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(ambient_task(I2cDevice::new(board_io.i2c_bus))) {
+        defmt::panic!("spawn ambient_task failed: {}", defmt::Debug2Format(&e));
+    }
+
+    // One-shot wall-clock read for the boot log. Single I²C round-trip;
+    // failures are warn-only (logged inside `wallclock::read_and_format`).
+    let mut rtc_buf = [0u8; 19];
+    let rtc_bus = I2cDevice::new(board_io.i2c_bus);
+    if let Some(stamp) = wallclock::read_and_format(rtc_bus, &mut rtc_buf).await {
+        defmt::info!("boot @ {=str} (RTC)", stamp);
     }
 
     defmt::info!("boot complete — idle heartbeat");

--- a/crates/stackchan-firmware/src/wallclock.rs
+++ b/crates/stackchan-firmware/src/wallclock.rs
@@ -1,0 +1,43 @@
+//! BM8563 wall-clock read, used to timestamp a single boot log line.
+//!
+//! The `defmt` timestamp stays as `embassy_time::Instant::now()` in
+//! milliseconds — that's what the embassy / defmt integration expects.
+//! This module exists only to give the boot log an absolute time
+//! ("boot @ 2026-04-24 13:37:05") so post-reboot logs can be
+//! correlated without maintaining a side channel on the host.
+//!
+//! No attempt to keep a running wall-clock: the one caller today
+//! pays for one I²C round-trip at boot. YAGNI until we grow a second
+//! caller.
+
+use bm8563::{Bm8563, format_datetime};
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+
+/// Read + format the current wall time from the RTC.
+///
+/// Writes into `buffer` in `YYYY-MM-DD HH:MM:SS` form (19 ASCII bytes)
+/// and returns the filled string slice, or `None` if the RTC was
+/// unreachable / unreliable.
+///
+/// Using a caller-provided buffer keeps the allocator out of the hot
+/// path.
+pub async fn read_and_format<I: AsyncI2c>(bus: I, buffer: &mut [u8; 19]) -> Option<&str> {
+    let mut rtc = Bm8563::new(bus);
+    if let Err(e) = rtc.init().await {
+        defmt::warn!(
+            "BM8563: init failed ({}); boot log will omit wall-clock",
+            defmt::Debug2Format(&e),
+        );
+        return None;
+    }
+    match rtc.read_datetime().await {
+        Ok(dt) => Some(format_datetime(dt, buffer)),
+        Err(e) => {
+            defmt::warn!(
+                "BM8563: read failed ({}); boot log will omit wall-clock",
+                defmt::Debug2Format(&e),
+            );
+            None
+        }
+    }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,11 +17,17 @@
     "crates/aw9523": {
       "package-name": "aw9523"
     },
+    "crates/bm8563": {
+      "package-name": "bm8563"
+    },
     "crates/bmi270": {
       "package-name": "bmi270"
     },
     "crates/ft6336u": {
       "package-name": "ft6336u"
+    },
+    "crates/ltr553": {
+      "package-name": "ltr553"
     },
     "crates/scservo": {
       "package-name": "scservo"


### PR DESCRIPTION
## Summary
- New `bm8563` crate: async RTC driver with zero-alloc `format_datetime` helper for `YYYY-MM-DD HH:MM:SS` log stamps. No `chrono` dep.
- New `ltr553` crate: ambient-light + proximity driver with Lite-On app-note piecewise lux formula.
- New `AmbientSleepy` modifier in stackchan-core: hysteresis-based Sleepy trigger (20 lux enter / 50 lux exit) using the shared `manual_until` hold. Respects existing touch / pickup holds.
- `Avatar::ambient_lux: Option<f32>` added. Excluded from `frame_eq`.
- Firmware: new `ambient` and `wallclock` modules; 3rd shared-bus consumer spawned for LTR-553; one-shot BM8563 wall-clock read prints `boot @ YYYY-MM-DD HH:MM:SS` in the boot log.
- Standalone `examples/ambient_bench.rs` streams ch0 / ch1 / lux for threshold calibration against real lighting.

## Test plan
- [x] `cargo test --workspace --exclude stackchan-firmware`: **166 pass** (up from 143). 7 new `AmbientSleepy` sim tests cover hysteresis, wake, touch-override, hold renewal, and no-reading no-op. 5 `bm8563` tests cover BCD round-trip + format + century bit. 3 `ltr553` tests cover lux formula + part-ID mask.
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings`: clean.
- [x] `cargo +esp clippy --all-features --examples -- -D warnings` (firmware): clean.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware`: clean.
- [ ] Hardware flash test: boot log should show `BM8563: ...` and `LTR-553: init complete`, plus `boot @ YYYY-MM-DD HH:MM:SS` if the RTC battery is charged. Cover / uncover the ambient sensor to verify Sleepy ↔ autonomy transitions.
- [ ] `cargo run --example ambient_bench -p stackchan-firmware --release` (follow-up): stream lux readings under different lighting to confirm 20 / 50 thresholds are appropriate for the physical unit.