### PR TITLE
feat: PY32 WS2812 LED ring + first output-sink path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "py32"
+version = "0.2.0"
+dependencies = [
+ "embedded-hal-async",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1512,7 @@ dependencies = [
  "ir-nec",
  "ltr553",
  "mipidsi",
+ "py32",
  "scservo",
  "stackchan-core",
  "static_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/ft6336u",
     "crates/ir-nec",
     "crates/ltr553",
+    "crates/py32",
     "crates/scservo",
     "crates/stackchan-firmware",
 ]
@@ -23,6 +24,7 @@ default-members = [
     "crates/ft6336u",
     "crates/ir-nec",
     "crates/ltr553",
+    "crates/py32",
     "crates/scservo",
 ]
 

--- a/crates/py32/Cargo.toml
+++ b/crates/py32/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "py32"
+version = "0.2.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Driver for the Stack-chan CoreS3 PY32 IO expander (I²C 0x6F): GPIO output config for servo-power enable and WS2812 fan-out for the 12-LED ring."
+
+[lints]
+workspace = true
+
+[dependencies]
+embedded-hal-async = { workspace = true }

--- a/crates/py32/src/lib.rs
+++ b/crates/py32/src/lib.rs
@@ -1,0 +1,605 @@
+//! # py32
+//!
+//! `no_std` async driver for the Stack-chan CoreS3's PY32 IO expander
+//! at I²C address `0x6F`.
+//!
+//! On this board the PY32 is a custom-firmware co-processor — it is *not*
+//! a standard GPIO expander part. M5Stack ships it with a small MCU
+//! firmware (the Puya PY32 family) that exposes, over a single I²C
+//! target, GPIO / pull / drive-mode control plus a WS2812-family fan-out
+//! buffer on the pin wired to the 12-LED ring. This crate implements the
+//! subset this firmware needs:
+//!
+//! - Configure one GPIO pin as a push-pull output with pull-up
+//!   (read-modify-write, so previously configured pins stay put). This
+//!   is how the servo-power rail gate on pin 0 is raised.
+//! - Load a pixel frame into the on-chip LED RAM and latch it to the
+//!   WS2812 chain on pin 13 (the dedicated LED-fan-out pin). Pixel data
+//!   is little-endian RGB565; the PY32 firmware handles all WS2812 bit
+//!   timing internally.
+//!
+//! The PWM / ADC / IRQ / UID surfaces that the M5Stack C++ class also
+//! exposes are intentionally omitted — add them when a caller needs them.
+//!
+//! Register layout + LED-RAM semantics are lifted from
+//! `m5stack/StackChan` — `firmware/main/hal/drivers/PY32IOExpander_Class/`
+//! (MIT-licensed upstream).
+//!
+//! ## Example
+//!
+//! ```no_run
+//! # use embedded_hal_async::i2c::I2c;
+//! # async fn demo<B: I2c>(bus: B) -> Result<(), py32::Error<B::Error>> {
+//! let mut py = py32::Py32::new(bus);
+//! // Raise the servo-power rail (pin 0 = push-pull, pull-up, HIGH).
+//! py.configure_output_pin(0, true).await?;
+//! // Drive the 12-LED ring with a single warm-white frame.
+//! py.set_led_count(12).await?;
+//! let frame: [u16; 12] = [0xFFE0; 12]; // RGB565: yellowish white.
+//! py.write_led_pixels(&frame).await?;
+//! py.refresh_leds().await?;
+//! # Ok(())
+//! # }
+//! ```
+
+#![cfg_attr(not(test), no_std)]
+#![deny(unsafe_code)]
+
+use embedded_hal_async::i2c::I2c;
+
+/// 7-bit I²C address of the PY32 on the Stack-chan CoreS3.
+pub const ADDRESS: u8 = 0x6F;
+
+/// Maximum number of WS2812 pixels the on-chip LED RAM can hold.
+/// The LED-count field in the LED-config register is 6 bits wide.
+pub const MAX_LEDS: usize = 32;
+
+/// Highest GPIO pin index exposed by the PY32 firmware (pins `0..=13`).
+const PIN_MAX: u8 = 13;
+
+// --- Register map (from m5stack/StackChan PY32IOExpander_Class.cpp) ---
+
+/// GPIO direction register, low byte (pins `0..=7`). Bit set = output.
+const REG_DIR_LO: u8 = 0x03;
+/// GPIO direction register, high byte (pins `8..=13`).
+const REG_DIR_HI: u8 = 0x04;
+/// GPIO output-level register, low byte (pins `0..=7`). Bit set = HIGH.
+const REG_OUT_LO: u8 = 0x05;
+/// GPIO output-level register, high byte (pins `8..=13`).
+const REG_OUT_HI: u8 = 0x06;
+/// Pull-up enable register, low byte (pins `0..=7`). Bit set = enabled.
+const REG_PULLUP_LO: u8 = 0x09;
+/// Pull-up enable register, high byte (pins `8..=13`).
+const REG_PULLUP_HI: u8 = 0x0A;
+/// LED configuration. Bits `0..=5` hold the live LED count (max 32).
+/// Bit 6 is a refresh-trigger: the PY32 latches the LED RAM contents
+/// onto the WS2812 chain when bit 6 is set.
+const REG_LED_CFG: u8 = 0x24;
+/// First byte of LED RAM. Each pixel occupies 2 bytes (LE RGB565), so
+/// pixel `i` lives at `REG_LED_RAM + 2 * i`. Bulk writes auto-increment.
+const REG_LED_RAM: u8 = 0x30;
+
+/// LED count field mask within [`REG_LED_CFG`].
+const LED_COUNT_MASK: u8 = 0x3F;
+/// Refresh-trigger bit within [`REG_LED_CFG`].
+const LED_REFRESH_BIT: u8 = 1 << 6;
+
+/// Driver error type.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error<E> {
+    /// Transport error from the underlying I²C bus.
+    I2c(E),
+    /// Caller passed a pin index outside the `0..=13` range the PY32
+    /// firmware exposes.
+    InvalidPin(u8),
+    /// Caller passed more than [`MAX_LEDS`] pixels.
+    TooManyLeds(usize),
+}
+
+impl<E> From<E> for Error<E> {
+    fn from(e: E) -> Self {
+        Self::I2c(e)
+    }
+}
+
+/// PY32 IO-expander driver.
+///
+/// Holds the I²C bus handle and issues register reads / writes to
+/// [`ADDRESS`]. The driver is state-free: every public call that touches
+/// GPIO registers does a read-modify-write, so interleaving calls on
+/// different pins is safe.
+pub struct Py32<B> {
+    /// Async I²C bus handle used for every transaction.
+    bus: B,
+}
+
+impl<B: I2c> Py32<B> {
+    /// Construct a driver over an async I²C bus.
+    #[must_use = "holds the I²C bus; drop it to release"]
+    pub const fn new(bus: B) -> Self {
+        Self { bus }
+    }
+
+    /// Consume the driver and return the underlying bus.
+    #[must_use = "dropping the bus drops any pending transactions"]
+    pub fn release(self) -> B {
+        self.bus
+    }
+
+    /// Configure `pin` as a push-pull output with pull-up enabled, and
+    /// drive it to `level`.
+    ///
+    /// Uses read-modify-write on each affected register so previously
+    /// configured pins keep their state. The PY32 firmware's reset
+    /// default is all-zeros for every GPIO register, so the very first
+    /// call on a fresh chip degrades to three plain register writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidPin`] if `pin > 13`, or [`Error::I2c`]
+    /// if any of the six I²C transactions fails.
+    pub async fn configure_output_pin(
+        &mut self,
+        pin: u8,
+        level: bool,
+    ) -> Result<(), Error<B::Error>> {
+        if pin > PIN_MAX {
+            return Err(Error::InvalidPin(pin));
+        }
+        let regs = pin_regs(pin);
+        self.set_bit(regs.dir, regs.mask).await?;
+        self.set_bit(regs.pullup, regs.mask).await?;
+        if level {
+            self.set_bit(regs.out, regs.mask).await
+        } else {
+            self.clear_bit(regs.out, regs.mask).await
+        }
+    }
+
+    /// Set the active LED count (0..=32) on the WS2812 fan-out.
+    ///
+    /// Preserves the refresh-trigger bit so an in-flight `refresh_leds`
+    /// isn't cleared by a reconfiguration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TooManyLeds`] if `count > 32`, or [`Error::I2c`]
+    /// on transport failure.
+    pub async fn set_led_count(&mut self, count: u8) -> Result<(), Error<B::Error>> {
+        if usize::from(count) > MAX_LEDS {
+            return Err(Error::TooManyLeds(usize::from(count)));
+        }
+        let current = self.read_reg(REG_LED_CFG).await?;
+        let new = (current & !LED_COUNT_MASK) | (count & LED_COUNT_MASK);
+        self.write_reg(REG_LED_CFG, new).await
+    }
+
+    /// Bulk-write `pixels` into the on-chip LED RAM.
+    ///
+    /// Each pixel is an RGB565 value; the wire format is little-endian
+    /// (low byte first) to match the PY32 firmware. The write does
+    /// **not** update the WS2812 chain — call [`Py32::refresh_leds`]
+    /// after staging the frame to latch it. That two-step write-then-
+    /// refresh sequence is what prevents torn frames on the ring during
+    /// a bulk update.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TooManyLeds`] if `pixels.len() > 32`, or
+    /// [`Error::I2c`] on transport failure.
+    pub async fn write_led_pixels(&mut self, pixels: &[u16]) -> Result<(), Error<B::Error>> {
+        if pixels.len() > MAX_LEDS {
+            return Err(Error::TooManyLeds(pixels.len()));
+        }
+        if pixels.is_empty() {
+            // Zero-pixel frame = no-op; skip the wire write entirely so
+            // an empty update doesn't poke the I²C bus at all.
+            return Ok(());
+        }
+        // Stage [REG_LED_RAM, b0, b1, b0, b1, ...] on the stack. Max
+        // payload is 1 + 32*2 = 65 bytes, well under any reasonable
+        // I²C FIFO limit; single transaction keeps the write atomic
+        // from the host's perspective.
+        let mut buf = [0u8; 1 + MAX_LEDS * 2];
+        buf[0] = REG_LED_RAM;
+        for (i, &px) in pixels.iter().enumerate() {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "masked to 8 bits before truncation"
+            )]
+            {
+                buf[1 + i * 2] = (px & 0xFF) as u8;
+                buf[2 + i * 2] = ((px >> 8) & 0xFF) as u8;
+            }
+        }
+        let len = 1 + pixels.len() * 2;
+        self.bus.write(ADDRESS, &buf[..len]).await?;
+        Ok(())
+    }
+
+    /// Latch the buffered LED RAM onto the WS2812 chain.
+    ///
+    /// Sets the refresh-trigger bit in the LED-config register via
+    /// read-modify-write so the LED count field isn't disturbed. The
+    /// PY32 firmware clears the bit itself once the latch completes.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::I2c`] on transport failure.
+    pub async fn refresh_leds(&mut self) -> Result<(), Error<B::Error>> {
+        self.set_bit(REG_LED_CFG, LED_REFRESH_BIT).await
+    }
+
+    /// Read a single byte from register `reg`.
+    async fn read_reg(&mut self, reg: u8) -> Result<u8, Error<B::Error>> {
+        let mut buf = [0u8; 1];
+        self.bus.write_read(ADDRESS, &[reg], &mut buf).await?;
+        Ok(buf[0])
+    }
+
+    /// Write `value` to register `reg`.
+    async fn write_reg(&mut self, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
+        self.bus.write(ADDRESS, &[reg, value]).await?;
+        Ok(())
+    }
+
+    /// Set the bits in `mask` within register `reg` (read-modify-write).
+    async fn set_bit(&mut self, reg: u8, mask: u8) -> Result<(), Error<B::Error>> {
+        let v = self.read_reg(reg).await?;
+        self.write_reg(reg, v | mask).await
+    }
+
+    /// Clear the bits in `mask` within register `reg` (read-modify-write).
+    async fn clear_bit(&mut self, reg: u8, mask: u8) -> Result<(), Error<B::Error>> {
+        let v = self.read_reg(reg).await?;
+        self.write_reg(reg, v & !mask).await
+    }
+}
+
+/// Register triplet + pin-bit mask for a given pin index.
+struct PinRegs {
+    /// Direction register for the port this pin lives on.
+    dir: u8,
+    /// Output-level register for the port this pin lives on.
+    out: u8,
+    /// Pull-up enable register for the port this pin lives on.
+    pullup: u8,
+    /// Bitmask selecting this pin within its port byte.
+    mask: u8,
+}
+
+/// Select the correct register triplet and pin-bit mask for pin `0..=13`.
+const fn pin_regs(pin: u8) -> PinRegs {
+    if pin < 8 {
+        PinRegs {
+            dir: REG_DIR_LO,
+            out: REG_OUT_LO,
+            pullup: REG_PULLUP_LO,
+            mask: 1 << pin,
+        }
+    } else {
+        PinRegs {
+            dir: REG_DIR_HI,
+            out: REG_OUT_HI,
+            pullup: REG_PULLUP_HI,
+            mask: 1 << (pin - 8),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test scaffolding: Infallible bus error makes unwrap() sound"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "mock I²C expects matching Write-then-Read ops; a bare Read is a test-harness bug, not runtime code"
+)]
+#[allow(
+    clippy::decimal_bitwise_operands,
+    reason = "LED count literals (3, 12) read more clearly in base-10 than as 0x03/0x0C in tests"
+)]
+#[allow(
+    clippy::future_not_send,
+    reason = "test mocks hold RefCell for event recording; single-threaded block_on runs them"
+)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use embedded_hal_async::i2c::{Operation, SevenBitAddress};
+
+    /// Event recorded by the mock. Reads and writes are kept distinct so
+    /// tests can assert the full transaction order (critical for
+    /// read-modify-write correctness).
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Event {
+        /// I²C write transaction; full payload after the register byte.
+        /// Address is implicit (always [`ADDRESS`]).
+        Write(Vec<u8>),
+        /// I²C write-read: driver wrote `reg`, got back `value`.
+        ReadReg(u8, u8),
+    }
+
+    /// Mock that simulates a 256-byte register bank. Reads serve the
+    /// bank; single-byte-payload `write` transactions update it so
+    /// read-modify-write loops converge naturally. Multi-byte payloads
+    /// (bulk LED writes) update the bank too, auto-incrementing the
+    /// register index.
+    struct MockI2c {
+        regs: RefCell<[u8; 256]>,
+        events: RefCell<Vec<Event>>,
+    }
+
+    impl MockI2c {
+        fn new() -> Self {
+            Self {
+                regs: RefCell::new([0u8; 256]),
+                events: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn events(&self) -> Vec<Event> {
+            self.events.borrow().clone()
+        }
+
+        fn preset_reg(&self, reg: u8, value: u8) {
+            self.regs.borrow_mut()[usize::from(reg)] = value;
+        }
+    }
+
+    impl embedded_hal_async::i2c::ErrorType for MockI2c {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal_async::i2c::I2c for MockI2c {
+        async fn transaction(
+            &mut self,
+            address: SevenBitAddress,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            assert_eq!(address, ADDRESS, "driver addressed wrong I²C target");
+
+            // Track the "current" register index across ops in one
+            // transaction so a Write([reg]) followed by Read(buf) pulls
+            // `buf.len()` bytes starting at `reg`.
+            let mut cursor: Option<u8> = None;
+
+            for op in operations {
+                match op {
+                    Operation::Write(buf) => {
+                        if buf.is_empty() {
+                            continue;
+                        }
+                        let reg = buf[0];
+                        cursor = Some(reg);
+                        if buf.len() >= 2 {
+                            // Data write. Auto-increment the reg pointer
+                            // for each payload byte to mirror the PY32
+                            // firmware's bulk-LED-RAM behaviour.
+                            let mut regs = self.regs.borrow_mut();
+                            for (i, &b) in buf[1..].iter().enumerate() {
+                                let idx = usize::from(reg).saturating_add(i);
+                                if idx < regs.len() {
+                                    regs[idx] = b;
+                                }
+                            }
+                            drop(regs);
+                            self.events.borrow_mut().push(Event::Write(buf.to_vec()));
+                        }
+                        // A lone `Write([reg])` with no data is the
+                        // address-phase of a write-read; emit nothing —
+                        // the Read op that follows will log ReadReg.
+                    }
+                    Operation::Read(buf) => {
+                        let reg = cursor.expect("read without prior register-address write");
+                        let regs = self.regs.borrow();
+                        for (i, slot) in buf.iter_mut().enumerate() {
+                            let idx = usize::from(reg).saturating_add(i);
+                            *slot = if idx < regs.len() { regs[idx] } else { 0 };
+                        }
+                        // Log only single-byte reads; bulk reads aren't
+                        // exercised by this driver.
+                        if buf.len() == 1 {
+                            self.events.borrow_mut().push(Event::ReadReg(reg, buf[0]));
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    fn block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut fut = pin!(future);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn configure_output_pin_low_byte_from_reset_state() {
+        // Pin 0: low-byte registers, bit 0. Registers reset to zero, so
+        // read-modify-write writes back `0x01` each time — matching the
+        // inline servo-power sequence this driver replaces.
+        let mut py = Py32::new(MockI2c::new());
+        block_on(py.configure_output_pin(0, true)).unwrap();
+
+        assert_eq!(
+            py.bus.events(),
+            vec![
+                Event::ReadReg(REG_DIR_LO, 0x00),
+                Event::Write(vec![REG_DIR_LO, 0x01]),
+                Event::ReadReg(REG_PULLUP_LO, 0x00),
+                Event::Write(vec![REG_PULLUP_LO, 0x01]),
+                Event::ReadReg(REG_OUT_LO, 0x00),
+                Event::Write(vec![REG_OUT_LO, 0x01]),
+            ]
+        );
+    }
+
+    #[test]
+    fn configure_output_pin_preserves_other_bits() {
+        // If another pin on the same port is already configured, RMW
+        // must OR rather than overwrite. Simulate: pin 1 already set as
+        // output (dir=0x02, pullup=0x02, level=0x02), then configure
+        // pin 0 HIGH. Resulting bytes should have bits 0 AND 1 set.
+        let bus = MockI2c::new();
+        bus.preset_reg(REG_DIR_LO, 0x02);
+        bus.preset_reg(REG_PULLUP_LO, 0x02);
+        bus.preset_reg(REG_OUT_LO, 0x02);
+        let mut py = Py32::new(bus);
+        block_on(py.configure_output_pin(0, true)).unwrap();
+
+        let events = py.bus.events();
+        // Each write should OR in bit 0 without touching bit 1.
+        assert!(events.contains(&Event::Write(vec![REG_DIR_LO, 0x03])));
+        assert!(events.contains(&Event::Write(vec![REG_PULLUP_LO, 0x03])));
+        assert!(events.contains(&Event::Write(vec![REG_OUT_LO, 0x03])));
+    }
+
+    #[test]
+    fn configure_output_pin_high_byte_uses_correct_registers() {
+        // Pin 13 lives in the high-byte register trio and uses mask
+        // 1 << (13 - 8) = 0x20.
+        let mut py = Py32::new(MockI2c::new());
+        block_on(py.configure_output_pin(13, true)).unwrap();
+
+        let events = py.bus.events();
+        assert!(events.contains(&Event::Write(vec![REG_DIR_HI, 0x20])));
+        assert!(events.contains(&Event::Write(vec![REG_PULLUP_HI, 0x20])));
+        assert!(events.contains(&Event::Write(vec![REG_OUT_HI, 0x20])));
+        // And must NOT have touched the low-byte registers.
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Event::Write(b) if b[0] == REG_DIR_LO || b[0] == REG_OUT_LO))
+        );
+    }
+
+    #[test]
+    fn configure_output_pin_low_level_clears_bit() {
+        let bus = MockI2c::new();
+        bus.preset_reg(REG_OUT_LO, 0xFF);
+        let mut py = Py32::new(bus);
+        block_on(py.configure_output_pin(3, false)).unwrap();
+
+        // Bit 3 cleared, bits 0,1,2,4..7 preserved -> 0xF7.
+        assert!(
+            py.bus
+                .events()
+                .contains(&Event::Write(vec![REG_OUT_LO, 0xF7]))
+        );
+    }
+
+    #[test]
+    fn configure_output_pin_rejects_out_of_range() {
+        let mut py = Py32::new(MockI2c::new());
+        let result = block_on(py.configure_output_pin(14, true));
+        assert!(matches!(result, Err(Error::InvalidPin(14))));
+        assert!(py.bus.events().is_empty(), "no I²C traffic on error");
+    }
+
+    #[test]
+    fn set_led_count_writes_count_and_preserves_refresh_bit() {
+        let bus = MockI2c::new();
+        // Simulate a stale refresh bit (unlikely on real hardware since
+        // the PY32 clears it, but verifies the RMW contract).
+        bus.preset_reg(REG_LED_CFG, LED_REFRESH_BIT);
+        let mut py = Py32::new(bus);
+        block_on(py.set_led_count(12)).unwrap();
+
+        assert!(
+            py.bus
+                .events()
+                .contains(&Event::Write(vec![REG_LED_CFG, LED_REFRESH_BIT | 12]))
+        );
+    }
+
+    #[test]
+    fn set_led_count_rejects_over_max() {
+        let mut py = Py32::new(MockI2c::new());
+        let result = block_on(py.set_led_count(33));
+        assert!(matches!(result, Err(Error::TooManyLeds(33))));
+    }
+
+    #[test]
+    fn write_led_pixels_emits_one_bulk_le_rgb565_transaction() {
+        let mut py = Py32::new(MockI2c::new());
+        // Two pixels: amber-ish, cyan-ish.
+        let pixels = [0x1234u16, 0xABCDu16];
+        block_on(py.write_led_pixels(&pixels)).unwrap();
+
+        // Wire format: [REG_LED_RAM, lo0, hi0, lo1, hi1]
+        assert_eq!(
+            py.bus.events(),
+            vec![Event::Write(vec![REG_LED_RAM, 0x34, 0x12, 0xCD, 0xAB])]
+        );
+    }
+
+    #[test]
+    fn write_led_pixels_rejects_over_max() {
+        let mut py = Py32::new(MockI2c::new());
+        let pixels = [0u16; MAX_LEDS + 1];
+        let result = block_on(py.write_led_pixels(&pixels));
+        assert!(matches!(result, Err(Error::TooManyLeds(n)) if n == MAX_LEDS + 1));
+    }
+
+    #[test]
+    fn write_led_pixels_empty_slice_is_noop() {
+        let mut py = Py32::new(MockI2c::new());
+        block_on(py.write_led_pixels(&[])).unwrap();
+        assert!(
+            py.bus.events().is_empty(),
+            "empty pixel slice should not touch the bus"
+        );
+    }
+
+    #[test]
+    fn refresh_leds_sets_bit_6_and_preserves_count() {
+        let bus = MockI2c::new();
+        bus.preset_reg(REG_LED_CFG, 12); // count = 12, refresh = 0
+        let mut py = Py32::new(bus);
+        block_on(py.refresh_leds()).unwrap();
+
+        assert!(
+            py.bus
+                .events()
+                .contains(&Event::Write(vec![REG_LED_CFG, LED_REFRESH_BIT | 12]))
+        );
+    }
+
+    #[test]
+    fn full_led_frame_sequence_matches_m5stack_protocol() {
+        // End-to-end golden: set_led_count -> bulk write -> refresh.
+        // This is the exact per-frame traffic the firmware will emit.
+        let mut py = Py32::new(MockI2c::new());
+        let pixels: [u16; 3] = [0x001F, 0x07E0, 0xF800]; // R, G, B in 565.
+        block_on(async {
+            py.set_led_count(3).await.unwrap();
+            py.write_led_pixels(&pixels).await.unwrap();
+            py.refresh_leds().await.unwrap();
+        });
+
+        assert_eq!(
+            py.bus.events(),
+            vec![
+                // set_led_count: RMW 0x24 from 0x00 to 0x03
+                Event::ReadReg(REG_LED_CFG, 0x00),
+                Event::Write(vec![REG_LED_CFG, 0x03]),
+                // bulk write: 3 pixels, LE RGB565
+                Event::Write(vec![REG_LED_RAM, 0x1F, 0x00, 0xE0, 0x07, 0x00, 0xF8]),
+                // refresh: RMW 0x24 to set bit 6 (count field stays 3)
+                Event::ReadReg(REG_LED_CFG, 0x03),
+                Event::Write(vec![REG_LED_CFG, LED_REFRESH_BIT | 0x03]),
+            ]
+        );
+    }
+}

--- a/crates/stackchan-core/src/leds.rs
+++ b/crates/stackchan-core/src/leds.rs
@@ -1,0 +1,313 @@
+//! LED-ring output sink.
+//!
+//! The avatar wears a 12-pixel WS2812 ring; this module maps [`Avatar`]
+//! state onto a packed [`LedFrame`] of RGB565 pixels that the firmware
+//! pushes to the PY32 IO expander.
+//!
+//! Architectural role: this is the **first** non-[`Modifier`](crate::Modifier) consumer
+//! of [`Avatar`] state. Modifiers mutate the avatar; this is a pure
+//! function over it. The firmware's `render_task` runs the modifier
+//! stack, then calls [`render_leds`] on the resulting avatar and
+//! signals the frame out to a transport task. The sim uses the same
+//! function against a `FakeClock` to golden-test the mapping without
+//! any hardware.
+//!
+//! ## Mapping
+//!
+//! - **Emotion → base colour** via a warm/cool palette
+//!   ([`Neutral`]=soft white, [`Happy`]=amber, [`Sad`]=deep blue,
+//!   [`Sleepy`]=dim violet, [`Surprised`]=cyan).
+//! - **Breath-phase → brightness envelope** in `[0.6, 1.0]` over a
+//!   6-second triangle cycle, matching the default
+//!   [`Breath`](crate::modifiers::Breath) modifier. The LED pulse stays
+//!   visually synchronised with the on-screen breath without the LED
+//!   pipeline having to introspect the modifier stack's state.
+//! - **Global cap at ~40% of full drive** keeps the ring readable
+//!   through a head shell without being harsh. Palette values are
+//!   stored at full 888 and scaled at render time.
+//!
+//! The mapping is uniform across all 12 pixels — no per-pixel animation
+//! yet. A gaze-direction arc is an obvious next iteration.
+//!
+//! [`Neutral`]: crate::Emotion::Neutral
+//! [`Happy`]: crate::Emotion::Happy
+//! [`Sad`]: crate::Emotion::Sad
+//! [`Sleepy`]: crate::Emotion::Sleepy
+//! [`Surprised`]: crate::Emotion::Surprised
+
+use crate::{Avatar, Emotion, Instant};
+
+/// Number of pixels on the StackChan LED ring.
+pub const LED_COUNT: usize = 12;
+
+/// Peak 8-bit brightness applied to any single channel. WS2812 at full
+/// drive is harsh inside a small head shell; ~40% is the sweet spot.
+pub const BRIGHTNESS_PEAK: u8 = 102;
+
+/// Fraction of [`BRIGHTNESS_PEAK`] the breath envelope dips to at the
+/// exhale minimum. Tenths, so `6` = 60%.
+const BREATH_TROUGH_NUM: u32 = 6;
+/// Denominator for [`BREATH_TROUGH_NUM`].
+const BREATH_TROUGH_DEN: u32 = 10;
+
+/// Full breath cycle in milliseconds. Locked to
+/// [`Breath::DEFAULT_CYCLE_MS`](crate::modifiers::Breath) so the LED
+/// pulse stays in phase with the on-face breath at the default config.
+const BREATH_CYCLE_MS: u64 = 6_000;
+
+/// A full frame of RGB565 pixels, ready to ship to the LED ring.
+///
+/// Bit layout of each pixel is `RRRRRGGG_GGGBBBBB` (big-endian within
+/// the word); the firmware writes the values to the PY32 little-endian
+/// on the I²C bus, which is handled by `py32::Py32::write_led_pixels`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LedFrame(pub [u16; LED_COUNT]);
+
+impl Default for LedFrame {
+    /// All pixels off.
+    fn default() -> Self {
+        Self([0; LED_COUNT])
+    }
+}
+
+impl LedFrame {
+    /// Borrow the underlying pixel array as a slice of `u16`, suitable
+    /// for direct hand-off to the PY32 driver's bulk LED write.
+    #[must_use]
+    pub const fn as_u16_slice(&self) -> &[u16] {
+        &self.0
+    }
+}
+
+/// Emotion → base RGB888 colour palette.
+///
+/// Packed as `0xRRGGBB`. Conversion to RGB565 happens after brightness
+/// scaling so we don't compound quantisation on the way in.
+#[must_use]
+const fn palette(emotion: Emotion) -> u32 {
+    // Exhaustive on purpose: adding an Emotion variant must also extend
+    // the palette. `#[non_exhaustive]` only affects downstream matches.
+    match emotion {
+        Emotion::Neutral => 0x00FF_FFE8,
+        Emotion::Happy => 0x00FF_B020,
+        Emotion::Sad => 0x0015_30A0,
+        Emotion::Sleepy => 0x0030_1448,
+        Emotion::Surprised => 0x0030_E0FF,
+    }
+}
+
+/// Brightness envelope for the breath-phase pulse at time `now`.
+///
+/// Returns an 8-bit multiplier where `255` = [`BRIGHTNESS_PEAK`] and
+/// the trough value is `BRIGHTNESS_PEAK * BREATH_TROUGH_NUM /
+/// BREATH_TROUGH_DEN`. Triangle wave to stay libm-free.
+fn breath_brightness(now: Instant) -> u8 {
+    let phase = now.as_millis() % BREATH_CYCLE_MS;
+    let half = BREATH_CYCLE_MS / 2;
+    let within = if phase < half {
+        phase
+    } else {
+        BREATH_CYCLE_MS - phase
+    };
+    // `within` is in 0..=half (0..=3000); normalise to a 0..=255
+    // triangle. The numerator fits in u64 comfortably and the quotient
+    // is bounded by 255.
+    let t_u64 = within.saturating_mul(255) / half.max(1);
+    let t = u32::try_from(t_u64).unwrap_or(255);
+    let peak = u32::from(BRIGHTNESS_PEAK);
+    let trough = peak * BREATH_TROUGH_NUM / BREATH_TROUGH_DEN;
+    let envelope = trough + (peak - trough) * t / 255;
+    // envelope <= peak <= BRIGHTNESS_PEAK (102) < 256.
+    u8::try_from(envelope).unwrap_or(BRIGHTNESS_PEAK)
+}
+
+/// Apply an 8-bit brightness multiplier to one channel.
+///
+/// `channel * multiplier / 255`, kept in `u32` to avoid overflow on the
+/// intermediate product (`255 * 255 = 65_025`).
+#[inline]
+fn scale_channel(channel: u8, multiplier: u8) -> u8 {
+    let scaled = u32::from(channel) * u32::from(multiplier) / 255;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "scaled <= channel <= 255, truncation lossless"
+    )]
+    {
+        scaled as u8
+    }
+}
+
+/// Pack an RGB888 triple into an RGB565 pixel. Bit layout is
+/// `RRRRRGGG_GGGBBBBB` in the returned `u16`.
+#[inline]
+const fn rgb888_to_565(r: u8, g: u8, b: u8) -> u16 {
+    let r5 = (r as u16 & 0xF8) << 8;
+    let g6 = (g as u16 & 0xFC) << 3;
+    let b5 = (b as u16) >> 3;
+    r5 | g6 | b5
+}
+
+/// Render the LED ring for the current [`Avatar`] state.
+///
+/// Writes all [`LED_COUNT`] pixels of `out` with a uniform colour
+/// derived from `avatar.emotion`, dimmed by both the global brightness
+/// cap and the current breath-envelope phase at `now`. Deterministic
+/// with respect to `(avatar.emotion, now)` — host-testable.
+pub fn render_leds(avatar: &Avatar, now: Instant, out: &mut LedFrame) {
+    let base = palette(avatar.emotion);
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "bitmasked to 8 bits before truncation"
+    )]
+    let (r_raw, g_raw, b_raw) = (
+        ((base >> 16) & 0xFF) as u8,
+        ((base >> 8) & 0xFF) as u8,
+        (base & 0xFF) as u8,
+    );
+    let brightness = breath_brightness(now);
+    let pixel = rgb888_to_565(
+        scale_channel(r_raw, brightness),
+        scale_channel(g_raw, brightness),
+        scale_channel(b_raw, brightness),
+    );
+    for slot in &mut out.0 {
+        *slot = pixel;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test scaffolding")]
+#[allow(
+    clippy::field_reassign_with_default,
+    reason = "Avatar has many fields; post-init assignment reads more clearly than struct-update syntax"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn breath_brightness_peaks_at_midcycle() {
+        let trough = breath_brightness(Instant::from_millis(0));
+        let peak = breath_brightness(Instant::from_millis(3_000));
+        let trough_again = breath_brightness(Instant::from_millis(6_000));
+
+        assert!(peak > trough, "peak {peak} must exceed trough {trough}");
+        assert_eq!(peak, BRIGHTNESS_PEAK);
+        // Trough is ~60% of peak = 61.
+        assert_eq!(trough, 61);
+        // One full cycle returns to trough.
+        assert_eq!(trough, trough_again);
+    }
+
+    #[test]
+    fn breath_brightness_stays_within_bounds() {
+        for ms in 0..12_000u64 {
+            let b = breath_brightness(Instant::from_millis(ms));
+            assert!(
+                b <= BRIGHTNESS_PEAK,
+                "brightness {b} exceeds cap at ms {ms}"
+            );
+            assert!(b >= 61, "brightness {b} below trough at ms {ms}");
+        }
+    }
+
+    #[test]
+    fn render_leds_fills_every_pixel_with_same_colour() {
+        let mut avatar = Avatar::default();
+        avatar.emotion = Emotion::Happy;
+        let mut frame = LedFrame::default();
+        render_leds(&avatar, Instant::from_millis(3_000), &mut frame);
+        let first = frame.0[0];
+        assert_ne!(first, 0, "frame should not be black at peak brightness");
+        for (i, px) in frame.0.iter().enumerate() {
+            assert_eq!(*px, first, "pixel {i} diverged from pixel 0");
+        }
+    }
+
+    #[test]
+    fn emotion_changes_colour() {
+        let mut avatar = Avatar::default();
+        let mut frame = LedFrame::default();
+        let now = Instant::from_millis(3_000); // peak brightness, deterministic
+
+        avatar.emotion = Emotion::Happy;
+        render_leds(&avatar, now, &mut frame);
+        let happy = frame.0[0];
+
+        avatar.emotion = Emotion::Sad;
+        render_leds(&avatar, now, &mut frame);
+        let sad = frame.0[0];
+
+        avatar.emotion = Emotion::Sleepy;
+        render_leds(&avatar, now, &mut frame);
+        let sleepy = frame.0[0];
+
+        assert_ne!(happy, sad, "happy and sad should produce different pixels");
+        assert_ne!(
+            happy, sleepy,
+            "happy and sleepy should produce different pixels"
+        );
+        assert_ne!(
+            sad, sleepy,
+            "sad and sleepy should produce different pixels"
+        );
+    }
+
+    #[test]
+    fn breath_envelope_modulates_brightness_across_cycle() {
+        let mut avatar = Avatar::default();
+        avatar.emotion = Emotion::Happy; // amber: high R, moderate G, low B
+        let mut frame = LedFrame::default();
+
+        render_leds(&avatar, Instant::from_millis(0), &mut frame);
+        let trough_r = (frame.0[0] >> 11) & 0x1F;
+
+        render_leds(&avatar, Instant::from_millis(3_000), &mut frame);
+        let peak_r = (frame.0[0] >> 11) & 0x1F;
+
+        assert!(
+            peak_r > trough_r,
+            "red channel should be brighter at breath peak ({peak_r}) than trough ({trough_r})"
+        );
+    }
+
+    #[test]
+    fn rgb565_packing_matches_reference_formula() {
+        // Pure red 888 -> 0xF800 in 565.
+        assert_eq!(rgb888_to_565(0xFF, 0x00, 0x00), 0xF800);
+        // Pure green -> 0x07E0.
+        assert_eq!(rgb888_to_565(0x00, 0xFF, 0x00), 0x07E0);
+        // Pure blue -> 0x001F.
+        assert_eq!(rgb888_to_565(0x00, 0x00, 0xFF), 0x001F);
+        // Black stays black.
+        assert_eq!(rgb888_to_565(0, 0, 0), 0);
+    }
+
+    #[test]
+    fn scale_channel_caps_at_input_when_multiplier_255() {
+        assert_eq!(scale_channel(255, 255), 255);
+        assert_eq!(scale_channel(100, 255), 100);
+    }
+
+    #[test]
+    fn scale_channel_zero_multiplier_is_zero() {
+        assert_eq!(scale_channel(255, 0), 0);
+    }
+
+    #[test]
+    fn as_u16_slice_matches_underlying_pixels() {
+        let frame = LedFrame([0xF800; LED_COUNT]);
+        let slice = frame.as_u16_slice();
+        assert_eq!(slice.len(), LED_COUNT);
+        for v in slice {
+            assert_eq!(*v, 0xF800);
+        }
+    }
+
+    #[test]
+    fn default_frame_is_all_zeros() {
+        let frame = LedFrame::default();
+        for px in &frame.0 {
+            assert_eq!(*px, 0);
+        }
+    }
+}

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -34,10 +34,12 @@ pub mod clock;
 pub mod draw;
 pub mod emotion;
 pub mod head;
+pub mod leds;
 pub mod modifiers;
 
 pub use avatar::{Avatar, Eye, EyePhase, Mouth, Point, SCALE_DEFAULT};
 pub use clock::{Clock, Instant};
 pub use emotion::Emotion;
 pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, Pose};
+pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use modifiers::Modifier;

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -20,6 +20,7 @@ bmi270 = { path = "../bmi270" }
 ft6336u = { path = "../ft6336u" }
 ir-nec = { path = "../ir-nec" }
 ltr553 = { path = "../ltr553" }
+py32 = { path = "../py32" }
 scservo = { path = "../scservo" }
 embedded-graphics = { workspace = true }
 embedded-hal = { workspace = true }
@@ -104,3 +105,7 @@ path = "examples/ambient_bench.rs"
 [[example]]
 name = "ir_bench"
 path = "examples/ir_bench.rs"
+
+[[example]]
+name = "leds_bench"
+path = "examples/leds_bench.rs"

--- a/crates/stackchan-firmware/examples/leds_bench.rs
+++ b/crates/stackchan-firmware/examples/leds_bench.rs
@@ -1,0 +1,155 @@
+//! LED-ring bench: brings up shared I²C, initialises the PY32 LED
+//! fan-out, and cycles through each [`Emotion`] palette entry every
+//! 2 seconds to verify on-device that:
+//!
+//! 1. The PY32 responds at I²C `0x6F` and accepts `set_led_count(12)`.
+//! 2. `write_led_pixels` + `refresh_leds` produce a visible change on
+//!    the WS2812 ring.
+//! 3. `stackchan_core::render_leds` produces distinguishable colours
+//!    through the warm/cool palette with breath-envelope modulation.
+//!
+//! The bench does **not** depend on the render pipeline; it drives the
+//! LED path directly so a regression in the firmware's modifier stack
+//! won't mask a hardware or transport fault.
+//!
+//! Output per tick (via defmt):
+//!
+//! ```text
+//! leds-bench: emotion=Happy frame[0]=0xFBE0 brightness=102
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Ticker};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use stackchan_core::{Avatar, Emotion, Instant as CoreInstant, LED_COUNT, LedFrame, render_leds};
+use stackchan_firmware::board;
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped. See
+/// `main.rs` for the full rationale.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+/// Panic handler for the bench binary.
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("leds-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Heap size: no framebuffer, small drivers, embassy task arena.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Per-frame push cadence. 30 Hz matches main render task so the
+/// breath envelope looks identical to the real firmware.
+const PUSH_PERIOD_MS: u64 = 33;
+
+/// Hold each emotion for 2 seconds before advancing. Long enough to
+/// visually confirm the palette entry is correct.
+const EMOTION_HOLD_MS: u64 = 2_000;
+
+/// Fixed cycle of emotions driven by this bench. Neutral → Happy →
+/// Sad → Sleepy → Surprised → (loop).
+const EMOTIONS: [Emotion; 5] = [
+    Emotion::Neutral,
+    Emotion::Happy,
+    Emotion::Sad,
+    Emotion::Sleepy,
+    Emotion::Surprised,
+];
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "the esp_rtos::main macro requires the `spawner` arg; leds-bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-leds-bench v{} — CoreS3 boot, cycling emotion palette",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let mut py = py32::Py32::new(board_io.i2c);
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "LED_COUNT is a compile-time constant well under u8::MAX"
+    )]
+    let led_count = LED_COUNT as u8;
+    match py.set_led_count(led_count).await {
+        Ok(()) => defmt::info!("leds-bench: PY32 set_led_count({=u8}) ok", led_count),
+        Err(e) => defmt::panic!(
+            "leds-bench: PY32 set_led_count failed: {}",
+            defmt::Debug2Format(&e)
+        ),
+    }
+
+    let mut ticker = Ticker::every(Duration::from_millis(PUSH_PERIOD_MS));
+    let mut frame = LedFrame::default();
+    let mut avatar = Avatar::default();
+    let mut emotion_idx: usize = 0;
+    let mut hold_counter: u64 = 0;
+    let hold_ticks = EMOTION_HOLD_MS.div_ceil(PUSH_PERIOD_MS);
+
+    loop {
+        // `now` drives the breath envelope so brightness pulses the
+        // same way it does in the real firmware.
+        let now = CoreInstant::from_millis(embassy_time::Instant::now().as_millis());
+        avatar.emotion = EMOTIONS[emotion_idx];
+        render_leds(&avatar, now, &mut frame);
+
+        if let Err(e) = py.write_led_pixels(frame.as_u16_slice()).await {
+            defmt::warn!(
+                "leds-bench: write_led_pixels failed: {}",
+                defmt::Debug2Format(&e)
+            );
+        } else if let Err(e) = py.refresh_leds().await {
+            defmt::warn!(
+                "leds-bench: refresh_leds failed: {}",
+                defmt::Debug2Format(&e)
+            );
+        }
+
+        hold_counter = hold_counter.saturating_add(1);
+        if hold_counter >= hold_ticks {
+            hold_counter = 0;
+            emotion_idx = (emotion_idx + 1) % EMOTIONS.len();
+            defmt::info!(
+                "leds-bench: emotion={=?} frame[0]=0x{=u16:04X}",
+                defmt::Debug2Format(&avatar.emotion),
+                frame.0[0],
+            );
+        }
+
+        ticker.next().await;
+    }
+}

