### PR TITLE
docs: add READMEs for the remaining 11 workspace crates

### DIFF
--- a/crates/aw9523/README.md
+++ b/crates/aw9523/README.md
@@ -1,0 +1,72 @@
+---
+crate: aw9523
+role: I/O expander driver + CoreS3 LCD bring-up
+bus: I²C
+address: "0x58"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+status: stable
+---
+
+# aw9523
+
+`no_std` async driver for the AW9523B I²C IO expander, with a
+CoreS3-specific bring-up helper that pulses `LCD_RST` and gates the
+backlight-boost converter rail. Without this dance the ILI9342C stays
+in reset or — worse — runs with no backlight while the LCD shows a
+confused image.
+
+## Key Files
+
+- `src/lib.rs` — `CORES3_ADDRESS`, port-0 / port-1 register constants, board-specific init values, `Error<E>`, `init_cores3` (the free function that runs the full bring-up), mock-I²C tests covering the reference sequence + reset-pulse invariants
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** `0x58` (CoreS3 wiring is `AD1 = AD0 = GND`)
+- **Transaction model:** simple register-write via `bus.write`, no reads — every register value is known at compile time
+- **No driver struct** — the public surface is a single free `init_cores3` function; the chip has no state worth caching and consumers never need to poke it again after boot
+
+## Register Map (CoreS3 Init)
+
+| Reg    | Name            | Value      | Purpose                                                     |
+|--------|-----------------|------------|-------------------------------------------------------------|
+| `0x02` | `OUTPUT_P0`     | `0b0000_0111` | P0_0..2 HIGH (release LCD_RST, AW88298_RST, TP_RST)      |
+| `0x03` | `OUTPUT_P1`     | `0b1000_1111` | P1_1 HIGH (LCD_RST released), P1_7 HIGH (backlight boost)|
+| `0x04` | `DIR_P0`        | `0b0001_1000` | Bits 3+4 input, rest output                              |
+| `0x05` | `DIR_P1`        | `0b0000_1100` | Bits 2+3 input (touch IRQ + tear-effect), rest output    |
+| `0x11` | `CONTROL`       | `0x10`     | Bit 4 = push-pull on P0                                     |
+| `0x12` | `LEDMODE_P0`    | `0xFF`     | All P0 pins in GPIO mode (not LED-sink)                     |
+| `0x13` | `LEDMODE_P1`    | `0xFF`     | All P1 pins in GPIO mode                                    |
+
+Then the reset pulse:
+
+| Reg    | Value             | Action                                                        |
+|--------|-------------------|---------------------------------------------------------------|
+| `0x03` | `0b1000_0001`     | P1_1 LOW (assert LCD_RST), keep P1_7 HIGH (boost stays on)    |
+| —      | `delay 20 ms`     | Reset-pulse width (≥10 µs datasheet, 20 ms matches M5Stack)   |
+| `0x03` | `0b1000_1111`     | P1_1 HIGH (release reset), P1_7 HIGH                          |
+| —      | `delay 120 ms`    | ILI9342C post-reset settle (datasheet minimum)                |
+
+## Init Sequence
+
+1. Configure port outputs + directions with known values *before* flipping to output
+2. Set push-pull on P0, GPIO mode on both ports
+3. Pulse `LCD_RST` on P1_1 while keeping `BACKLIGHT_BOOST_EN` on P1_7 held HIGH
+4. Wait 120 ms for the ILI9342C internal init
+
+AXP2101 rails MUST be up before this runs — touching the expander
+before LDOs stabilize latches bad state from mid-rising rails.
+
+## Gotchas
+
+1. **Backlight-boost enable MUST stay HIGH during reset.** Bit 7 of `OUTPUT_P1` drives the boost converter — dropping it during the reset pulse leaves the panel dark after reset even though the LCD comes up. Test `lcd_reset_pulse_keeps_backlight_boost_enable_high` guards this
+2. **Output values are written BEFORE direction flips.** This order guarantees each pin drives its final level the instant the direction register enables output — no glitch window between "direction = output" and "value = correct"
+3. **No driver struct; just a function.** Consumers that hold the bus across multiple calls should import `init_cores3` directly and not try to wrap it
+4. **120 ms post-reset is the ILI9342C's minimum** — cutting it short risks the panel rejecting the first SPI command. Test `post_reset_settle_meets_ili9342c_datasheet_minimum` guards this
+
+## Integration
+
+- **Runs after AXP2101 and before the LCD SPI init** in firmware boot. Any earlier and the rails aren't up; any later and the panel stays in reset
+- **Called by `board::init` once** — the firmware holds no driver struct because there's nothing to call after boot (unless a future release adds dynamic IO-expander use for other CoreS3 pins)
+- **Host-testable** via a mock I²C bus that records ordered events (writes + delays) — tests assert the full reference sequence, the reset-pulse keeps boost-enable high, and the timing meets datasheet minimums

--- a/crates/axp2101/README.md
+++ b/crates/axp2101/README.md
@@ -1,0 +1,74 @@
+---
+crate: axp2101
+role: PMIC driver + CoreS3 bring-up
+bus: I²C
+address: "0x34"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+status: stable
+---
+
+# axp2101
+
+`no_std` async driver for the X-Powers AXP2101 power-management IC on
+the M5Stack CoreS3. Scope is the minimum needed to boot the LCD rails
+*and* configure the chip not to auto-shutdown on idle, plus one-shot
+power-key IRQ helpers for the hardware button. Battery-state readout
+and charging config are left for future releases.
+
+## Key Files
+
+- `src/lib.rs` — `ADDRESS`, register + bit constants, `CORES3_INIT_SEQUENCE` (the full `M5Unified` register sequence as a `[(reg, value)]` slice), `Axp2101` struct, `init_cores3`, `read_reg` / `write_reg`, power-key IRQ helpers, mock-I²C golden-sequence tests
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** fixed at `0x34` on the CoreS3
+- **Transaction model:** single-register reads + writes (`write_read` / `write`)
+- **No chip-ID probe** — the driver doesn't expose one; `init_cores3` is fire-and-forget, and a missing / wrong PMIC fails at the first I²C transaction
+
+## CoreS3 Init Sequence
+
+Thirteen writes in order, copied verbatim from `M5Unified`'s
+`Power_Class.cpp`. Applied by `init_cores3()` in one shot.
+
+| Reg    | Value  | Purpose                                                    |
+|--------|--------|------------------------------------------------------------|
+| `0x92` | `13`   | ALDO1 = 1.8 V — AW88298 audio codec                        |
+| `0x93` | `28`   | ALDO2 = 3.3 V — ES7210 audio ADC                           |
+| `0x94` | `28`   | ALDO3 = 3.3 V — camera                                     |
+| `0x95` | `28`   | ALDO4 = 3.3 V — TF card slot                               |
+| `0x96` | `28`   | BLDO1 = 3.3 V — LCD backlight (voltage BEFORE enable)      |
+| `0x97` | `28`   | BLDO2 = 3.3 V — LCD logic                                  |
+| `0x90` | `0xBF` | Enable ALDO1..4 + BLDO1..2                                 |
+| `0x27` | `0x00` | Power-key timing: 1 s hold to wake, 4 s to power off       |
+| `0x10` | `0x30` | PMU common config — internal off-discharge enable          |
+| `0x12` | `0x00` | BATFET disable (prevents undervoltage shutdown, no battery)|
+| `0x68` | `0x01` | Battery-detect enable                                      |
+| `0x69` | `0x13` | CHGLED on charger, flashing on charge                      |
+| `0x99` | `28`   | DLDO1 = 3.3 V — LCD backlight brightness                   |
+| `0x30` | `0x0F` | ADC block enable (battery / VBUS voltage reads)            |
+
+## Power-Key IRQ
+
+Two helpers for the CoreS3 hardware button:
+
+- `enable_power_key_short_press_irq()` — `IRQ_EN_1` bit 4 set, preserves other bits via RMW
+- `check_short_press_edge()` — reads `IRQ_STATUS_1` (`0x49`), returns `true` + write-1-clears the bit, or `false` if no edge
+
+Bit layout of `IRQ_STATUS_1`: bit 0 = key release, bit 1 = key press,
+bit 4 = short-press (< 1 s), bit 5 = long-press, bit 6 = over-press (> 2 s).
+
+## Gotchas
+
+1. **Voltage setpoints MUST precede the enable bitmap.** BLDO1 default is 0.5 V — enabling it before writing `0x96 = 28` lights the panel with no backlight. The test `init_cores3_writes_backlight_voltage_before_enable_bitmap` guards this
+2. **BATFET disable is load-bearing when no battery is attached.** Leaving it enabled routes the chip through the battery FET; with no battery, that path triggers an undervoltage shutdown
+3. **Power-key timing (`0x27`)** must be written or the chip treats mild button glitches as shutdown requests. Default values are aggressive
+4. **ADC must be enabled (`0x30 = 0x0F`)** before any battery / VBUS voltage read returns meaningful data
+5. **`into_inner()` releases the bus.** Useful for single-task firmware bringing up AW9523 after the PMIC — avoids pulling in a shared-bus abstraction
+
+## Integration
+
+- **Runs first in firmware boot**, before `aw9523::init_cores3` or the LCD SPI init. Rails must be up before any downstream peripheral is touched
+- **Shares the main `SharedI2cBus`** once embassy's shared-bus wrapper is installed
+- **Host-testable** via mock I²C — tests assert the init sequence byte-for-byte, verify ordering invariants, and confirm battery-detect + ADC are in the sequence

