### PR TITLE
chore: rename project to stackchan-kai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,4 +56,4 @@ wrapper that shares its render path with a headless simulator.
   registers, GCR, LED-mode = GPIO, and `LCD_RST` pulsed on `P1_1`. The
   prior `P0_0`-only helper left the backlight-boost gate on P1 floating.
 
-[0.1.0]: https://github.com/andymai/stackchan-rs/releases/tag/v0.1.0
+[0.1.0]: https://github.com/andymai/stackchan-kai/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# stackchan-rs
+# stackchan-kai
 
 ## Project Structure
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ default-members = [
 # lockstep; release-please bumps them together.
 edition = "2024"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/andymai/stackchan-rs"
+repository = "https://github.com/andymai/stackchan-kai"
 rust-version = "1.88"
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stackchan-rs
+# stackchan-kai
 
 A clean-slate Rust firmware for the M5Stack CoreS3 StackChan character. No AI.
 No upstream cloud. No C blobs. Just a desk toy that animates a face.

--- a/crates/aw9523/CHANGELOG.md
+++ b/crates/aw9523/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-rs/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-rs/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))
+* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-kai/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-kai/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))

--- a/crates/axp2101/CHANGELOG.md
+++ b/crates/axp2101/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-rs/issues/19)) ([0542ced](https://github.com/andymai/stackchan-rs/commit/0542ced96f320938db52c58a436b988f654255f4))
+* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-kai/issues/19)) ([0542ced](https://github.com/andymai/stackchan-kai/commit/0542ced96f320938db52c58a436b988f654255f4))

--- a/crates/bm8563/CHANGELOG.md
+++ b/crates/bm8563/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-rs/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-rs/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))
+* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-kai/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-kai/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))

