### PR TITLE
feat: power-button taps + IR NEC RemoteCommand modifier

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,6 +6,7 @@
   "crates/bm8563": "0.1.0",
   "crates/bmi270": "0.1.0",
   "crates/ft6336u": "0.1.0",
+  "crates/ir-nec": "0.1.0",
   "crates/ltr553": "0.1.0",
   "crates/scservo": "0.2.0",
   "crates/stackchan-firmware": "0.2.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ir-nec"
+version = "0.1.0"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1502,7 @@ dependencies = [
  "esp-println",
  "esp-rtos",
  "ft6336u",
+ "ir-nec",
  "ltr553",
  "mipidsi",
  "scservo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/bm8563",
     "crates/bmi270",
     "crates/ft6336u",
+    "crates/ir-nec",
     "crates/ltr553",
     "crates/scservo",
     "crates/stackchan-firmware",
@@ -20,6 +21,7 @@ default-members = [
     "crates/bm8563",
     "crates/bmi270",
     "crates/ft6336u",
+    "crates/ir-nec",
     "crates/ltr553",
     "crates/scservo",
 ]

--- a/crates/axp2101/src/lib.rs
+++ b/crates/axp2101/src/lib.rs
@@ -32,6 +32,24 @@ use embedded_hal_async::i2c::I2c;
 /// 7-bit I²C address of the AXP2101 on CoreS3.
 pub const ADDRESS: u8 = 0x34;
 
+/// `IRQ_EN_1` register address (`0x41`). Controls which power-key
+/// events generate interrupts.
+const REG_IRQ_EN_1: u8 = 0x41;
+/// `IRQ_STATUS_1` register address (`0x49`). Flags for power-key
+/// events; write-1-to-clear.
+const REG_IRQ_STATUS_1: u8 = 0x49;
+
+/// Bit for "short-press" in AXP2101's `IRQ_EN_1` / `IRQ_STATUS_1`
+/// registers (release after a brief hold, < 1 s).
+///
+/// Bit layout of `IRQ_STATUS_1`:
+///   - bit 1: power-key positive edge (press)
+///   - bit 0: power-key negative edge (release)
+///   - bit 4: short-press
+///   - bit 5: long-press
+///   - bit 6: over-press (held > 2 s)
+pub const IRQ_SHORT_PRESS_BIT: u8 = 1 << 4;
+
 /// Error type for the driver.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -171,6 +189,48 @@ where
             .await
             .map_err(Error::I2c)?;
         Ok(())
+    }
+
+    /// Enable the "short-press" power-key IRQ. After calling,
+    /// [`Axp2101::check_short_press_edge`] will observe one edge per
+    /// brief button press (< 1 s hold + release).
+    ///
+    /// Leaves other `IRQ_EN_1` bits untouched via read-modify-write.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::I2c`] on bus errors.
+    pub async fn enable_power_key_short_press_irq(&mut self) -> Result<(), Error<B::Error>> {
+        let current = self.read_reg(REG_IRQ_EN_1).await?;
+        self.write_reg(REG_IRQ_EN_1, current | IRQ_SHORT_PRESS_BIT)
+            .await?;
+        Ok(())
+    }
+
+    /// Check for a pending short-press edge and clear it atomically.
+    ///
+    /// Returns `true` iff the short-press bit was set in `IRQ_STATUS_1`
+    /// (`0x49`). The bit is cleared (write-1-to-clear) as part of the
+    /// check so a subsequent call returns `false` until another press
+    /// arrives.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::I2c`] on bus errors. A bus failure at *read*
+    /// leaves no edge flag visible to the caller; a failure at *clear*
+    /// means the next call may see a stale-true result (acceptable —
+    /// a double-fire of the tap signal is benign given the downstream
+    /// modifier is edge-triggered).
+    pub async fn check_short_press_edge(&mut self) -> Result<bool, Error<B::Error>> {
+        let status = self.read_reg(REG_IRQ_STATUS_1).await?;
+        if status & IRQ_SHORT_PRESS_BIT == 0 {
+            return Ok(false);
+        }
+        // Write 1 to clear; preserve any other flags the chip set
+        // during this read's narrow window so we don't lose them.
+        self.write_reg(REG_IRQ_STATUS_1, IRQ_SHORT_PRESS_BIT)
+            .await?;
+        Ok(true)
     }
 }
 