--- a/crates/bm8563/README.md
+++ b/crates/bm8563/README.md
@@ -1,0 +1,70 @@
+---
+crate: bm8563
+role: Real-time clock driver
+bus: I²C
+address: "0x51"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+status: stable
+---
+
+# bm8563
+
+`no_std` async driver for the NXP BM8563 real-time clock (a
+pin-compatible clone of the PCF8563). Scope is tight: set / read
+date-time and detect the voltage-low flag. Alarm, timer, and CLKOUT
+features are deliberately out of scope.
+
+## Key Files
+
+- `src/lib.rs` — `ADDRESS`, register constants, `DateTime` struct (year / month / day / weekday / hours / minutes / seconds), `Bm8563` driver, `init` / `read_datetime` / `write_datetime`, pure `encode_datetime` / `decode_datetime` / `format_datetime` / BCD helpers, round-trip + century-bit + saturation tests
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** fixed at `0x51`
+- **Transaction model:** single-register writes for `Control_1` / `Control_2` init; one 7-byte `write_read` burst for the date-time block; one 8-byte burst-write (register address + 7 payload) to set the time
+- **No chip-ID register** — the BM8563 has no identity byte; presence is inferred from I²C ACKs
+
+## Register Map
+
+| Reg    | Name                   | Purpose                                                              |
+|--------|------------------------|----------------------------------------------------------------------|
+| `0x00` | `Control_1`            | Top bit `STOP`: `0` = RTC running, `1` = stopped                     |
+| `0x01` | `Control_2`            | Alarm / timer interrupt flags (zeroed at init)                       |
+| `0x02` | `VL_SECONDS`           | Bit 7 = `VL` voltage-low flag, bits 6:0 = BCD seconds                |
+| `0x03` | `MINUTES`              | Bits 6:0 BCD                                                         |
+| `0x04` | `HOURS`                | Bits 5:0 BCD                                                         |
+| `0x05` | `DAYS`                 | Bits 5:0 BCD                                                         |
+| `0x06` | `WEEKDAYS`             | Bits 2:0; 0 = Sunday convention                                      |
+| `0x07` | `CENTURY_MONTHS`       | Bit 7 = century (1 → 1900s, 0 → 2000s), bits 4:0 BCD month           |
+| `0x08` | `YEARS`                | Two-digit BCD year; combined with `CENTURY_MONTHS` for 1900..=2099   |
+
+## `DateTime`
+
+Plain struct, no timezone — the RTC is timezone-agnostic. Year is
+expanded to four digits using the century bit; the rest are plain
+decimals inside their natural ranges (hour `0..=23`, month `1..=12`,
+weekday `0..=6` Sunday-based).
+
+## Init Sequence
+
+1. `Control_1 = 0x00` — clear STOP, RTC starts ticking
+2. `Control_2 = 0x00` — disable lingering alarm / timer interrupts
+
+That's it. `init` does NOT set the time; a freshly-powered RTC has
+arbitrary values and a set `VL` flag. Set the time explicitly via
+`write_datetime`.
+
+## Gotchas
+
+1. **`VL` flag surfaces as a typed error.** `read_datetime` returns `Error::VoltageLow` if bit 7 of the seconds register is set — callers can retry, treat it as unset-time, or display the raw value anyway
+2. **BCD masks differ per register.** Seconds uses `0x7F` (strip VL); hours uses `0x3F`; days uses `0x3F`; month uses `0x1F` (leave century bit alone). Hard-coded in `decode_datetime`
+3. **Century encoding is inverted from intuition.** Bit 7 SET = 1900s, CLEAR = 2000s. The driver hides this by producing a 4-digit `year` on decode and reconstructing the bit on encode
+4. **`format_datetime` saturates pathological inputs** — a garbled register read producing `month = 99` becomes `"99"` in the output, so the function always produces exactly 19 ASCII bytes. Tests cover the pathological case
+5. **No `alloc`, no `chrono`.** The crate intentionally avoids both: `chrono` pulls in tons of date arithmetic; callers that need it can convert `DateTime` at their boundary
+
+## Integration
+
+- **Firmware `wallclock` module** sets the RTC from Wi-Fi NTP (eventually) or manual boot-time settings, and reads it for log timestamps + status line
+- **Host-testable** — `encode_datetime`, `decode_datetime`, `format_datetime`, and `bcd_to_u8`/`u8_to_bcd` are all pure functions with round-trip tests

