### PR TITLE
feat(audio): codec bring-up + audio signal plumbing (firmware task scaffold)

### DIFF
--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -27,6 +27,7 @@ modifier pipeline at ~30 FPS.
 - `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
 - `src/imu.rs` / `src/mag.rs` — BMI270 / BMM150 tasks publishing to signal channels for the 9-axis data path
 - `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` — per-peripheral tasks
+- `src/audio.rs` — codec bring-up (AW88298 + ES7210) + `AUDIO_RMS_SIGNAL` channel. Task parks until the I²S peripheral wiring lands in a follow-up
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
 - `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; no I²S / streaming data on the audio pair until PR 2 of the audio stack lands)
 

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -100,12 +100,24 @@ pub enum BringupError {
 /// (pending PR 2B). The amp stays muted until a future un-mute call
 /// after the I²S master clocks are stable.
 ///
+/// ## Known issue pre-PR 2B: ES7210 needs MCLK to answer I²C
+///
+/// The ES7210 gates its I²C state machine on the `MCLK` clock
+/// domain, so until the ESP32-S3 I²S peripheral is configured and
+/// outputting MCLK on GPIO0, this call NACKs at the chip-ID probe
+/// (`BadChipId(0xFF, 0xFF)`). This matches esp-bsp's ordering in
+/// `bsp_audio_codec_microphone_init`, which calls `bsp_audio_init`
+/// (spins up I²S + MCLK) *before* `es7210_codec_new`. PR 2B fixes
+/// the order; until then, expect a warn-level "ES7210 bring-up
+/// failed" at boot on real hardware. AW88298 has no such
+/// dependency — it comes up fine today.
+///
 /// # Errors
 ///
 /// - [`BringupError::AmpInit`] if the AW88298 fails its sequence
 ///   (usually a NACK from an un-released `RST` pin).
 /// - [`BringupError::AdcInit`] if the ES7210 fails its sequence
-///   (usually a chip-ID mismatch — wrong address / wrong part).
+///   (expected until PR 2B — see note above).
 pub async fn bringup<B: I2c>(bus_amp: B, bus_adc: B) -> Result<(), BringupError> {
     let mut delay = Delay;
     let mut amp = Aw88298::new(bus_amp);

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -1,0 +1,146 @@
+//! Audio boot-up and signal plumbing.
+//!
+//! This module owns the firmware's audio control path: bringing the
+//! two codecs ([`aw88298`] speaker amp, [`es7210`] mic ADC) online at
+//! the fixed 16 kHz / 16-bit mono shape the avatar's voice-reactive
+//! pipeline expects, and exposing the channel that will carry
+//! microphone-RMS values to consumer modifiers.
+//!
+//! ## What's wired today (PR 2A)
+//!
+//! - [`bringup`] applies both codec initialisation sequences over the
+//!   shared I²C bus. After it returns, the amp is muted but I²S-ready,
+//!   and the ADC is power-on with mic1+2 active.
+//! - [`AUDIO_RMS_SIGNAL`] is the embassy `Signal` the audio task will
+//!   publish to. Declared at module scope so consumer tasks (the
+//!   `MouthOpenAudio` modifier in PR 3) can import it even before the
+//!   producer runs.
+//!
+//! ## What's pending (PR 2B)
+//!
+//! - ESP32-S3 I²S0 peripheral setup: master mode, MCLK out on GPIO0,
+//!   BCLK on GPIO34, LRCK on GPIO33, DOUT on GPIO13, DIN on GPIO14,
+//!   12.288 MHz MCLK, 16 kHz LRCK, Philips 16-bit mono slot.
+//! - DMA ring buffers + [`run_audio_loop`] streaming mic samples,
+//!   computing RMS per render-tick window, publishing via
+//!   [`AUDIO_RMS_SIGNAL`].
+//! - Speaker-side sine-tone generator (driven by emotion transitions
+//!   in PR 3's modifier stack).
+//!
+//! Until PR 2B lands, [`run_audio_loop`] is a park loop that emits a
+//! one-time boot log and then yields forever. The signal stays at its
+//! default `AudioRms(0.0)` value, which produces a closed mouth in the
+//! downstream modifier — a graceful degradation.
+
+use aw88298::Aw88298;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Delay, Duration, Timer};
+use embedded_hal_async::i2c::I2c;
+use es7210::Es7210;
+
+/// Audio configuration constants the I²S side must match once wired up.
+
+/// Target sample rate for both codecs.
+pub const SAMPLE_RATE_HZ: u32 = 16_000;
+/// Master clock the ESP32-S3 I²S peripheral feeds both codecs.
+///
+/// `12.288 MHz = 256 × 48 kHz = 768 × 16 kHz`. Using 768× oversample
+/// at 16 kHz keeps the ES7210 coefficient table row we ported in
+/// `crates/es7210/src/lib.rs` valid (`coeff_div[{12288000, 16000}]`).
+pub const MCLK_HZ: u32 = 12_288_000;
+/// Sample bit-depth. AW88298 spec is 16-bit; ES7210 ADC runs 24-bit
+/// internally but truncates to 16-bit over I²S at this slot width.
+pub const BIT_DEPTH_BITS: u8 = 16;
+
+/// Microphone RMS sample, published per render tick.
+///
+/// Value is the linear-RMS amplitude of the most recent ~33 ms
+/// audio window, normalised to `[0.0, 1.0]` against full-scale i16
+/// (`32768.0`). A value of `0.01` ≈ -40 dBFS, a value of `0.3` ≈ -10 dBFS.
+///
+/// The downstream [`MouthOpenAudio`] modifier (PR 3) converts this to
+/// `dB` + applies an attack/release envelope before writing to the
+/// avatar's `mouth_open` field. Keeping the raw value as the channel
+/// payload lets the modifier stack own the feel-tuning.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct AudioRms(pub f32);
+
+/// Microphone RMS channel. Single-producer (the audio task) /
+/// multiple-consumer (modifier pipeline + eventual diagnostics).
+///
+/// Uses `Signal` rather than `Channel` because consumers always want
+/// the latest value, never a backlog — if the modifier misses a frame,
+/// the next one should reflect current mic state, not queued history.
+pub static AUDIO_RMS_SIGNAL: Signal<CriticalSectionRawMutex, AudioRms> = Signal::new();
+
+/// Audio-subsystem bring-up error.
+///
+/// Split from the per-driver `Error<E>` types so `main.rs` can log a
+/// single enum — the firmware boot path treats "audio failed" as
+/// degrade-gracefully, not panic.
+#[derive(Debug, defmt::Format)]
+pub enum BringupError {
+    /// AW88298 rejected its init sequence. Wrapped in `defmt::Display2Format`
+    /// to stay `no_std`-compatible without pulling the `E` generic up.
+    AmpInit,
+    /// ES7210 rejected its init sequence.
+    AdcInit,
+}
+
+/// Apply both codec initialisation sequences over the shared I²C bus.
+///
+/// After this returns:
+///
+/// - AW88298 is configured for 16 kHz / 16-bit Philips I²S, muted,
+///   boost disabled, volume at the esp-adf default (-24 dB).
+/// - ES7210 is configured for 12.288 MHz → 16 kHz, mic1+2 active at
+///   ~+30 dB, mic3+4 gated.
+///
+/// Does **not** start any streaming — that's the I²S peripheral's job
+/// (pending PR 2B). The amp stays muted until a future un-mute call
+/// after the I²S master clocks are stable.
+///
+/// # Errors
+///
+/// - [`BringupError::AmpInit`] if the AW88298 fails its sequence
+///   (usually a NACK from an un-released `RST` pin).
+/// - [`BringupError::AdcInit`] if the ES7210 fails its sequence
+///   (usually a chip-ID mismatch — wrong address / wrong part).
+pub async fn bringup<B: I2c>(bus_amp: B, bus_adc: B) -> Result<(), BringupError> {
+    let mut delay = Delay;
+    let mut amp = Aw88298::new(bus_amp);
+    amp.init(&mut delay).await.map_err(|e| {
+        defmt::error!("audio: AW88298 init: {}", defmt::Debug2Format(&e));
+        BringupError::AmpInit
+    })?;
+    defmt::info!(
+        "audio: AW88298 ready — I²S 16 kHz mono, muted, boost off (un-mute via audio task)"
+    );
+
+    let mut adc = Es7210::new(bus_adc);
+    adc.init(&mut delay).await.map_err(|e| {
+        defmt::error!("audio: ES7210 init: {}", defmt::Debug2Format(&e));
+        BringupError::AdcInit
+    })?;
+    defmt::info!("audio: ES7210 ready — 12.288 MHz MCLK / 16 kHz / mic1+2 on");
+    Ok(())
+}
+
+/// Audio task entry point.
+///
+/// **Placeholder until PR 2B lands.** Logs one boot message, then
+/// parks the task forever. [`AUDIO_RMS_SIGNAL`] stays at its default
+/// `AudioRms(0.0)` — consumer modifiers see a silent mic until the
+/// I²S peripheral starts streaming.
+///
+/// The signature already takes the pieces the real task will need:
+/// once PR 2B wires I²S, the body becomes an `embassy-futures::select`
+/// between RX DMA completions and the render-tick cadence.
+pub async fn run_audio_loop() -> ! {
+    defmt::info!(
+        "audio: task parked — I²S peripheral wiring pending (PR 2B); RMS signal stays at 0.0"
+    );
+    loop {
+        Timer::after(Duration::from_secs(3600)).await;
+    }
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate alloc;
 
 pub mod ambient;
+pub mod audio;
 pub mod board;
 pub mod button;
 pub mod clock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -25,7 +25,7 @@
 extern crate alloc;
 
 use stackchan_firmware::{
-    ambient, board, button, clock, framebuffer, head, imu, ir, leds, mag, touch, wallclock,
+    ambient, audio, board, button, clock, framebuffer, head, imu, ir, leds, mag, touch, wallclock,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -408,6 +408,14 @@ async fn mag_task(shared_i2c: SharedI2c) -> ! {
     mag::run_mag_loop(shared_i2c).await
 }
 
+/// Audio task. Today a park loop; in PR 2B this becomes the I²S DMA
+/// read loop that computes mic RMS per render window and publishes to
+/// [`audio::AUDIO_RMS_SIGNAL`].
+#[embassy_executor::task]
+async fn audio_task() -> ! {
+    audio::run_audio_loop().await
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
@@ -517,6 +525,20 @@ async fn main(spawner: Spawner) -> ! {
     }
     if let Err(e) = spawner.spawn(mag_task(I2cDevice::new(board_io.i2c_bus))) {
         defmt::panic!("spawn mag_task failed: {}", defmt::Debug2Format(&e));
+    }
+
+    // Audio bring-up: configure AW88298 + ES7210 over shared I²C. Does
+    // not start I²S streaming (that's PR 2B). Failures are warn-only —
+    // audio degrades to "silent mic, muted speaker" rather than
+    // halting the boot, since the rest of the avatar still works.
+    let amp_bus = I2cDevice::new(board_io.i2c_bus);
+    let adc_bus = I2cDevice::new(board_io.i2c_bus);
+    match audio::bringup(amp_bus, adc_bus).await {
+        Ok(()) => defmt::info!("audio: codecs up (I²S streaming pending PR 2B)"),
+        Err(e) => defmt::warn!("audio: bring-up failed ({:?}) — audio disabled", e),
+    }
+    if let Err(e) = spawner.spawn(audio_task()) {
+        defmt::panic!("spawn audio_task failed: {}", defmt::Debug2Format(&e));
     }
 
     // One-shot wall-clock read for the boot log. Single I²C round-trip;


### PR DESCRIPTION
## Summary

PR 2A of the audio stack. Lands the firmware-side audio-boot path and the embassy `Signal` channel modifiers will consume — deliberately stops short of I²S peripheral wiring so we can ship + verify what works today.

### What's in

- **`stackchan-firmware/src/audio.rs`** (new):
  - `SAMPLE_RATE_HZ = 16_000`, `MCLK_HZ = 12_288_000`, `BIT_DEPTH_BITS = 16` — public config constants the future I²S setup must match
  - `AudioRms(pub f32)` channel payload (normalised against i16 full-scale)
  - `AUDIO_RMS_SIGNAL: Signal<CriticalSectionRawMutex, AudioRms>` — single-producer / multi-consumer, latest-wins
  - `BringupError { AmpInit, AdcInit }` — defmt-formattable, log-and-degrade rather than panic
  - `bringup(amp_bus, adc_bus)` runs both codec inits via the `aw88298` + `es7210` crates
  - `run_audio_loop()` is a park loop until PR 2B
- **`src/lib.rs`** — registers `pub mod audio`
- **`src/main.rs`** — imports `audio`, calls `audio::bringup` during boot (warn-only on failure), spawns `audio_task()`
- **`stackchan-firmware/README.md`** — adds the audio module to Key Files

### Hardware-verified on CoreS3

Flashed from this branch. Boot log excerpt:

```
audio: AW88298 ready — I²S 16 kHz mono, muted, boost off
audio: ES7210 init: BadChipId(255, 255)
audio: bring-up failed (AdcInit) — audio disabled
audio: task parked — I²S peripheral wiring pending (PR 2B); RMS signal stays at 0.0
```

**✅ AW88298 init succeeded on real hardware.** Our esp-adf-ported 6-write sequence + 16-bit big-endian register encoding works — amp is ready to accept I²S data once PR 2B lands.

**⚠ ES7210 init fails with `BadChipId(0xFF, 0xFF)` — expected and documented.** ES7210 gates its I²C state machine on the external MCLK domain, so every I²C transaction NACKs until the ESP32-S3 I²S peripheral is outputting MCLK. This matches esp-bsp's ordering (`bsp_audio_codec_microphone_init` calls `bsp_audio_init` before `es7210_codec_new`). PR 2B fixes the order by spinning up I²S + MCLK before the ES7210 I²C probe. The `bringup` docstring now calls this out explicitly so future debuggers don't chase a phantom wiring fault.

The rest of the boot proceeds normally — the audio task parks gracefully, the avatar animates, LEDs cycle, head nods. Audio degradation is warn-only by design.

### What's NOT in (deferred to PR 2B)

- ESP32-S3 I²S0 master setup — MCLK on GPIO0, BCLK GPIO34, LRCK GPIO33, DOUT GPIO13, DIN GPIO14
- DMA ring buffers + RX streaming loop
- Per-window RMS computation
- `AUDIO_RMS_SIGNAL` population
- ES7210 bring-up reordered to run after I²S MCLK is stable

### What's NOT in (deferred to PR 3)

- `stackchan_core::Mouth::mouth_open: f32` field
- `MouthOpenAudio` modifier
- Firmware binding audio signal → avatar mouth

## Test plan

- [x] `just check` passes (fmt + strict clippy + host tests + doctests + workspace check)
- [x] `just build-firmware` compiles clean on the esp toolchain
- [x] `just fmr` flashes successfully — boot logs confirm AW88298 bring-up OK; ES7210 warning is expected
- [ ] PR 2B unblocks ES7210 by spinning up I²S MCLK first