### PR TITLE
feat(audio): I²S0 master + MCLK, codec bring-up inside task

### DIFF
--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -1,157 +1,245 @@
-//! Audio boot-up and signal plumbing.
+//! Audio boot-up, I²S peripheral, and signal plumbing.
 //!
-//! This module owns the firmware's audio control path: bringing the
-//! two codecs ([`aw88298`] speaker amp, [`es7210`] mic ADC) online at
-//! the fixed 16 kHz / 16-bit mono shape the avatar's voice-reactive
-//! pipeline expects, and exposing the channel that will carry
-//! microphone-RMS values to consumer modifiers.
+//! Owns the firmware's audio control path: ESP32-S3 I²S0 master setup
+//! (MCLK on GPIO0, BCLK GPIO34, LRCK GPIO33, DIN GPIO14, DOUT GPIO13),
+//! both codec bring-ups over the shared I²C bus, and the embassy
+//! `Signal` channel the downstream avatar modifier consumes.
 //!
-//! ## What's wired today (PR 2A)
+//! ## Bring-up ordering
 //!
-//! - [`bringup`] applies both codec initialisation sequences over the
-//!   shared I²C bus. After it returns, the amp is muted but I²S-ready,
-//!   and the ADC is power-on with mic1+2 active.
-//! - [`AUDIO_RMS_SIGNAL`] is the embassy `Signal` the audio task will
-//!   publish to. Declared at module scope so consumer tasks (the
-//!   `MouthOpenAudio` modifier in PR 3) can import it even before the
-//!   producer runs.
+//! ES7210 gates its I²C state machine on the external MCLK domain —
+//! until the I²S peripheral is clocking MCLK on GPIO0, every I²C
+//! transaction against the ADC returns `0xFF` (NACK). So the boot
+//! order inside [`run_audio_task`] is:
 //!
-//! ## What's pending (PR 2B)
+//! 1. Configure I²S0 with MCLK + BCLK + LRCK + DIN pins
+//! 2. Start RX DMA on a circular buffer — this is what actually drives
+//!    clocks out of the I²S peripheral onto the pins
+//! 3. Small settle delay
+//! 4. Bring up AW88298 (doesn't need MCLK but comes up with the pair)
+//! 5. Bring up ES7210 (now responds — MCLK is flowing)
+//! 6. [TODO PR 2C] enter the sample-processing loop: pop DMA samples,
+//!    compute RMS per ~33 ms window, publish via [`AUDIO_RMS_SIGNAL`]
 //!
-//! - ESP32-S3 I²S0 peripheral setup: master mode, MCLK out on GPIO0,
-//!   BCLK on GPIO34, LRCK on GPIO33, DOUT on GPIO13, DIN on GPIO14,
-//!   12.288 MHz MCLK, 16 kHz LRCK, Philips 16-bit mono slot.
-//! - DMA ring buffers + [`run_audio_loop`] streaming mic samples,
-//!   computing RMS per render-tick window, publishing via
-//!   [`AUDIO_RMS_SIGNAL`].
-//! - Speaker-side sine-tone generator (driven by emotion transitions
-//!   in PR 3's modifier stack).
+//! This matches esp-bsp's ordering in `bsp_audio_codec_microphone_init`:
+//! `bsp_audio_init` (spins up I²S + MCLK) runs *before* `es7210_codec_new`.
 //!
-//! Until PR 2B lands, [`run_audio_loop`] is a park loop that emits a
-//! one-time boot log and then yields forever. The signal stays at its
-//! default `AudioRms(0.0)` value, which produces a closed mouth in the
-//! downstream modifier — a graceful degradation.
+//! ## What this PR lands (PR 2B)
+//!
+//! Steps 1–5 above. The task parks after both codecs are up. Sample
+//! processing + RMS publication land in PR 2C, which replaces the park
+//! with a real loop. [`AUDIO_RMS_SIGNAL`] stays at its default
+//! `AudioRms(0.0)` until then — consumer modifiers see a silent mic,
+//! which produces a closed mouth in the downstream binding.
 
 use aw88298::Aw88298;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Delay, Duration, Timer};