--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -4,7 +4,7 @@
 //! [`bringup`] owns the full sequence:
 //!
 //! 1. Internal I²C0 on GPIO11/12 → AXP2101 → AW9523 → PY32 (enable
-//!    servo power pin, 200 ms settle).
+//!    servo power pin via the [`py32`] crate, 200 ms settle).
 //! 2. External UART1 on GPIO6/7 at 1 Mbaud for the `SCServo` bus.
 //! 3. `SCServo::ping` each configured servo ID, log presence.
 //! 4. Run the boot-nod gesture so the head visibly exercises both
@@ -81,12 +81,13 @@ pub struct BoardIo {
     pub i2c_bus: &'static SharedI2cBus,
 }
 
-/// 7-bit I²C address of the CoreS3 PY32 IO expander.
-const PY32_ADDRESS: u8 = 0x6F;
-
 /// Milliseconds to wait after raising the servo-power pin on the PY32.
 /// Matches the 200 ms delay in `hal_io_expander.cpp`.
 const SERVO_POWER_SETTLE_MS: u64 = 200;
+
+/// PY32 pin the servo-power rail MOSFET gate is wired to. HIGH enables
+/// the rail — see `device_specs.md`.
+const PY32_SERVO_POWER_PIN: u8 = 0;
 
 /// Retry delay between failed AXP2101 init attempts. Covers transient
 /// I²C glitches during cold boot.