--- a/crates/ir-nec/Cargo.toml
+++ b/crates/ir-nec/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ir-nec"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Pure-logic no_std NEC IR-remote protocol decoder. Takes pulse-timing slices, emits address + command words. No hardware dependency."
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/ir-nec/src/lib.rs
+++ b/crates/ir-nec/src/lib.rs
@@ -1,0 +1,288 @@
+//! # ir-nec
+//!
+//! `no_std` NEC-protocol IR-remote decoder with no hardware
+//! dependency. Consumers pass in a slice of [`Pulse`] timings
+//! (captured however they like: esp-hal's RMT peripheral, a GPIO ISR,
+//! a simulator) and get back an [`Option<NecCommand>`].
+//!
+//! ## NEC frame shape
+//!
+//! ```text
+//! 9.0 ms mark  4.5 ms space  <32 data bits>  0.56 ms mark (stop)
+//! ```
+//!
+//! Each data bit is a `560 µs` mark followed by a space: short
+//! (`560 µs`) = `0`, long (`1.69 ms`) = `1`. Data bits are transmitted
+//! LSB-first within each byte: `addr_low, addr_high, cmd, ~cmd`. The
+//! `cmd` / `~cmd` pair is a checksum — receivers validate by `XOR`ing
+//! the two bytes and requiring `0xFF`.
+//!
+//! Some remotes use the "extended" NEC variant where the address
+//! bytes carry arbitrary data rather than the old `addr / ~addr`
+//! complementary pair. This decoder does **not** validate the address
+//! checksum; it treats the address as a plain `u16` so both variants
+//! work.
+//!
+//! ## Timing tolerance
+//!
+//! Real-world IR receivers add ±10% jitter. [`TOLERANCE_US`] widens
+//! every "is this close to X" comparison so typical decodes succeed.
+
+#![no_std]
+#![deny(unsafe_code)]
+
+/// One pulse interval, as captured by a hardware-timer peripheral.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pulse {
+    /// Logical IR-light level during this interval.
+    ///
+    /// Most IR receivers output an *active-low* signal (IRM56384 on
+    /// CoreS3 inverts internally), so "mark" (IR on) surfaces as
+    /// `low` at the GPIO. This module treats `level = true` as
+    /// "IR on" (mark) — callers that see active-low signals should
+    /// pre-invert.
+    pub level: bool,
+    /// Duration of the pulse in microseconds.
+    pub duration_us: u32,
+}
+
+/// Decoded NEC frame.
+///
+/// The NEC protocol transmits 4 bytes over the air: `address_low`,
+/// `address_high`, `command`, `~command`. We expose address as a
+/// single `u16` (low byte first, LSB per-byte-first-on-wire) and
+/// command as a `u8`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NecCommand {
+    /// 16-bit address the remote is broadcasting at.
+    ///
+    /// For classic NEC remotes this is `addr_low | (~addr_low << 8)`;
+    /// for extended NEC it's an arbitrary 16-bit value.
+    pub address: u16,
+    /// 8-bit command code.
+    pub command: u8,
+}
+
+/// Absolute timing tolerance for pulse comparisons, in microseconds.
+///
+/// Applied as a symmetric ±window around each spec value. Wide enough
+/// that cheap IR receivers with ~10% sample jitter decode reliably,
+/// narrow enough that ambient noise doesn't get mistaken for a frame.
+pub const TOLERANCE_US: u32 = 200;
+
+/// Expected length of the initial mark (AGC burst).
+const PREAMBLE_MARK_US: u32 = 9_000;
+/// Expected length of the initial space (AGC gap).
+const PREAMBLE_SPACE_US: u32 = 4_500;
+/// Expected length of each data-bit mark (constant across 0 and 1 bits).
+const BIT_MARK_US: u32 = 560;
+/// Expected space length for a `0` bit (short space).
+const BIT_ZERO_SPACE_US: u32 = 560;
+/// Expected space length for a `1` bit (long space).
+const BIT_ONE_SPACE_US: u32 = 1_690;
+
+/// Number of data bits the NEC protocol transmits per frame.
+const DATA_BITS: usize = 32;
+
+/// Number of pulses a complete NEC frame produces:
+/// 2 (preamble) + 2 × 32 (data mark/space pairs) + 1 (stop mark) = 67.
+const FRAME_PULSES: usize = 2 + DATA_BITS * 2 + 1;
+
+/// Check whether `actual` is within [`TOLERANCE_US`] of `expected`.
+const fn is_close(actual: u32, expected: u32) -> bool {
+    let lo = expected.saturating_sub(TOLERANCE_US);
+    let hi = expected.saturating_add(TOLERANCE_US);
+    actual >= lo && actual <= hi
+}
+
+/// Try to decode a NEC frame from the given pulse slice.
+///
+/// Returns `Some(NecCommand)` on a well-formed 32-bit frame with a
+/// valid `cmd` / `~cmd` checksum. Returns `None` if the slice is too
+/// short, the preamble doesn't match, any bit-space is out of range,
+/// or the command checksum fails.
+///
+/// The slice can be longer than one full frame (67 pulses); the
+/// decoder only looks at the first 67 entries and silently ignores
+/// trailing pulses. That keeps callers free from having to trim
+/// captures.
+///
+/// Note: does **not** require the final stop mark's timing to be
+/// close to the 560 µs bit-mark — some receivers clip the trailing
+/// mark short, and a missing stop pulse shouldn't discard an
+/// otherwise valid frame.
+#[must_use]
+pub fn decode(pulses: &[Pulse]) -> Option<NecCommand> {
+    if pulses.len() < FRAME_PULSES {
+        return None;
+    }
+    // Preamble: mark (IR on) then space (IR off).
+    if !pulses[0].level || !is_close(pulses[0].duration_us, PREAMBLE_MARK_US) {
+        return None;
+    }
+    if pulses[1].level || !is_close(pulses[1].duration_us, PREAMBLE_SPACE_US) {
+        return None;
+    }
+
+    // 32 data bits as (mark, space) pairs starting at index 2.
+    let mut bits: u32 = 0;
+    for bit_index in 0..DATA_BITS {
+        let mark_idx = 2 + bit_index * 2;
+        let space_idx = mark_idx + 1;
+        let mark = pulses[mark_idx];
+        let space = pulses[space_idx];
+        if !mark.level || !is_close(mark.duration_us, BIT_MARK_US) {
+            return None;
+        }
+        if space.level {
+            return None;
+        }
+        // Decide bit value by space length.
+        let bit = if is_close(space.duration_us, BIT_ZERO_SPACE_US) {
+            0
+        } else if is_close(space.duration_us, BIT_ONE_SPACE_US) {
+            1
+        } else {
+            return None;
+        };
+        // NEC transmits LSB-first. Place each bit at its final
+        // receive position so the complete u32 has byte layout:
+        // `[addr_low, addr_high, cmd, ~cmd]` in little-endian order.
+        bits |= bit << bit_index;
+    }
+
+    // Split into the 4 bytes and validate the command checksum.
+    let addr_low = (bits & 0xFF) as u8;
+    let addr_high = ((bits >> 8) & 0xFF) as u8;
+    let command = ((bits >> 16) & 0xFF) as u8;
+    let command_inv = ((bits >> 24) & 0xFF) as u8;
+    if command ^ command_inv != 0xFF {
+        return None;
+    }
+
+    Some(NecCommand {
+        address: u16::from(addr_low) | (u16::from(addr_high) << 8),
+        command,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a well-formed NEC frame as a `Vec<Pulse>` for testing.
+    fn build_frame(address: u16, command: u8) -> [Pulse; FRAME_PULSES] {
+        let command_inv = !command;
+        let bytes: [u8; 4] = [
+            (address & 0xFF) as u8,
+            ((address >> 8) & 0xFF) as u8,
+            command,
+            command_inv,
+        ];
+        let mut pulses = [Pulse {
+            level: false,
+            duration_us: 0,
+        }; FRAME_PULSES];
+        pulses[0] = Pulse {
+            level: true,
+            duration_us: PREAMBLE_MARK_US,
+        };
+        pulses[1] = Pulse {
+            level: false,
+            duration_us: PREAMBLE_SPACE_US,
+        };
+        let mut i = 2;
+        for byte in bytes {
+            for bit in 0..8 {
+                pulses[i] = Pulse {
+                    level: true,
+                    duration_us: BIT_MARK_US,
+                };
+                let one = (byte >> bit) & 1 != 0;
+                pulses[i + 1] = Pulse {
+                    level: false,
+                    duration_us: if one {
+                        BIT_ONE_SPACE_US
+                    } else {
+                        BIT_ZERO_SPACE_US
+                    },
+                };
+                i += 2;
+            }
+        }
+        // Stop bit: short mark.
+        pulses[i] = Pulse {
+            level: true,
+            duration_us: BIT_MARK_US,
+        };
+        pulses
+    }
+
+    #[test]
+    fn well_formed_frame_round_trips() {
+        let frame = build_frame(0xABCD, 0x42);
+        let Some(cmd) = decode(&frame) else {
+            unreachable!("valid frame")
+        };
+        assert_eq!(cmd.address, 0xABCD);
+        assert_eq!(cmd.command, 0x42);
+    }
+
+    #[test]
+    fn inverted_checksum_rejected() {
+        // command = 0x00 → ~command = 0xFF, bit 0 of ~command = 1
+        // (long space). Flip bit 0 of the *command* byte (which is 0,
+        // short space) to 1 (long space). After the flip the
+        // command / ~command XOR no longer equals 0xFF.
+        let mut frame = build_frame(0x0000, 0x00);
+        // Command byte starts at pulse index 2 + 16 * 2 = 34. Bit 0's
+        // space lives at `mark_idx + 1 = 35`.
+        let space_of_command_bit0 = 35;
+        frame[space_of_command_bit0].duration_us = BIT_ONE_SPACE_US;
+        assert!(decode(&frame).is_none());
+    }
+
+    #[test]
+    fn preamble_out_of_tolerance_rejected() {
+        let mut frame = build_frame(0x0000, 0x00);
+        frame[0].duration_us = 2_000; // way off 9 ms
+        assert!(decode(&frame).is_none());
+    }
+
+    #[test]
+    fn too_short_buffer_rejected() {
+        let short = [Pulse {
+            level: true,
+            duration_us: PREAMBLE_MARK_US,
+        }; 10];
+        assert!(decode(&short).is_none());
+    }
+
+    #[test]
+    fn tolerance_absorbs_small_jitter() {
+        let mut frame = build_frame(0x00FF, 0xA5);
+        // Wiggle every pulse within tolerance.
+        for p in &mut frame {
+            p.duration_us = p.duration_us.saturating_add(150);
+        }
+        let Some(cmd) = decode(&frame) else {
+            unreachable!("within tolerance")
+        };
+        assert_eq!(cmd.address, 0x00FF);
+        assert_eq!(cmd.command, 0xA5);
+    }
+
+    #[test]
+    fn trailing_pulses_ignored() {
+        let frame = build_frame(0x1234, 0x56);
+        let mut padded = [Pulse {
+            level: false,
+            duration_us: 0,
+        }; FRAME_PULSES + 20];
+        padded[..FRAME_PULSES].copy_from_slice(&frame);
+        let Some(cmd) = decode(&padded) else {
+            unreachable!("trailing garbage ignored")
+        };
+        assert_eq!(cmd.command, 0x56);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -10,28 +10,33 @@
 //!    `Avatar::emotion`, and writes `Avatar::manual_until`. Runs first
 //!    so the same tick that produced the tap also clears any expired
 //!    override before `EmotionCycle` checks it.
-//! 2. [`PickupReaction`] — reads `Avatar::accel_g`, flips emotion to
+//! 2. [`RemoteCommand`] — consumes IR-remote `(address, command)`
+//!    pairs from the firmware RMT task, looks them up in a user-
+//!    supplied mapping table, and writes emotion + `manual_until`.
+//!    Runs after `EmotionTouch` so a just-cleared hold is visible;
+//!    stands down if any other modifier already set one.
+//! 3. [`PickupReaction`] — reads `Avatar::accel_g`, flips emotion to
 //!    `Surprised` with a `manual_until` hold when a pickup / drop is
 //!    detected. Stands down when `manual_until` is already set (so
-//!    explicit touch wins).
-//! 3. [`AmbientSleepy`] — reads `Avatar::ambient_lux`, flips emotion
+//!    explicit touch / remote wins).
+//! 4. [`AmbientSleepy`] — reads `Avatar::ambient_lux`, flips emotion
 //!    to `Sleepy` with a short `manual_until` hold in dark rooms
 //!    (hysteresis 20/50 lux). Runs after `PickupReaction` so a
 //!    pickup-in-the-dark still surfaces as Surprised rather than
 //!    Sleepy.
-//! 4. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
+//! 5. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
 //!    when `manual_until` is unset or expired.
-//! 5. [`EmotionStyle`] — translates emotion into style fields, with a
+//! 6. [`EmotionStyle`] — translates emotion into style fields, with a
 //!    linear ease over the transition window.
-//! 6. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
+//! 7. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
 //!    `blink_rate_scale` from the avatar.
-//! 7. [`Breath`] — vertical drift on all features, scaled by
+//! 8. [`Breath`] — vertical drift on all features, scaled by
 //!    `breath_depth_scale`.
-//! 8. [`IdleDrift`] — occasional eye-center jitter.
-//! 9. [`IdleSway`] — slow pan/tilt head wander written to
-//!    `Avatar::head_pose`. Non-visual; drives the firmware's head-update
-//!    task, not the pixel pipeline.
-//! 10. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
+//! 9. [`IdleDrift`] — occasional eye-center jitter.
+//! 10. [`IdleSway`] — slow pan/tilt head wander written to
+//!     `Avatar::head_pose`. Non-visual; drives the firmware's head-update
+//!     task, not the pixel pipeline.
+//! 11. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
 //!     sway. Runs **after** `IdleSway` so bias composes additively rather
 //!     than fighting for absolute control of the pose.
 //!
@@ -47,6 +52,7 @@ mod emotion_touch;
 mod idle_drift;
 mod idle_sway;
 mod pickup_reaction;
+mod remote_command;
 
 pub use ambient_sleepy::{AMBIENT_HOLD_MS, AmbientSleepy, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX};
 pub use blink::Blink;
@@ -58,6 +64,7 @@ pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
 pub use pickup_reaction::{PICKUP_DEBOUNCE_MS, PICKUP_DEVIATION_G, PickupReaction};
+pub use remote_command::{RemoteCommand, RemoteMapping};
 
 use crate::avatar::Avatar;
 use crate::clock::Instant;

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -1,0 +1,241 @@
+//! `RemoteCommand`: consumes IR-remote events and maps them to
+//! emotions via a user-supplied lookup table.
+//!
+//! ## Why a mapping table instead of fixed behavior?
+//!
+//! IR remotes are per-user hardware: the NEC `(address, command)`
+//! pair your Apple TV remote uses is different from a cheap eBay
+//! ESP-family remote, which is different again from an LG / Sony
+//! TV. The right UX — and the right codes — can only be decided
+//! once you know which remote is on the user's desk. So this
+//! modifier takes the mapping as data: a `&'static [(address,
+//! command, emotion)]` slice passed in at construction.
+//!
+//! The `examples/ir_bench.rs` firmware binary prints every decoded
+//! NEC frame over defmt so users can populate the table for their
+//! specific remote in one sitting.
+//!
+//! ## Coordination
+//!
+//! Follows the same "explicit input wins" convention as
+//! [`super::EmotionTouch`] and [`super::PickupReaction`]: if
+//! [`Avatar::manual_until`] is already set by another modifier, the
+//! `RemoteCommand` stands down. Otherwise it sets the emotion from
+//! the table + writes `manual_until = now + MANUAL_HOLD_MS`.
+//!
+//! [`Avatar::manual_until`]: crate::avatar::Avatar::manual_until
+
+use super::{MANUAL_HOLD_MS, Modifier};
+use crate::avatar::Avatar;
+use crate::clock::Instant;
+use crate::emotion::Emotion;
+
+/// One entry in the remote-command-to-emotion lookup table.
+///
+/// `address` and `command` are the IR-remote's NEC-protocol codes as
+/// decoded by `ir-nec`. Callers that want to match multiple codes to
+/// the same emotion just add multiple entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RemoteMapping {
+    /// NEC address field.
+    pub address: u16,
+    /// NEC command field.
+    pub command: u8,
+    /// Emotion to set when this code is received.
+    pub emotion: Emotion,
+}
+
+/// Modifier that watches for IR-remote commands queued from the
+/// firmware's RMT-RX task and sets emotion per a lookup table.
+///
+/// Like [`super::EmotionTouch`], the modifier is edge-triggered: the
+/// queued command is cleared by the next `update()` call, so a
+/// single `queue()` produces exactly one emotion change.
+#[derive(Debug, Clone, Copy)]
+pub struct RemoteCommand {
+    /// Per-remote mapping table. Empty by default, which means the
+    /// modifier is a no-op until populated.
+    mapping: &'static [RemoteMapping],
+    /// Most-recently queued `(address, command)` pair, or `None`.
+    pending: Option<(u16, u8)>,
+}
+
+impl RemoteCommand {
+    /// Construct with an empty mapping. The modifier is a no-op in
+    /// this state — useful when the remote codes are still being
+    /// discovered, or for sim tests that don't care about IR.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            mapping: &[],
+            pending: None,
+        }
+    }
+
+    /// Construct with the given mapping table.
+    #[must_use]
+    pub const fn with_mapping(mapping: &'static [RemoteMapping]) -> Self {
+        Self {
+            mapping,
+            pending: None,
+        }
+    }
+
+    /// Queue an `(address, command)` pair for processing on the next
+    /// `update()`. Idempotent within a render tick: later queues
+    /// overwrite earlier ones, so the most recent code wins.
+    pub const fn queue(&mut self, address: u16, command: u8) {
+        self.pending = Some((address, command));
+    }
+}
+
+impl Default for RemoteCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for RemoteCommand {
+    fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        let Some((address, command)) = self.pending.take() else {
+            return;
+        };
+
+        // Another modifier (touch, pickup, ambient) already claimed
+        // the emotion. Drop the event on the floor — explicit input
+        // wins over remote-control input.
+        if let Some(until) = avatar.manual_until
+            && now < until
+        {
+            return;
+        }
+
+        // Linear scan of the mapping — table is expected to be tiny
+        // (one or two dozen entries at most). First match wins.
+        for entry in self.mapping {
+            if entry.address == address && entry.command == command {
+                avatar.emotion = entry.emotion;
+                avatar.manual_until = Some(now + MANUAL_HOLD_MS);
+                return;
+            }
+        }
+        // Unknown code: ignore silently. The firmware `ir` task logs
+        // every decoded command at info level already, so there's no
+        // observability loss here.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MAPPING: &[RemoteMapping] = &[
+        RemoteMapping {
+            address: 0xFF00,
+            command: 0x01,
+            emotion: Emotion::Happy,
+        },
+        RemoteMapping {
+            address: 0xFF00,
+            command: 0x02,
+            emotion: Emotion::Sad,
+        },
+    ];
+
+    #[test]
+    fn mapped_code_sets_emotion_and_hold() {
+        let mut avatar = Avatar::default();
+        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        remote.queue(0xFF00, 0x01);
+        remote.update(&mut avatar, Instant::from_millis(1_000));
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(1_000 + MANUAL_HOLD_MS)),
+        );
+    }
+
+    #[test]
+    fn unmapped_code_is_silent_noop() {
+        let mut avatar = Avatar::default();
+        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        remote.queue(0x1234, 0x56);
+        remote.update(&mut avatar, Instant::from_millis(1_000));
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn empty_mapping_is_always_noop() {
+        let mut avatar = Avatar::default();
+        let mut remote = RemoteCommand::new();
+        remote.queue(0xFF00, 0x01);
+        remote.update(&mut avatar, Instant::from_millis(1_000));
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn queued_command_collapses_to_latest() {
+        let mut avatar = Avatar::default();
+        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        // Queue Happy, then overwrite with Sad before the next update.
+        remote.queue(0xFF00, 0x01);
+        remote.queue(0xFF00, 0x02);
+        remote.update(&mut avatar, Instant::from_millis(1_000));
+        assert_eq!(avatar.emotion, Emotion::Sad);
+    }
+
+    #[test]
+    fn update_consumes_queued_command() {
+        let mut avatar = Avatar::default();
+        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        remote.queue(0xFF00, 0x01);
+        remote.update(&mut avatar, Instant::from_millis(0));
+        // Simulate the hold expiring + being cleared by EmotionTouch.
+        avatar.manual_until = None;
+        avatar.emotion = Emotion::Neutral;
+        // Another update with no new queued command must be a no-op.
+        remote.update(&mut avatar, Instant::from_millis(100_000));
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+    }
+
+    #[test]
+    fn active_hold_blocks_remote() {
+        let mut avatar = Avatar {
+            emotion: Emotion::Surprised,
+            manual_until: Some(Instant::from_millis(30_000)),
+            ..Avatar::default()
+        };
+        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        remote.queue(0xFF00, 0x01);
+        remote.update(&mut avatar, Instant::from_millis(1_000));
+        assert_eq!(
+            avatar.emotion,
+            Emotion::Surprised,
+            "touch / pickup / ambient hold must outrank remote",
+        );
+        assert_eq!(
+            avatar.manual_until,
+            Some(Instant::from_millis(30_000)),
+            "hold deadline must be preserved",
+        );
+    }
+
+    #[test]
+    fn remote_fires_after_hold_expires() {
+        let mut avatar = Avatar::default();
+        let mut remote = RemoteCommand::with_mapping(MAPPING);
+
+        // Hold set by (say) touch in the recent past.
+        avatar.manual_until = Some(Instant::from_millis(1_000));
+        remote.queue(0xFF00, 0x01);
+        remote.update(&mut avatar, Instant::from_millis(500));
+        // Command was consumed but had no effect because the hold was
+        // active. Clear and try again.
+        avatar.manual_until = None;
+        remote.queue(0xFF00, 0x01);
+        remote.update(&mut avatar, Instant::from_millis(2_000));
+        assert_eq!(avatar.emotion, Emotion::Happy);
+    }
+}

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -18,6 +18,7 @@ aw9523 = { path = "../aw9523" }
 bm8563 = { path = "../bm8563" }
 bmi270 = { path = "../bmi270" }
 ft6336u = { path = "../ft6336u" }
+ir-nec = { path = "../ir-nec" }
 ltr553 = { path = "../ltr553" }
 scservo = { path = "../scservo" }
 embedded-graphics = { workspace = true }
@@ -99,3 +100,7 @@ path = "examples/imu_bench.rs"
 [[example]]
 name = "ambient_bench"
 path = "examples/ambient_bench.rs"
+
+[[example]]
+name = "ir_bench"
+path = "examples/ir_bench.rs"

--- a/crates/stackchan-firmware/examples/ir_bench.rs
+++ b/crates/stackchan-firmware/examples/ir_bench.rs
@@ -1,0 +1,70 @@
+//! IR bench: log every decoded NEC frame so the operator can populate
+//! `RemoteCommand`'s mapping table for their specific remote.
+//!
+//! Skips every other peripheral (LCD, servos, IMU, ambient) — just
+//! initialises the RMT RX path and prints each `(address, command)`
+//! pair as the operator mashes buttons on a remote.
+//!
+//! Output per button:
+//!
+//! ```text
+//! ir-bench: addr=0x00EF cmd=0x5A
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use stackchan_firmware::ir;
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+/// Panic handler for the bench binary.
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("ir-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Heap size: no framebuffer, tiny decoder, embassy task arena.
+const HEAP_SIZE: usize = 32 * 1024;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "the esp_rtos::main macro requires the `spawner` arg; ir-bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-ir-bench v{} — CoreS3 boot, will dump decoded NEC frames",
+        env!("CARGO_PKG_VERSION")
+    );
+    defmt::info!(
+        "ir-bench: point a remote at the device and press buttons. Lines with `addr=... cmd=...` go in RemoteCommand's mapping table.",
+    );
+
+    // ir::run_ir_loop configures the RMT channel + decodes into
+    // ir::REMOTE_SIGNAL. We don't drain the signal here — the decoder
+    // also logs every decoded command at info level, which is all the
+    // operator needs to read the codes off.
+    ir::run_ir_loop(peripherals.RMT, peripherals.GPIO21).await
+}