--- a/crates/bmm150/README.md
+++ b/crates/bmm150/README.md
@@ -1,0 +1,75 @@
+---
+crate: bmm150
+role: 3-axis geomagnetic sensor driver
+bus: I²C
+address: "0x10 / 0x11"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+chip_id: "0x32 @ register 0x40"
+status: stable
+---
+
+# bmm150
+
+`no_std` async driver for the Bosch BMM150 3-axis geomagnetic sensor.
+Covers the boot dance (soft-reset → wake → trim-register readout →
+regular 10 Hz preset), compensated microtesla readings, and nothing
+else. Heading computation, tilt compensation, and hard-/soft-iron
+calibration are intentionally left to downstream consumers.
+
+## Key Files
+
+- `src/lib.rs` — `ADDRESS_PRIMARY` / `SECONDARY`, register constants, `Bmm150` struct, `detect` / `new` / `init` / `read_measurement`, `Trim` + Bosch-reference compensation port, `Measurement` struct (µT output), tests
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** `0x10` (SDO → GND) or `0x11` (SDO → VDDIO). `Bmm150::detect` probes both
+- **Transaction model:** `write_read` for single registers; one 8-byte burst for the measurement block; one 21-byte burst for the trim registers (includes reserved bytes that are read + discarded)
+- **CHIP_ID:** `0x32` at register `0x40`. Mismatch → `Error::ChipId { expected, actual }`
+
+## Register Map
+
+| Reg         | Name            | Access | Purpose                                                  |
+|-------------|-----------------|--------|----------------------------------------------------------|
+| `0x40`      | `CHIP_ID`       | R      | Identity byte; expected `0x32`                           |
+| `0x42–0x49` | `DATA`          | R      | 8-byte burst: `X_L, X_M, Y_L, Y_M, Z_L, Z_M, RHALL_L, RHALL_M` |
+| `0x4B`      | `POWER`         | W      | Bit 0 = wake; `0x82` = soft-reset while suspended        |
+| `0x4C`      | `OPMODE_ODR`    | W      | ODR (bits 5:3), op-mode (bits 2:1), self-test (bit 0)    |
+| `0x51`      | `REP_XY`        | W      | XY repetitions = `2 * reg + 1`                           |
+| `0x52`      | `REP_Z`         | W      | Z repetitions = `reg + 1` (asymmetric — not `2 * reg + 1`) |
+| `0x5D–0x71` | `TRIM`          | R      | 21-byte per-chip compensation constants                  |
+
+## Init Sequence
+
+1. Read `CHIP_ID`; expect `0x32`
+2. Soft-reset: `POWER = 0x82` (bit 7 | bit 1, stays in suspend); wait ≥5 ms
+3. Wake: `POWER = 0x01` (bit 0 set); wait ≥5 ms (I²C NACKs against a still-suspended chip)
+4. Read the 21-byte trim block into a `Trim` struct; cache for every future `read_measurement`
+5. Regular preset: `REP_XY = 4` (REPXY = 9), `REP_Z = 14` (REPZ = 15)
+6. `OPMODE_ODR = 0x00` — 10 Hz normal mode
+
+## Compensation
+
+Raw ADC counts don't mean anything without per-chip trim — every BMM150
+ships with factory calibration stored in the trim registers. The driver
+ports Bosch's reference compensation (same fixed-point integer math,
+same overflow sentinels) and converts the 1/16 µT per LSB output to
+`f32` µT at the public boundary. Total earth-field magnitude is
+25–65 µT at the surface; readings well outside that window indicate
+hard-iron distortion (nearby magnets / motors / speaker).
+
+## Gotchas
+
+1. **Suspend mode is I²C-unreachable.** Issuing any register read against a chip that hasn't been woken NACKs. The `POWER = 0x01` wake step is non-negotiable
+2. **`REP_Z` encoding is different from `REP_XY`.** XY uses `(n-1) / 2`, Z uses `n - 1`. One of the few asymmetries in the register map
+3. **Trim registers include four reserved bytes.** The 21-byte block spans `0x5D..=0x71`; the driver reads all 21 and extracts only the Bosch-defined trim fields from it. Don't assume the block is contiguous trim
+4. **Overflow is a separate error variant.** `X_OVERFLOW = -4096` (13-bit field), `Z_OVERFLOW = -16384` (15-bit field). The driver surfaces these as `Error::Overflow` rather than returning nonsense µT; the firmware's `mag` module logs them at `debug` since brief overflows on a spinning magnetometer are normal
+5. **Output unit is `f32` µT, not raw counts.** Callers that want the raw 1/16-µT LSBs need to reach into the crate privately or accept the conversion cost
+6. **`detect()` costs up to one extra NACK.** Similar to `bmi270` — the firmware uses it anyway to log which address answered
+
+## Integration
+
+- **Used by `stackchan-firmware/src/mag.rs`** as the other half of the 9-axis data path, paired with `bmi270` on the same `SharedI2cBus`
+- **Overflow logging:** the firmware's mag task logs `Error::Overflow` at `defmt::debug` — the avatar's gaze-steering is fine with brief gaps in the stream
+- **Host-testable** — the compensation math is pure and unit-testable against Bosch's reference vectors; the register-access surface is mockable via `embedded-hal-async` fakes

--- a/crates/ft6336u/README.md
+++ b/crates/ft6336u/README.md
@@ -1,0 +1,71 @@
+---
+crate: ft6336u
+role: Capacitive touch controller driver (single-touch subset)
+bus: I²C
+address: "0x38"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+vendor_id: "0x11 @ register 0xA8"
+status: stable
+---
+
+# ft6336u
+
+`no_std` async driver for the FocalTech FT6336U capacitive touch
+controller. MVP single-touch subset — one `read_touch()` returns finger
+count + first touch coordinates. Multi-touch, native gesture registers,
+and power-saving modes are intentionally out of scope; adding them
+doesn't change the `Ft6336u` type surface.
+
+## Key Files
+
+- `src/lib.rs` — `CORES3_ADDRESS`, `VENDOR_ID_FOCALTECH`, register + offset constants, `TouchReport` (fingers + first `(x, y)`), `Ft6336u` driver, `read_vendor_id` / `read_touch` / `into_inner`, pure `decode_touch` + unit tests
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** fixed at `0x38` on the CoreS3
+- **Transaction model:** one 7-byte `write_read` burst starting at `G_MODE` (`0x00`) covers status + first touch-point in a single transaction
+- **Vendor ID:** `0x11` at register `0xA8` — cheap presence check at boot
+- **Reset:** external, driven by AW9523 during LCD bring-up. The driver assumes the chip is out of reset by the time `new()` is called
+
+## Register Map
+
+Only the registers this driver touches.
+
+| Offset | Reg         | Contents                                          |
+|--------|-------------|---------------------------------------------------|
+| 0      | `G_MODE`    | Operating mode (unused, but the burst starts here) |
+| 1      | `GESTURE`   | HW-detected gesture code (unused)                 |
+| 2      | `TD_STATUS` | Low nibble = touch count (0..=2)                  |
+| 3      | `P1_XH`     | `[7:6]` event flag, `[3:0]` x\[11:8\]             |
+| 4      | `P1_XL`     | x\[7:0\]                                          |
+| 5      | `P1_YH`     | `[7:4]` touch id, `[3:0]` y\[11:8\]               |
+| 6      | `P1_YL`     | y\[7:0\]                                          |
+
+Plus `0xA8` (vendor ID, read-only).
+
+## Usage
+
+No `init()` method — the chip's reset defaults work for this MVP.
+Construct with `Ft6336u::new(bus)`, optionally probe with
+`read_vendor_id()`, then call `read_touch()` on whatever cadence the
+caller wants (chip caps at 60 Hz internal polling).
+
+`TouchReport::point()` and `TouchReport::is_touched()` are convenience
+accessors for the common "is a finger down, and where?" question.
+
+## Gotchas
+
+1. **Coordinate masking strips metadata.** Top 2 bits of `P1_XH` carry an event flag (press / release / contact / no-event) that the MVP ignores; top nibble of `P1_YH` carries the touch ID. Both are masked out by `COORD_HIGH_MASK = 0x0F`
+2. **`TD_STATUS` high nibble is reserved.** Don't read it as "many fingers" — masked with `0x0F` in `decode_touch`. Test `td_status_high_nibble_is_ignored` guards this
+3. **Unpowered chip reads as all-ones.** A chip in reset or with no power returns `0xFF` bytes, which decode to `fingers = 15`. Callers can filter as a sanity check; the crate doesn't do it automatically
+4. **Every read hits the bus.** No caching — the chip's ≤60 Hz internal polling is the rate-limit, not any client-side throttle
+5. **No init or chip-ID probe in `new()`.** `read_vendor_id()` exists for explicit boot-time checks; construction is infallible and doesn't touch the bus
+6. **Native coordinate space is 12-bit.** Panel orientation may require callers to swap / invert axes to match the framebuffer — the driver doesn't know which orientation the panel is mounted in
+
+## Integration
+
+- **Firmware `touch` module** polls via `read_touch()` and feeds results to the avatar's `EmotionTouch` modifier (tap → emotion change)
+- **Shares the main `SharedI2cBus`** with AXP2101, AW9523, BMI270, BMM150, BM8563, and the upcoming audio codecs
+- **Host-testable** — `decode_touch` is a pure `[u8; 7] → TouchReport` function with coverage for zero-touch, one-touch, two-touch, and reserved-bit edge cases

