### PR TITLE
feat(draw): visibly render Mouth::mouth_open as growing ellipse

### DIFF
--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -131,13 +131,27 @@ where
     )
 }
 
+/// Maximum pixel height the audio-driven `mouth_open` can add to the
+/// drawn mouth. At `mouth_open = 1.0` the mouth ellipse gains this
+/// many pixels of total height (i.e. this many pixels of `radius_y`
+/// growth mirrored across the center line).
+///
+/// Chosen to land roughly in line with the Surprised weight-100
+/// ellipse (40 px tall) so a loud-speech mouth reads as "open" without
+/// towering over the eyes.
+const MOUTH_OPEN_MAX_HEIGHT_PX: f32 = 40.0;
+
 /// Draw the mouth. Decision tree:
 ///
 /// 1. `curve != 0`: stroked parabolic arc. `curve > 0` (Happy) smiles,
-///    `curve < 0` (Sad) frowns. `Mouth::weight` is ignored.
-/// 2. Else `weight == 0`: horizontal resting line (v0.1.0 neutral mouth).
-/// 3. Else: filled ellipse whose height scales with `weight` (v0.1.0
-///    open-mouth behavior — Surprised uses this path).
+///    `curve < 0` (Sad) frowns. `Mouth::weight` and `mouth_open` are
+///    ignored — arcs stay as the v0.1.0 smile/frown look. (Follow-up
+///    can composite an audio-driven open ellipse behind the arc.)
+/// 2. Else: filled ellipse whose height is the maximum of the
+///    weight-derived height (emotion's static open-mouth — Surprised
+///    uses this) and the `mouth_open`-derived audio height. When both
+///    are zero, falls back to a horizontal resting line (v0.1.0
+///    neutral mouth).
 fn draw_mouth<D>(mouth: &Mouth, curve: i8, target: &mut D) -> Result<(), D::Error>
 where
     D: DrawTarget<Color = Rgb565>,
@@ -156,7 +170,9 @@ where
         );
     }
 
-    let height = scaled_height(mouth.radius_y, mouth.weight);
+    let weight_height = scaled_height(mouth.radius_y, mouth.weight);
+    let audio_height = audio_open_height(mouth.mouth_open);
+    let height = weight_height.max(audio_height);
     if height == 0 {
         return draw_horizontal_line(
             mouth.center.x,
@@ -176,6 +192,30 @@ where
     Ellipse::new(top_left, size)
         .into_styled(fill(MOUTH_COLOR))
         .draw(target)
+}
+
+/// Map `Mouth::mouth_open` (`0.0..=1.0`) to an ellipse height in pixels.
+///
+/// Non-finite values, values below 0, and values above 1 clamp to
+/// `[0.0, 1.0]` before scaling. Returns 0 when `mouth_open` is at or
+/// below zero, so a fresh avatar (audio silent) renders the same
+/// horizontal line as before this feature landed.
+fn audio_open_height(mouth_open: f32) -> u16 {
+    let clamped = if mouth_open.is_nan() || mouth_open <= 0.0 {
+        0.0
+    } else if mouth_open >= 1.0 {
+        1.0
+    } else {
+        mouth_open
+    };
+    let pixels = clamped * MOUTH_OPEN_MAX_HEIGHT_PX;
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "pixels is clamped to [0, MOUTH_OPEN_MAX_HEIGHT_PX]; fits in u16"
+    )]
+    let rounded = pixels as u16;
+    rounded
 }
 
 /// Draw a cheek circle below `eye` with color blended between white and

--- a/crates/stackchan-sim/tests/render_snapshot.rs
+++ b/crates/stackchan-sim/tests/render_snapshot.rs
@@ -56,3 +56,80 @@ fn out_of_bounds_reads_return_none() {
     assert!(fb.pixel(WIDTH, 0).is_none());
     assert!(fb.pixel(0, HEIGHT).is_none());
 }
