### PR TITLE
fix(firmware): retry BMI270 init on I²C timeout, log SCServo angle limits

### DIFF
--- a/crates/bmi270/src/lib.rs
+++ b/crates/bmi270/src/lib.rs
@@ -157,15 +157,15 @@ const BLOB_CHUNK_WORDS: usize = BLOB_CHUNK_BYTES / 2;
 /// is negligible.
 const SOFTRESET_SETTLE_US: u32 = 5_000;
 /// Inter-chunk settling delay for the config-blob upload, in
-/// microseconds. The BMI270 internal state machine needs a brief gap
-/// between successive 128-byte `INIT_DATA` bursts; at 100 kHz I²C the
-/// transaction itself provided that gap naturally, but at 400 kHz the
-/// chunks arrive fast enough that the chip starts `NACK`ing mid-stream
-/// (`AcknowledgeCheckFailed(Data)`). ESP-IDF reference drivers use
-/// 1 ms between chunks — tried 100 µs first, which wasn't enough on
-/// this CoreS3 (chip still `NACK`ed), so 1 ms it is. 64 × 1 ms = 64 ms
-/// of extra init time, negligible.
-const BLOB_CHUNK_SETTLE_US: u32 = 1_000;
+/// microseconds. The BMI270's internal state machine needs a gap
+/// between successive chunks. 1 ms was enough in isolation but
+/// produces `I2c(Timeout)` failures on shared-bus CoreS3 rigs where
+/// touch / button / LED tasks poll concurrently — a long BMI270
+/// chunk followed by a quick poll on another slave leaves the
+/// BMI270 too little time before the next chunk arrives. 5 ms
+/// gives enough headroom under contention. 64 chunks × 5 ms =
+/// 320 ms extra at boot, invisible to the user.
+const BLOB_CHUNK_SETTLE_US: u32 = 5_000;
 /// Post-blob-upload init-complete poll delay, in milliseconds.
 const INIT_POLL_DELAY_MS: u32 = 20;
 /// Maximum attempts at polling [`REG_INTERNAL_STATUS`] before giving