--- a/crates/ltr553/README.md
+++ b/crates/ltr553/README.md
@@ -1,0 +1,68 @@
+---
+crate: ltr553
+role: Ambient-light + proximity sensor driver
+bus: I²C
+address: "0x23"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+part_id_upper: "0x9 @ register 0x86"
+status: stable
+---
+
+# ltr553
+
+`no_std` async driver for the Lite-On LTR-553ALS ambient-light +
+proximity sensor. Minimal surface: one `init()`, plus `read_ambient`
+and `read_proximity` polling accessors. Configures the chip for default
+gain + integration so the lux math matches Lite-On's app-note piecewise
+formula at unit scale — other gain / integration settings need a more
+complete driver.
+
+## Key Files
+
+- `src/lib.rs` — `ADDRESS`, register constants, `AmbientReading` struct (`ch0` + `ch1` raw + computed `lux`), `Ltr553` driver, `init` / `read_part_id` / `read_ambient` / `read_proximity` / `read_status`, private `lux_from_channels` piecewise formula, unit tests
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** fixed at `0x23` on the CoreS3 (no strap pin)
+- **Transaction model:** single-register writes for config; 4-byte burst read for the ambient data pair; 2-byte burst for the proximity pair
+- **Part ID:** upper nibble `0x9` identifies the LTR-553 family; lower nibble is silicon revision
+
+## Register Map
+
+| Reg    | Name            | Access | Purpose                                                   |
+|--------|-----------------|--------|-----------------------------------------------------------|
+| `0x80` | `ALS_CONTR`     | W      | ALS mode + gain; driver writes `0x02` (active, 1× gain)   |
+| `0x81` | `PS_CONTR`      | W      | PS mode + gain; driver writes `0x03` (active)             |
+| `0x86` | `PART_ID`       | R      | Upper nibble `0x9` for LTR-553 family                     |
+| `0x88–0x8B` | `ALS_DATA`  | R      | 4-byte burst: `CH1_LSB, CH1_MSB, CH0_LSB, CH0_MSB`        |
+| `0x8C` | `ALS_PS_STATUS` | R      | Bit 2 = ALS data ready, bit 0 = PS data ready             |
+| `0x8D–0x8E` | `PS_DATA`   | R      | 2-byte burst: 11-bit proximity + saturation flag          |
+
+## Init Sequence
+
+1. Read `PART_ID`; verify upper nibble is `0x9`
+2. `ALS_CONTR = 0x02` — ALS active, gain 1× (default)
+3. `PS_CONTR = 0x03` — PS active, default gain 16×
+
+Default ALS config: gain 1×, integration 100 ms, measurement rate 500 ms.
+
+## Reading
+
+- **`read_ambient()`** — returns `AmbientReading { ch0, ch1, lux }`. `ch0` is visible + IR, `ch1` is IR-only. Lux is a piecewise formula that returns `0.0` when the scene is IR-only (e.g. incandescent behind filters)
+- **`read_proximity()`** — returns an 11-bit raw count, larger = closer. Bit 7 of the MSB is a saturation flag the driver ignores
+
+## Gotchas
+
+1. **Datasheet byte order is `CH1_LSB, CH1_MSB, CH0_LSB, CH0_MSB`** — NOT `CH0` first. Easy to get backwards; the driver's `read_ambient` decodes it correctly
+2. **Lux formula is gain-dependent.** `lux_from_channels` assumes 1× gain / 100 ms integration (what `init` sets). Changing either side breaks the formula — a more general driver would need a lookup or scale
+3. **Proximity is raw counts, not mm.** "Larger = closer" but there's no linear distance mapping without calibration against known reflectance
+4. **Proximity saturation is silent.** Bit 15 of the MSB signals that the IR LED output saturated the photodiode. The driver masks it with `0x07` rather than reporting it — callers that care can read the status register
+5. **`init()` gates on PART_ID.** A wrong chip at `0x23` fails with `Error::BadPartId`; a bus NACK fails with `Error::I2c`
+
+## Integration
+
+- **Firmware `ambient` module** polls ambient lux + proximity. Lux drives the `AmbientSleepy` avatar modifier (darkroom → sleepy face); proximity will drive a "someone is close" reaction once the integration is done
+- **Shares the main `SharedI2cBus`**
+- **Host-testable** — the lux formula and byte-order handling are both testable via mock I²C