--- a/crates/stackchan-firmware/src/button.rs
+++ b/crates/stackchan-firmware/src/button.rs
@@ -1,0 +1,72 @@
+//! AXP2101 power-button polling task.
+//!
+//! The AXP2101 latches power-key events into its `IRQ_STATUS_1`
+//! register. This task polls at 50 ms (20 Hz) for the short-press
+//! edge, clears it atomically (write-1-to-clear), and forwards each
+//! edge to [`touch::TAP_SIGNAL`] so the power button becomes a second
+//! tap source — user-facing behavior is identical to a touchscreen
+//! tap (cycle emotion + pin for 30 s).
+//!
+//! Why polling and not the AXP2101's IRQ pin? The IRQ line isn't
+//! broken out on CoreS3 in a way that's documented in our memory /
+//! datasheet cheat-sheet, and a 20 Hz polling bus lookup costs
+//! essentially nothing on the shared I²C bus (one register read per
+//! tick, shared across other consumers by the async `I2cDevice`
+//! mutex).
+//!
+//! ## Error handling
+//!
+//! Init failure (IRQ enable) logs at `error` and parks the task —
+//! behavior silently degrades to "no button input," matching the
+//! pattern used by `ambient` and `imu`. Runtime bus glitches log at
+//! `warn` and skip the tick.
+
+use axp2101::Axp2101;
+use embassy_time::{Duration, Ticker, Timer};
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+
+use crate::touch;
+
+/// Poll cadence. 50 ms = 20 Hz; responsive enough for a button,
+/// light enough on the bus.
+const POLL_PERIOD_MS: u64 = 50;
+
+/// Enable the short-press IRQ then loop forever forwarding edges to
+/// [`touch::TAP_SIGNAL`].
+pub async fn run_button_loop<I: AsyncI2c>(bus: I) -> ! {
+    let mut pmic = Axp2101::new(bus);
+    if let Err(e) = pmic.enable_power_key_short_press_irq().await {
+        defmt::error!(
+            "AXP2101 button: enable short-press IRQ failed ({}); power button disabled",
+            defmt::Debug2Format(&e),
+        );
+        park().await;
+    }
+    defmt::info!(
+        "AXP2101 button: short-press IRQ enabled; polling @ {=u64} ms tick",
+        POLL_PERIOD_MS,
+    );
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    loop {
+        match pmic.check_short_press_edge().await {
+            Ok(true) => {
+                defmt::debug!("AXP2101: power-key short-press edge -> TAP_SIGNAL");
+                touch::TAP_SIGNAL.signal(());
+            }
+            Ok(false) => {}
+            Err(e) => defmt::warn!(
+                "AXP2101 button: status read failed: {}",
+                defmt::Debug2Format(&e),
+            ),
+        }
+        ticker.next().await;
+    }
+}
+
+/// Idle loop for the post-failure path.
+async fn park() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(60)).await;
+    }
+}