@@ -206,40 +207,35 @@ pub async fn bringup(
     }
 }
 
-/// Drive pin 0 of the PY32 IO expander HIGH to enable the servo power
-/// rail. Three register writes with values that match the PY32's
-/// reset-state of all zeros (no read-modify-write yet — future RGB-LED
-/// work will need that). Logs at `warn` on any I²C failure and keeps
-/// going.
-async fn enable_servo_power(i2c: &mut I2c<'_, esp_hal::Async>) {
-    use embedded_hal_async::i2c::I2c as AsyncI2c;
-    /// Write `[reg, value]` to the PY32; log + return Err on transport failure.
-    async fn write_py32(i2c: &mut I2c<'_, esp_hal::Async>, reg: u8, value: u8) -> Result<(), ()> {
-        // Fully-qualified `AsyncI2c::write` — `esp_hal::i2c::master::I2c`
-        // has an inherent `write` that's blocking; we want the trait
-        // version for its `async fn`.
-        match AsyncI2c::write(i2c, PY32_ADDRESS, &[reg, value]).await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                defmt::warn!(
-                    "PY32 0x{=u8:02X} ← 0x{=u8:02X} failed: {}",
-                    reg,
-                    value,
-                    defmt::Debug2Format(&e)
-                );
-                Err(())
-            }
-        }
+/// Drive the PY32's servo-power pin HIGH via the `py32` crate.
+///
+/// Uses [`py32::Py32::configure_output_pin`], which does read-modify-
+/// write on the direction / pull-up / output registers. That's a change
+/// from v0.1.0's inline three-write sequence: it cooperates cleanly
+/// with any future multi-pin PY32 traffic (e.g. LED fan-out on pin 13),
+/// whereas the old path only worked because the chip's GPIO registers
+/// happen to reset to zero.
+///
+/// `Py32::new` takes ownership of its bus, but the blanket impl
+/// `impl<T: I2c> I2c for &mut T` in embedded-hal-async 1.0 lets us
+/// lend the bus via a mutable borrow and drop the `Py32` handle at
+/// end of scope, releasing the borrow for the shared-bus wrapper.
+///
+/// Failures are logged at `warn` and the function returns; the servo
+/// bus will still initialise but `ping_servo` will time out, which is
+/// the already-handled path for "servos missing".
+async fn enable_servo_power(i2c: &mut I2c<'static, esp_hal::Async>) {
+    let mut py = py32::Py32::new(i2c);
+    match py.configure_output_pin(PY32_SERVO_POWER_PIN, true).await {
+        Ok(()) => defmt::info!(
+            "PY32: servo power enabled (pin {=u8} HIGH)",
+            PY32_SERVO_POWER_PIN
+        ),
+        Err(e) => defmt::warn!(
+            "PY32: servo-power enable incomplete ({}) — servos may stay unpowered",
+            defmt::Debug2Format(&e)
+        ),
     }
-    // Pin 0: direction = output, pull-up = enabled, level = HIGH.
-    if write_py32(i2c, 0x03, 0x01).await.is_err()
-        || write_py32(i2c, 0x09, 0x01).await.is_err()
-        || write_py32(i2c, 0x05, 0x01).await.is_err()
-    {
-        defmt::warn!("PY32: servo-power enable incomplete — servos may stay unpowered");
-        return;
-    }
-    defmt::info!("PY32: servo power enabled (pin 0 HIGH)");
 }
 
 /// Probe one `SCServo` ID and log the outcome. 10 ms is well past the