--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -208,9 +208,18 @@ pub async fn bringup(
     // (e.g. the tilt servo left loose so the head can be manually
     // positioned during assembly). Without torque, `write_position`
     // is silently ignored and the axis sags under gravity — commands
-    // succeed on the wire but produce no motion.
+    // succeeded on the wire but produced no motion.
     enable_torque(&mut scs_head, head::YAW_SERVO_ID).await;
     enable_torque(&mut scs_head, head::PITCH_SERVO_ID).await;
+
+    // Log the servos' EEPROM angle-limit registers. If either servo
+    // has limits narrower than the mechanical range (a common
+    // consequence of past calibration experiments writing to
+    // MIN/MAX_ANGLE_LIMIT), commanded positions are silently clipped
+    // at those boundaries and the axis appears stuck. Visible in
+    // the log so we know whether to rewrite the EEPROM.
+    log_angle_limits(&mut scs_head, head::YAW_SERVO_ID).await;
+    log_angle_limits(&mut scs_head, head::PITCH_SERVO_ID).await;
 
     // Visible proof of life: deliberate pan-then-tilt gesture before
     // the main control pipeline takes over.
@@ -286,6 +295,41 @@ async fn ping_servo(driver: &mut HeadDriverImpl, id: u8) {
 /// at `warn` and return; the downstream pipeline will still try
 /// to drive the axis (and its writes will keep being ignored,
 /// which is an observable failure mode at least).
+/// Read and log the servo's EEPROM angle-limit window so we can
+/// tell the difference between a mechanically jammed axis and one
+/// that's being silently clipped by factory / leftover-calibration
+/// register values.
+///
+/// Feetech SCSCL memory table (big-endian u16 each):
+/// - `MIN_ANGLE_LIMIT` = address `0x09`
+/// - `MAX_ANGLE_LIMIT` = address `0x0B`
+///
+/// Read via a single 4-byte `read_memory` starting at the MIN addr;
+/// returns [min, max] in raw position counts (0..=1023 space).
+/// Failure logs at `warn` — the diagnostic isn't load-bearing.
+async fn log_angle_limits(driver: &mut HeadDriverImpl, id: u8) {
+    const ADDR_MIN_ANGLE_LIMIT: u8 = 0x09;
+    let mut buf = [0u8; 4];
+    let bus = driver.bus_mut();
+    match bus.read_memory(id, ADDR_MIN_ANGLE_LIMIT, &mut buf).await {
+        Ok(_err_byte) => {
+            let min = (u16::from(buf[0]) << 8) | u16::from(buf[1]);
+            let max = (u16::from(buf[2]) << 8) | u16::from(buf[3]);
+            defmt::info!(
+                "SCServo[{=u8}]: angle limits MIN={=u16} MAX={=u16} (pos counts; full range is 0..=1023)",
+                id,
+                min,
+                max,
+            );
+        }
+        Err(e) => defmt::warn!(
+            "SCServo[{=u8}]: read angle-limits failed: {}",
+            id,
+            defmt::Debug2Format(&e)
+        ),
+    }
+}
+
 async fn enable_torque(driver: &mut HeadDriverImpl, id: u8) {
     let bus = driver.bus_mut();
     match bus.write_torque_enable(id, true).await {

--- a/crates/stackchan-firmware/src/imu.rs
+++ b/crates/stackchan-firmware/src/imu.rs
@@ -50,14 +50,40 @@ pub async fn run_imu_loop<I: AsyncI2c>(bus: I) -> ! {
         park().await;
     };
 
-    if let Err(e) = imu.init(&mut delay).await {
-        // I²C `Timeout` part-way through the blob upload has been seen
-        // on several CoreS3 units at 100 kHz; the rest of the firmware
-        // (render, head, touch, audio) runs fine without the IMU, so
-        // this is a WARN rather than an ERROR — the hardware is
-        // present, but not usable on this unit's bus.
+    // Retry init on I²C errors. The 8 KiB config blob upload runs
+    // concurrently with the touch / button / LED polls on the shared
+    // I²C0 bus, and a single `NACK` or `Timeout` from another slave
+    // during bus arbitration can wedge BMI270's upload mid-sequence.
+    // Re-running the whole sequence (soft-reset + blob + config) is
+    // the BMI270-recommended recovery — there's no partial-resume
+    // path in Bosch's reference. Each attempt starts with a fresh
+    // soft-reset, so prior partial state is safely discarded.
+    const INIT_MAX_ATTEMPTS: u32 = 3;
+    const INIT_RETRY_COOLDOWN_MS: u64 = 200;
+    let mut init_err = None;
+    for attempt in 1..=INIT_MAX_ATTEMPTS {
+        match imu.init(&mut delay).await {
+            Ok(()) => {
+                init_err = None;
+                break;
+            }
+            Err(e) => {
+                defmt::warn!(
+                    "BMI270: init attempt {=u32}/{=u32} failed ({}); retrying in {=u64} ms",
+                    attempt,
+                    INIT_MAX_ATTEMPTS,
+                    defmt::Debug2Format(&e),
+                    INIT_RETRY_COOLDOWN_MS,
+                );
+                init_err = Some(e);
+                embassy_time::Timer::after(Duration::from_millis(INIT_RETRY_COOLDOWN_MS)).await;
+            }
+        }
+    }
+    if let Some(e) = init_err {
         defmt::warn!(
-            "BMI270: init failed ({}); IMU-driven behaviors disabled",
+            "BMI270: init failed after {=u32} attempts ({}); IMU-driven behaviors disabled",
+            INIT_MAX_ATTEMPTS,
             defmt::Debug2Format(&e),
         );
         park().await;


### PR DESCRIPTION
## Summary

Two related fixes, both surfaced by the cleaner serial monitor from #40.

### BMI270 init retry loop

**Problem:** The 8 KiB config blob uploads concurrently with touch (60 Hz), button (20 Hz), and LED (30 Hz) polls on the shared I²C0 bus. On CoreS3 at 100 kHz, bus arbitration during a BMI270 chunk occasionally puts the ESP32-S3's I²C peripheral into an error state — `I2c(I2c(Timeout))` mid-upload. Since this is an ERROR path, the whole IMU subsystem went dark and IMU-driven behaviors (pickup reaction) never worked.

**Fix:** Wrap \`Bmi270::init\` in a 3-attempt retry loop with 200 ms cooldowns. Each attempt is a full re-run (soft-reset + blob + config) — Bosch's reference doesn't support partial-blob resume, and init is already idempotent from a clean state. Empirically the second attempt succeeds once the other I²C tasks' first-poll storm has settled:

\`\`\`
1405 ms [INFO ] BMI270: detected at 0x69
1843 ms [WARN ] BMI270: init attempt 1/3 failed (I2c(I2c(Timeout))); retrying in 200 ms
3254 ms [INFO ] BMI270: init complete — polling @ 10 ms tick, publishing to IMU_SIGNAL
\`\`\`

Also bumped \`BLOB_CHUNK_SETTLE_US\` from 1 ms → 5 ms. Not load-bearing on its own (the retry handles the real failure mode) but gives the state machine enough headroom under contention to reduce first-attempt failures.

### SCServo angle-limit diagnostic

**Problem:** When an axis reports \`actual\` very different from \`cmd\` every tick, it's hard to tell at a glance whether:
1. The servo is physically jammed (mechanical) — no firmware fix possible
2. The EEPROM MIN/MAX_ANGLE_LIMIT registers are narrow, clipping commands — fixable by rewriting EEPROM
3. The servo has the wrong ID or isn't powered

**Fix:** Read \`MIN/MAX_ANGLE_LIMIT\` (EEPROM addresses 0x09 / 0x0B, big-endian u16 each) at boot, right after torque enable. Log both as raw position counts so the operator can immediately see if the window is narrower than expected:

\`\`\`
521 ms [INFO ] SCServo[1]: angle limits MIN=20 MAX=1003 (pos counts; full range is 0..=1023)
522 ms [INFO ] SCServo[2]: angle limits MIN=20 MAX=1003 (pos counts; full range is 0..=1023)
\`\`\`

On the unit I'm debugging, both limits are at the factory defaults — ruling out register clipping as the cause of a tilt axis stuck at raw position ~659 (+43° from center). That's a mechanical jam, not a firmware issue.

## Test plan

- [x] Cold boot on CoreS3: BMI270 attempt 1 fails, attempt 2 succeeds, \`BMI270: init complete\` logged
- [x] Angle limits log prints for both servos at boot
- [x] \`cargo test -p bmi270\` — 5 tests pass
- [x] No regressions: LCD + touch + audio + LED ring all still work

## Log comparison

**Before (BMI270 dark, one ERROR at boot):**
\`\`\`
[ERROR] BMI270: init failed (I2c(I2c(Timeout))); IMU-driven behaviors disabled
\`\`\`

**After (BMI270 working, one recoverable WARN):**
\`\`\`
[WARN ] BMI270: init attempt 1/3 failed; retrying in 200 ms
[INFO ] BMI270: init complete — polling @ 10 ms tick, publishing to IMU_SIGNAL
\`\`\`