-use embedded_hal_async::i2c::I2c;
 use es7210::Es7210;
+use esp_hal::{
+    dma_buffers,
+    i2s::master::{Channels, Config as I2sConfig, DataFormat, I2s},
+    peripherals::{DMA_CH0, GPIO0, GPIO13, GPIO14, GPIO33, GPIO34, I2S0},
+    time::Rate,
+};
 
-/// Audio configuration constants the I²S side must match once wired up.
+use crate::board::SharedI2c;
 
 /// Target sample rate for both codecs.
 pub const SAMPLE_RATE_HZ: u32 = 16_000;
 /// Master clock the ESP32-S3 I²S peripheral feeds both codecs.
 ///
-/// `12.288 MHz = 256 × 48 kHz = 768 × 16 kHz`. Using 768× oversample
-/// at 16 kHz keeps the ES7210 coefficient table row we ported in
-/// `crates/es7210/src/lib.rs` valid (`coeff_div[{12288000, 16000}]`).
+/// `12.288 MHz = 256 × 48 kHz = 768 × 16 kHz`. 768× oversample at
+/// 16 kHz keeps the ES7210 coefficient table row we ported (`coeff_div[
+/// {12288000, 16000}]`) valid.
 pub const MCLK_HZ: u32 = 12_288_000;
 /// Sample bit-depth. AW88298 spec is 16-bit; ES7210 ADC runs 24-bit
 /// internally but truncates to 16-bit over I²S at this slot width.
 pub const BIT_DEPTH_BITS: u8 = 16;
 
+/// Size of the RX DMA circular buffer, in bytes.
+///
+/// Sized to hold roughly ~100 ms of audio at 16 kHz × 16-bit mono
+/// (32 kB/s data rate → ~3.2 kB per 100 ms). Larger buffers tolerate
+/// longer consumer-side processing gaps; smaller ones tighten latency.
+/// 8 KiB is a comfortable middle ground and fits in internal SRAM
+/// (DMA-capable) without impacting the PSRAM framebuffer budget.
+const RX_DMA_BYTES: usize = 8 * 1024;
+
 /// Microphone RMS sample, published per render tick.
 ///
-/// Value is the linear-RMS amplitude of the most recent ~33 ms
-/// audio window, normalised to `[0.0, 1.0]` against full-scale i16
-/// (`32768.0`). A value of `0.01` ≈ -40 dBFS, a value of `0.3` ≈ -10 dBFS.
+/// Value is the linear-RMS amplitude of the most recent ~33 ms audio
+/// window, normalised to `[0.0, 1.0]` against full-scale i16
+/// (`32768.0`). A value of `0.01` ≈ -40 dBFS, `0.3` ≈ -10 dBFS.
 ///
-/// The downstream [`MouthOpenAudio`] modifier (PR 3) converts this to
-/// `dB` + applies an attack/release envelope before writing to the
-/// avatar's `mouth_open` field. Keeping the raw value as the channel
-/// payload lets the modifier stack own the feel-tuning.
+/// The downstream `MouthOpenAudio` modifier (PR 3) converts this to
+/// dB + applies an attack/release envelope before writing to the
+/// avatar's `mouth_open` field.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct AudioRms(pub f32);
 
-/// Microphone RMS channel. Single-producer (the audio task) /
-/// multiple-consumer (modifier pipeline + eventual diagnostics).
+/// Microphone RMS channel. Single-producer (audio task) /
+/// multi-consumer (modifier pipeline + diagnostics).
 ///
-/// Uses `Signal` rather than `Channel` because consumers always want
-/// the latest value, never a backlog — if the modifier misses a frame,
-/// the next one should reflect current mic state, not queued history.
+/// `Signal` semantics (latest-wins, no backlog) match the consumer's
+/// need: if the modifier misses a frame, the next one should reflect
+/// current mic state, not queued history.
 pub static AUDIO_RMS_SIGNAL: Signal<CriticalSectionRawMutex, AudioRms> = Signal::new();
 