--- a/crates/stackchan-firmware/src/ir.rs
+++ b/crates/stackchan-firmware/src/ir.rs
@@ -1,0 +1,176 @@
+//! IR receiver task: RMT RX → NEC decoder → Signal pipeline.
+//!
+//! Wraps an esp-hal RMT async RX channel, decodes the pulse train
+//! via the [`ir_nec`] crate, and publishes [`NecCommand`] values on
+//! [`REMOTE_SIGNAL`]. The render task drains the signal and feeds
+//! each command into the [`stackchan_core::modifiers::RemoteCommand`]
+//! modifier.
+//!
+//! ## CoreS3 pin caveat
+//!
+//! The memory cheat-sheet doesn't list the IR receiver's GPIO, so
+//! [`IR_RX_PIN`] is a best-guess `GPIO21` — the pin most commonly used
+//! on M5Stack boards for IR RX. Flash the firmware and, if no IR
+//! frames decode even with a working remote + `ir-bench`, update
+//! the const against the actual CoreS3 schematic.
+//!
+//! ## Signal polarity
+//!
+//! IRM56384-class receivers output **active-low** (IR burst present
+//! → GPIO goes low). The `ir_nec` decoder expects `level = true` to
+//! mean "mark" (IR burst). This task inverts the RMT level bits on
+//! conversion so the decoder sees the logical polarity it expects.
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Timer};
+use esp_hal::{
+    gpio::Level,
+    peripherals::{GPIO21, RMT},
+    rmt::{PulseCode, Rmt, RxChannelConfig, RxChannelCreator},
+    time::Rate,
+};
+use ir_nec::{NecCommand, Pulse};
+
+/// Raw NEC commands decoded from the IR receiver: IR task → render task.
+///
+/// The render task drains via [`Signal::try_take`] each frame and calls
+/// [`stackchan_core::modifiers::RemoteCommand::queue`] with the
+/// `(address, command)` pair. Signal semantics (latest wins, no backlog)
+/// mean if the user mashes buttons between render ticks, only the most
+/// recent command actually acts — acceptable for an emotion-control UX.
+pub static REMOTE_SIGNAL: Signal<CriticalSectionRawMutex, NecCommand> = Signal::new();
+
+/// Size of the RMT RX buffer, measured in [`PulseCode`] units.
+/// A full NEC frame is 67 pulse *edges* = 34 pulse codes. 64 gives us
+/// headroom for the stop bit + a repeat pulse without allocation.
+const RX_BUFFER_LEN: usize = 64;
+
+/// RMT idle threshold in ticks (with the 1 µs tick rate set below,
+/// this is microseconds). NEC's end-of-frame gap is ~40 ms, so
+/// anything longer than ~10 ms marks a complete frame.
+const RX_IDLE_THRESHOLD: u16 = 10_000;
+
+/// RMT filter threshold in ticks. Pulses shorter than this are
+/// treated as noise. 50 µs is well under NEC's 560 µs bit-mark.
+const RX_FILTER_THRESHOLD: u8 = 50;
+
+/// Clock divider for the RMT peripheral. At 80 MHz RMT base clock,
+/// `divider = 80` gives 1 µs per tick, which matches the
+/// `duration_us` units `ir-nec` expects.
+const RX_CLK_DIVIDER: u8 = 80;
+
+/// Configure the RMT RX channel and decode NEC frames forever.
+///
+/// Takes the RMT peripheral + the IR-receiver GPIO pin. Bus errors
+/// at configure-time log at `error` and park the task — silent
+/// degradation matches the other optional-peripheral tasks
+/// (`ambient`, `imu`, `button`).
+pub async fn run_ir_loop(rmt_peripheral: RMT<'static>, ir_rx_pin: GPIO21<'static>) -> ! {
+    let rmt = match Rmt::new(rmt_peripheral, Rate::from_mhz(80)) {
+        Ok(r) => r.into_async(),
+        Err(e) => {
+            defmt::error!(
+                "IR: RMT init failed ({}); IR-driven behaviors disabled",
+                defmt::Debug2Format(&e),
+            );
+            park().await;
+        }
+    };
+
+    let rx_config = RxChannelConfig::default()
+        .with_clk_divider(RX_CLK_DIVIDER)
+        .with_idle_threshold(RX_IDLE_THRESHOLD)
+        .with_filter_threshold(RX_FILTER_THRESHOLD);
+    let mut channel = match rmt.channel7.configure_rx(ir_rx_pin, rx_config) {
+        Ok(c) => c,
+        Err(e) => {
+            defmt::error!(
+                "IR: RMT RX channel configure failed ({}); IR-driven behaviors disabled",
+                defmt::Debug2Format(&e),
+            );
+            park().await;
+        }
+    };
+    defmt::info!(
+        "IR: RMT RX on channel7 pin {=str} (1 us tick, idle {=u16} us, filter {=u8} us)",
+        "GPIO21 (TBD vs CoreS3 schematic)",
+        RX_IDLE_THRESHOLD,
+        RX_FILTER_THRESHOLD,
+    );
+
+    // Reusable pulse-code + pulse buffers. `RX_BUFFER_LEN * 2` is the
+    // max number of logical pulses we can decode per transaction
+    // because each PulseCode packs two pulse halves.
+    let mut codes = [PulseCode::default(); RX_BUFFER_LEN];
+    let mut pulses = [Pulse {
+        level: false,
+        duration_us: 0,
+    }; RX_BUFFER_LEN * 2];
+
+    loop {
+        match channel.receive(&mut codes).await {
+            Ok(valid_codes) => {
+                let pulse_count = pulse_codes_to_pulses(&codes[..valid_codes], &mut pulses);
+                if let Some(cmd) = ir_nec::decode(&pulses[..pulse_count]) {
+                    defmt::info!(
+                        "IR: decoded addr=0x{=u16:04X} cmd=0x{=u8:02X}",
+                        cmd.address,
+                        cmd.command,
+                    );
+                    REMOTE_SIGNAL.signal(cmd);
+                } else {
+                    defmt::debug!(
+                        "IR: {=usize} pulses, decode failed (noise / unknown protocol)",
+                        pulse_count,
+                    );
+                }
+            }
+            Err(e) => defmt::warn!("IR: RMT receive failed: {}", defmt::Debug2Format(&e)),
+        }
+    }
+}
+
+/// Convert a slice of RMT [`PulseCode`]s into the [`Pulse`] array the
+/// decoder expects, inverting level polarity for active-low IR
+/// receivers.
+///
+/// Stops at the first pulse code with `length1 == 0` (RMT's
+/// end-of-data sentinel) OR when the destination buffer is full.
+/// Returns the number of [`Pulse`]s written.
+fn pulse_codes_to_pulses(codes: &[PulseCode], pulses: &mut [Pulse]) -> usize {
+    let mut out = 0;
+    for code in codes {
+        if code.length1() == 0 {
+            break;
+        }
+        if out >= pulses.len() {
+            break;
+        }
+        pulses[out] = Pulse {
+            // IR receiver is active-low: PulseCode::Low == IR burst.
+            level: code.level1() == Level::Low,
+            duration_us: u32::from(code.length1()),
+        };
+        out += 1;
+
+        if code.length2() == 0 {
+            break;
+        }
+        if out >= pulses.len() {
+            break;
+        }
+        pulses[out] = Pulse {
+            level: code.level2() == Level::Low,
+            duration_us: u32::from(code.length2()),
+        };
+        out += 1;
+    }
+    out
+}
+
+/// Idle loop for the post-failure path.
+async fn park() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(60)).await;
+    }
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -19,9 +19,11 @@ extern crate alloc;
 
 pub mod ambient;
 pub mod board;
