### PR TITLE
fix(bmi270): add inter-chunk settle delay during config-blob upload

### DIFF
--- a/crates/bmi270/src/lib.rs
+++ b/crates/bmi270/src/lib.rs
@@ -149,9 +149,23 @@ const BLOB_CHUNK_BYTES: usize = 128;
 /// increments by per chunk.
 const BLOB_CHUNK_WORDS: usize = BLOB_CHUNK_BYTES / 2;
 
-/// Post-soft-reset settling delay, in microseconds. Bosch reference
-/// uses 450 µs; we use 1 ms for robustness.
-const SOFTRESET_SETTLE_US: u32 = 1_000;
+/// Post-soft-reset settling delay, in microseconds. Bosch's reference
+/// uses 450 µs, but on CoreS3 at 400 kHz I²C the chip NACKs at the
+/// address level on the next transaction if we only wait that long
+/// (the soft-reset takes the I²C state machine offline for longer
+/// than the spec implies). 5 ms is conservative and init-time cost
+/// is negligible.
+const SOFTRESET_SETTLE_US: u32 = 5_000;
+/// Inter-chunk settling delay for the config-blob upload, in
+/// microseconds. The BMI270 internal state machine needs a brief gap
+/// between successive 128-byte `INIT_DATA` bursts; at 100 kHz I²C the
+/// transaction itself provided that gap naturally, but at 400 kHz the
+/// chunks arrive fast enough that the chip starts `NACK`ing mid-stream
+/// (`AcknowledgeCheckFailed(Data)`). ESP-IDF reference drivers use
+/// 1 ms between chunks — tried 100 µs first, which wasn't enough on
+/// this CoreS3 (chip still `NACK`ed), so 1 ms it is. 64 × 1 ms = 64 ms
+/// of extra init time, negligible.
+const BLOB_CHUNK_SETTLE_US: u32 = 1_000;
 /// Post-blob-upload init-complete poll delay, in milliseconds.
 const INIT_POLL_DELAY_MS: u32 = 20;
 /// Maximum attempts at polling [`REG_INTERNAL_STATUS`] before giving
@@ -326,6 +340,7 @@ impl<B: I2c> Bmi270<B> {
             self.write_register(REG_INIT_ADDR_0, addr_lo).await?;
             self.write_register(REG_INIT_ADDR_1, addr_hi).await?;
             self.burst_write(REG_INIT_DATA, chunk).await?;
+            delay.delay_us(BLOB_CHUNK_SETTLE_US).await;
             // u16 cannot overflow: 8192 / 2 = 4096 words max.
             word_offset = word_offset.saturating_add(chunk_words);
         }


### PR DESCRIPTION
## Summary

Follow-up to PR #34's I²C speed bump. PR 34 cleared BMI270's `Timeout` error at 100 kHz but surfaced `AcknowledgeCheckFailed(Data)` mid-blob at 400 kHz — the chip's internal state machine can't keep pace with back-to-back 128-byte `INIT_DATA` bursts at fast-mode.

## Changes

Two defensive timing bumps in `crates/bmi270/src/lib.rs`:

- **`BLOB_CHUNK_SETTLE_US` = 1000** (new) — 1 ms delay after each 128-byte chunk's `burst_write`. Matches Bosch / ESP-IDF reference drivers. Total overhead: 64 chunks × 1 ms = 64 ms of extra init time.
- **`SOFTRESET_SETTLE_US` = 5000** (up from 1000) — chip takes longer than datasheet-spec 450 µs to come back on I²C after soft-reset at 400 kHz; next transaction was NACKing at the address level with 1 ms wait.

## Hardware results on Andy's unit

Iterated three times on device. Each increment revealed the next bottleneck:

| Config | BMI270 result |
|---|---|
| Pre-PR-34 (100 kHz) | `Timeout` mid-blob |
| PR 34 (400 kHz, no chunk delay) | `AcknowledgeCheckFailed(Data)` mid-blob |
| + 100 µs chunk delay | Still `Data` NACK |
| + 1 ms chunk delay | `Data` NACK **gone**; new error `AcknowledgeCheckFailed(Address)` post-soft-reset |
| + 1 ms chunk + 5 ms soft-reset settle | **This PR's state**: post-reset address NACK gone; now hits `Timeout` at some later write |

So the Data and Address NACKs are both cleared. BMI270 still fails to complete init on this specific unit (now with `Timeout`) — I suspect either bus contention with the concurrently-running audio bring-up, or chip damage specific to Andy's kit (consistent with BMM150 being dead and FT6336U returning wrong vendor ID on the same unit).

## What this PR does and doesn't do

- **Does**: make BMI270 init more robust by two independently-motivated timing bumps. Both changes are defensive and match reference-driver practice.
- **Doesn't**: fully resolve BMI270 init on Andy's unit. Further debug likely needs a second kit, a scope on SDA/SCL, or a refactor to sequence audio bring-up after IMU bring-up so the bus is quiet during the 64-chunk blob upload.

Worth merging on its own — both delays are the right thing regardless of the remaining issue.

## Test plan

- [x] `just check` passes
- [x] `cargo +esp build --release` clean
- [x] Hardware-flashed through three iterations; each timing bump cleared the error it targeted
- [ ] Follow-up PR: either sequence audio after IMU, or investigate on known-good unit