-/// Audio-subsystem bring-up error.
-///
-/// Split from the per-driver `Error<E>` types so `main.rs` can log a
-/// single enum — the firmware boot path treats "audio failed" as
-/// degrade-gracefully, not panic.
-#[derive(Debug, defmt::Format)]
-pub enum BringupError {
-    /// AW88298 rejected its init sequence. Wrapped in `defmt::Display2Format`
-    /// to stay `no_std`-compatible without pulling the `E` generic up.
-    AmpInit,
-    /// ES7210 rejected its init sequence.
-    AdcInit,
-}
-
-/// Apply both codec initialisation sequences over the shared I²C bus.
-///
-/// After this returns:
-///
-/// - AW88298 is configured for 16 kHz / 16-bit Philips I²S, muted,
-///   boost disabled, volume at the esp-adf default (-24 dB).
-/// - ES7210 is configured for 12.288 MHz → 16 kHz, mic1+2 active at
-///   ~+30 dB, mic3+4 gated.
-///
-/// Does **not** start any streaming — that's the I²S peripheral's job
-/// (pending PR 2B). The amp stays muted until a future un-mute call
-/// after the I²S master clocks are stable.
-///
-/// ## Known issue pre-PR 2B: ES7210 needs MCLK to answer I²C
-///
-/// The ES7210 gates its I²C state machine on the `MCLK` clock
-/// domain, so until the ESP32-S3 I²S peripheral is configured and
-/// outputting MCLK on GPIO0, this call NACKs at the chip-ID probe
-/// (`BadChipId(0xFF, 0xFF)`). This matches esp-bsp's ordering in
-/// `bsp_audio_codec_microphone_init`, which calls `bsp_audio_init`
-/// (spins up I²S + MCLK) *before* `es7210_codec_new`. PR 2B fixes
-/// the order; until then, expect a warn-level "ES7210 bring-up
-/// failed" at boot on real hardware. AW88298 has no such
-/// dependency — it comes up fine today.
-///
-/// # Errors
-///
-/// - [`BringupError::AmpInit`] if the AW88298 fails its sequence
-///   (usually a NACK from an un-released `RST` pin).
-/// - [`BringupError::AdcInit`] if the ES7210 fails its sequence
-///   (expected until PR 2B — see note above).
-pub async fn bringup<B: I2c>(bus_amp: B, bus_adc: B) -> Result<(), BringupError> {
-    let mut delay = Delay;
-    let mut amp = Aw88298::new(bus_amp);
-    amp.init(&mut delay).await.map_err(|e| {
-        defmt::error!("audio: AW88298 init: {}", defmt::Debug2Format(&e));
-        BringupError::AmpInit
-    })?;
-    defmt::info!(
-        "audio: AW88298 ready — I²S 16 kHz mono, muted, boost off (un-mute via audio task)"
-    );
-
-    let mut adc = Es7210::new(bus_adc);
-    adc.init(&mut delay).await.map_err(|e| {
-        defmt::error!("audio: ES7210 init: {}", defmt::Debug2Format(&e));
-        BringupError::AdcInit
-    })?;
-    defmt::info!("audio: ES7210 ready — 12.288 MHz MCLK / 16 kHz / mic1+2 on");
-    Ok(())
+/// Audio task peripherals, grouped so `main.rs` spawns the task with
+/// a single `Spawner::spawn` call rather than a 9-argument function.
+pub struct AudioPeripherals {
+    /// I²S0 controller.
+    pub i2s: I2S0<'static>,
+    /// DMA channel for the I²S RX path.
+    pub dma: DMA_CH0<'static>,
+    /// Master-clock output pin. CoreS3 schematic: `GPIO0`.
+    pub mclk: GPIO0<'static>,
+    /// Bit-clock output pin. CoreS3 schematic: `GPIO34`.
+    pub bclk: GPIO34<'static>,
+    /// Word-select (LRCK) output pin. CoreS3 schematic: `GPIO33`.
+    pub ws: GPIO33<'static>,
+    /// Data-in pin (ES7210 → ESP32-S3). CoreS3 schematic: `GPIO14`.
+    pub din: GPIO14<'static>,
+    /// Data-out pin (ESP32-S3 → AW88298). CoreS3 schematic: `GPIO13`.
+    /// Held even though this PR doesn't stream TX, so PR 2C/3 can
+    /// wire speaker output without another plumbing change.
+    pub dout: GPIO13<'static>,
+    /// I²C device handle for the AW88298.
+    pub amp_bus: SharedI2c,
+    /// I²C device handle for the ES7210.
+    pub adc_bus: SharedI2c,
 }
 
 /// Audio task entry point.
 ///
-/// **Placeholder until PR 2B lands.** Logs one boot message, then
-/// parks the task forever. [`AUDIO_RMS_SIGNAL`] stays at its default
-/// `AudioRms(0.0)` — consumer modifiers see a silent mic until the
-/// I²S peripheral starts streaming.
+/// Runs the full bring-up sequence (I²S + codecs), then parks
+/// indefinitely. PR 2C replaces the park with the real RMS-processing
+/// loop.
 ///
-/// The signature already takes the pieces the real task will need:
-/// once PR 2B wires I²S, the body becomes an `embassy-futures::select`
-/// between RX DMA completions and the render-tick cadence.
-pub async fn run_audio_loop() -> ! {
+/// Failures at any step log-and-degrade: audio goes silent (signal
+/// stays at `AudioRms(0.0)`) but the rest of the avatar keeps running.
+pub async fn run_audio_task(p: AudioPeripherals) -> ! {
     defmt::info!(
-        "audio: task parked — I²S peripheral wiring pending (PR 2B); RMS signal stays at 0.0"
+        "audio: I²S0 bring-up — {=u32} Hz / {=u8}-bit mono, MCLK {=u32} Hz",
+        SAMPLE_RATE_HZ,
+        BIT_DEPTH_BITS,
+        MCLK_HZ,
     );
+
+    // RX DMA buffers live on the task's stack via the `dma_buffers!`
+    // macro. The buffer outlives the transfer because the task itself
+    // never returns.
+    let (rx_buffer, rx_descriptors, _tx_buffer, _tx_descriptors) = dma_buffers!(RX_DMA_BYTES, 0);
+
+    let i2s = match I2s::new(
+        p.i2s,
+        p.dma,
+        I2sConfig::new_tdm_philips()
+            .with_sample_rate(Rate::from_hz(SAMPLE_RATE_HZ))
+            .with_data_format(DataFormat::Data16Channel16)
+            .with_channels(Channels::MONO),
+    ) {
+        Ok(i2s) => i2s.into_async(),
+        Err(e) => {
+            defmt::error!(
+                "audio: I²S0 config rejected ({:?}); task parking",
+                defmt::Debug2Format(&e)
+            );
+            park_forever().await;
+        }
+    };
+    // `with_mclk` connects the internal MCLK signal to `GPIO0`. MCLK
+    // only *flows* once a DMA transfer starts on the RX or TX side,
+    // so we start RX below.
+    let i2s = i2s.with_mclk(p.mclk);
+
+    let i2s_rx = i2s
+        .i2s_rx
+        .with_bclk(p.bclk)
+        .with_ws(p.ws)
+        .with_din(p.din)
+        .build(rx_descriptors);
+    // `p.dout` is held for future TX streaming (PR 2C / 3); suppress
+    // the unused warning without dropping the pin.
+    let _ = p.dout;
+
+    // Start the RX DMA circular transfer. From this point MCLK / BCLK
+    // / LRCK are all clocking on their pins; ES7210 can now answer
+    // I²C. The transfer keeps running for the lifetime of the task.
+    let _rx_transfer = match i2s_rx.read_dma_circular_async(rx_buffer) {
+        Ok(t) => t,
+        Err(e) => {
+            defmt::error!(
+                "audio: RX DMA start failed ({:?}); task parking",
+                defmt::Debug2Format(&e)
+            );
+            park_forever().await;
+        }
+    };
+    defmt::info!("audio: I²S RX DMA running — MCLK / BCLK / LRCK clocking");
+
+    // MCLK settle. ES7210 datasheet says "a few ms" but empirically
+    // (and per esp-adf), the chip can take longer to latch the clock
+    // domain on cold-boot — give it 200 ms.
+    Timer::after(Duration::from_millis(200)).await;
+
+    let mut delay = Delay;
+    let mut amp = Aw88298::new(p.amp_bus);
+    match amp.init(&mut delay).await {
+        Ok(()) => defmt::info!(
+            "audio: AW88298 ready — I²S 16 kHz mono, muted, boost off (un-mute deferred)"
+        ),
+        Err(e) => {
+            defmt::error!(
+                "audio: AW88298 init failed ({:?}); task parking",
+                defmt::Debug2Format(&e)
+            );
+            park_forever().await;
+        }
+    }
+
+    // ES7210 probe loop. If the first chip-ID read NACKs, retry up to
+    // 5 × 100 ms — accommodates codecs that take a while to wake from
+    // power-on once MCLK is present.
+    let mut adc = Es7210::new(p.adc_bus);
+    let mut attempt = 0;
+    let init_result = loop {
+        match adc.init(&mut delay).await {
+            Ok(()) => break Ok(()),
+            Err(e) if attempt < 5 => {
+                defmt::warn!(
+                    "audio: ES7210 init attempt {=u8} failed ({:?}); retrying",
+                    attempt,
+                    defmt::Debug2Format(&e),
+                );
+                attempt += 1;
+                Timer::after(Duration::from_millis(100)).await;
+            }
+            Err(e) => break Err(e),
+        }
+    };
+    match init_result {
+        Ok(()) => defmt::info!(
+            "audio: ES7210 ready — 12.288 MHz MCLK / 16 kHz / mic1+2 on (attempt {=u8})",
+            attempt
+        ),
+        Err(e) => {
+            defmt::error!(
+                "audio: ES7210 init failed after retries ({:?}); task parking",
+                defmt::Debug2Format(&e)
+            );
+            park_forever().await;
+        }
+    }
+
+    defmt::info!("audio: bring-up complete — I²S RX running, RMS processing TODO (PR 2C)");
+    park_forever().await
+}
+
+/// Infinite sleep for tasks that have nothing else to do. `-> !` so
+/// callers can use it in a no-return branch.
+async fn park_forever() -> ! {
     loop {
         Timer::after(Duration::from_secs(3600)).await;
     }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -408,12 +408,14 @@ async fn mag_task(shared_i2c: SharedI2c) -> ! {
     mag::run_mag_loop(shared_i2c).await
 }
 
-/// Audio task. Today a park loop; in PR 2B this becomes the I²S DMA
-/// read loop that computes mic RMS per render window and publishes to
-/// [`audio::AUDIO_RMS_SIGNAL`].
+/// Audio task. Owns the I²S0 peripheral + DMA, runs the full bring-up
+/// sequence (I²S MCLK first so ES7210 can answer I²C, then both
+/// codecs), and (in PR 2C) will compute mic RMS per render window
+/// publishing to [`audio::AUDIO_RMS_SIGNAL`]. Today parks after
+/// bring-up.
 #[embassy_executor::task]
-async fn audio_task() -> ! {
-    audio::run_audio_loop().await
+async fn audio_task(peripherals: audio::AudioPeripherals) -> ! {
+    audio::run_audio_task(peripherals).await
 }
 
 #[esp_rtos::main]
@@ -527,17 +529,23 @@ async fn main(spawner: Spawner) -> ! {
         defmt::panic!("spawn mag_task failed: {}", defmt::Debug2Format(&e));
     }
 
-    // Audio bring-up: configure AW88298 + ES7210 over shared I²C. Does
-    // not start I²S streaming (that's PR 2B). Failures are warn-only —
+    // Audio subsystem. The task owns I²S0 + DMA + audio pins and
+    // runs the full bring-up sequence itself (I²S MCLK first, then
+    // AW88298, then ES7210). Failures inside the task log-and-park —
     // audio degrades to "silent mic, muted speaker" rather than
-    // halting the boot, since the rest of the avatar still works.
-    let amp_bus = I2cDevice::new(board_io.i2c_bus);
-    let adc_bus = I2cDevice::new(board_io.i2c_bus);
-    match audio::bringup(amp_bus, adc_bus).await {
-        Ok(()) => defmt::info!("audio: codecs up (I²S streaming pending PR 2B)"),
-        Err(e) => defmt::warn!("audio: bring-up failed ({:?}) — audio disabled", e),
-    }
-    if let Err(e) = spawner.spawn(audio_task()) {
+    // halting the avatar.
+    let audio_periph = audio::AudioPeripherals {
+        i2s: peripherals.I2S0,
+        dma: peripherals.DMA_CH0,
+        mclk: peripherals.GPIO0,
+        bclk: peripherals.GPIO34,
+        ws: peripherals.GPIO33,
+        din: peripherals.GPIO14,
+        dout: peripherals.GPIO13,
+        amp_bus: I2cDevice::new(board_io.i2c_bus),
+        adc_bus: I2cDevice::new(board_io.i2c_bus),
+    };
+    if let Err(e) = spawner.spawn(audio_task(audio_periph)) {
         defmt::panic!("spawn audio_task failed: {}", defmt::Debug2Format(&e));
     }
 


### PR DESCRIPTION
## Summary

PR 2B of the audio stack. The firmware audio task now owns the ESP32-S3 I²S0 peripheral + DMA, brings up both codecs from inside the task with MCLK running first (fixing the ES7210 I²C clock-domain gate identified in PR 2A's boot log), and parks after bring-up. Sample processing + RMS publication land in PR 2C.

### What's in

- **`audio::AudioPeripherals`** groups `I2S0`, `DMA_CH0`, `GPIO0`/34/33/14/13, and the two I²C device handles so `main.rs` spawns with a single arg.
- **`audio::run_audio_task`** performs, in order:
  1. `I2s::new` at 16 kHz / 16-bit mono Philips on I²S0 + `DMA_CH0`
  2. `with_mclk(GPIO0)` — MCLK pin muxing
  3. `i2s_rx.build` wiring BCLK/LRCK/DIN
  4. `read_dma_circular_async` — RX DMA starts; MCLK / BCLK / LRCK now clocking
  5. 200 ms settle
  6. `Aw88298::init`
  7. `Es7210::init` with 5×100 ms retry
  8. Park (PR 2C adds the RMS-processing loop)
- **`main.rs`** spawns `audio_task(AudioPeripherals)` with the grouped peripherals. No more boot-time `audio::bringup` call.
- **`SharedI2c`** alias reused from the `board` module (dropped the duplicate in `audio.rs`).

### Hardware flash

Flashed to this CoreS3 unit. Relevant defmt log:

```
audio: I²S0 bring-up — 16000 Hz / 16-bit mono, MCLK 12288000 Hz
audio: I²S RX DMA running — MCLK / BCLK / LRCK clocking
audio: AW88298 ready — I²S 16 kHz mono, muted, boost off
audio: ES7210 init attempt 0 failed (BadChipId(255, 255)); retrying
… (4 more retries, all NACK)
audio: ES7210 init failed after retries
```

- ✅ I²S peripheral accepts the config without error
- ✅ RX DMA starts and runs for the lifetime of the task
- ✅ AW88298 still comes up after the reorder
- ⚠ **ES7210 still returns `0xFF / 0xFF`** even with ~700 ms of MCLK. Same flash shows BMM150 `NotDetected`, BMI270 init failure, FT6336U vendor ID `0x01` — all on the sensor/audio I²C chain. Plausibly hardware on this specific unit rather than firmware; worth scope-probing GPIO0 or trying on a second kit.

### Known / deferred

- **ES7210 root cause** — needs scope or second unit. Firmware is now ordered correctly (MCLK before I²C); if ES7210 keeps NACKing on a known-good device we have a real firmware bug to chase
- **PR 2C** — drain the DMA buffer, compute RMS per render-window, publish `AUDIO_RMS_SIGNAL`, add sqrt dep
- **PR 3** — `Mouth::mouth_open` field + `MouthOpenAudio` modifier (attack 20 ms / release 100 ms) + firmware binding + optional speaker TX sine on emotion change

### Test plan

- [x] `just check` passes
- [x] `cargo +esp build --release` compiles clean
- [x] `just fmr` flashes; I²S logs confirm MCLK / BCLK / LRCK clocking and AW88298 ready
- [ ] Resolve ES7210 NACK (separate PR — scope probe or swap unit)