+
+#[test]
+fn audio_open_lifts_mouth_above_resting_line() {
+    // Default avatar has `weight = 0` + `mouth_curve = 0` → 3 px
+    // horizontal pink stroke centered on y=180. With `mouth_open =
+    // 1.0` the audio-driven ellipse grows to ~40 px tall (radius_y
+    // = 20), painting mouth colour at centre column y values well
+    // outside the 3 px stroke.
+    let mouth_pink = Rgb565::new(30, 32, 16);
+
+    // Pre-condition: centre column at y=175 is background on the
+    // resting mouth (3 px stroke covers y=179..=181 only).
+    let mut resting = Framebuffer::new(WIDTH, HEIGHT);
+    Avatar::default()
+        .draw(&mut resting)
+        .expect("Framebuffer DrawTarget is Infallible");
+    assert_eq!(
+        resting.pixel(160, 175),
+        Some(Rgb565::WHITE),
+        "pre-condition: y=175 is background when mouth_open = 0.0"
+    );
+    assert_eq!(
+        resting.pixel(160, 185),
+        Some(Rgb565::WHITE),
+        "pre-condition: y=185 is background when mouth_open = 0.0"
+    );
+
+    // With full-scale audio (mouth_open = 1.0) the ellipse spans
+    // roughly y=160..=199, comfortably including both y=175 and y=185.
+    let mut avatar = Avatar::default();
+    avatar.mouth.mouth_open = 1.0;
+    let mut open = Framebuffer::new(WIDTH, HEIGHT);
+    avatar
+        .draw(&mut open)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    assert_eq!(
+        open.pixel(160, 175),
+        Some(mouth_pink),
+        "mouth_open=1.0 should paint y=175"
+    );
+    assert_eq!(
+        open.pixel(160, 185),
+        Some(mouth_pink),
+        "mouth_open=1.0 should paint y=185"
+    );
+
+    // Mouth centre stays pink.
+    assert_eq!(open.pixel(160, 180), Some(mouth_pink), "mouth centre");
+}
+
+#[test]
+fn audio_open_zero_renders_identical_to_default_avatar() {
+    // Backwards-compat: a freshly-defaulted avatar (mouth_open = 0.0)
+    // must render exactly as it did before this feature landed.
+    let mut default_fb = Framebuffer::new(WIDTH, HEIGHT);
+    Avatar::default()
+        .draw(&mut default_fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    let mut avatar = Avatar::default();
+    avatar.mouth.mouth_open = 0.0;
+    let mut zero_fb = Framebuffer::new(WIDTH, HEIGHT);
+    avatar
+        .draw(&mut zero_fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            assert_eq!(
+                default_fb.pixel(x, y),
+                zero_fb.pixel(x, y),
+                "pixel ({x}, {y}) should match default avatar"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes the visible half of the mic → mouth-animation feature. PR 32 declared `Mouth::mouth_open` and wired the modifier; this PR teaches `Avatar::draw` to actually paint it. Landing now means the moment PR 2C publishes real RMS samples, the mouth animates — no further renderer changes required.

## Changes

- **`draw_mouth`** — in the non-arc path (emotion's `mouth_curve == 0`: Neutral / Sleepy / Surprised), the drawn ellipse height is now `max(weight_derived, mouth_open_derived)`. Audio drives the dynamic open-amount on top of emotion's static geometry. Cap: `MOUTH_OPEN_MAX_HEIGHT_PX = 40.0` (≈ Surprised at weight=100).
- **`audio_open_height(f32) -> u16`** — pure helper with explicit clamping. NaN, negative, and >1.0 all normalise to `[0, 40]` so a pathological avatar state can't poison the render.
- **Arc path unchanged** (Happy / Sad). Emotion's smile / frown stays the v0.1.0 look. Follow-up can composite an audio-driven open behind the arc if desired.

## Tests

Two new sim snapshot tests in `stackchan-sim/tests/render_snapshot.rs`:

- `audio_open_lifts_mouth_above_resting_line` — `mouth_open = 1.0` paints centre-column pixels at y=175 and y=185 (well outside the 3 px resting line), confirming the ellipse grows
- `audio_open_zero_renders_identical_to_default_avatar` — every pixel of a `mouth_open = 0.0` avatar matches the default, proving this is a strict extension with no regression

## Test plan

- [x] `just check` passes
- [x] 3 new sim tests pass
- [ ] Next CoreS3 flash: visible open-mouth once PR 2C publishes real RMS; until then the default `AudioRms(0.0)` keeps `mouth_open = 0.0` and renders are pixel-identical to main