--- a/crates/bmi270/CHANGELOG.md
+++ b/crates/bmi270/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* BMI270 IMU + pickup-reaction modifier ([#17](https://github.com/andymai/stackchan-rs/issues/17)) ([3dae938](https://github.com/andymai/stackchan-rs/commit/3dae938089eaa76b28a5fc258e80a6f44999f4d9))
+* BMI270 IMU + pickup-reaction modifier ([#17](https://github.com/andymai/stackchan-kai/issues/17)) ([3dae938](https://github.com/andymai/stackchan-kai/commit/3dae938089eaa76b28a5fc258e80a6f44999f4d9))

--- a/crates/ft6336u/CHANGELOG.md
+++ b/crates/ft6336u/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* FT6336U tap-to-cycle emotion + shared I²C0 bus ([#15](https://github.com/andymai/stackchan-rs/issues/15)) ([b724304](https://github.com/andymai/stackchan-rs/commit/b7243041f173deaa70d9cdf8b65f3a74430828c3))
+* FT6336U tap-to-cycle emotion + shared I²C0 bus ([#15](https://github.com/andymai/stackchan-kai/issues/15)) ([b724304](https://github.com/andymai/stackchan-kai/commit/b7243041f173deaa70d9cdf8b65f3a74430828c3))

--- a/crates/ir-nec/CHANGELOG.md
+++ b/crates/ir-nec/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-rs/issues/19)) ([0542ced](https://github.com/andymai/stackchan-rs/commit/0542ced96f320938db52c58a436b988f654255f4))
+* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-kai/issues/19)) ([0542ced](https://github.com/andymai/stackchan-kai/commit/0542ced96f320938db52c58a436b988f654255f4))

--- a/crates/ltr553/CHANGELOG.md
+++ b/crates/ltr553/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-rs/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-rs/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))
+* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-kai/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-kai/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))

--- a/crates/scservo/CHANGELOG.md
+++ b/crates/scservo/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* **dx:** boot PING health check + boot-nod gesture + justfile ([#6](https://github.com/andymai/stackchan-rs/issues/6)) ([e854251](https://github.com/andymai/stackchan-rs/commit/e854251decac986420a04065850fa910dff101d1))
-* servo position readback + calibration bench binary ([#11](https://github.com/andymai/stackchan-rs/issues/11)) ([e5bf109](https://github.com/andymai/stackchan-rs/commit/e5bf10988ce5bf147b1cf2b5135874196d40255b))
-* swap PCA9685 for Feetech SCServo on UART1 (matches real HW) ([#5](https://github.com/andymai/stackchan-rs/issues/5)) ([3d8a14b](https://github.com/andymai/stackchan-rs/commit/3d8a14b371fefd2c5f1803a1ad332c2137cfb4fe))
+* **dx:** boot PING health check + boot-nod gesture + justfile ([#6](https://github.com/andymai/stackchan-kai/issues/6)) ([e854251](https://github.com/andymai/stackchan-kai/commit/e854251decac986420a04065850fa910dff101d1))
+* servo position readback + calibration bench binary ([#11](https://github.com/andymai/stackchan-kai/issues/11)) ([e5bf109](https://github.com/andymai/stackchan-kai/commit/e5bf10988ce5bf147b1cf2b5135874196d40255b))
+* swap PCA9685 for Feetech SCServo on UART1 (matches real HW) ([#5](https://github.com/andymai/stackchan-kai/issues/5)) ([3d8a14b](https://github.com/andymai/stackchan-kai/commit/3d8a14b371fefd2c5f1803a1ad332c2137cfb4fe))

--- a/crates/stackchan-core/CHANGELOG.md
+++ b/crates/stackchan-core/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-## [0.3.0](https://github.com/andymai/stackchan-rs/compare/v0.2.0...v0.3.0) (2026-04-24)
+## [0.3.0](https://github.com/andymai/stackchan-kai/compare/v0.2.0...v0.3.0) (2026-04-24)
 
 
 ### Features
 
-* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-rs/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-rs/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))
-* BMI270 IMU + pickup-reaction modifier ([#17](https://github.com/andymai/stackchan-rs/issues/17)) ([3dae938](https://github.com/andymai/stackchan-rs/commit/3dae938089eaa76b28a5fc258e80a6f44999f4d9))
-* FT6336U tap-to-cycle emotion + shared I²C0 bus ([#15](https://github.com/andymai/stackchan-rs/issues/15)) ([b724304](https://github.com/andymai/stackchan-rs/commit/b7243041f173deaa70d9cdf8b65f3a74430828c3))
-* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-rs/issues/19)) ([0542ced](https://github.com/andymai/stackchan-rs/commit/0542ced96f320938db52c58a436b988f654255f4))
+* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-kai/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-kai/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))
+* BMI270 IMU + pickup-reaction modifier ([#17](https://github.com/andymai/stackchan-kai/issues/17)) ([3dae938](https://github.com/andymai/stackchan-kai/commit/3dae938089eaa76b28a5fc258e80a6f44999f4d9))
+* FT6336U tap-to-cycle emotion + shared I²C0 bus ([#15](https://github.com/andymai/stackchan-kai/issues/15)) ([b724304](https://github.com/andymai/stackchan-kai/commit/b7243041f173deaa70d9cdf8b65f3a74430828c3))
+* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-kai/issues/19)) ([0542ced](https://github.com/andymai/stackchan-kai/commit/0542ced96f320938db52c58a436b988f654255f4))
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* emotion-coupled head motion (EmotionHead modifier) ([#4](https://github.com/andymai/stackchan-rs/issues/4)) ([f144bb8](https://github.com/andymai/stackchan-rs/commit/f144bb8dcb3f0e810137c0989ac22a0913067eda))
-* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-rs/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-rs/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))
-* servo position readback + calibration bench binary ([#11](https://github.com/andymai/stackchan-rs/issues/11)) ([e5bf109](https://github.com/andymai/stackchan-rs/commit/e5bf10988ce5bf147b1cf2b5135874196d40255b))
+* emotion-coupled head motion (EmotionHead modifier) ([#4](https://github.com/andymai/stackchan-kai/issues/4)) ([f144bb8](https://github.com/andymai/stackchan-kai/commit/f144bb8dcb3f0e810137c0989ac22a0913067eda))
+* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-kai/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-kai/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))
+* servo position readback + calibration bench binary ([#11](https://github.com/andymai/stackchan-kai/issues/11)) ([e5bf109](https://github.com/andymai/stackchan-kai/commit/e5bf10988ce5bf147b1cf2b5135874196d40255b))

--- a/crates/stackchan-firmware/CHANGELOG.md
+++ b/crates/stackchan-firmware/CHANGELOG.md
@@ -1,22 +1,22 @@
 # Changelog
 
-## [0.3.0](https://github.com/andymai/stackchan-rs/compare/v0.2.0...v0.3.0) (2026-04-24)
+## [0.3.0](https://github.com/andymai/stackchan-kai/compare/v0.2.0...v0.3.0) (2026-04-24)
 
 
 ### Features
 
-* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-rs/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-rs/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))
-* BMI270 IMU + pickup-reaction modifier ([#17](https://github.com/andymai/stackchan-rs/issues/17)) ([3dae938](https://github.com/andymai/stackchan-rs/commit/3dae938089eaa76b28a5fc258e80a6f44999f4d9))
-* FT6336U tap-to-cycle emotion + shared I²C0 bus ([#15](https://github.com/andymai/stackchan-rs/issues/15)) ([b724304](https://github.com/andymai/stackchan-rs/commit/b7243041f173deaa70d9cdf8b65f3a74430828c3))
-* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-rs/issues/19)) ([0542ced](https://github.com/andymai/stackchan-rs/commit/0542ced96f320938db52c58a436b988f654255f4))
+* BM8563 wall-clock + LTR-553 AmbientSleepy modifier ([#18](https://github.com/andymai/stackchan-kai/issues/18)) ([a1f1af8](https://github.com/andymai/stackchan-kai/commit/a1f1af89d0409319cdf8cde60071dd8176ffae3b))
+* BMI270 IMU + pickup-reaction modifier ([#17](https://github.com/andymai/stackchan-kai/issues/17)) ([3dae938](https://github.com/andymai/stackchan-kai/commit/3dae938089eaa76b28a5fc258e80a6f44999f4d9))
+* FT6336U tap-to-cycle emotion + shared I²C0 bus ([#15](https://github.com/andymai/stackchan-kai/issues/15)) ([b724304](https://github.com/andymai/stackchan-kai/commit/b7243041f173deaa70d9cdf8b65f3a74430828c3))
+* power-button taps + IR NEC RemoteCommand modifier ([#19](https://github.com/andymai/stackchan-kai/issues/19)) ([0542ced](https://github.com/andymai/stackchan-kai/commit/0542ced96f320938db52c58a436b988f654255f4))
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* **dx:** boot PING health check + boot-nod gesture + justfile ([#6](https://github.com/andymai/stackchan-rs/issues/6)) ([e854251](https://github.com/andymai/stackchan-rs/commit/e854251decac986420a04065850fa910dff101d1))
-* emotion-coupled head motion (EmotionHead modifier) ([#4](https://github.com/andymai/stackchan-rs/issues/4)) ([f144bb8](https://github.com/andymai/stackchan-rs/commit/f144bb8dcb3f0e810137c0989ac22a0913067eda))
-* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-rs/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-rs/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))
-* servo position readback + calibration bench binary ([#11](https://github.com/andymai/stackchan-rs/issues/11)) ([e5bf109](https://github.com/andymai/stackchan-rs/commit/e5bf10988ce5bf147b1cf2b5135874196d40255b))
-* swap PCA9685 for Feetech SCServo on UART1 (matches real HW) ([#5](https://github.com/andymai/stackchan-rs/issues/5)) ([3d8a14b](https://github.com/andymai/stackchan-rs/commit/3d8a14b371fefd2c5f1803a1ad332c2137cfb4fe))
+* **dx:** boot PING health check + boot-nod gesture + justfile ([#6](https://github.com/andymai/stackchan-kai/issues/6)) ([e854251](https://github.com/andymai/stackchan-kai/commit/e854251decac986420a04065850fa910dff101d1))
+* emotion-coupled head motion (EmotionHead modifier) ([#4](https://github.com/andymai/stackchan-kai/issues/4)) ([f144bb8](https://github.com/andymai/stackchan-kai/commit/f144bb8dcb3f0e810137c0989ac22a0913067eda))
+* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-kai/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-kai/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))
+* servo position readback + calibration bench binary ([#11](https://github.com/andymai/stackchan-kai/issues/11)) ([e5bf109](https://github.com/andymai/stackchan-kai/commit/e5bf10988ce5bf147b1cf2b5135874196d40255b))
+* swap PCA9685 for Feetech SCServo on UART1 (matches real HW) ([#5](https://github.com/andymai/stackchan-kai/issues/5)) ([3d8a14b](https://github.com/andymai/stackchan-kai/commit/3d8a14b371fefd2c5f1803a1ad332c2137cfb4fe))

--- a/crates/stackchan-sim/CHANGELOG.md
+++ b/crates/stackchan-sim/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [0.2.1](https://github.com/andymai/stackchan-rs/compare/v0.2.0...v0.2.1) (2026-04-24)
+## [0.2.1](https://github.com/andymai/stackchan-kai/compare/v0.2.0...v0.2.1) (2026-04-24)
 
-## [0.2.0](https://github.com/andymai/stackchan-rs/compare/v0.1.0...v0.2.0) (2026-04-24)
+## [0.2.0](https://github.com/andymai/stackchan-kai/compare/v0.1.0...v0.2.0) (2026-04-24)
 
 
 ### Features
 
-* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-rs/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-rs/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))
+* pan/tilt servo head motion (+aw9523 extract, pca9685 driver) ([#2](https://github.com/andymai/stackchan-kai/issues/2)) ([1caa3ce](https://github.com/andymai/stackchan-kai/commit/1caa3ced220093864b65f54dbba34cfe4a6a70c1))

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# cargo-deny configuration for stackchan-rs.
+# cargo-deny configuration for stackchan-kai.
 # See https://embarkstudios.github.io/cargo-deny/ for schema documentation.
 
 [graph]

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-# stackchan-rs development tasks.
+# stackchan-kai development tasks.
 #
 # Install just: https://github.com/casey/just
 # Install espup + esp toolchain:


### PR DESCRIPTION
## Summary

- Rename workspace project from `stackchan-rs` to `stackchan-kai` following the GitHub repository rename.
- Scope is **workspace-root only** — individual crate names (`stackchan-core`, `stackchan-firmware`, `axp2101`, `aw9523`, `scservo`, `bm8563`, `bmi270`, `ft6336u`, `ir-nec`, `ltr553`, `bmm150`, `py32`, `stackchan-sim`) are unchanged so release-please, Cargo.lock, and all `use …` imports stay stable.
- Touched files:
  - Titles / headers: `README.md`, `CLAUDE.md`
  - Project-name comments: `justfile`, `deny.toml`
  - `[workspace.package].repository` URL in `Cargo.toml` (inherited by every member crate)
  - Release-link URLs in root `CHANGELOG.md` and all 10 per-crate CHANGELOGs (full consistency; GitHub's rename-redirect would have kept the old URLs working, but in-repo text now matches the new canonical name)

47 lines changed, all one-for-one substitutions — no semantic edits.

## Test plan

- [x] `cargo fmt --check` (pre-commit)
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings` (pre-commit)
- [x] `cargo test --workspace --exclude stackchan-firmware` (pre-commit)
- [x] Workspace doctests (pre-commit)
- [x] `cargo check --workspace` lock-drift guard (pre-commit)
- [ ] CI reruns the above on GitHub Actions
- [ ] greptile review