--- a/crates/py32/README.md
+++ b/crates/py32/README.md
@@ -1,0 +1,73 @@
+---
+crate: py32
+role: Stack-chan PY32 co-processor driver (GPIO + WS2812 fan-out)
+bus: I²C
+address: "0x6F"
+transport: embedded-hal-async
+no_std: true
+unsafe: forbidden
+max_leds: 32
+status: stable
+---
+
+# py32
+
+`no_std` async driver for the Stack-chan CoreS3's **PY32 co-processor**.
+Despite the name, this chip is *not* a stock GPIO expander — it's a
+Puya PY32-family MCU running custom M5Stack firmware that exposes GPIO
+config *and* a WS2812 fan-out buffer on the pin wired to the 12-LED
+ring. This crate implements the subset our firmware needs: servo-power
+rail gating (pin 0) and LED frame staging + latch.
+
+## Key Files
+
+- `src/lib.rs` — `ADDRESS`, `MAX_LEDS`, GPIO register map, LED RAM / config map, `Py32` driver, `configure_output_pin` (RMW on dir / pullup / out), `set_led_count` / `write_led_pixels` / `refresh_leds`, unit tests
+
+## Bus + Addressing
+
+- **I²C 7-bit address:** `0x6F` (Stack-chan CoreS3 wiring)
+- **Transaction model:** single-register writes for GPIO config; read-modify-write for all direction / pullup / level changes so other pins stay put; bulk writes for LED RAM (register address + pixel bytes in one transaction)
+- **No chip-ID register** — the PY32 firmware doesn't publish one; presence is inferred from I²C ACKs
+- **Firmware provenance:** register layout + LED-RAM semantics lifted from [m5stack/StackChan `PY32IOExpander_Class.cpp`](https://github.com/m5stack/stackchan) (MIT upstream)
+
+## Register Map
+
+| Reg    | Name          | Purpose                                                          |
+|--------|---------------|------------------------------------------------------------------|
+| `0x03` | `DIR_LO`      | Direction bits for pins 0..7 (1 = output)                        |
+| `0x04` | `DIR_HI`      | Direction bits for pins 8..13                                    |
+| `0x05` | `OUT_LO`      | Output level for pins 0..7 (1 = HIGH)                            |
+| `0x06` | `OUT_HI`      | Output level for pins 8..13                                      |
+| `0x09` | `PULLUP_LO`   | Pull-up enable for pins 0..7 (1 = enabled)                       |
+| `0x0A` | `PULLUP_HI`   | Pull-up enable for pins 8..13                                    |
+| `0x24` | `LED_CFG`     | Bits 0..5 = LED count (max 32); bit 6 = refresh-trigger          |
+| `0x30+` | `LED_RAM`    | 2 bytes per pixel (LE RGB565), auto-increment; pixel `i` at `0x30 + 2i` |
+
+## Capabilities
+
+- **GPIO output config** — `configure_output_pin(pin, level)`:
+  1. Sets direction bit via RMW
+  2. Enables pull-up via RMW
+  3. Writes the level bit
+  Used to raise the servo-power rail on pin 0.
+- **LED frame:**
+  1. `set_led_count(n)` — bits 0..5 of `LED_CFG` (preserves bit 6 so an in-flight refresh isn't dropped)
+  2. `write_led_pixels(&[u16])` — stages up to 32 RGB565 pixels in LED RAM (LE byte order)
+  3. `refresh_leds()` — sets bit 6 of `LED_CFG`; the PY32 firmware clocks the entire RAM onto the WS2812 chain on pin 13
+- **`release()`** — gives the bus back to the caller (useful when the PY32 is touched once at boot and the bus belongs to someone else afterward)
+
+## Gotchas
+
+1. **RMW everywhere.** Every GPIO operation reads the current register, masks, writes. Interleaving calls on different pins is safe; calling the driver while another task also touches `0x6F` is NOT — the driver assumes exclusive access
+2. **LED refresh is a two-step dance.** `write_led_pixels` stages a frame in RAM without touching the chain; `refresh_leds` latches it. Skipping the refresh leaves the displayed frame unchanged — and a torn frame isn't possible because the chain doesn't update until the trigger bit is set
+3. **Empty frame is a wire no-op.** `write_led_pixels(&[])` skips the I²C transaction entirely — no blank frame gets staged. Callers that want to clear the ring need to write explicit all-zero pixels
+4. **Pin range is 0..=13.** Out-of-range pins return `Error::InvalidPin(pin)` rather than silently dropping. Only these pin indices exist in the firmware's register layout
+5. **LED count ≤ 32.** The LED count field is 6 bits (max 63) but the RAM only holds 32 pixels; the driver rejects `count > 32` with `Error::TooManyLeds`
+6. **RGB565 wire order is little-endian.** Pixel `0xFFE0` (yellowish white) becomes `[0xE0, 0xFF]` in the I²C payload — matches what the PY32 firmware expects, NOT the byte order most LED libraries use
+
+## Integration
+
+- **Firmware `board::init`** raises the servo-power rail via `configure_output_pin(0, true)` as part of boot
+- **Firmware `leds` module** owns the WS2812 fan-out: renders a frame via `stackchan_core::render_leds`, writes it with `write_led_pixels`, latches with `refresh_leds`
+- **Shares the main `SharedI2cBus`**
+- **Bench recipe:** `just leds-bench` exercises the LED path end-to-end on hardware

--- a/crates/scservo/README.md
+++ b/crates/scservo/README.md
@@ -1,0 +1,78 @@
+---
+crate: scservo
+role: Feetech SCServo (SCSCL / SCS0009) driver
+bus: UART (half-duplex, 1 Mbaud)
+transport: embedded-io-async
+no_std: true
+unsafe: forbidden
+protocol: "Feetech packet (0xFF 0xFF ID len instr addr data... ~chk)"
+status: stable
+---
+
+# scservo
+
+`no_std` async driver for the Feetech SCServo family (SCSCL / SCS0009).
+The servos share a half-duplex TTL bus at 1 Mbaud, each addressed by a
+1-byte ID. The crate speaks the Feetech packet protocol over any
+`embedded_io_async::Write` (for position / torque commands) and
+optionally `Read` (for `ping`, the boot-time health check).
+
+## Key Files
+
+- `src/lib.rs` — protocol constants, `Instruction` enum, `Scservo` driver, `write_position` / `write_torque_enable` / `write_memory` / `read_memory` / `ping`, packet build / checksum / response parse helpers, golden-packet tests
+
+## Bus + Wire Format
+
+- **Transport:** half-duplex TTL UART at 1 Mbaud (default). Caller configures the baud
+- **Packet:** `| 0xFF | 0xFF | ID | msgLen | Instruction | MemAddr | Data... | ~checksum |`
+- **`msgLen`** = payload bytes after `msgLen` itself. For a write of N data bytes: `msgLen = N + 3` (instruction + addr + checksum). For `PING`: `msgLen = 2` and `MemAddr` is omitted
+- **Checksum** = `~(ID + msgLen + Instruction + MemAddr + sum(Data))` — bitwise-NOT of the byte sum
+- **16-bit values are big-endian** (SCSCL `End = 1`)
+- **Broadcast ID `0xFE`** — every servo acts on the packet, no response. Reads / pings against broadcast return `Error::BroadcastNotAllowed`
+
+## Instructions
+
+| Instruction  | Opcode | Purpose                                                |
+|--------------|--------|--------------------------------------------------------|
+| `Ping`       | `0x01` | Query — servo responds with its status byte            |
+| `Read`       | `0x02` | Read N bytes from a register                           |
+| `Write`      | `0x03` | Write N bytes to a register                            |
+| `RegWrite`   | `0x04` | Stage a deferred write                                 |
+| `RegAction`  | `0x05` | Execute all pending `RegWrite`s                        |
+| `SyncWrite`  | `0x83` | Broadcast write of identical-shape payload to many IDs |
+
+## Memory Table
+
+Register addresses the crate exposes as consts:
+
+| Addr | Name                    | Size  | Purpose                                             |
+|------|-------------------------|-------|-----------------------------------------------------|
+| 40   | `ADDR_TORQUE_ENABLE`    | 1     | `0` = free, `1` = holding                           |
+| 42   | `ADDR_GOAL_POSITION`    | 2+2+2 | Position (0..=1023), time (ms), speed — big-endian  |
+| 56   | `ADDR_PRESENT_POSITION` | 2     | Current position in counts                          |
+| 62   | `ADDR_PRESENT_VOLTAGE`  | 1     | 0.1 V per count                                     |
+| 63   | `ADDR_PRESENT_TEMPERATURE` | 1  | °C (direct, no scaling)                             |
+| 66   | `ADDR_MOVING`           | 1     | `0` = settled, non-zero = tracking                  |
+
+## Position Space
+
+0..=1023 counts across ~300° of travel, centered at 512.
+`POSITION_CENTER = 512`, `POSITION_PER_DEGREE = 1023.0 / 300.0 ≈ 3.41`.
+`write_position` rejects counts > 1023 with `Error::PositionOutOfRange`
+— the servo would interpret the high bits as an address in the memory
+table.
+
+## Gotchas
+
+1. **No internal timeout.** UART reads block until the full response arrives. A disconnected servo hangs forever unless the caller wraps `ping` / `read_memory` with their runtime's timeout primitive (`embassy_time::with_timeout(Duration::from_millis(10), bus.ping(1))` — 10 ms is generous, RTT at 1 Mbaud is < 200 µs)
+2. **Big-endian 16-bit values.** Most embedded serial protocols are little-endian; Feetech isn't. The packet builder and response parser handle it
+3. **Broadcast is for writes only.** `ping` and `read_memory` against `0xFE` garble the frame (every servo replies at once). The crate returns `Error::BroadcastNotAllowed` at the boundary
+4. **`write_position` data payload is 6 bytes.** Position (2), time (2), speed (2) — commanding just the position without time / speed isn't supported by the memory layout
+5. **Response parsing is strict.** Wrong headers → `MalformedResponse`. Bad checksum → `ChecksumMismatch`. Partial read → `NoResponse`. Callers log verbatim at defmt level
+6. **`MAX_DATA_BYTES = 6`** caps the write payload. `WritePos` is the only instruction that reaches the limit; the bound exists so arbitrary-length writers added later stay bounded
+
+## Integration
+
+- **Firmware `head` module** drives pan + tilt via `write_position`. Values come from `stackchan_core::Pose` after the `EmotionHead` / `IdleDrift` / `IdleSway` modifier stack resolves
+- **Calibration bench** (`crates/stackchan-firmware/examples/bench.rs`, invoked via `just bench`) sweeps each servo and reads back `ADDR_PRESENT_POSITION` to find mechanical limits
+- **Host-testable** — packet encoding / decoding and checksum math are pure functions with golden-packet tests; response parsing has "malformed / checksum bad / truncated" coverage

--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -1,14 +1,105 @@
+---
+crate: stackchan-core
+role: Avatar domain library (no_std, no hardware deps)
+bus: none
+transport: "pure data + Modifier trait"
+no_std: true
+unsafe: forbidden
+status: experimental (v0.x)
+---
+
 # stackchan-core
 
-`no_std`, dependency-free domain library for the StackChan avatar. Models
-the face as data (`Avatar` holding two eyes + a mouth + an emotion) and
-drives animation through a `Modifier` trait that mutates the avatar in
-response to time.
+`no_std` domain library for the Stack-chan avatar. Models the face as
+**data** and drives animation through a `Modifier` trait that mutates
+an `Avatar` in response to the passage of time (supplied by a `Clock`).
+No hardware, OS, or `alloc` dependency — this crate is the
+platform-independent heart of the firmware and the simulator.
 
-The crate has no hardware, OS, or allocation dependencies — it's the
-platform-independent heart of the firmware. A renderer (in
-`stackchan-firmware`) turns `Avatar` into pixels; a simulator (in
-`stackchan-sim`) drives `Modifier`s against a fake clock for testing.
+## Key Files
 
-See the workspace [README](../../README.md) and [CLAUDE.md](../../CLAUDE.md)
-for project-wide conventions.
+- `src/lib.rs` — crate root, public re-exports
+- `src/avatar.rs` — `Avatar`, `Eye`, `EyePhase`, `Mouth`, `Point`, `SCALE_DEFAULT`
+- `src/clock.rs` — `Clock` trait, `Instant` (millisecond-resolution monotonic)
+- `src/draw.rs` — `Avatar::draw` renders into any `embedded_graphics::DrawTarget<Color = Rgb565>`
+- `src/emotion.rs` — `Emotion` (Neutral, Happy, Sleepy, Surprised, Sad) and per-emotion style presets
+- `src/head.rs` — `Pose`, `HeadDriver` trait, pan / tilt range constants
+- `src/leds.rs` — `LedFrame`, `render_leds` — maps avatar state to the 12-pixel ring
+- `src/modifiers/mod.rs` — `Modifier` trait + re-exports
+- `src/modifiers/*.rs` — one file per modifier (blink, breath, emotion-cycle / style / head / touch, idle drift / sway, ambient-sleepy, pickup-reaction, remote-command)
+
+## Architecture
+
+```mermaid
+flowchart TB
+    subgraph Inputs
+        Clock[Clock trait<br/><i>Instant</i>]
+        Hardware[Hardware signals<br/><i>touch, IMU, IR, ambient</i>]
+    end
+    subgraph Core
+        Avatar[(Avatar)]
+        Modifiers[Modifier pipeline]
+    end
+    subgraph Outputs
+        Draw[Avatar::draw<br/><i>embedded-graphics DrawTarget</i>]
+        Head[HeadDriver trait<br/><i>Pose → pan/tilt</i>]
+        Leds[render_leds<br/><i>LedFrame</i>]
+    end
+
+    Clock --> Modifiers
+    Hardware --> Modifiers
+    Modifiers -->|update(&mut Avatar, Instant)| Avatar
+    Avatar --> Draw
+    Avatar --> Head
+    Avatar --> Leds
+```
+
+## Modifier Pipeline
+
+Modifiers implement `fn update(&mut self, avatar: &mut Avatar, now: Instant)`.
+Each one composes with the others — the firmware runs the full stack per
+render tick. Listed roughly in application order:
+
+| Modifier          | Effect                                                         |
+|-------------------|----------------------------------------------------------------|
+| `RemoteCommand`   | IR remote → emotion / pose override                            |
+| `EmotionTouch`    | Touch-panel tap → emotion bump                                 |
+| `AmbientSleepy`   | Dark room (low lux) → sleepy emotion                           |
+| `PickupReaction`  | IMU motion event → surprised emotion                           |
+| `EmotionCycle`    | Default sequence: Neutral → Happy → Sleepy → Surprised → Sad   |
+| `EmotionStyle`    | 300 ms ease on style fields (curves, scale, blush) per emotion |
+| `EmotionHead`     | Per-emotion pose bias (neutral center, surprised up, etc.)     |
+| `IdleDrift`       | Slow randomized gaze drift                                     |
+| `IdleSway`        | Subtle head-pan sway when idle                                 |
+| `Blink`           | Lid close / open pulses                                        |
+| `Breath`          | Per-cycle eye + mouth scale oscillation                        |
+
+`EmotionCycle → EmotionStyle → Blink → Breath → IdleDrift` is the
+minimum stack; the firmware adds the others. The `Clock` argument makes
+time a trait so the simulator can advance deterministically while
+firmware advances from `embassy-time`.
+
+## Key Types
+
+- **`Avatar`** — `{ left_eye: Eye, right_eye: Eye, mouth: Mouth, emotion: Emotion }`. Plain data — no hidden state, no runtime invariants beyond "values stay in their documented ranges"
+- **`Eye`** — `{ phase: EyePhase, weight: f32, offset: Point, ... }`. `weight` is the lid openness (0 = closed, 1 = open)
+- **`Mouth`** — `{ rotation: f32, scale: f32, cheek_blush: f32, ... }`
+- **`Clock`** — single method `fn now(&self) -> Instant`. Stable against re-entry, takes `&self`
+- **`Instant`** — `u64` ms since some epoch. Operators for `+ delta_ms: u64` and sequences of differences
+- **`Pose`** — `{ pan_deg: f32, tilt_deg: f32 }`. Bounded by `MAX_PAN_DEG` / `MAX_TILT_DEG`
+- **`HeadDriver`** — `fn drive(&mut self, pose: Pose, now: Instant)`. Implemented by firmware (SCServo) and sim (recorder)
+
+## Gotchas
+
+1. **No `alloc`.** Modifiers own their state in fixed-size fields. Callers that want N of a modifier build a wrapper; the crate won't `Box` anything
+2. **Time must be monotonic.** `Clock::now()` is trusted — a backward jump breaks modifiers that cache `last_update`. Wall-clock sources need a wrapper
+3. **Draw is pure.** `Avatar::draw` produces pixels into the provided `DrawTarget`; it doesn't mutate the avatar. Run modifiers first, then draw
+4. **Emotion transitions are 300 ms eased by `EmotionStyle`.** Don't snap emotion changes directly on the `Avatar` — go through the modifier so the ease kicks in
+5. **No panic in library code.** Workspace lints deny `unwrap` / `expect` / `panic`. All APIs return values in documented ranges; pathological inputs saturate rather than panic
+
+## Integration
+
+- **Used by `stackchan-firmware`** for the render loop + head / LED output
+- **Used by `stackchan-sim`** for host-side tests — the same `Avatar::draw` path runs against a `Vec<Rgb565>` framebuffer for pixel-golden snapshots
+- **Unit-tested** with doctests; golden-test behaviour lives in `stackchan-sim`
+- **Stability:** everything is `Experimental` in v0.x. The module structure and modifier set are stable; names and fields may still evolve before anything graduates to `Stable`

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -1,0 +1,119 @@
+---
+crate: stackchan-firmware
+role: Binary firmware for M5Stack CoreS3 Stack-chan
+bus: many (I²C main bus, UART1, SPI2, RMT, I2S, USB-Serial-JTAG)
+transport: "esp-hal + embassy + esp-rtos"
+no_std: true
+alloc: true (PSRAM heap via esp-alloc)
+unsafe: "per-module exceptions, reason-tagged"
+status: experimental (v0.x)
+target: ESP32-S3 (Xtensa, Rust `esp` toolchain)
+---
+
+# stackchan-firmware
+
+Binary crate. `no_std` + `alloc`, embassy executor on esp-rtos, runs on
+the M5Stack CoreS3 Stack-chan. Boots the hardware, wires up every
+driver, spawns the embassy task set, and runs the `stackchan-core`
+modifier pipeline at ~30 FPS.
+
+## Key Files
+
+- `src/main.rs` — binary entry: heap init, esp-rtos boot, board init, task spawn, heartbeat loop
+- `src/lib.rs` — shared library surface (modules the main binary + `examples/*.rs` both use)
+- `src/board.rs` — `BoardIo`, `SharedI2c(Bus)`, `HeadDriverImpl`. One-shot hardware bring-up: AXP2101 → AW9523 → SPI2 ILI9342C via mipidsi → SCServo UART
+- `src/framebuffer.rs` — PSRAM-backed 320×240 RGB565 double-buffer + dirty-check blit
+- `src/clock.rs` — `HalClock` wraps `embassy_time::Instant` to implement `stackchan_core::Clock`
+- `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
+- `src/imu.rs` / `src/mag.rs` — BMI270 / BMM150 tasks publishing to signal channels for the 9-axis data path
+- `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` — per-peripheral tasks
+- `examples/bench.rs` — calibration bench, flashed via `just bench`
+
+## Boot Sequence
+
+```mermaid
+flowchart TB
+    Start[Reset vector]
+    Start --> Hal[esp-hal init<br/><i>clocks, timers</i>]
+    Hal --> Heap[esp-alloc:<br/><i>PSRAM heap + internal SRAM</i>]
+    Heap --> Rtos[esp-rtos embassy executor]
+    Rtos --> Pmic[AXP2101::init_cores3<br/><i>ALDO/BLDO rails, power-key, BATFET, ADC</i>]
+    Pmic --> Exp[aw9523::init_cores3<br/><i>LCD reset pulse, backlight-boost</i>]
+    Exp --> Lcd[SPI2 + mipidsi ILI9342C<br/><i>RGB565, 320×240</i>]
+    Lcd --> Servo[SCServo on UART1<br/><i>head pan/tilt</i>]
+    Servo --> Py[PY32 co-processor<br/><i>servo-power, WS2812 ring</i>]
+    Py --> Spawn[Spawn tasks]
+    Spawn --> Render[render_task<br/><i>30 FPS Avatar::draw</i>]
+    Spawn --> Head[head_task<br/><i>Pose → SCServo</i>]
+    Spawn --> Imu[imu_task]
+    Spawn --> Mag[mag_task]
+    Spawn --> Touch[touch_task]
+    Spawn --> Ir[ir_task]
+    Spawn --> Ambient[ambient_task]
+    Spawn --> Button[button_task]
+    Spawn --> Led[led_task]
+    Spawn --> Clock[wallclock_task]
+    Spawn --> Main[main heartbeat loop]
+```
+
+## Modifier Stack
+
+Main spawns a render task that runs this stack per tick:
+
+```
+RemoteCommand → EmotionTouch → AmbientSleepy → PickupReaction →
+EmotionCycle → EmotionStyle → EmotionHead → IdleDrift → IdleSway →
+Blink → Breath
+```
+
+Inputs arrive through embassy `Signal` channels from the per-peripheral
+tasks; the modifiers read those signals and mutate the `Avatar` each
+frame.
+
+## I²C Bus Sharing
+
+All I²C peripherals share one `SharedI2cBus` (`Mutex<NoopRawMutex, I2c<'static, Async>>`)
+and talk to it through `I2cDevice` handles. Addresses on the bus:
+
+| Address | Chip                |
+|---------|---------------------|
+| `0x10/11` | BMM150 magnetometer |
+| `0x23`  | LTR-553 ambient / prox |
+| `0x34`  | AXP2101 PMIC         |
+| `0x36`  | AW88298 amp (future) |
+| `0x38`  | FT6336U touch        |
+| `0x40`  | ES7210 ADC (future)  |
+| `0x51`  | BM8563 RTC           |
+| `0x58`  | AW9523 I/O expander  |
+| `0x68/69` | BMI270 IMU         |
+| `0x6F`  | PY32 co-processor    |
+
+## Gotchas
+
+1. **`unsafe` is allowed per-module, reason-tagged.** The firmware crate's `#![deny(unsafe_code)]` has per-module exceptions for the app-descriptor LTO anchor and any register-map pointer work. Each exception carries a comment explaining why
+2. **Panic handler halts; defmt emits the trace over RTT first.** `--catch-hardfault` on the probe-rs side decodes it. For dev, `espflash monitor --log-format defmt` also picks it up
+3. **Render path is dirty-checked.** `framebuffer` only blits when the `Avatar` state changes from the previous frame. Skipping this costs ~20 ms per frame in SPI traffic
+4. **PSRAM is the framebuffer's home.** Internal SRAM is reserved for ISR / real-time paths. The framebuffer at 320×240×2 bytes = 153 KB wouldn't fit in SRAM anyway
+5. **BMI270 + BMM150 share `SharedI2c`.** Both tasks compete for the mutex; running them at ≤50 Hz each keeps contention negligible for the 30 FPS render task that also uses the bus
+6. **`panic!` IS the error-handling layer.** Firmware `main` can't bubble init failures to a caller, so init errors panic. Library code elsewhere returns typed errors; this rule only applies at the `#[no_main]` boundary
+7. **Log timestamps come from embassy-time.** `defmt::timestamp!` captures `embassy_time::Instant::now().as_millis()`, which starts from esp-rtos boot. No wall-clock alignment unless `wallclock_task` sets the RTC
+
+## Build + Flash
+
+```bash
+source ~/export-esp.sh       # adds the esp Xtensa toolchain to PATH
+just build-firmware          # cargo +esp build --release
+just fmr                     # flash + monitor in one go
+just bench                   # flash the calibration-bench example
+just mag-bench               # magnetometer bench
+just leds-bench              # WS2812 LED ring bench
+```
+
+See the [justfile](../../justfile) for the full recipe set. Default
+port is `/dev/ttyACM1`; override with `just PORT=/dev/ttyACM0 flash`.
+
+## Integration
+
+- **Consumes `stackchan-core`** for every domain type (`Avatar`, `Modifier`, `Pose`, `Clock`, `HeadDriver`, `LedFrame`)
+- **Consumes every driver crate in the workspace** — axp2101, aw9523, bm8563, bmi270, bmm150, ft6336u, ir-nec, ltr553, py32, scservo. Scaffolded drivers (aw88298, es7210, gc0308, si12t, st25r3916) will land as additional tasks once implemented
+- **HIL via probe-rs + defmt-test** (planned) — CI runs host tests today; on-device integration tests run on a flash-and-capture rig

--- a/crates/stackchan-sim/README.md
+++ b/crates/stackchan-sim/README.md
@@ -1,0 +1,77 @@
+---
+crate: stackchan-sim
+role: Headless simulator for stackchan-core
+bus: none
+transport: "Vec<Rgb565> framebuffer + FakeClock"
+no_std: false (host-only, uses alloc)
+unsafe: forbidden
+status: stable
+---
+
+# stackchan-sim
+
+Host-side simulator for `stackchan-core`. Runs the full domain model —
+modifier pipeline, `Avatar::draw`, `HeadDriver` — on the dev machine
+with a deterministic clock and a `Vec<Rgb565>`-backed framebuffer, so
+most of the firmware's behaviour is testable without flashing hardware.
+
+## Key Files
+
+- `src/lib.rs` — `FakeClock`, `Framebuffer`, `RecordingHead`
+- `tests/head_sway.rs` — golden test for the head-sway trajectory: feed a clock forward in controlled steps, assert that the captured `(Instant, Pose)` sequence matches expectations
+- `tests/leds.rs` — LED-ring rendering regression tests
+- `tests/render_snapshot.rs` — one-minute full-stack cadence test that renders `Avatar::draw` into the framebuffer and compares pixel hashes
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph "Test / bench"
+        T[Test case]
+    end
+    subgraph "stackchan-sim"
+        FC[FakeClock<br/><i>tests.advance(dt)</i>]
+        FB[Framebuffer<br/><i>Vec&lt;Rgb565&gt;</i>]
+        RH[RecordingHead<br/><i>Vec&lt;(Instant, Pose)&gt;</i>]
+    end
+    subgraph "stackchan-core"
+        A[Avatar]
+        Mods[Modifier stack]
+        Draw[Avatar::draw]
+    end
+
+    T -->|advance| FC
+    FC --> Mods
+    Mods --> A
+    A --> Draw
+    Draw -->|pixels| FB
+    A --> RH
+    FB --> T
+    RH --> T
+```
+
+## What It Provides
+
+- **`FakeClock`** — deterministic `Clock` impl backed by a `Cell<Instant>`. `advance(delta_ms)` and `set(instant)` are the only ways time moves. `now()` is re-entrant safe (takes `&self` via `Cell`)
+- **`Framebuffer`** — `width × height` `Vec<Rgb565>` that implements `embedded_graphics::DrawTarget<Color = Rgb565>` with `Infallible` errors. Out-of-bounds pixels are silently clipped (matches how `embedded-graphics` clips to `OriginDimensions`). `pixel(x, y) → Option<Rgb565>` for read-back
+- **`RecordingHead`** — `HeadDriver` impl that pushes every `(Instant, Pose)` call into a `Vec`, so motion-modifier tests can assert on the full trajectory
+
+## Test Patterns
+
+- **Golden pixel snapshots.** Render a frame, hash the pixel buffer, compare to a stored digest. Catches regressions in `Avatar::draw` or any upstream modifier that changes displayed output
+- **Golden trajectory.** Advance the clock in documented steps, assert on the `(Instant, Pose)` sequence `RecordingHead` captured. Catches timing drifts in motion modifiers
+- **Full-stack cadence.** Run the complete firmware modifier pipeline for one minute of simulated time, sample the framebuffer periodically, confirm the face looks right at known timestamps (emotion cycle boundaries, blink instants, etc.)
+
+## Gotchas
+
+1. **No `no_std` here.** The sim lives on the host; it uses `alloc` freely for the pixel buffer and pose trajectory. Don't import from this crate into firmware code
+2. **FakeClock is not monotonic-enforcing.** `set()` trusts the caller; a test can intentionally go backward to exercise a pathological path. In-test assertions need to know what they're asserting
+3. **Framebuffer clipping is silent.** Pixels written outside `width × height` don't error — they disappear. Match the framebuffer size to the firmware's (320×240 for CoreS3)
+4. **Pixel-golden tests are sensitive to embedded-graphics upgrades.** Any sub-pixel rendering change in the upstream crate invalidates the stored hashes. Update deliberately when bumping the dep
+5. **`RecordingHead` has unbounded memory.** Long-running tests will accumulate millions of `(Instant, Pose)` entries — use `clear()` between phases, or cap simulated duration
+
+## Integration
+
+- **Runs on every `cargo test`** as part of the host-side default-members. No hardware required
+- **Paired with `stackchan-core`** — the sim consumes the same `Avatar` / `Modifier` / `Clock` / `HeadDriver` types the firmware does. Any behaviour change in core surfaces here first
+- **Future:** add a `Scenario` harness that scripts sensor signals (touch taps, IR commands) against the full modifier pipeline for integration tests


### PR DESCRIPTION
## Summary

Fans out the bmi270-reference README pattern to every remaining crate in the workspace. Each README now has YAML frontmatter (crate / role / bus / address / transport / no_std / unsafe / status), Key Files, Bus + Addressing (or Architecture for top-level crates), Register Map, Init Sequence / Capabilities, Gotchas, and Integration.

### Drivers (8)

| Crate | Role | Bus |
|---|---|---|
| `axp2101` | PMIC + CoreS3 init sequence | I²C @ 0x34 |
| `aw9523` | I/O expander — LCD reset + backlight-boost gate | I²C @ 0x58 |
| `bm8563` | Real-time clock + BCD DateTime | I²C @ 0x51 |
| `bmm150` | 3-axis magnetometer, trim compensation | I²C @ 0x10/0x11 |
| `ft6336u` | Capacitive touch (single-touch MVP) | I²C @ 0x38 |
| `ltr553` | Ambient light + proximity | I²C @ 0x23 |
| `py32` | Stack-chan co-processor (GPIO + WS2812 fan-out) | I²C @ 0x6F |
| `scservo` | Feetech SCServo packet protocol | UART 1 Mbaud |

### Top-level crates (3) — with Mermaid diagrams

- `stackchan-core` — domain library, Modifier pipeline, Avatar / Clock / HeadDriver traits
- `stackchan-sim` — headless simulator: `FakeClock`, `Framebuffer` (Vec<Rgb565>), `RecordingHead`
- `stackchan-firmware` — binary crate: boot sequence, task set, I²C address map, build + flash recipes

The existing minimal `stackchan-core/README.md` is replaced with the full version.

## Test plan

- [x] `just check` passes (no source changes — Rust gates are a no-op)
- [x] Pre-commit runs clean
- [x] `.githooks/check-readme-reminders.sh` doesn't fire for READMEs-only change (intentional — it reminds when source changes without its README)
- [ ] Greptile review flags any mis-sourced register addresses / chip IDs / init-sequence claims
- [ ] Follow-up: as the scaffolded drivers (aw88298, es7210, gc0308, si12t, st25r3916) get real implementations, their READMEs lose the `status: scaffold` frontmatter marker