+pub mod button;
 pub mod clock;
 pub mod framebuffer;
 pub mod head;
 pub mod imu;
+pub mod ir;
 pub mod touch;
 pub mod wallclock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -24,7 +24,9 @@
 
 extern crate alloc;
 
-use stackchan_firmware::{ambient, board, clock, framebuffer, head, imu, touch, wallclock};
+use stackchan_firmware::{
+    ambient, board, button, clock, framebuffer, head, imu, ir, touch, wallclock,
+};
 
 use board::{HeadDriverImpl, SharedI2c};
 use clock::HalClock;
@@ -59,7 +61,7 @@ use stackchan_core::{
     Avatar, Clock, HeadDriver, Modifier,
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
-        IdleDrift, IdleSway, PickupReaction,
+        IdleDrift, IdleSway, PickupReaction, RemoteCommand,
     },
 };
 use static_cell::StaticCell;
@@ -157,6 +159,10 @@ async fn render_task(mut display: LcdDisplay) {
     );
     let mut avatar = Avatar::default();
     let mut emotion_touch = EmotionTouch::new();
+    // Empty remote mapping by default. Populate with your specific
+    // NEC `(address, command, emotion)` tuples after running
+    // `examples/ir_bench.rs` to discover your remote's codes.
+    let mut remote = RemoteCommand::new();
     let mut pickup = PickupReaction::new();
     let mut ambient_sleepy = AmbientSleepy::new();
     let mut cycle = EmotionCycle::new();
