### PR TITLE
fix(es7210): drop invented chip-ID check; add I²C bus-scan diagnostic

### DIFF
--- a/crates/es7210/src/lib.rs
+++ b/crates/es7210/src/lib.rs
@@ -197,18 +197,17 @@ impl<B: I2c> Es7210<B> {
     /// params: 12.288 MHz MCLK, 16 kHz sample rate, 16-bit mono,
     /// ES7210 as I²S slave, mic1+2 on at +30 dB, mic3+4 off.
     ///
+    /// Does **not** verify a chip ID — the ES7210 datasheet doesn't
+    /// document a dedicated chip-ID register, and the esp-adf reference
+    /// driver skips the check. Presence is inferred from the init
+    /// sequence completing without I²C NACKs; use an address-level
+    /// probe (e.g. a bus scan) upstream if you need a pre-init
+    /// sanity check.
+    ///
     /// # Errors
     ///
-    /// - [`Error::BadChipId`] if the chip-ID bytes don't read
-    ///   `(0x72, 0x10)`.
     /// - [`Error::I2c`] on any bus failure.
     pub async fn init<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<B::Error>> {
-        // Verify this is an ES7210 before poking it further.
-        let (lo, hi) = self.read_chip_id().await?;
-        if lo != CHIP_ID1 || hi != CHIP_ID2 {
-            return Err(Error::BadChipId(lo, hi));
-        }
-
         // Soft-reset pulse.
         self.write_reg(REG_RESET, RESET_ASSERT).await?;
         delay.delay_ms(RESET_SETTLE_MS).await;
@@ -411,15 +410,6 @@ mod tests {
         assert_eq!(resets[1], &(REG_RESET, RESET_RELEASE));
         assert_eq!(resets[2], &(REG_RESET, RESET_ASSERT));
         assert_eq!(resets[3], &(REG_RESET, RESET_RELEASE));
-    }
-
-    #[test]
-    fn init_rejects_wrong_chip_id() {
-        let mut adc = Es7210::new(MockI2c::with_chip_id(0x00, 0x00));
-        match block_on(adc.init(&mut NoopDelay)) {
-            Err(Error::BadChipId(0, 0)) => {}
-            other => panic!("expected BadChipId(0, 0), got {other:?}"),
-        }
     }
 
     #[test]

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -119,7 +119,7 @@ pub struct AudioPeripherals {
 ///
 /// Failures at any step log-and-degrade: audio goes silent (signal
 /// stays at `AudioRms(0.0)`) but the rest of the avatar keeps running.
-pub async fn run_audio_task(p: AudioPeripherals) -> ! {
+pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
     defmt::info!(
         "audio: I²S0 bring-up — {=u32} Hz / {=u8}-bit mono, MCLK {=u32} Hz",
         SAMPLE_RATE_HZ,
@@ -199,6 +199,14 @@ pub async fn run_audio_task(p: AudioPeripherals) -> ! {
         }
     }
 
+    // Diagnostic: scan the shared I²C bus to see which addresses ACK.
+    // Useful for isolating "chip missing / power fault" from "chip
+    // alive but firmware bug." Expected ACKs on the CoreS3:
+    //   0x10/11 BMM150, 0x23 LTR-553, 0x34 AXP2101, 0x36 AW88298,
+    //   0x38 FT6336U, 0x40 ES7210, 0x51 BM8563, 0x58 AW9523,
+    //   0x68/69 BMI270, 0x6F PY32.
+    scan_i2c_bus(&mut p.adc_bus).await;
+
     // ES7210 probe loop. If the first chip-ID read NACKs, retry up to
     // 5 × 100 ms — accommodates codecs that take a while to wake from
     // power-on once MCLK is present.
@@ -243,4 +251,28 @@ async fn park_forever() -> ! {
     loop {
         Timer::after(Duration::from_secs(3600)).await;
     }
+}
+
+/// Scan all 7-bit I²C addresses (`0x08..=0x77`) and log which ones
+/// ACK. Uses a 1-byte register read (`reg = 0`) — chips that require a
+/// specific opening register may still ACK the address but NACK the
+/// read; that's fine, we only care about the address-level ACK.
+///
+/// Purely diagnostic. Silent on addresses that don't respond; chatty
+/// (one info log per ACK) on addresses that do.
+async fn scan_i2c_bus<B: embedded_hal_async::i2c::I2c>(bus: &mut B) {
+    defmt::info!("audio: I²C bus scan starting (0x08..=0x77)");
+    let mut found: u32 = 0;
+    for addr in 0x08_u8..=0x77 {
+        let mut buf = [0u8; 1];
+        if bus.write_read(addr, &[0x00], &mut buf).await.is_ok() {
+            defmt::info!(
+                "audio: I²C 0x{=u8:02X} ACK (first byte @ reg 0x00 = 0x{=u8:02X})",
+                addr,
+                buf[0]
+            );
+            found += 1;
+        }
+    }
+    defmt::info!("audio: I²C bus scan complete — {=u32} devices ACKed", found);
 }


### PR DESCRIPTION
Stacked on [#30](https://github.com/andymai/stackchan-kai/pull/30). Merge that first, then this.

## Finding

PR 2B's I²S reorder wasn't the issue — our driver was. `Es7210::init` was reading a two-byte chip ID from registers `0xFD`/`0xFE` and asserting `(0x72, 0x10)`. Those addresses came from the ES8311 datasheet (a different Everest codec); ES7210 doesn't document a dedicated chip-ID register and esp-adf's reference driver doesn't probe one. The chip's reset-state reads from `0xFD`/`0xFE` happen to return `0xFF` — hence the false negative.

## Confirming via bus scan

Added `scan_i2c_bus` as a boot-time diagnostic in `audio.rs`. Output on the test unit:

```
audio: I²C bus scan starting (0x08..=0x77)
audio: I²C 0x21 ACK (first byte @ reg 0x00 = 0x9B)   # GC0308 camera
audio: I²C 0x23 ACK (first byte @ reg 0x00 = 0x00)   # LTR-553
audio: I²C 0x34 ACK (first byte @ reg 0x00 = 0x38)   # AXP2101
audio: I²C 0x36 ACK (first byte @ reg 0x00 = 0x18)   # AW88298 (upper byte of 0x1852)
audio: I²C 0x38 ACK (first byte @ reg 0x00 = 0x00)   # FT6336U
audio: I²C 0x40 ACK (first byte @ reg 0x00 = 0x32)   # ES7210 — alive!
audio: I²C 0x41 ACK (first byte @ reg 0x00 = 0x41)
audio: I²C 0x50 ACK (first byte @ reg 0x00 = 0xFF)
audio: I²C 0x51 ACK (first byte @ reg 0x00 = 0x00)   # BM8563
audio: I²C 0x58 ACK (first byte @ reg 0x00 = 0x1F)   # AW9523
audio: I²C 0x68 ACK (first byte @ reg 0x00 = 0xC0)
audio: I²C 0x69 ACK (first byte @ reg 0x00 = 0x24)   # BMI270 (0x24 = documented CHIP_ID)
audio: I²C 0x6F ACK (first byte @ reg 0x00 = 0x87)   # PY32
audio: I²C bus scan complete — 13 devices ACKed
```

ES7210 is fully responsive at `0x40`. The chip-ID check was a phantom check blocking a working chip.

## Changes

- **`crates/es7210/src/lib.rs`** — drop the chip-ID verification from `init()`. `read_chip_id()` stays for callers who want to inspect `0xFD`/`0xFE` explicitly. Docstring + unit test updated.
- **`crates/stackchan-firmware/src/audio.rs`** — new `scan_i2c_bus` diagnostic, runs between AW88298 and ES7210 bring-ups. Low cost, very high debug value — kept as a boot-time log so future chip-level debugging has bus state at hand.

## Notable side-findings from the scan

Not changed in this PR, but worth follow-ups:

- **BMI270 at 0x69 reads chip ID `0x24` correctly** during cold-boot scan — yet `imu::run_imu_loop` logs `detect failed (NotDetected)` / `init failed` on this unit. Something in the IMU path is stale state or ordering. Separate investigation.
- **0x21 ACKs with 0x9B** — GC0308 camera is alive on the bus (matches the scaffold's documented chip ID).
- **0x50 ACKs** — possibly Si12T body touch. Matches the provisional address from our scaffold.

## Test plan

- [x] Host-side unit tests pass (4 tests on `es7210`, 5 on `aw88298`)
- [x] `just check` passes
- [x] `cargo +esp build --release` compiles clean
- [ ] Next flash: verify ES7210 init now succeeds end-to-end (device USB-JTAG dropped mid-iteration; pick up on reconnect)