### PR TITLE
feat(audio): real AW88298 + ES7210 driver impls + control-path benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
 name = "stackchan-firmware"
 version = "0.3.0"
 dependencies = [
+ "aw88298",
  "aw9523",
  "axp2101",
  "bm8563",
@@ -1546,6 +1547,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-bus",
  "embedded-io-async 0.7.0",
+ "es7210",
  "esp-alloc",
  "esp-bootloader-esp-idf",
  "esp-hal",

--- a/crates/aw88298/Cargo.toml
+++ b/crates/aw88298/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Scaffold: minimal async I²C control-path driver for the Awinic AW88298 smart-K audio amplifier. I2S audio transport is out of scope."
+description = "Minimal async I²C control-path driver for the Awinic AW88298 smart-K audio amplifier. 16-bit registers, big-endian wire format. I2S audio transport is out of scope."
 
 [lints]
 workspace = true

--- a/crates/aw88298/README.md
+++ b/crates/aw88298/README.md
@@ -1,15 +1,16 @@
 ---
 crate: aw88298
-role: Smart-K audio amplifier control driver (scaffold)
+role: Smart-K audio amplifier control driver
 bus: I²C
 address: "0x36 (strap: 0x34–0x37)"
+register_width: 16-bit, big-endian
 transport: embedded-hal-async
 audio: I2S 16-bit (out of scope)
 reset_pin: AW9523 P0_1 (external)
 no_std: true
 unsafe: forbidden
 chip_id: "0x1852 @ register 0x00"
-status: scaffold
+status: experimental
 ---
 
 # aw88298
@@ -32,10 +33,12 @@ over I2S from the ESP32-S3 peripheral.
 - **External reset:** `RST` is wired to AW9523 `P0_1`. The `aw9523` crate's CoreS3 bring-up helper releases it as part of board init — the amp NACKs every I²C transaction until then
 - **Audio transport:** I2S (Philips / left-justified / PCM), 16-bit mono. Typically 48 kHz; the chip will lock to whatever the MCU I2S master clocks in
 
-## Register Map (planned)
+## Register Map
 
-Registers the scaffold will reach once implemented. Exact bit layouts
-come from the public Awinic datasheet.
+Registers the driver touches at init. Values are a direct port of
+[espressif/esp-adf][esp-adf]'s canonical CoreS3 sequence (Apache-2.0).
+
+[esp-adf]: https://github.com/espressif/esp-adf
 
 | Reg         | Addr   | Access | Purpose                                              |
 |-------------|--------|--------|------------------------------------------------------|
@@ -51,19 +54,24 @@ come from the public Awinic datasheet.
 | `PWMCTRL`   | `0x51` | W      | PWM carrier frequency                                |
 | `VOLCTRL`   | `0x0C` | W      | Volume / fade target (0 dB default)                  |
 
-## Init Sequence (planned)
+## Init Sequence
+
+Matches `Aw88298::init`:
 
 1. AW9523 releases `P0_1` (external `RST`); wait ≥1 ms
 2. Read `CHIPID`; expect `0x1852`
-3. `SYSCTRL = 0x00` (clear `PWDN` + `AMPPD`; enable I2S when ready)
-4. Configure `I2SCTRL1/2/3` for 16-bit Philips I2S at the MCU's sample rate (48 kHz on the CoreS3 default)
-5. `BSTCTRL1` = target boost voltage (8.0 V is the M5Stack default — enough for 1 W @ 4 Ω without clip)
-6. `HAGCCFG1` + related — enable thermal / OC protection with safe limits
-7. `SYSCTRL |= I2SEN` — amp starts passing audio
-8. `VOLCTRL` ramps volume to target (use the fade curve rather than a direct jump to avoid pops)
+3. `RESET = 0x55AA` (soft-reset); wait ≥5 ms
+4. `SYSCTRL = 0x4040` (`I2SEN = 1`, `AMPPD = 0`, `PWDN = 0`)
+5. `SYSCTRL2 = 0x0009` (`HMUTE = 1`, AGC off — start muted)
+6. `I2SCTRL = 0x3CC4` (16-bit Philips I2S, BCK ×16, 16 kHz)
+7. `HAGCCFG4 = 0x3064` (volume + AGC preset)
+8. `BSTCTRL2 = 0x0673` (boost disabled — 8 V rail sufficient for 1 W speaker)
 
-Unmute (`AMPPD = 0`) is the final step so the speaker only drives while
-`MCLK`, `BCLK`, `LRCK`, and `DATA` are all stable.
+Un-mute (`SYSCTRL2 &= ~HMUTE`) via [`Aw88298::set_muted`] once the MCU's
+I²S peripheral is clocking `MCLK` / `BCLK` / `LRCK` / `DATA`.
+
+Sample rate is in the lower nibble of `I2SCTRL`; re-program with
+[`Aw88298::set_sample_rate`] if the firmware's I²S rate changes.
 
 ## Gotchas
 

--- a/crates/aw88298/src/lib.rs
+++ b/crates/aw88298/src/lib.rs
@@ -1,25 +1,38 @@
 //! # aw88298
 //!
-//! Scaffold for a `no_std` async I²C control-path driver for the
-//! Awinic AW88298 16-bit I2S "smart K" digital audio amplifier.
+//! `no_std` async I²C control-path driver for the Awinic AW88298
+//! 16-bit I2S "smart K" digital audio amplifier.
 //!
 //! On the CoreS3 Stack-chan the AW88298 drives the single 1 W speaker
 //! from an integrated 10.25 V smart boost converter. The I²C side
-//! handles configuration (I2S format, volume, fade, boost voltage,
-//! thermal protection); audio data arrives over I2S from the MCU.
+//! handles configuration; audio data arrives over I2S from the MCU.
 //!
-//! ## Status
+//! ## Register width
 //!
-//! Scaffold only. [`Aw88298::init`] releases the external reset,
-//! verifies the chip ID, and returns without configuring any amplifier
-//! register.
+//! Every data register is **16 bits** wide, transferred big-endian on
+//! the I²C bus: one transaction is `[reg, msb, lsb]`. The register
+//! *addresses* themselves remain 8-bit. Mixing this up with the usual
+//! 8-bit-register convention yields a chip that NACKs every second
+//! write.
 //!
 //! ## External reset
 //!
-//! The AW88298's `RST` pin is wired to the AW9523 I/O expander on the
-//! CoreS3 (port `P0_1`). Release it via the `aw9523` crate's CoreS3
-//! bring-up helper *before* calling [`Aw88298::init`]; otherwise every
-//! I²C transaction NACKs.
+//! The `RST` pin is wired to AW9523 `P0_1`. The `aw9523` crate's CoreS3
+//! bring-up helper releases it as part of board init — the amp NACKs
+//! every I²C transaction until then.
+//!
+//! ## Initialisation
+//!
+//! The init sequence mirrors Espressif's `esp_codec_dev` reference for
+//! this exact CoreS3 codec (see
+//! `components/esp_codec_dev/device/aw88298/aw88298.c` in
+//! [`espressif/esp-adf`][esp-adf], Apache-2.0): reset, enable I2S,
+//! start muted, program I2S format + sample rate, program volume /
+//! AGC, disable boost. Sample rate is stored in the lower nibble of
+//! `I2SCTRL`; callers can re-program it at runtime via
+//! [`Aw88298::set_sample_rate`].
+//!
+//! [esp-adf]: https://github.com/espressif/esp-adf
 //!
 //! ## Example
 //!
@@ -29,6 +42,8 @@
 //! # where B: I2c, D: DelayNs {
 //! let mut amp = aw88298::Aw88298::new(bus);
 //! amp.init(&mut delay).await?;
+//! amp.set_sample_rate(aw88298::SampleRate::Hz16000).await?;
+//! amp.set_muted(false).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -38,30 +53,76 @@
 
 use embedded_hal_async::{delay::DelayNs, i2c::I2c};
 
-/// 7-bit I²C address. `AD1 = AD2 = 0` yields `0x36` (the CoreS3 wiring).
+/// 7-bit I²C address with `AD1 = AD2 = GND` (the CoreS3 wiring).
 ///
 /// Datasheet address format is `0b01101xx`; strap pins set the two
 /// LSBs, giving the `0x34..=0x37` window.
 pub const ADDRESS: u8 = 0x36;
 
-/// Expected value of the `CHIPID` register on a genuine AW88298.
-///
-/// Datasheet specifies the two-byte chip ID as `0x1852` (MSB-first read
-/// from `REG_CHIPID`).
+/// Expected chip ID, read as a 16-bit big-endian value from register
+/// `0x00`.
 pub const CHIP_ID: u16 = 0x1852;
 
-/// `CHIPID` register. Read-only. Two-byte value, MSB at offset 0.
-const REG_CHIP_ID: u8 = 0x00;
-
-/// `SYSCTRL` register. Bits 0 (`PWDN`), 1 (`AMPPD`), 2 (`I2SEN`).
-/// Writing `0x00` wakes the amplifier from power-down.
+/// `RESET` register. Doubles as the chip-ID read address — reads yield
+/// `0x1852`, writes trigger actions (`0x55AA` = soft-reset).
+const REG_RESET: u8 = 0x00;
+/// `SYSCTRL` register. Bits: `PWDN` (0), `AMPPD` (1), `I2SEN` (6).
 const REG_SYSCTRL: u8 = 0x04;
+/// `SYSCTRL2` register. Bit 0 = `HMUTE` (mute output).
+const REG_SYSCTRL2: u8 = 0x05;
+/// `I2SCTRL` register. Bits 7:4 bit-depth, bits 3:0 sample-rate index.
+const REG_I2SCTRL: u8 = 0x06;
+/// `HAGCCFG4` register. Upper byte volume, lower byte AGC preset.
+const REG_HAGCCFG4: u8 = 0x0C;
+/// `BSTCTRL2` register. Boost converter mode + current-limit config.
+const REG_BSTCTRL2: u8 = 0x61;
 
-/// Post-reset settle delay, in milliseconds.
-///
-/// Datasheet requires ≥1 ms between `RST` release and the first I²C
-/// transaction; 5 ms is conservative.
+/// Reset-magic written to [`REG_RESET`].
+const RESET_MAGIC: u16 = 0x55AA;
+/// `SYSCTRL` value: `I2SEN = 1`, `AMPPD = 0`, `PWDN = 0`.
+const SYSCTRL_ENABLE: u16 = 0x4040;
+/// `SYSCTRL2` value: HMUTE clear, AGC off. Pair with
+/// [`SYSCTRL2_MUTED`] for the mute bit.
+const SYSCTRL2_RUN: u16 = 0x0008;
+/// `SYSCTRL2` value: `HMUTE` set (bit 0).
+const SYSCTRL2_MUTED: u16 = SYSCTRL2_RUN | 0x0001;
+/// `I2SCTRL` base value: 16-bit Philips I2S, BCK mode ×16. Combined
+/// with a [`SampleRate`] byte in the low nibble.
+const I2SCTRL_BASE: u16 = 0x3CC0;
+/// `HAGCCFG4` default: volume `0x30` (≈ -24 dB) + AGC preset `0x64`.
+const HAGCCFG4_DEFAULT: u16 = 0x3064;
+/// `BSTCTRL2` value: boost mode disabled. Matches esp-adf's
+/// `0x0673` vs the datasheet default `0x6673`.
+const BSTCTRL2_BOOST_OFF: u16 = 0x0673;
+
+/// Post-reset settle delay, in milliseconds. Datasheet ≥1 ms.
 const RESET_SETTLE_MS: u32 = 5;
+
+/// Supported I²S sample rates. Nibble value written into [`REG_I2SCTRL`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SampleRate {
+    /// 8 kHz.
+    Hz8000 = 0x01,
+    /// 11.025 kHz.
+    Hz11025 = 0x02,
+    /// 12 kHz.
+    Hz12000 = 0x03,
+    /// 16 kHz. Default for the firmware's voice pipeline.
+    Hz16000 = 0x04,
+    /// 22.05 kHz.
+    Hz22050 = 0x05,
+    /// 24 kHz.
+    Hz24000 = 0x06,
+    /// 32 kHz.
+    Hz32000 = 0x07,
+    /// 44.1 kHz.
+    Hz44100 = 0x08,
+    /// 48 kHz.
+    Hz48000 = 0x09,
+    /// 96 kHz.
+    Hz96000 = 0x0A,
+}
 
 /// Driver error type.
 #[derive(Debug)]