--- a/crates/stackchan-firmware/src/leds.rs
+++ b/crates/stackchan-firmware/src/leds.rs
@@ -1,0 +1,131 @@
+//! LED-ring transport task.
+//!
+//! Owns the `py32::Py32` driver for the 12× WS2812C ring on CoreS3.
+//! Drains [`LED_FRAME_SIGNAL`] at 30 Hz and pushes each frame to the
+//! PY32 IO expander, which fans out WS2812 timing internally. The
+//! render task (the authoritative owner of `Avatar`) runs
+//! `stackchan_core::render_leds` after the modifier stack and publishes
+//! into the signal — this task is pure transport.
+//!
+//! ## Boot
+//!
+//! On first entry the task runs a brief fade-in from black to the
+//! Neutral palette peak (~250 ms, 8 steps) so there's no harsh LED
+//! flash at power-up, and so "boot completed cleanly" has a visible
+//! signal even if the LCD is slow to light.
+//!
+//! ## Error handling
+//!
+//! Every I²C transaction failure is logged at `warn` and the loop
+//! continues. A briefly absent PY32 shouldn't drag the rest of the
+//! firmware down — modifiers, head motion, and the LCD render task
+//! keep running whether or not the ring is alive.
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker, Timer};
+use stackchan_core::{Avatar, Instant, LED_COUNT, LedFrame, render_leds};
+
+use crate::board::SharedI2c;
+
+/// Latest `LedFrame`, render task → led task.
+///
+/// Latest-wins semantics: the render task publishes every tick via
+/// [`Signal::signal`], which overwrites any un-consumed value. The led
+/// task drains with [`Signal::try_take`] and ships the frame over I²C.
+/// Dropped frames are fine — the next one is already in flight.
+///
+/// The render task publishes unconditionally; during the boot fade-in
+/// the led task simply doesn't call `try_take`, so published values
+/// are overwritten until fade completes. No gating flag needed.
+pub static LED_FRAME_SIGNAL: Signal<CriticalSectionRawMutex, LedFrame> = Signal::new();
+
+/// Number of fade-in steps from black to Neutral palette peak. 8 steps
+/// over 250 ms lands one step per ~31 ms, matching the 30 Hz cadence
+/// of the main render loop.
+const FADE_STEPS: u8 = 8;
+/// Total duration of the boot fade-in, in milliseconds.
+const FADE_TOTAL_MS: u64 = 250;
+/// LED ring push rate after fade-in. Matches the LCD render task.
+const PUSH_RATE_HZ: u64 = 30;
+
+/// Run the LED-ring transport loop forever. Spawned from `main` as an
+/// embassy task.
+pub async fn run_led_loop(i2c: SharedI2c) -> ! {
+    let mut py = py32::Py32::new(i2c);
+
+    // Set LED count once. Failure here isn't fatal — the PY32 might be
+    // sluggish on the first write; we'll retry implicitly on the next
+    // bulk-write call (the count field stays at its last value).
+    let count = u8::try_from(LED_COUNT).unwrap_or(u8::MAX);
+    if let Err(e) = py.set_led_count(count).await {
+        defmt::warn!("PY32: set_led_count failed: {}", defmt::Debug2Format(&e));
+    } else {
+        defmt::info!("PY32: LED count set to {=u8}", count);
+    }
+
+    // Boot fade-in: black → Neutral palette at peak brightness.
+    let target = neutral_peak_frame();
+    for step in 1..=FADE_STEPS {
+        let faded = scale_frame(&target, step, FADE_STEPS);
+        push_frame(&mut py, &faded).await;
+        Timer::after(Duration::from_millis(FADE_TOTAL_MS / u64::from(FADE_STEPS))).await;
+    }
+    defmt::info!("LED ring: boot fade complete, joining render pipeline");
+
+    // Steady-state: drain the signal at 30 Hz and push whatever the
+    // render task published. If nothing was published this tick, skip
+    // the wire write — the ring holds the last frame.
+    let mut ticker = Ticker::every(Duration::from_hz(PUSH_RATE_HZ));
+    loop {
+        ticker.next().await;
+        if let Some(frame) = LED_FRAME_SIGNAL.try_take() {
+            push_frame(&mut py, frame.as_u16_slice()).await;
+        }
+    }
+}
+
+/// Push one frame to the ring: bulk write pixel RAM, then latch.
+/// Logs `warn` on either transport failure and returns (loop continues).
+async fn push_frame<B>(py: &mut py32::Py32<B>, pixels: &[u16])
+where
+    B: embedded_hal_async::i2c::I2c,
+    B::Error: core::fmt::Debug,
+{
+    if let Err(e) = py.write_led_pixels(pixels).await {
+        defmt::warn!("PY32: write_led_pixels failed: {}", defmt::Debug2Format(&e));
+        return;
+    }
+    if let Err(e) = py.refresh_leds().await {
+        defmt::warn!("PY32: refresh_leds failed: {}", defmt::Debug2Format(&e));
+    }
+}
+
+/// Build the "Neutral emotion at breath-peak brightness" frame used as
+/// the target colour for the boot fade-in.
+fn neutral_peak_frame() -> LedFrame {
+    let mut frame = LedFrame::default();
+    // Breath peaks at the halfway point of the 6 s cycle.
+    render_leds(&Avatar::default(), Instant::from_millis(3_000), &mut frame);
+    frame
+}
+
+/// Scale every RGB565 channel of `target` by `step / denom` into a
+/// fresh output frame. Used for boot fade.
+fn scale_frame(target: &LedFrame, step: u8, denom: u8) -> [u16; LED_COUNT] {
+    let mut out = [0u16; LED_COUNT];
+    let num = u32::from(step);
+    let den = u32::from(denom.max(1));
+    for (i, &px) in target.0.iter().enumerate() {
+        let r = (u32::from(px >> 11) & 0x1F) * num / den;
+        let g = (u32::from(px >> 5) & 0x3F) * num / den;
+        let b = (u32::from(px) & 0x1F) * num / den;
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "packed value fits in 16 bits by construction"
+        )]
+        {
+            out[i] = ((r << 11) | (g << 5) | b) as u16;
+        }
+    }
+    out
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -25,5 +25,6 @@ pub mod framebuffer;
 pub mod head;
 pub mod imu;
 pub mod ir;
