### PR TITLE
fix(firmware): I²C 400 kHz + justfile reliability fixes

### DIFF
--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -125,15 +125,18 @@ pub async fn bringup(
     uart_rx: GPIO7<'static>,
     delay: &mut Delay,
 ) -> BoardIo {
-    // Internal I²C0: 100 kHz standard-mode rate — works from cold boot
-    // before PLLs are fully settled. AXP2101 / AW9523 / PY32 all share
-    // this bus.
-    let i2c_cfg = I2cConfig::default().with_frequency(Rate::from_khz(100));
+    // Internal I²C0: 400 kHz fast-mode. Every device on this bus
+    // (AXP2101, AW9523, BM8563, BMI270, BMM150, FT6336U, LTR-553,
+    // AW88298, ES7210, PY32) supports 400 kHz, and the lower-latency
+    // transactions matter for BMI270's 64-chunk config-blob upload —
+    // at 100 kHz the blob upload contends hard with the other tasks
+    // on the shared bus and trips timeouts mid-init.
+    let i2c_cfg = I2cConfig::default().with_frequency(Rate::from_khz(400));
     let i2c = match I2c::new(i2c_periph, i2c_cfg) {
         Ok(bus) => bus.with_sda(sda).with_scl(scl).into_async(),
         Err(e) => defmt::panic!("I2C0 config rejected: {}", defmt::Debug2Format(&e)),
     };
-    defmt::debug!("I2C0 ready on GPIO12/11 @ 100 kHz");
+    defmt::debug!("I2C0 ready on GPIO12/11 @ 400 kHz");
 
     let mut pmic = axp2101::Axp2101::new(i2c);
     loop {

--- a/justfile
+++ b/justfile
@@ -60,17 +60,40 @@ build-firmware:
 # recipes go through espflash over the serial-JTAG port. The `sg dialout`
 # wrapper is required until dialout group membership is active in the
 # interactive shell's supplementary groups.
+#
+# ## USB-Serial-JTAG reliability
+#
+# Prefer `fmr` (combined flash + monitor) over separate `flash; monitor`
+# calls — each espflash invocation toggles DTR/RTS to reset the chip,
+# and back-to-back resets against ESP32-S3's USB-Serial-JTAG peripheral
+# can wedge the USB enumeration until a physical power cycle. The
+# combined form issues one reset and transitions straight to monitor,
+# keeping the port open. See `just reattach` for a no-reset way to
+# pick up a running device's log without reflashing.
 
 # Flash the latest release build. Rebuilds first.
+# Prefer `fmr` for normal flash-and-monitor cycles — this recipe is
+# split out only for CI or scripted workflows that don't want a monitor
+# attached.
 flash: build-firmware
     sg dialout -c "espflash flash --port {{PORT}} {{firmware_elf}}"
 
 # Monitor defmt logs from a running device (no reflash). Exits on Ctrl+C.
+# Default form triggers a chip reset on attach — use `just reattach`
+# instead to preserve the current boot state.
 monitor:
     sg dialout -c "espflash monitor --port {{PORT}} --log-format defmt --elf {{firmware_elf}}"
 
+# Re-attach to a running device *without* resetting it. Useful when a
+# monitor session dropped (`Ctrl+C`, terminal closed, ssh dropped) and
+# you want to pick up the log stream without restarting the firmware.
+# Also the safer choice when debugging the USB-JTAG disconnect pattern.
+reattach:
+    sg dialout -c "espflash monitor --no-reset --port {{PORT}} --log-format defmt --elf {{firmware_elf}}"
+
 # Flash + monitor in one recipe. `fmr` = flash-monitor-reload, the
 # default inner-loop verb. Build first, then flash, then stream logs.
+# One port-open, one reset — preferred over split `flash; monitor`.
 fmr: build-firmware
     sg dialout -c "espflash flash --monitor --log-format defmt --port {{PORT}} {{firmware_elf}}"
 


### PR DESCRIPTION
## Summary

Two reliability fixes triaged in today's session:

### 1. I²C speed: 100 kHz → 400 kHz (fast-mode)

Boot logs were consistently showing BMI270 init timeout:

```
BMI270: init failed (I2c(I2c(Timeout)))
```

Root cause: BMI270 uploads an 8192-byte config blob in 64 × 128-byte chunks. With the audio RX DMA + mag + ambient + button + led tasks all sharing the bus, contention at 100 kHz tripped the per-transaction timeout somewhere in that 64-chunk loop. Every peripheral on the CoreS3's main I²C bus (AXP2101, AW9523, BM8563, BMI270, BMM150, FT6336U, LTR-553, AW88298, ES7210, PY32) supports 400 kHz per its datasheet, so bumping the bus rate is free.

Post-fix, BMI270 no longer times out. It now fails with a different error (`AcknowledgeCheckFailed(Data)` — a separate chip-protocol issue) but it's progress: we cleared the timing-contention hazard.

### 2. USB-Serial-JTAG disconnects → justfile reliability

Kernel logs were showing `usb 1-5.3: USB disconnect` events requiring physical replug. Correlated cleanly with bursts of back-to-back `espflash` invocations — each one toggles DTR/RTS, reset cycles stress the USB-JTAG peripheral, and enough back-to-back resets wedge enumeration.

Idle-runtime sanity check: I ran `espflash monitor` on an unattended device for ~112 s. **Zero drops.** The firmware runtime is healthy; the disconnects are entirely flash/reset-cycle driven.

Mitigations:

- New `just reattach` recipe — `espflash monitor --no-reset`, picks up a running device's log without triggering another reset
- Warning comment on the `flash` and `monitor` recipes recommending `fmr` for the normal flow (one reset per cycle instead of two)
- Explanatory note in the "Flash + monitor" section documenting the USB-JTAG reset pattern so future maintainers don't reinvent the split-mode footgun

## Out of scope

- BMI270's new `AcknowledgeCheckFailed(Data)` error (filed as follow-up; likely needs explicit inter-step delays the 100 kHz bus provided naturally)
- BMM150 not detected on this unit (probably damaged — `0x10` and `0x11` both silent in the bus scan)
- FT6336U vendor ID reading `0x01` instead of `0x11` (likely unit-specific)

## Test plan

- [x] `just check` passes
- [x] `cargo +esp build --release` clean
- [x] Flashed to CoreS3; boot logs confirm:
  - `audio: ES7210 ready — 12.288 MHz MCLK / 16 kHz / mic1+2 on (attempt 0)` ✅
  - `audio: AW88298 ready` ✅
  - BMI270 error changed from `Timeout` → `AcknowledgeCheckFailed(Data)` (progress: no longer a contention issue)
- [x] No USB disconnects during this PR's flash + monitor cycle