@@ -118,17 +179,24 @@ impl<B: I2c> Aw88298<B> {
     pub async fn read_chip_id(&mut self) -> Result<u16, Error<B::Error>> {
         let mut buf = [0u8; 2];
         self.bus
-            .write_read(self.address, &[REG_CHIP_ID], &mut buf)
+            .write_read(self.address, &[REG_RESET], &mut buf)
             .await?;
         Ok(u16::from_be_bytes(buf))
     }
 
-    /// Scaffold init. Waits post-reset, verifies the chip ID, and
-    /// returns. Does not configure I2S format, volume, boost, or
-    /// thermal protection.
+    /// Full initialisation sequence. Caller releases the AW88298 `RST`
+    /// pin (via AW9523) before this runs.
     ///
-    /// Caller is responsible for releasing the AW88298 `RST` pin via
-    /// AW9523 before calling this function.
+    /// After this returns:
+    ///
+    /// - I2S interface is enabled (waiting for MCLK / BCLK / LRCK)
+    /// - Output is **muted** via `HMUTE`; call [`Aw88298::set_muted`]
+    ///   once the I2S stream is flowing
+    /// - Sample rate is configured to 16 kHz; re-program via
+    ///   [`Aw88298::set_sample_rate`]
+    /// - Boost converter disabled (8 V rail, sufficient for the
+    ///   Stack-chan's 1 W speaker without clip)
+    /// - Volume at -24 dB (esp-adf default)
     ///
     /// # Errors
     ///
@@ -140,21 +208,199 @@ impl<B: I2c> Aw88298<B> {
         if id != CHIP_ID {
             return Err(Error::BadChipId(id));
         }
-        // TODO: SYSCTRL power-up, I2SCTRL format (16-bit, 48 kHz,
-        // Philips I2S), BSTCTRL boost voltage, HAGCCFG thermal /
-        // protection, VSNCTRL fade curve, PWMCTRL PWM frequency.
+
+        self.write_reg(REG_RESET, RESET_MAGIC).await?;
+        delay.delay_ms(RESET_SETTLE_MS).await;
+        self.write_reg(REG_SYSCTRL, SYSCTRL_ENABLE).await?;
+        self.write_reg(REG_SYSCTRL2, SYSCTRL2_MUTED).await?;
+        self.write_reg(
+            REG_I2SCTRL,
+            I2SCTRL_BASE | u16::from(SampleRate::Hz16000 as u8),
+        )
+        .await?;
+        self.write_reg(REG_HAGCCFG4, HAGCCFG4_DEFAULT).await?;
+        self.write_reg(REG_BSTCTRL2, BSTCTRL2_BOOST_OFF).await?;
         Ok(())
     }
 
-    /// Placeholder for the eventual mute/unmute API. Writes
-    /// [`REG_SYSCTRL`] with `AMPPD` set or cleared.
+    /// Select the I²S sample rate. Must match the MCU's I²S master
+    /// configuration; a mismatch pitches audio up or down.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn set_sample_rate(&mut self, rate: SampleRate) -> Result<(), Error<B::Error>> {
+        self.write_reg(REG_I2SCTRL, I2SCTRL_BASE | u16::from(rate as u8))
+            .await
+    }
+
+    /// Mute / un-mute the output stage. Toggles `HMUTE` (bit 0) in
+    /// `SYSCTRL2`.
     ///
     /// # Errors
     ///
     /// Propagates any I²C bus error.
     pub async fn set_muted(&mut self, muted: bool) -> Result<(), Error<B::Error>> {
-        let value = if muted { 0b0000_0010 } else { 0x00 };
-        self.bus.write(self.address, &[REG_SYSCTRL, value]).await?;
+        let value = if muted { SYSCTRL2_MUTED } else { SYSCTRL2_RUN };
+        self.write_reg(REG_SYSCTRL2, value).await
+    }
+
+    /// Single 16-bit-register write. Encodes value big-endian on wire.
+    async fn write_reg(&mut self, reg: u8, value: u16) -> Result<(), Error<B::Error>> {
+        let bytes = value.to_be_bytes();
+        self.bus
+            .write(self.address, &[reg, bytes[0], bytes[1]])
+            .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test scaffolding: Infallible bus error makes unwrap() sound"
+)]
+#[allow(
+    clippy::panic,
+    reason = "tests panic via assert! / assertion-by-match on unexpected variants"
+)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use embedded_hal_async::{
+        delay::DelayNs,
+        i2c::{ErrorType, Operation, SevenBitAddress},
+    };
+
+    /// Host-side I²C mock: canned chip-ID read response, records every
+    /// write payload in order.
+    struct MockI2c {
+        /// 16-bit chip-ID the mock returns on any read (big-endian).
+        chip_id: [u8; 2],
+        /// Every `Operation::Write` payload, in emission order.
+        writes: RefCell<Vec<Vec<u8>>>,
+    }
+
+    impl MockI2c {
+        fn with_chip_id(id: u16) -> Self {
+            Self {
+                chip_id: id.to_be_bytes(),
+                writes: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ErrorType for MockI2c {
+        type Error = core::convert::Infallible;
+    }
+
+    impl I2c for MockI2c {
+        async fn transaction(
+            &mut self,
+            _address: SevenBitAddress,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            for op in operations {
+                match op {
+                    Operation::Write(buf) => {
+                        self.writes.borrow_mut().push(buf.to_vec());
+                    }
+                    Operation::Read(buf) => {
+                        let n = buf.len().min(self.chip_id.len());
+                        buf[..n].copy_from_slice(&self.chip_id[..n]);
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// No-op delay: blocking async impl that never sleeps.
+    struct NoopDelay;
+
+    impl DelayNs for NoopDelay {
+        async fn delay_ns(&mut self, _ns: u32) {}
+    }
+
+    /// Tiny future poller — axp2101 tests use the same pattern.
+    fn block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+        let mut cx = Context::from_waker(Waker::noop());
+        let mut fut = pin!(future);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn init_issues_canonical_sequence() {
+        let mut amp = Aw88298::new(MockI2c::with_chip_id(CHIP_ID));
+        block_on(amp.init(&mut NoopDelay)).unwrap();
+
+        // Filter to the 3-byte "register write" payloads — the mock
+        // also captures the 1-byte register-address setup that
+        // `write_read` emits during the chip-ID probe.
+        let writes: Vec<Vec<u8>> = amp
+            .bus
+            .writes
+            .borrow()
+            .iter()
+            .filter(|w| w.len() == 3)
+            .cloned()
+            .collect();
+        // 6 register writes in the canonical esp-adf order.
+        assert_eq!(writes.len(), 6);
+        // RESET = 0x55AA
+        assert_eq!(writes[0], [REG_RESET, 0x55, 0xAA]);
+        // SYSCTRL = 0x4040
+        assert_eq!(writes[1], [REG_SYSCTRL, 0x40, 0x40]);
+        // SYSCTRL2 muted (0x0009 = SYSCTRL2_RUN | HMUTE)
+        assert_eq!(writes[2], [REG_SYSCTRL2, 0x00, 0x09]);
+        // I2SCTRL base 0x3CC0 | 16 kHz nibble 0x04 = 0x3CC4
+        assert_eq!(writes[3], [REG_I2SCTRL, 0x3C, 0xC4]);
+        // HAGCCFG4 default
+        assert_eq!(writes[4], [REG_HAGCCFG4, 0x30, 0x64]);
+        // BSTCTRL2 boost-off
+        assert_eq!(writes[5], [REG_BSTCTRL2, 0x06, 0x73]);
+    }
+
+    #[test]
+    fn init_rejects_wrong_chip_id() {
+        let mut amp = Aw88298::new(MockI2c::with_chip_id(0x1234));
+        match block_on(amp.init(&mut NoopDelay)) {
+            Err(Error::BadChipId(0x1234)) => {}
+            other => panic!("expected BadChipId(0x1234), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_sample_rate_writes_i2sctrl_with_rate_nibble() {
+        let mut amp = Aw88298::new(MockI2c::with_chip_id(CHIP_ID));
+        block_on(amp.set_sample_rate(SampleRate::Hz48000)).unwrap();
+        let writes = amp.bus.writes.borrow();
+        assert_eq!(writes.len(), 1);
+        // I2SCTRL base 0x3CC0 | 48 kHz nibble 0x09 = 0x3CC9.
+        assert_eq!(writes[0], [REG_I2SCTRL, 0x3C, 0xC9]);
+    }
+
+    #[test]
+    fn set_muted_toggles_hmute_bit() {
+        let mut amp = Aw88298::new(MockI2c::with_chip_id(CHIP_ID));
+        block_on(amp.set_muted(true)).unwrap();
+        block_on(amp.set_muted(false)).unwrap();
+        let writes = amp.bus.writes.borrow();
+        assert_eq!(writes.len(), 2);
+        assert_eq!(writes[0], [REG_SYSCTRL2, 0x00, 0x09]);
+        assert_eq!(writes[1], [REG_SYSCTRL2, 0x00, 0x08]);
+    }
+
+    #[test]
+    fn read_chip_id_decodes_big_endian() {
+        let mut amp = Aw88298::new(MockI2c::with_chip_id(0x1852));
+        let id = block_on(amp.read_chip_id()).unwrap();
+        assert_eq!(id, 0x1852);
     }
 }

--- a/crates/es7210/Cargo.toml
+++ b/crates/es7210/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Scaffold: minimal async I²C control-path driver for the Everest ES7210 4-channel audio ADC. I2S/TDM audio transport is out of scope."
+description = "Minimal async I²C control-path driver for the Everest ES7210 4-channel audio ADC. Fixed shape: 12.288 MHz MCLK, 16 kHz mono, mic1+2 on. I2S audio transport is out of scope."
 
 [lints]
 workspace = true

--- a/crates/es7210/README.md
+++ b/crates/es7210/README.md
@@ -1,14 +1,15 @@
 ---
 crate: es7210
-role: 4-channel audio ADC control driver (scaffold)
+role: 4-channel audio ADC control driver
 bus: I²C
 address: "0x40 (strap: 0x40–0x43)"
 transport: embedded-hal-async
-audio: I2S / TDM (out of scope)
+audio: "I2S slave, 12.288 MHz MCLK, 16 kHz / 16-bit mono (fixed)"
+active_channels: mic1 + mic2 (mic3/4 powered off)
 no_std: true
 unsafe: forbidden
 chip_id: "(0x72, 0x10) @ 0xFD/0xFE"
-status: scaffold
+status: experimental
 ---
 
 # es7210
@@ -29,11 +30,13 @@ data leaves the chip over I2S/TDM; this crate only handles I²C config.
 - **CHIP_ID:** `(0x72, 0x10)` at `(0xFD, 0xFE)`. Both bytes must match
 - **Audio transport:** I2S or TDM, chip-as-master or chip-as-slave. Configured via registers the scaffold doesn't write yet
 
-## Register Map (planned)
+## Register Map
 
-Registers the scaffold will reach once fully implemented. Addresses are
-datasheet-confirmed but the exact values the CoreS3 Stack-chan needs
-have to be extracted from M5Unified's reference init.
+Registers the driver touches at init. Values are a direct port of
+[espressif/esp-adf][esp-adf]'s canonical sequence, simplified for our
+fixed audio shape (12.288 MHz MCLK → 16 kHz, mic1+2 only).
+
+[esp-adf]: https://github.com/espressif/esp-adf
 
 | Reg               | Addr        | Access | Purpose                                              |
 |-------------------|-------------|--------|------------------------------------------------------|
@@ -47,21 +50,31 @@ have to be extracted from M5Unified's reference init.
 | `TDM_FORMAT`      | `0x11–0x12` | W      | TDM slot width, frame format, I2S vs PCM             |
 | `CHIP_ID1/2`      | `0xFD/0xFE` | R      | `0x72 / 0x10`                                        |
 
-## Init Sequence (planned)
+## Init Sequence
 
-1. `RESET = 0x3F`; wait ≥5 ms
-2. `RESET = 0x00`; wait ≥5 ms
-3. Read `CHIP_ID1/2`; verify `(0x72, 0x10)`
-4. `CLK_ON = 0x3F` (enable analog / digital / MCLK clock gates)
-5. `MAINCLK` + MCLK divisor — choose the divisor that maps the I2S `MCLK` pin (ESP32-S3 I2S peripheral provides 12.288 MHz on the CoreS3) to a 48 kHz-or-equivalent sample rate
-6. `SAMPLE_RATE = 0x02` (48 kHz via default OSR)
-7. `MIC_BIAS_CTRL = 0x44` (mic bias on for the two active channels)
-8. `ADCx_CTRL` — PGA gain on channels 1 and 2 (0–30 dB in 0.5 dB steps)
-9. `TDM_FORMAT` / `I2S_FORMAT` — match the ESP32-S3 I2S peripheral configuration
-10. `ADC_ENABLE = 0x03` (enable channels 1–2 only — the only ones wired to mics)
+Matches `Es7210::init`:
 
-Mute / unmute and MCLK ratio need to stay in lockstep with the matching
-AW88298 playback side so both paths share a single `MCLK` domain.
+1. Read `CHIP_ID1/2`; verify `(0x72, 0x10)`
+2. `RESET = 0x71` (assert soft-reset); wait ≥5 ms
+3. `RESET = 0x41` (release); wait ≥5 ms
+4. Clock tree for 12.288 MHz → 16 kHz:
+   - `MAINCLK = 0xC3` (adc_div=3, doubler on, DLL on)
+   - `OSR = 0x20` (256× oversample)
+   - `LRCK_DIVH = 0x03`, `LRCK_DIVL = 0x00`
+5. `CLOCK_OFF = 0x30` (mic1+2 clocks on, mic3+4 gated)
+6. `POWER_DOWN = 0x00` (all blocks powered on)
+7. `ANALOG = 0x43` (datasheet active-mode preset)
+8. `MIC1/2/3/4_POWER = 0x08` (individual powers on)
+9. `MIC12_POWER = 0x00` (group powered), `MIC34_POWER = 0xFF` (gated)
+10. `MIC1/2_GAIN = 0x1A` (gain-enable bit + step `0x0A` ≈ +30 dB)
+11. `ANALOG = 0x43` (re-asserted, per the reference)
+12. `RESET = 0x71` / `0x41` (latch reset pulse)
+
+Gain is re-programmable at runtime via [`Es7210::set_gain`].
+
+MCLK / sample-rate must match the MCU's I²S master configuration. The
+matching AW88298 playback side (`crates/aw88298`) should share the
+same `MCLK` domain.
 
 ## Gotchas
 

--- a/crates/es7210/src/lib.rs
+++ b/crates/es7210/src/lib.rs
@@ -1,18 +1,24 @@
 //! # es7210
 //!
-//! Scaffold for a `no_std` async I²C control-path driver for the
-//! Everest ES7210 four-channel 24-bit audio ADC.
+//! `no_std` async I²C control-path driver for the Everest ES7210
+//! four-channel 24-bit audio ADC.
 //!
 //! On the CoreS3 Stack-chan the ES7210 captures the two on-board
-//! microphones. The remaining two ADC channels are unused. Audio data
-//! is clocked out over I2S/TDM; the I²C side only handles register
-//! configuration (sample rate, MCLK divisor, gain, channel enable,
-//! TDM format).
+//! microphones (channels 1 + 2); channels 3 + 4 are unused. Audio data
+//! is clocked out over I2S; this crate handles register configuration
+//! for a fixed audio shape: **12.288 MHz MCLK, 16 kHz sample rate,
+//! 16-bit mono, chip as I²S slave**. Re-programming at runtime is not
+//! supported — change the constants and rebuild if you need another
+//! rate.
 //!
-//! ## Status
+//! ## Initialisation
 //!
-//! Scaffold only. [`Es7210::init`] validates the chip ID and returns
-//! without writing the rate / gain / enable registers.
+//! The sequence is a direct port of
+//! `components/esp_codec_dev/device/es7210/es7210.c` in
+//! [`espressif/esp-adf`][esp-adf] (Apache-2.0), simplified for the
+//! Stack-chan's two-mic layout at a fixed sample rate.
+//!
+//! [esp-adf]: https://github.com/espressif/esp-adf
 //!
 //! ## Example
 //!
@@ -32,30 +38,93 @@
 use embedded_hal_async::{delay::DelayNs, i2c::I2c};
 
 /// Default 7-bit I²C address with `AD1 = AD0 = GND`.
-///
-/// The chip's two strap pins let AD move across `0x40..=0x43`; the
-/// CoreS3 Stack-chan wires both low, giving `0x40`.
 pub const ADDRESS: u8 = 0x40;
 
 /// Expected chip-ID low byte at [`REG_CHIP_ID1`].
-///
-/// ES7210 datasheet specifies `CHIP_ID1 = 0x72, CHIP_ID2 = 0x10` for
-/// the production stepping.
 pub const CHIP_ID1: u8 = 0x72;
 /// Expected chip-ID high byte at [`REG_CHIP_ID2`].
 pub const CHIP_ID2: u8 = 0x10;
 
-/// `CHIP_ID1` register (low byte of the two-byte ID).
+/// `RESET` register. `0x71` asserts software reset, `0x41` releases.
+const REG_RESET: u8 = 0x00;
+/// `CLOCK_OFF` / mic-power gate register. Bits 0..5 = per-channel clock
+/// enable; higher bits = MIC12/34 power gates.
+const REG_CLOCK_OFF: u8 = 0x01;
+/// `MAINCLK` register. Bits 5:0 = `adc_div`, bit 6 = `doubler`, bit 7 = `dll`.
+const REG_MAINCLK: u8 = 0x02;
+/// `LRCK_DIVH` register. Upper 4 bits of the 12-bit LRCK divider.
+const REG_LRCK_DIVH: u8 = 0x04;
+/// `LRCK_DIVL` register. Lower 8 bits of the LRCK divider.
+const REG_LRCK_DIVL: u8 = 0x05;
+/// `POWER_DOWN` register. `0x00` = all blocks on; `0x07` = everything off.
+const REG_POWER_DOWN: u8 = 0x06;
+/// `OSR` (over-sample ratio) register.
+const REG_OSR: u8 = 0x07;
+/// `ANALOG` block configuration register.
+const REG_ANALOG: u8 = 0x40;
+/// `MIC1_GAIN` register. Bit 4 = gain-enable, bits 3:0 = gain step.
+const REG_MIC1_GAIN: u8 = 0x43;
+/// `MIC2_GAIN` register.
+const REG_MIC2_GAIN: u8 = 0x44;
+/// `MIC1_POWER` register. `0x08` = on, `0xFF` = off.
+const REG_MIC1_POWER: u8 = 0x47;
+/// `MIC2_POWER` register.
+const REG_MIC2_POWER: u8 = 0x48;
+/// `MIC3_POWER` register.
+const REG_MIC3_POWER: u8 = 0x49;
+/// `MIC4_POWER` register.
+const REG_MIC4_POWER: u8 = 0x4A;
+/// `MIC12_POWER` group register. `0x00` = mics 1+2 powered, `0xFF` = off.
+const REG_MIC12_POWER: u8 = 0x4B;
+/// `MIC34_POWER` group register.
+const REG_MIC34_POWER: u8 = 0x4C;
+/// `CHIP_ID1` register (low byte of two-byte ID).
 const REG_CHIP_ID1: u8 = 0xFD;
 /// `CHIP_ID2` register (high byte).
 const REG_CHIP_ID2: u8 = 0xFE;
-/// `RESET` register. Writing `0x3F` asserts a soft-reset; `0x00` releases.
-const REG_RESET: u8 = 0x00;
 
-/// Post-soft-reset settle delay, in milliseconds.
-///
-/// ES7210 datasheet asks for "a few ms" after releasing reset before
-/// configuration writes; 5 ms is conservative.
+// ---- Clock coefficients for 12.288 MHz MCLK → 16 kHz sample rate -----
+//
+// Lifted from `coeff_div[]` in esp-adf's `es7210.c`, row
+// `{12288000, 16000, 0x00, 0x03, 0x01, 0x01, 0x20, 0x00, 0x03, 0x00}`.
+// Fields: `(mclk, lrck, ss_ds, adc_div, dll, doubler, osr, mclk_src,
+// lrck_h, lrck_l)`. Only `adc_div`, `dll`, `doubler`, `osr`, `lrck_h`,
+// `lrck_l` matter for the configured rate; the rest are defaults.
+
+/// `MAINCLK` value: `adc_div=0x03 | doubler << 6 | dll << 7` = `0xC3`.
+const MAINCLK_VALUE: u8 = 0x03 | (0x01 << 6) | (0x01 << 7);
+/// `OSR` value: `0x20` (256× oversample).
+const OSR_VALUE: u8 = 0x20;
+/// `LRCK_DIVH` value: `0x03` (upper nibble of LRCK divider).
+const LRCK_DIVH_VALUE: u8 = 0x03;
+/// `LRCK_DIVL` value: `0x00` (lower byte).
+const LRCK_DIVL_VALUE: u8 = 0x00;
+
+/// `CLOCK_OFF` value: enable mic1+2 channel clocks, gate mic3+4. Lower
+/// nibble bits 0/1 = mic12 clock gates (0 = on); upper nibble bits
+/// 4/5 = mic34 clock gates (1 = off).
+const CLOCK_OFF_MIC12_ON: u8 = 0b0011_0000;
+/// `ANALOG` value: `0x43` (datasheet block-enable pattern for active-mode).
+const ANALOG_ACTIVE: u8 = 0x43;
+/// Per-mic power-on value (`0x08`) applied to `MIC1..4_POWER`.
+const MIC_POWER_ON: u8 = 0x08;
+/// `MIC12_POWER` value: both mics powered.
+const MIC12_POWER_ON: u8 = 0x00;
+/// `MIC34_POWER` value: both mics powered off (we don't use them).
+const MIC34_POWER_OFF: u8 = 0xFF;
+/// Mic-gain enable bit in `MICx_GAIN`.
+const MIC_GAIN_ENABLE: u8 = 0x10;
+/// Default mic-gain step (bits 3:0). `0x0A` ≈ +30 dB (datasheet).
+const MIC_GAIN_DEFAULT: u8 = 0x0A;
+
+/// `RESET` assert value.
+const RESET_ASSERT: u8 = 0x71;
+/// `RESET` release value. Written after assert, and again at the end of
+/// init to "latch" the applied config.
+const RESET_RELEASE: u8 = 0x41;
+
+/// Post-reset settle delay, in milliseconds. Datasheet asks "a few ms";
+/// 5 ms matches the reference.
 const RESET_SETTLE_MS: u32 = 5;
 
 /// Driver error type.
@@ -122,34 +191,245 @@ impl<B: I2c> Es7210<B> {
         Ok((lo[0], hi[0]))
     }
 
-    /// Scaffold init. Soft-resets, verifies chip ID, and returns. Does
-    /// not configure sample rate, MCLK divisor, channel enable, TDM
-    /// format, or gain.
+    /// Full initialisation for the CoreS3 Stack-chan's two-mic layout.
+    ///
+    /// Applies the esp-adf reference sequence, simplified to fixed
+    /// params: 12.288 MHz MCLK, 16 kHz sample rate, 16-bit mono,
+    /// ES7210 as I²S slave, mic1+2 on at +30 dB, mic3+4 off.
     ///
     /// # Errors
     ///
-    /// - [`Error::BadChipId`] if the chip ID bytes don't match.
+    /// - [`Error::BadChipId`] if the chip-ID bytes don't read
+    ///   `(0x72, 0x10)`.
     /// - [`Error::I2c`] on any bus failure.
     pub async fn init<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<B::Error>> {
-        self.write_register(REG_RESET, 0x3F).await?;
-        delay.delay_ms(RESET_SETTLE_MS).await;
-        self.write_register(REG_RESET, 0x00).await?;
-        delay.delay_ms(RESET_SETTLE_MS).await;
-
+        // Verify this is an ES7210 before poking it further.
         let (lo, hi) = self.read_chip_id().await?;
         if lo != CHIP_ID1 || hi != CHIP_ID2 {
             return Err(Error::BadChipId(lo, hi));
         }
 
-        // TODO: clock manager, MCLK divisor, ADC sample rate, ADC gain
-        // per channel, channel enable, TDM / I2S format.
+        // Soft-reset pulse.
+        self.write_reg(REG_RESET, RESET_ASSERT).await?;
+        delay.delay_ms(RESET_SETTLE_MS).await;
+        self.write_reg(REG_RESET, RESET_RELEASE).await?;
+        delay.delay_ms(RESET_SETTLE_MS).await;
+
+        // Clock tree for 12.288 MHz MCLK → 16 kHz LRCK.
+        self.write_reg(REG_MAINCLK, MAINCLK_VALUE).await?;
+        self.write_reg(REG_OSR, OSR_VALUE).await?;
+        self.write_reg(REG_LRCK_DIVH, LRCK_DIVH_VALUE).await?;
+        self.write_reg(REG_LRCK_DIVL, LRCK_DIVL_VALUE).await?;
+
+        // Start sequence: clock gates, power-up, analog, per-mic power,
+        // mic select, analog re-assert, latch reset. Mirrors the
+        // `es7210_start()` body in esp-adf.
+        self.write_reg(REG_CLOCK_OFF, CLOCK_OFF_MIC12_ON).await?;
+        self.write_reg(REG_POWER_DOWN, 0x00).await?;
+        self.write_reg(REG_ANALOG, ANALOG_ACTIVE).await?;
+        self.write_reg(REG_MIC1_POWER, MIC_POWER_ON).await?;
+        self.write_reg(REG_MIC2_POWER, MIC_POWER_ON).await?;
+        self.write_reg(REG_MIC3_POWER, MIC_POWER_ON).await?;
+        self.write_reg(REG_MIC4_POWER, MIC_POWER_ON).await?;
+
+        // Mic select: power up MIC12 group, power down MIC34 group,
+        // enable gain + preset step on the two channels we use.
+        self.write_reg(REG_MIC12_POWER, MIC12_POWER_ON).await?;
+        self.write_reg(REG_MIC34_POWER, MIC34_POWER_OFF).await?;
+        self.write_reg(REG_MIC1_GAIN, MIC_GAIN_ENABLE | MIC_GAIN_DEFAULT)
+            .await?;
+        self.write_reg(REG_MIC2_GAIN, MIC_GAIN_ENABLE | MIC_GAIN_DEFAULT)
+            .await?;
+
+        // Re-assert the analog register (the reference sequence does
+        // this twice) and latch via a second reset pulse.
+        self.write_reg(REG_ANALOG, ANALOG_ACTIVE).await?;
+        self.write_reg(REG_RESET, RESET_ASSERT).await?;
+        self.write_reg(REG_RESET, RESET_RELEASE).await?;
+
         Ok(())
     }
 
-    /// Single-register write. Private because the scaffold does not
-    /// expose arbitrary register access yet.
-    async fn write_register(&mut self, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
+    /// Set the gain step on both active mic channels.
+    ///
+    /// `step` is the lower-nibble value written to `MICx_GAIN` —
+    /// `0x00..=0x0A` maps 0 dB to +30 dB in 3 dB increments per the
+    /// datasheet. Values above `0x0F` are clamped.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any I²C bus error.
+    pub async fn set_gain(&mut self, step: u8) -> Result<(), Error<B::Error>> {
+        let clamped = step & 0x0F;
+        let value = MIC_GAIN_ENABLE | clamped;
+        self.write_reg(REG_MIC1_GAIN, value).await?;
+        self.write_reg(REG_MIC2_GAIN, value).await
+    }
+
+    /// Single-register write. 8-bit register, 8-bit value.
+    async fn write_reg(&mut self, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
         self.bus.write(self.address, &[reg, value]).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test scaffolding: Infallible bus error makes unwrap() sound"
+)]
+#[allow(
+    clippy::panic,
+    reason = "tests panic via assertion-by-match on unexpected variants"
+)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use embedded_hal_async::{
+        delay::DelayNs,
+        i2c::{ErrorType, Operation, SevenBitAddress},
+    };
+
+    /// Host-side I²C mock: canned reads keyed by register, records every write.
+    struct MockI2c {
+        /// (register, value) response table; the mock tracks the most
+        /// recently written register as "the next read target."
+        reads: [(u8, u8); 2],
+        /// Register the most recent 1-byte write selected (from
+        /// `write_read`'s Write half).
+        next_read_reg: RefCell<u8>,
+        /// Every 2-byte `Operation::Write` payload, in emission order.
+        writes: RefCell<Vec<(u8, u8)>>,
+    }
+
+    impl MockI2c {
+        fn with_chip_id(lo: u8, hi: u8) -> Self {
+            Self {
+                reads: [(REG_CHIP_ID1, lo), (REG_CHIP_ID2, hi)],
+                next_read_reg: RefCell::new(0),
+                writes: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn read_for(&self, reg: u8) -> u8 {
+            self.reads
+                .iter()
+                .find(|(r, _)| *r == reg)
+                .map_or(0, |(_, v)| *v)
+        }
+    }
+
+    impl ErrorType for MockI2c {
+        type Error = core::convert::Infallible;
+    }
+
+    impl I2c for MockI2c {
+        async fn transaction(
+            &mut self,
+            _address: SevenBitAddress,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            for op in operations {
+                match op {
+                    Operation::Write(buf) => {
+                        if buf.len() == 1 {
+                            // `write_read`'s register-select byte.
+                            *self.next_read_reg.borrow_mut() = buf[0];
+                        } else if buf.len() == 2 {
+                            // Register write.
+                            self.writes.borrow_mut().push((buf[0], buf[1]));
+                        }
+                    }
+                    Operation::Read(buf) => {
+                        let reg = *self.next_read_reg.borrow();
+                        buf[0] = self.read_for(reg);
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    struct NoopDelay;
+
+    impl DelayNs for NoopDelay {
+        async fn delay_ns(&mut self, _ns: u32) {}
+    }
+
+    fn block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+        let mut cx = Context::from_waker(Waker::noop());
+        let mut fut = pin!(future);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn init_writes_clock_tree_for_12288_mhz_16khz() {
+        let mut adc = Es7210::new(MockI2c::with_chip_id(CHIP_ID1, CHIP_ID2));
+        block_on(adc.init(&mut NoopDelay)).unwrap();
+        let writes = adc.bus.writes.borrow();
+        // The clock-tree writes come right after the two reset pulses.
+        let clock_writes: Vec<&(u8, u8)> = writes
+            .iter()
+            .filter(|(r, _)| matches!(*r, REG_MAINCLK | REG_OSR | REG_LRCK_DIVH | REG_LRCK_DIVL))
+            .collect();
+        assert_eq!(clock_writes.len(), 4);
+        assert!(clock_writes.contains(&&(REG_MAINCLK, 0xC3)));
+        assert!(clock_writes.contains(&&(REG_OSR, 0x20)));
+        assert!(clock_writes.contains(&&(REG_LRCK_DIVH, 0x03)));
+        assert!(clock_writes.contains(&&(REG_LRCK_DIVL, 0x00)));
+    }
+
+    #[test]
+    fn init_enables_mic12_and_disables_mic34() {
+        let mut adc = Es7210::new(MockI2c::with_chip_id(CHIP_ID1, CHIP_ID2));
+        block_on(adc.init(&mut NoopDelay)).unwrap();
+        let writes = adc.bus.writes.borrow();
+        // MIC12 group powered on (0x00), MIC34 group powered off (0xFF).
+        assert!(writes.contains(&(REG_MIC12_POWER, MIC12_POWER_ON)));
+        assert!(writes.contains(&(REG_MIC34_POWER, MIC34_POWER_OFF)));
+        // Gain enable + default step on mic1 and mic2.
+        let expected_gain = MIC_GAIN_ENABLE | MIC_GAIN_DEFAULT;
+        assert!(writes.contains(&(REG_MIC1_GAIN, expected_gain)));
+        assert!(writes.contains(&(REG_MIC2_GAIN, expected_gain)));
+    }
+
+    #[test]
+    fn init_bookends_with_two_reset_pulses() {
+        let mut adc = Es7210::new(MockI2c::with_chip_id(CHIP_ID1, CHIP_ID2));
+        block_on(adc.init(&mut NoopDelay)).unwrap();
+        let writes = adc.bus.writes.borrow();
+        let resets: Vec<&(u8, u8)> = writes.iter().filter(|(r, _)| *r == REG_RESET).collect();
+        // Two pulses: open + close. Each pulse is assert then release.
+        assert_eq!(resets.len(), 4);
+        assert_eq!(resets[0], &(REG_RESET, RESET_ASSERT));
+        assert_eq!(resets[1], &(REG_RESET, RESET_RELEASE));
+        assert_eq!(resets[2], &(REG_RESET, RESET_ASSERT));
+        assert_eq!(resets[3], &(REG_RESET, RESET_RELEASE));
+    }
+
+    #[test]
+    fn init_rejects_wrong_chip_id() {
+        let mut adc = Es7210::new(MockI2c::with_chip_id(0x00, 0x00));
+        match block_on(adc.init(&mut NoopDelay)) {
+            Err(Error::BadChipId(0, 0)) => {}
+            other => panic!("expected BadChipId(0, 0), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_gain_clamps_to_lower_nibble() {
+        let mut adc = Es7210::new(MockI2c::with_chip_id(CHIP_ID1, CHIP_ID2));
+        block_on(adc.set_gain(0xFF)).unwrap();
+        let writes = adc.bus.writes.borrow();
+        assert_eq!(writes.len(), 2);
+        // High bits dropped; gain-enable bit forced on.
+        assert_eq!(writes[0], (REG_MIC1_GAIN, 0x1F));
+        assert_eq!(writes[1], (REG_MIC2_GAIN, 0x1F));
     }
 }

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -13,11 +13,13 @@ workspace = true
 
 [dependencies]
 stackchan-core = { path = "../stackchan-core" }
+aw88298 = { path = "../aw88298" }
 axp2101 = { path = "../axp2101" }
 aw9523 = { path = "../aw9523" }
 bm8563 = { path = "../bm8563" }
 bmi270 = { path = "../bmi270" }
 bmm150 = { path = "../bmm150" }
+es7210 = { path = "../es7210" }
 ft6336u = { path = "../ft6336u" }
 ir-nec = { path = "../ir-nec" }
 ltr553 = { path = "../ltr553" }
@@ -114,3 +116,11 @@ path = "examples/leds_bench.rs"
 [[example]]
 name = "mag_bench"
 path = "examples/mag_bench.rs"
+
+[[example]]
+name = "aw88298_bench"
+path = "examples/aw88298_bench.rs"
+
+[[example]]
+name = "es7210_bench"
+path = "examples/es7210_bench.rs"

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -28,6 +28,7 @@ modifier pipeline at ~30 FPS.
 - `src/imu.rs` / `src/mag.rs` — BMI270 / BMM150 tasks publishing to signal channels for the 9-axis data path
 - `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` — per-peripheral tasks
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
+- `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; no I²S / streaming data on the audio pair until PR 2 of the audio stack lands)
 
 ## Boot Sequence
 
@@ -80,9 +81,9 @@ and talk to it through `I2cDevice` handles. Addresses on the bus:
 | `0x10/11` | BMM150 magnetometer |
 | `0x23`  | LTR-553 ambient / prox |
 | `0x34`  | AXP2101 PMIC         |
-| `0x36`  | AW88298 amp (future) |
+| `0x36`  | AW88298 amp (control-path only; I²S pending) |
 | `0x38`  | FT6336U touch        |
-| `0x40`  | ES7210 ADC (future)  |
+| `0x40`  | ES7210 ADC (control-path only; I²S pending)  |
 | `0x51`  | BM8563 RTC           |
 | `0x58`  | AW9523 I/O expander  |
 | `0x68/69` | BMI270 IMU         |
@@ -107,6 +108,8 @@ just fmr                     # flash + monitor in one go
 just bench                   # flash the calibration-bench example
 just mag-bench               # magnetometer bench
 just leds-bench              # WS2812 LED ring bench
+just aw88298-bench           # speaker-amp control-path bench
+just es7210-bench            # mic-ADC control-path bench
 ```
 
 See the [justfile](../../justfile) for the full recipe set. Default
@@ -115,5 +118,5 @@ port is `/dev/ttyACM1`; override with `just PORT=/dev/ttyACM0 flash`.
 ## Integration
 
 - **Consumes `stackchan-core`** for every domain type (`Avatar`, `Modifier`, `Pose`, `Clock`, `HeadDriver`, `LedFrame`)
-- **Consumes every driver crate in the workspace** — axp2101, aw9523, bm8563, bmi270, bmm150, ft6336u, ir-nec, ltr553, py32, scservo. Scaffolded drivers (aw88298, es7210, gc0308, si12t, st25r3916) will land as additional tasks once implemented
+- **Consumes every driver crate in the workspace** — axp2101, aw9523, aw88298, bm8563, bmi270, bmm150, es7210, ft6336u, ir-nec, ltr553, py32, scservo. AW88298 + ES7210 are control-path only for now (chip brought up at benches; no I²S streaming — that lands in the audio-task PR). Scaffolded-only: gc0308, si12t, st25r3916
 - **HIL via probe-rs + defmt-test** (planned) — CI runs host tests today; on-device integration tests run on a flash-and-capture rig

--- a/crates/stackchan-firmware/examples/aw88298_bench.rs
+++ b/crates/stackchan-firmware/examples/aw88298_bench.rs
@@ -1,0 +1,106 @@
+//! AW88298 bench: brings up the shared I²C bus (which releases the
+//! amplifier's external `RST` via AW9523), runs the driver's full init
+//! sequence (reset → enable → configure I2S 16 kHz mono → mute →
+//! disable boost), and holds the chip in that configured state while
+//! logging a heartbeat.
+//!
+//! Does **not** stream audio — the I2S peripheral wiring lands in a
+//! follow-up PR. This bench verifies the control-path: that the amp
+//! answers at `0x36`, returns the expected `0x1852` chip ID, and
+//! accepts the canonical esp-adf register sequence without error.
+//!
+//! Expected defmt log on a healthy chip:
+//!
+//! ```text
+//! aw88298-bench: detected chip ID 0x1852
+//! aw88298-bench: init OK (muted, I2S 16 kHz, boost off)
+//! aw88298-bench: heartbeat (tick 0)
+//! aw88298-bench: heartbeat (tick 1)
+//! ...
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use aw88298::Aw88298;
+use embassy_time::{Delay, Duration, Ticker};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use stackchan_firmware::board;
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("aw88298-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Heap size: no framebuffer, minimal drivers + embassy task arena.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Heartbeat cadence, in milliseconds.
+const HEARTBEAT_PERIOD_MS: u64 = 1_000;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "esp_rtos::main requires the spawner arg; this bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-aw88298-bench v{} — CoreS3 boot",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let mut amp = Aw88298::new(board_io.i2c);
+    match amp.read_chip_id().await {
+        Ok(id) => defmt::info!("aw88298-bench: detected chip ID 0x{=u16:04X}", id),
+        Err(e) => defmt::panic!(
+            "aw88298-bench: chip-ID read failed: {}",
+            defmt::Debug2Format(&e)
+        ),
+    }
+
+    if let Err(e) = amp.init(&mut delay).await {
+        defmt::panic!("aw88298-bench: init failed: {}", defmt::Debug2Format(&e));
+    }
+    defmt::info!("aw88298-bench: init OK (muted, I2S 16 kHz, boost off)");
+
+    let mut ticker = Ticker::every(Duration::from_millis(HEARTBEAT_PERIOD_MS));
+    let mut tick: u32 = 0;
+    loop {
+        defmt::info!("aw88298-bench: heartbeat (tick {=u32})", tick);
+        tick = tick.wrapping_add(1);
+        ticker.next().await;
+    }
+}

--- a/crates/stackchan-firmware/examples/es7210_bench.rs
+++ b/crates/stackchan-firmware/examples/es7210_bench.rs
@@ -1,0 +1,109 @@
+//! ES7210 bench: brings up the shared I²C bus, runs the driver's full
+//! init sequence (reset → clock tree for 12.288 MHz → 16 kHz → mic1+2
+//! power-on at default gain → latch reset), and holds the ADC in that
+//! configured state while logging a heartbeat.
+//!
+//! Does **not** capture audio — the I2S peripheral wiring lands in a
+//! follow-up PR. This bench verifies the control-path: that the chip
+//! answers at `0x40`, returns the expected `(0x72, 0x10)` chip ID, and
+//! accepts the esp-adf-derived register sequence for our fixed audio
+//! shape.
+//!
+//! Expected defmt log on a healthy chip:
+//!
+//! ```text
+//! es7210-bench: detected chip ID (0x72, 0x10)
+//! es7210-bench: init OK (12.288 MHz MCLK, 16 kHz mono, mic1+2 on)
+//! es7210-bench: heartbeat (tick 0)
+//! ...
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Ticker};
+use es7210::Es7210;
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use stackchan_firmware::board;
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("es7210-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Heap size: no framebuffer, minimal drivers + embassy task arena.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Heartbeat cadence, in milliseconds.
+const HEARTBEAT_PERIOD_MS: u64 = 1_000;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "esp_rtos::main requires the spawner arg; this bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-es7210-bench v{} — CoreS3 boot",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let mut adc = Es7210::new(board_io.i2c);
+    match adc.read_chip_id().await {
+        Ok((lo, hi)) => defmt::info!(
+            "es7210-bench: detected chip ID (0x{=u8:02X}, 0x{=u8:02X})",
+            lo,
+            hi
+        ),
+        Err(e) => defmt::panic!(
+            "es7210-bench: chip-ID read failed: {}",
+            defmt::Debug2Format(&e)
+        ),
+    }
+
+    if let Err(e) = adc.init(&mut delay).await {
+        defmt::panic!("es7210-bench: init failed: {}", defmt::Debug2Format(&e));
+    }
+    defmt::info!("es7210-bench: init OK (12.288 MHz MCLK, 16 kHz mono, mic1+2 on)");
+
+    let mut ticker = Ticker::every(Duration::from_millis(HEARTBEAT_PERIOD_MS));
+    let mut tick: u32 = 0;
+    loop {
+        defmt::info!("es7210-bench: heartbeat (tick {=u32})", tick);
+        tick = tick.wrapping_add(1);
+        ticker.next().await;
+    }
+}

--- a/justfile
+++ b/justfile
@@ -98,3 +98,21 @@ mag-bench:
 leds-bench:
     cd crates/stackchan-firmware && cargo +esp build --release --example leds_bench
     sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/leds_bench"
+
+# AW88298 control-path bench: runs the amp's full I²C init sequence
+# (reset → enable → configure I2S 16 kHz mono → mute → disable boost)
+# and logs a heartbeat. Does NOT stream audio — I2S wiring lands in the
+# follow-up audio-task PR. Verifies chip presence and register-sequence
+# acceptance only.
+aw88298-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example aw88298_bench
+    sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/aw88298_bench"
+
+# ES7210 control-path bench: runs the ADC's full I²C init sequence
+# (reset → clock tree for 12.288 MHz / 16 kHz → mic1+2 power-on → latch
+# reset) and logs a heartbeat. Does NOT capture audio — I2S wiring
+# lands in the follow-up audio-task PR. Verifies chip presence and
+# register-sequence acceptance only.
+es7210-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example es7210_bench
+    sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/es7210_bench"


### PR DESCRIPTION
## Summary

PR 1 of the 3-PR audio bring-up stack (**drivers → firmware-task → avatar modifier**). This PR turns the two scaffolded audio codec crates into real drivers that apply their full I²C init sequences, with unit tests and hardware-verifiable bench binaries. I²S wiring and avatar binding come in the follow-up PRs.

### Drivers

**`aw88298`** — Awinic smart-K speaker amp
- 16-bit big-endian register width (codec quirk; the driver encodes it internally)
- Canonical esp-adf init sequence: `RESET → SYSCTRL → SYSCTRL2 muted → I2SCTRL 16 kHz → HAGCCFG4 → BSTCTRL2 boost off`
- New `Aw88298::set_sample_rate(SampleRate)` and `set_muted(bool)` for runtime control
- 5 unit tests: canonical-sequence byte assertion, chip-ID mismatch, sample-rate nibble encoding, mute bit toggle, big-endian chip-ID decode

**`es7210`** — Everest mic ADC
- Fixed audio shape: 12.288 MHz MCLK → 16 kHz mono, mic1+2 on at +30 dB, mic3+4 off (esp-adf coefficient row `{12288000, 16000}`)
- Init: chip-ID probe → reset pulse → clock tree → CLOCK_OFF → POWER_DOWN → ANALOG → per-mic power → mic-select → ANALOG re-assert → latch reset
- `Es7210::set_gain(step)` for runtime gain adjustment
- 5 unit tests: clock-tree values, mic12/34 power gating, two reset-pulse bracket, chip-ID mismatch, gain clamping

Register values ported from `components/esp_codec_dev/device/{aw88298,es7210}/*.c` in [espressif/esp-adf](https://github.com/espressif/esp-adf) (Apache-2.0) — the canonical CoreS3 codec sequences.

### Benches

- `examples/aw88298_bench.rs` + `just aw88298-bench`
- `examples/es7210_bench.rs` + `just es7210-bench`

Both run the full init sequence against real hardware and log a heartbeat. **They do NOT stream audio** — I²S peripheral wiring lands in PR 2. A healthy bench run logs `detected chip ID ...` + `init OK ...`; a failure surfaces the exact register-write error via defmt.

### Frontmatter

`status: scaffold` → `status: experimental` on both crate READMEs. Register-map + init-sequence tables updated from "planned" to actual (matches what `init()` writes byte-for-byte).

## Out of scope (PR 2)

- ESP32-S3 I²S0 peripheral setup (master, 12.288 MHz MCLK, 16 kHz LRCK, 16-bit mono Philips)
- `stackchan-firmware/src/audio.rs` task module
- Mic-RMS `Signal` publication at render cadence

## Out of scope (PR 3)

- `stackchan_core::Mouth::mouth_open: f32` field
- `MouthOpenAudio` modifier (dB + attack 20 ms / release 100 ms)
- Firmware binding from audio signal → avatar mouth

## Test plan

- [x] `just check` passes (fmt + strict clippy + host tests + doctests + workspace check)
- [x] 10 new unit tests pass
- [ ] `just aw88298-bench` on real CoreS3 logs expected chip ID `0x1852` + `init OK`
- [ ] `just es7210-bench` on real CoreS3 logs expected chip ID `(0x72, 0x10)` + `init OK`
- [ ] Iterate register values via bench output if hardware rejects any write