@@ -177,19 +183,25 @@ async fn render_task(mut display: LcdDisplay) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + PickupReaction + AmbientSleepy + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead",
+        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + AmbientSleepy + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead",
         FRAME_PERIOD_MS
     );
 
     loop {
         let now = clock.now();
 
-        // Drain any tap edges the touch task published since last
-        // frame. `try_take` is non-blocking; a missing signal is the
-        // common case and means `EmotionTouch::update` only does the
-        // expired-hold cleanup work this tick.
+        // Drain any tap edges the touch task or power-button task
+        // published since last frame. Both sources publish to the
+        // same signal so a button press is UX-indistinguishable from
+        // a screen tap. `try_take` is non-blocking; a missing signal
+        // is the common case and means `EmotionTouch::update` only
+        // does the expired-hold cleanup work this tick.
         if touch::TAP_SIGNAL.try_take().is_some() {
             emotion_touch.tap();
+        }
+        // Drain IR-remote decoded commands, if any.
+        if let Some(cmd) = ir::REMOTE_SIGNAL.try_take() {
+            remote.queue(cmd.address, cmd.command);
         }
         // Drain the latest IMU reading. Published at ~100 Hz by the
         // imu task; at a 33 ms render tick we'll usually have a fresh
@@ -206,6 +218,7 @@ async fn render_task(mut display: LcdDisplay) {
             avatar.ambient_lux = Some(lux);
         }
         emotion_touch.update(&mut avatar, now);
+        remote.update(&mut avatar, now);
         pickup.update(&mut avatar, now);
         ambient_sleepy.update(&mut avatar, now);
         cycle.update(&mut avatar, now);
@@ -345,6 +358,24 @@ async fn ambient_task(shared_i2c: SharedI2c) -> ! {
     ambient::run_ambient_loop(shared_i2c).await
 }
 
+/// AXP2101 power-button polling task. Fourth shared-I²C consumer.
+/// Forwards short-press edges to [`touch::TAP_SIGNAL`] so the power
+/// button behaves as a second tap source (cycle emotion + 30 s pin).
+#[embassy_executor::task]
+async fn button_task(shared_i2c: SharedI2c) -> ! {
+    button::run_button_loop(shared_i2c).await
+}
+
+/// IR RX task on the RMT peripheral. Decodes NEC-protocol frames
+/// from the IR receiver and publishes them on [`ir::REMOTE_SIGNAL`].
+#[embassy_executor::task]
+async fn ir_task(
+    rmt: esp_hal::peripherals::RMT<'static>,
+    pin: esp_hal::peripherals::GPIO21<'static>,
+) -> ! {
+    ir::run_ir_loop(rmt, pin).await
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
@@ -442,6 +473,12 @@ async fn main(spawner: Spawner) -> ! {
     }
     if let Err(e) = spawner.spawn(ambient_task(I2cDevice::new(board_io.i2c_bus))) {
         defmt::panic!("spawn ambient_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(button_task(I2cDevice::new(board_io.i2c_bus))) {
+        defmt::panic!("spawn button_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(ir_task(peripherals.RMT, peripherals.GPIO21)) {
+        defmt::panic!("spawn ir_task failed: {}", defmt::Debug2Format(&e));
     }
 
     // One-shot wall-clock read for the boot log. Single I²C round-trip;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,9 @@
     "crates/ft6336u": {
       "package-name": "ft6336u"
     },
+    "crates/ir-nec": {
+      "package-name": "ir-nec"
+    },
     "crates/ltr553": {
       "package-name": "ltr553"
     },


### PR DESCRIPTION
## Summary
Two new input modalities on existing infrastructure.

- **AXP2101 power button**: new polling task on shared I²C forwards short-press edges to `touch::TAP_SIGNAL` so the hardware button is UX-indistinguishable from a screen tap. `axp2101` crate grows `enable_power_key_short_press_irq()` + `check_short_press_edge()`.
- **IR RX**: new `ir-nec` crate decodes NEC-protocol frames from pulse timings (pure logic, no hardware dep). Firmware `ir` task wraps esp-hal's RMT RX channel on GPIO21 (1 µs tick, 10 ms idle, active-low polarity inversion) and publishes decoded commands on `REMOTE_SIGNAL`. New `RemoteCommand` modifier in stackchan-core maps `(address, command)` to emotions via a user-supplied table.
- Standalone `examples/ir_bench.rs` streams decoded NEC frames so users can populate the mapping table for their specific remote.

**Caveat:** IR RX GPIO defaults to GPIO21, a best-guess since the CoreS3 IR pin isn't in our device-specs memory. If no frames decode even with a working remote + `ir_bench`, update the pin arg in `main.rs` against the actual schematic. Everything downstream of the RMT is pin-agnostic.

## Test plan
- [x] `cargo test --workspace --exclude stackchan-firmware`: **179 pass** (up from 166). 6 new `ir-nec` decoder tests + 7 new `RemoteCommand` modifier tests.
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings`: clean.
- [x] `cargo +esp clippy --all-features --examples -- -D warnings` (firmware): clean.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware`: clean.
- [ ] Hardware flash test: boot log should include `AXP2101 button: short-press IRQ enabled` and `IR: RMT RX on channel7 ...`. Pressing the power button should cycle emotions like a screen tap.
- [ ] `cargo run --example ir_bench -p stackchan-firmware --release` (follow-up): confirm NEC decodes from a real remote; if nothing, the GPIO guess is wrong — try other candidates (GPIO2, GPIO5).