+pub mod leds;
 pub mod touch;
 pub mod wallclock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -25,7 +25,7 @@
 extern crate alloc;
 
 use stackchan_firmware::{
-    ambient, board, button, clock, framebuffer, head, imu, ir, touch, wallclock,
+    ambient, board, button, clock, framebuffer, head, imu, ir, leds, touch, wallclock,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -58,11 +58,12 @@ use mipidsi::{
     options::{ColorInversion, ColorOrder},
 };
 use stackchan_core::{
-    Avatar, Clock, HeadDriver, Modifier,
+    Avatar, Clock, HeadDriver, LedFrame, Modifier,
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
         IdleDrift, IdleSway, PickupReaction, RemoteCommand,
     },
+    render_leds,
 };
 use static_cell::StaticCell;
 
@@ -177,6 +178,7 @@ async fn render_task(mut display: LcdDisplay) {
     let mut sway = IdleSway::new();
     let mut emotion_head = EmotionHead::new();
     let mut last_rendered: Option<Avatar> = None;
+    let mut led_frame = LedFrame::default();
 
     // Pre-compute the blit rect once; it never changes.
     let canvas = Rectangle::new(EgPoint::zero(), Size::new(FB_WIDTH, FB_HEIGHT));
@@ -234,6 +236,14 @@ async fn render_task(mut display: LcdDisplay) {
         // head task never builds up a backlog — it just reads the most
         // recent pose.
         head::POSE_SIGNAL.signal(avatar.head_pose);
+
+        // Render the LED ring from the same avatar state and publish to
+        // the led task. The led task owns the PY32 transport; this
+        // keeps I²C latency off the render path. Always publish —
+        // `Signal::signal` overwrites unread values so the led task
+        // can tick at its own cadence without building up a backlog.
+        render_leds(&avatar, now, &mut led_frame);
+        leds::LED_FRAME_SIGNAL.signal(led_frame);
 
         // Drain the latest observed pose from the head task. Updated at
         // ~1 Hz over there, so most render ticks see nothing new and
@@ -376,6 +386,14 @@ async fn ir_task(
     ir::run_ir_loop(rmt, pin).await
 }
 
+/// LED-ring output-sink task. Drains [`leds::LED_FRAME_SIGNAL`] at
+/// 30 Hz and pushes each frame to the PY32 IO expander over the shared
+/// I²C0 bus. Runs a brief fade-in before joining the signal pipeline.
+#[embassy_executor::task]
+async fn led_task(shared_i2c: SharedI2c) -> ! {
+    leds::run_led_loop(shared_i2c).await
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
@@ -479,6 +497,9 @@ async fn main(spawner: Spawner) -> ! {
     }
     if let Err(e) = spawner.spawn(ir_task(peripherals.RMT, peripherals.GPIO21)) {
         defmt::panic!("spawn ir_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(led_task(I2cDevice::new(board_io.i2c_bus))) {
+        defmt::panic!("spawn led_task failed: {}", defmt::Debug2Format(&e));
     }
 
     // One-shot wall-clock read for the boot log. Single I²C round-trip;

--- a/crates/stackchan-sim/tests/leds.rs
+++ b/crates/stackchan-sim/tests/leds.rs
@@ -1,0 +1,181 @@
+//! Golden test for `render_leds`: drives a full modifier stack against a
+//! [`FakeClock`] and asserts that the resulting [`LedFrame`] matches the
+//! emotion palette at peak brightness, dims under the breath envelope at
+//! the trough, and tracks [`EmotionCycle`]'s rotation between variants.
+//!
+//! This is the sim counterpart to the host-side unit tests in
+//! `stackchan_core::leds` — same function, exercised through the whole
+//! modifier stack so regressions in any layer (emotion dispatch, breath
+//! timing, palette lookup) show up here.
+
+#![allow(
+    clippy::field_reassign_with_default,
+    reason = "Avatar has many fields; post-init assignment is clearer than ..Default::default() here"
+)]
+
+use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, EmotionStyle, IdleDrift};
+use stackchan_core::{Avatar, BRIGHTNESS_PEAK, Clock, Emotion, LED_COUNT, LedFrame, Modifier};
+use stackchan_core::{Instant, render_leds};
+use stackchan_sim::FakeClock;
+
+/// Run the default v0.1.0 modifier stack for `ms` milliseconds of
+/// simulated time (no clock ticks between; modifiers are sampled at
+/// the end-state only), then render LEDs and return the frame.
+fn render_at(avatar: &mut Avatar, modifiers_at: u64) -> LedFrame {
+    let clock = FakeClock::new();
+    let mut emotion_cycle = EmotionCycle::new();
+    let mut emotion_style = EmotionStyle::new();
+    let mut blink = Blink::new();
+    let mut breath = Breath::new();
+    let mut drift = IdleDrift::new();
+
+    // Drive the stack in small steps so stateful modifiers (EmotionCycle
+    // cadence, Breath delta accumulation) see intermediate times.
+    let mut t = 0u64;
+    while t <= modifiers_at {
+        clock.set(Instant::from_millis(t));
+        emotion_cycle.update(avatar, clock.now());
+        emotion_style.update(avatar, clock.now());
+        blink.update(avatar, clock.now());
+        breath.update(avatar, clock.now());
+        drift.update(avatar, clock.now());
+        t += 33;
+    }
+
+    let mut frame = LedFrame::default();
+    render_leds(avatar, Instant::from_millis(modifiers_at), &mut frame);
+    frame
+}
+
+#[test]
+fn neutral_emotion_lights_soft_white_at_peak_breath() {
+    let mut avatar = Avatar::default();
+    avatar.emotion = Emotion::Neutral;
+    // No modifier pipeline — we want a pure palette probe.
+    let mut frame = LedFrame::default();
+    render_leds(&avatar, Instant::from_millis(3_000), &mut frame);
+
+    // Soft white palette = 0xFFFFE8. At peak brightness (102/255) this
+    // lands around (102, 102, ~93). Check each channel stays warm-white
+    // (R >= G ~ B, with R and G saturated at the 5-bit / 6-bit limit).
+    let px = frame.0[0];
+    let r5 = (px >> 11) & 0x1F;
+    let g6 = (px >> 5) & 0x3F;
+    let b5 = px & 0x1F;
+    assert!(r5 >= 10, "neutral R should be bright: got {r5}");
+    assert!(g6 >= 20, "neutral G should be bright: got {g6}");
+    assert!(b5 >= 9, "neutral B should be roughly matched: got {b5}");
+    // All 12 pixels carry the same colour.
+    for (i, p) in frame.0.iter().enumerate() {
+        assert_eq!(*p, px, "pixel {i} diverged from pixel 0");
+    }
+}
+
+#[test]
+fn each_emotion_produces_a_distinct_pixel_at_peak() {
+    // At the same peak-brightness moment, every emotion must light up
+    // the ring with a visibly different RGB565 value. Protects against
+    // palette collisions.
+    let now = Instant::from_millis(3_000);
+    let mut frame = LedFrame::default();
+    let mut seen = Vec::new();
+    for emotion in [
+        Emotion::Neutral,
+        Emotion::Happy,
+        Emotion::Sad,
+        Emotion::Sleepy,
+        Emotion::Surprised,
+    ] {
+        let mut avatar = Avatar::default();
+        avatar.emotion = emotion;
+        render_leds(&avatar, now, &mut frame);
+        let px = frame.0[0];
+        assert!(
+            !seen.contains(&px),
+            "{emotion:?} collided with a previous emotion palette entry ({px:#06x})"
+        );
+        seen.push(px);
+    }
+    assert_eq!(seen.len(), 5);
+}
+
+#[test]
+fn breath_envelope_dims_the_ring_at_cycle_trough() {
+    let mut avatar = Avatar::default();
+    avatar.emotion = Emotion::Happy; // amber has big R + G components
+    let mut trough = LedFrame::default();
+    let mut peak = LedFrame::default();
+    render_leds(&avatar, Instant::from_millis(0), &mut trough);
+    render_leds(&avatar, Instant::from_millis(3_000), &mut peak);
+
+    // Red channel: peak should be strictly brighter than trough.
+    let r_trough = (trough.0[0] >> 11) & 0x1F;
+    let r_peak = (peak.0[0] >> 11) & 0x1F;
+    assert!(
+        r_peak > r_trough,
+        "breath peak R ({r_peak}) should exceed trough R ({r_trough})"
+    );
+    // Trough envelope is ~60% of peak; in RGB565 5-bit R that's a
+    // noticeable step, but the exact ratio varies with quantisation.
+    // Just verify the direction here.
+}
+
+#[test]
+fn render_leds_integrated_with_emotion_cycle() {
+    // Drive the stack long enough that EmotionCycle has definitely
+    // moved off Neutral, then confirm the LED palette follows.
+    let mut avatar = Avatar::default();
+    let neutral_frame = {
+        let mut f = LedFrame::default();
+        render_leds(&avatar, Instant::from_millis(3_000), &mut f);
+        f
+    };
+
+    // 30 seconds of sim time — EmotionCycle rotates every few seconds,
+    // so the emotion will definitely have changed from Neutral.
+    let later = render_at(&mut avatar, 30_000);
+    assert_ne!(
+        avatar.emotion,
+        Emotion::Neutral,
+        "EmotionCycle should have advanced off Neutral by 30s"
+    );
+    assert_ne!(
+        later.0[0], neutral_frame.0[0],
+        "LED palette should track EmotionCycle's emotion change"
+    );
+
+    // LED count invariant.
+    assert_eq!(later.0.len(), LED_COUNT);
+}
+
+#[test]
+fn frame_never_exceeds_brightness_cap() {
+    // Sweep a full breath cycle and verify no channel exceeds what
+    // BRIGHTNESS_PEAK allows. Tightens the host-side bound into a
+    // sim-level guarantee.
+    let mut avatar = Avatar::default();
+    avatar.emotion = Emotion::Surprised; // max R+G+B case
+    let max_5bit = u16::from(BRIGHTNESS_PEAK) >> 3; // 5-bit R/B field
+    let max_6bit = u16::from(BRIGHTNESS_PEAK) >> 2; // 6-bit G field
+    let mut frame = LedFrame::default();
+    for ms in (0..12_000).step_by(50) {
+        render_leds(&avatar, Instant::from_millis(ms), &mut frame);
+        for (i, px) in frame.0.iter().enumerate() {
+            let r5 = (px >> 11) & 0x1F;
+            let g6 = (px >> 5) & 0x3F;
+            let b5 = px & 0x1F;
+            assert!(
+                r5 <= max_5bit,
+                "ms {ms} px {i}: R channel {r5} exceeds 5-bit cap {max_5bit}"
+            );
+            assert!(
+                g6 <= max_6bit,
+                "ms {ms} px {i}: G channel {g6} exceeds 6-bit cap {max_6bit}"
+            );
+            assert!(
+                b5 <= max_5bit,
+                "ms {ms} px {i}: B channel {b5} exceeds 5-bit cap {max_5bit}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the 12-LED WS2812C ring via the CoreS3 PY32 IO expander (I²C `0x6F`), the first **output sink** in the avatar pipeline — `render_task` keeps sole ownership of `Avatar`, runs the modifier stack, and publishes a pure-function-computed `LedFrame` over `embassy_sync::Signal` to a new transport-only `led_task`.
- Introduces `crates/py32` with the register-level protocol extracted from [m5stack/StackChan](https://github.com/m5stack/StackChan)'s `PY32IOExpander_Class` (MIT-licensed). Minimal surface: RMW GPIO config (used for servo-power enable on pin 0) + LED-RAM bulk write + refresh latch (for WS2812 fan-out on pin 13). Refactors the inline servo-power poking in `board.rs` to use the new driver, which fixes the latent "only works because GPIO registers happen to reset to zero" bug the existing comment already flagged.
- Emotion palette: Neutral=soft white, Happy=amber, Sad=deep blue, Sleepy=violet, Surprised=cyan — scaled by a 40% global brightness cap × a 6 s triangle breath envelope matching the Breath modifier's default cycle. 12 unit tests in `crates/py32`, 10 in `stackchan_core::leds`, 5 golden tests in `stackchan-sim`.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings`, full host test suite + doc tests — all green (pre-commit hook).
- [x] `cargo +esp clippy --lib --bins --examples -- -D warnings` clean on firmware.
- [x] `cargo +esp build --release` builds main firmware + `leds_bench` example.
- [x] Flash-tested on CoreS3 (`just fmr`, MAC `1C:DB:D4:BA:58:1C`). Boot fade-in visible, emotion palette tracks `EmotionCycle`, breath envelope pulses at the expected ~6 s period, no regressions on the face render / head servo / touch / IMU / RTC / button / IR paths.
- [ ] Greptile review.