### PR TITLE
fix: tilt calibration for offset-encoder unit + asymmetric range support

### DIFF
--- a/crates/aw88298/src/lib.rs
+++ b/crates/aw88298/src/lib.rs
@@ -77,7 +77,7 @@ const REG_HAGCCFG4: u8 = 0x0C;
 /// `BSTCTRL2` register. Boost converter mode + current-limit config.
 const REG_BSTCTRL2: u8 = 0x61;
 
-/// Reset-magic written to [`REG_RESET`].
+/// Reset-magic written to `REG_RESET`.
 const RESET_MAGIC: u16 = 0x55AA;
 /// `SYSCTRL` value: `I2SEN = 1`, `AMPPD = 0`, `PWDN = 0`.
 const SYSCTRL_ENABLE: u16 = 0x4040;
@@ -98,7 +98,7 @@ const BSTCTRL2_BOOST_OFF: u16 = 0x0673;
 /// Post-reset settle delay, in milliseconds. Datasheet ≥1 ms.
 const RESET_SETTLE_MS: u32 = 5;
 
-/// Supported I²S sample rates. Nibble value written into [`REG_I2SCTRL`].
+/// Supported I²S sample rates. Nibble value written into `REG_I2SCTRL`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum SampleRate {

--- a/crates/es7210/src/lib.rs
+++ b/crates/es7210/src/lib.rs
@@ -40,9 +40,9 @@ use embedded_hal_async::{delay::DelayNs, i2c::I2c};
 /// Default 7-bit I²C address with `AD1 = AD0 = GND`.
 pub const ADDRESS: u8 = 0x40;
 
-/// Expected chip-ID low byte at [`REG_CHIP_ID1`].
+/// Expected chip-ID low byte at `REG_CHIP_ID1`.
 pub const CHIP_ID1: u8 = 0x72;
-/// Expected chip-ID high byte at [`REG_CHIP_ID2`].
+/// Expected chip-ID high byte at `REG_CHIP_ID2`.
 pub const CHIP_ID2: u8 = 0x10;
 
 /// `RESET` register. `0x71` asserts software reset, `0x41` releases.

--- a/crates/stackchan-core/src/head.rs
+++ b/crates/stackchan-core/src/head.rs
@@ -15,9 +15,10 @@
 //! - **Sign:** positive pan = head turns right from the *viewer's* POV
 //!   (the servo horn rotates clockwise looking down on the head). Positive
 //!   tilt = head nods up (chin rises).
-//! - **Range:** conservative `±MAX_PAN_DEG` / `±MAX_TILT_DEG` defaults
-//!   chosen to stay well inside SG90 mechanical limits, leaving headroom
-//!   for servo-horn alignment error. Firmware const-table trim is applied
+//! - **Range:** conservative pan range `±MAX_PAN_DEG` is symmetric, but
+//!   tilt is asymmetric `[MIN_TILT_DEG, MAX_TILT_DEG]` because the
+//!   Stack-chan chassis cutout permits upward but not downward head
+//!   travel from horizontal. Firmware const-table trim is applied
 //!   *after* Pose is produced, so the core-visible range is uniform.
 
 use crate::clock::Instant;
@@ -30,7 +31,18 @@ use crate::clock::Instant;
 /// hard plastic stops that will grind gear teeth if overshot.
 pub const MAX_PAN_DEG: f32 = 45.0;
 
-/// Conservative upper bound on tilt travel in degrees (±).
+/// Lower bound on tilt travel in degrees.
+///
+/// Asymmetric with [`MAX_TILT_DEG`] because Stack-chan's chassis
+/// cutout typically blocks downward head travel — the head's
+/// mechanical rest position already sits at the lower stop.
+/// Modifiers that request negative tilt (e.g. `EmotionHead::Sad`/
+/// `Sleepy`'s downcast bias) are silently clamped to `MIN_TILT_DEG`
+/// by [`Pose::clamped`]; the emotion's other channels (eyes, mouth,
+/// LEDs) still differentiate.
+pub const MIN_TILT_DEG: f32 = 0.0;
+
+/// Upper bound on tilt travel in degrees.
 ///
 /// Tilt has tighter mechanical limits than pan on most StackChan bases
 /// (the pan servo sits under the tilt linkage). Matches the 1000–2000 µs
@@ -65,7 +77,9 @@ impl Pose {
         Self { pan_deg, tilt_deg }
     }
 
-    /// Return this pose clamped to `±MAX_PAN_DEG` / `±MAX_TILT_DEG`.
+    /// Return this pose clamped to `±MAX_PAN_DEG` for pan and
+    /// `[MIN_TILT_DEG, MAX_TILT_DEG]` for tilt (asymmetric — see the
+    /// per-axis const docs).
     ///
     /// NaN inputs collapse to `NEUTRAL` for that axis — servos cannot
     /// honour a non-number command, and silently passing NaN into a
@@ -73,20 +87,29 @@ impl Pose {
     /// neutral fallback instead of panicking keeps the modifier pipeline
     /// robust under arithmetic mishaps.
     #[must_use]
-    pub fn clamped(self) -> Self {
+    pub const fn clamped(self) -> Self {
         Self {
-            pan_deg: clamp_or_zero(self.pan_deg, MAX_PAN_DEG),
-            tilt_deg: clamp_or_zero(self.tilt_deg, MAX_TILT_DEG),
+            pan_deg: clamp_symmetric_or_zero(self.pan_deg, MAX_PAN_DEG),
+            tilt_deg: clamp_range_or_zero(self.tilt_deg, MIN_TILT_DEG, MAX_TILT_DEG),
         }
     }
 }
 
 /// Clamp `value` into `[-max, +max]`, collapsing NaN to `0.0`.
-fn clamp_or_zero(value: f32, max: f32) -> f32 {
+const fn clamp_symmetric_or_zero(value: f32, max: f32) -> f32 {
     if value.is_nan() {
         0.0
     } else {
         value.clamp(-max, max)
+    }
+}
+
+/// Clamp `value` into `[min, max]`, collapsing NaN to `0.0`.
+const fn clamp_range_or_zero(value: f32, min: f32, max: f32) -> f32 {
+    if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(min, max)
     }
 }
 
@@ -134,14 +157,25 @@ mod tests {
     fn clamped_respects_safe_range() {
         let p = Pose::new(100.0, -100.0).clamped();
         assert_eq!(p.pan_deg, MAX_PAN_DEG);
-        assert_eq!(p.tilt_deg, -MAX_TILT_DEG);
+        // Tilt is asymmetric — negative inputs clamp up to MIN_TILT_DEG.
+        assert_eq!(p.tilt_deg, MIN_TILT_DEG);
+        let q = Pose::new(-100.0, 100.0).clamped();
+        assert_eq!(q.pan_deg, -MAX_PAN_DEG);
+        assert_eq!(q.tilt_deg, MAX_TILT_DEG);
     }
 
     #[test]
     fn clamped_preserves_in_range_values() {
-        let p = Pose::new(10.0, -5.0).clamped();
+        // Tilt of -5 is below MIN_TILT_DEG (0), so it'll clamp to 0.
+        let p = Pose::new(10.0, 5.0).clamped();
         assert_eq!(p.pan_deg, 10.0);
-        assert_eq!(p.tilt_deg, -5.0);
+        assert_eq!(p.tilt_deg, 5.0);
+    }
+
+    #[test]
+    fn clamped_tilt_lower_bound_is_zero() {
+        let p = Pose::new(0.0, -1.0).clamped();
+        assert_eq!(p.tilt_deg, MIN_TILT_DEG);
     }
 
     #[test]

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -40,6 +40,6 @@ pub mod modifiers;
 pub use avatar::{Avatar, Eye, EyePhase, Mouth, Point, SCALE_DEFAULT};
 pub use clock::{Clock, Instant};
 pub use emotion::Emotion;
-pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, Pose};
+pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use modifiers::Modifier;

--- a/crates/stackchan-core/src/modifiers/emotion_head.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_head.rs
@@ -175,8 +175,11 @@ impl Modifier for EmotionHead {
             avatar.head_pose.pan_deg - self.last_applied.pan_deg,
             avatar.head_pose.tilt_deg - self.last_applied.tilt_deg,
         );
-        let combined =
-            Pose::new(upstream.pan_deg + bias.pan_deg, upstream.tilt_deg + bias.tilt_deg).clamped();
+        let combined = Pose::new(
+            upstream.pan_deg + bias.pan_deg,
+            upstream.tilt_deg + bias.tilt_deg,
+        )
+        .clamped();
         self.last_applied = HeadBias {
             pan_deg: combined.pan_deg - upstream.pan_deg,
             tilt_deg: combined.tilt_deg - upstream.tilt_deg,

--- a/crates/stackchan-core/src/modifiers/emotion_head.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_head.rs
@@ -166,16 +166,22 @@ impl Modifier for EmotionHead {
         let bias = self.current_bias(now);
 
         // Layered compose via diff-and-undo (matches `IdleSway` /
-        // `Breath`): subtract the previous tick's bias, then add the
-        // new one. Keeps the bias a delta on `avatar.head_pose` rather
-        // than accumulating across ticks when upstream modifiers (e.g.
-        // a future additive head-pose source) write the pose each tick.
-        let combined = Pose::new(
-            avatar.head_pose.pan_deg - self.last_applied.pan_deg + bias.pan_deg,
-            avatar.head_pose.tilt_deg - self.last_applied.tilt_deg + bias.tilt_deg,
+        // `Breath`): subtract our previous *applied* (post-clamp) bias
+        // from the current pose to recover upstream, add the new bias
+        // request, then clamp. Storing the effective contribution into
+        // `last_applied` (rather than the intended `bias`) keeps the
+        // next tick's "undo" honest under asymmetric tilt clamping.
+        let upstream = Pose::new(
+            avatar.head_pose.pan_deg - self.last_applied.pan_deg,
+            avatar.head_pose.tilt_deg - self.last_applied.tilt_deg,
         );
-        avatar.head_pose = combined.clamped();
-        self.last_applied = bias;
+        let combined =
+            Pose::new(upstream.pan_deg + bias.pan_deg, upstream.tilt_deg + bias.tilt_deg).clamped();
+        self.last_applied = HeadBias {
+            pan_deg: combined.pan_deg - upstream.pan_deg,
+            tilt_deg: combined.tilt_deg - upstream.tilt_deg,
+        };
+        avatar.head_pose = combined;
     }
 }
 
@@ -279,20 +285,39 @@ mod tests {
 
     #[test]
     fn bias_is_additive_on_top_of_existing_pose() {
-        // Simulate IdleSway writing first, then EmotionHead biasing.
+        // Use a positive-tilt emotion so the test exercises additive
+        // composition without colliding with the asymmetric tilt clamp
+        // (downward tilts get pinned to MIN_TILT_DEG = 0 — see below).
         let mut avatar = Avatar::default();
-        avatar.emotion = Emotion::Sleepy;
+        avatar.emotion = Emotion::Happy;
         let mut eh = EmotionHead::new();
 
         // Advance past transition so the full bias applies.
-        avatar.head_pose = Pose::new(2.0, -1.5); // sway output
+        avatar.head_pose = Pose::new(2.0, 1.5); // sway output
         eh.update(
             &mut avatar,
             Instant::from_millis(EmotionHead::TRANSITION_MS + 1),
         );
-        // Sleepy tilt bias is -6 → final tilt = -1.5 + -6 = -7.5.
+        // Happy tilt bias is +3 → final tilt = 1.5 + 3 = 4.5.
         assert_eq!(avatar.head_pose.pan_deg, 2.0);
-        assert_eq!(avatar.head_pose.tilt_deg, -7.5);
+        assert_eq!(avatar.head_pose.tilt_deg, 4.5);
+    }
+
+    #[test]
+    fn negative_tilt_bias_clamps_to_min_when_combined() {
+        // Sleepy's bias is -6°; with `MIN_TILT_DEG = 0` (chassis can't
+        // tilt below horizontal) the combined pose pins to 0.
+        use crate::head::MIN_TILT_DEG;
+        let mut avatar = Avatar::default();
+        avatar.emotion = Emotion::Sleepy;
+        let mut eh = EmotionHead::new();
+
+        avatar.head_pose = Pose::new(0.0, -1.5);
+        eh.update(
+            &mut avatar,
+            Instant::from_millis(EmotionHead::TRANSITION_MS + 1),
+        );
+        assert_eq!(avatar.head_pose.tilt_deg, MIN_TILT_DEG);
     }
 
     #[test]
@@ -301,29 +326,29 @@ mod tests {
         // track the tilt trajectory across the mid-transition flip. With
         // diff-and-undo composition, the interesting invariant is that
         // the eventual steady-state matches the destination emotion; at
-        // no point does the bias double-count. This replaces the older
-        // pattern of resetting head_pose=0 every tick, which measured
-        // the absolute bias value only meaningful under absolute-set
-        // semantics.
+        // no point does the bias double-count.
+        //
+        // Uses Surprised (+2°) and Happy (+3°) — both in-range positive
+        // biases — so the asymmetric tilt clamp doesn't mask the
+        // re-anchoring behaviour we're testing.
         let mut avatar = Avatar::default();
         avatar.emotion = Emotion::Neutral;
         let mut eh = EmotionHead::new();
         eh.update(&mut avatar, Instant::from_millis(0));
         assert_eq!(avatar.head_pose.tilt_deg, 0.0, "Neutral snaps to zero bias");
 
-        // Flip to Sleepy; midway through the transition the bias is ~-3.
-        avatar.emotion = Emotion::Sleepy;
+        // Flip to Surprised; midway through the transition the bias is ~+1.
+        avatar.emotion = Emotion::Surprised;
         eh.update(&mut avatar, Instant::from_millis(0));
         eh.update(&mut avatar, Instant::from_millis(150));
-        let mid_sleepy = avatar.head_pose.tilt_deg;
+        let mid_surprised = avatar.head_pose.tilt_deg;
         assert!(
-            (mid_sleepy - (-3.0)).abs() < 0.1,
-            "mid-transition Sleepy tilt should be ~-3, got {mid_sleepy}"
+            (mid_surprised - 1.0).abs() < 0.1,
+            "mid-transition Surprised tilt should be ~+1, got {mid_surprised}"
         );
 
-        // Flip to Happy mid-transition. `from` should re-anchor to
-        // whatever `to` was before (Sleepy's final bias of -6). After
-        // the new 300 ms window elapses, we land on Happy's +3.
+        // Flip to Happy mid-transition. After the new window elapses,
+        // we land on Happy's +3.
         avatar.emotion = Emotion::Happy;
         eh.update(&mut avatar, Instant::from_millis(150));
         eh.update(
@@ -344,37 +369,51 @@ mod tests {
         // additively, EmotionHead must subtract the previous tick's bias
         // before adding the new one — otherwise a steady-state emotion
         // would see its bias compound each tick.
+        //
+        // Uses Happy (+3°) — a positive in-range bias — so the
+        // asymmetric tilt clamp can't disguise an accumulation bug
+        // by saturating both the buggy and correct cases at MIN_TILT_DEG.
         let mut avatar = Avatar::default();
-        avatar.emotion = Emotion::Sleepy; // -6° tilt bias at steady state
+        avatar.emotion = Emotion::Happy; // +3° tilt bias at steady state
         let mut eh = EmotionHead::new();
 
         // Drive past the transition, then many more ticks. The tilt must
-        // stay at -6, not drift to -12, -18, ...
+        // stay at +3, not drift to +6, +9, ...
         for i in 0..=50 {
             eh.update(
                 &mut avatar,
                 Instant::from_millis(EmotionHead::TRANSITION_MS + i * 33),
             );
         }
-        assert_eq!(avatar.head_pose.tilt_deg, -6.0);
+        assert_eq!(avatar.head_pose.tilt_deg, 3.0);
     }
 
     #[test]
     fn clamp_engages_when_combined_exceeds_safe_range() {
-        use crate::head::MAX_TILT_DEG;
+        use crate::head::{MAX_TILT_DEG, MIN_TILT_DEG};
 
+        // Upper clamp: hostile upstream + Happy (+3) push past MAX.
+        let mut avatar = Avatar::default();
+        avatar.emotion = Emotion::Happy;
+        avatar.head_pose = Pose::new(0.0, 29.0);
+        let mut eh = EmotionHead::new();
+        eh.update(
+            &mut avatar,
+            Instant::from_millis(EmotionHead::TRANSITION_MS + 1),
+        );
+        assert_eq!(avatar.head_pose.tilt_deg, MAX_TILT_DEG);
+
+        // Lower clamp: hostile upstream + Sleepy (-6) push below MIN.
+        // Asymmetric tilt range — MIN_TILT_DEG is 0, not -MAX_TILT_DEG.
         let mut avatar = Avatar::default();
         avatar.emotion = Emotion::Sleepy;
-        // A hostile IdleSway output that would push the combined tilt
-        // past MAX_TILT_DEG (30°).
         avatar.head_pose = Pose::new(0.0, -29.0);
         let mut eh = EmotionHead::new();
         eh.update(
             &mut avatar,
             Instant::from_millis(EmotionHead::TRANSITION_MS + 1),
         );
-        // -29 + Sleepy(-6) = -35, clamped to -MAX_TILT_DEG.
-        assert_eq!(avatar.head_pose.tilt_deg, -MAX_TILT_DEG);
+        assert_eq!(avatar.head_pose.tilt_deg, MIN_TILT_DEG);
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/idle_sway.rs
+++ b/crates/stackchan-core/src/modifiers/idle_sway.rs
@@ -61,11 +61,16 @@ pub struct IdleSway {
     pan_amplitude_deg: f32,
     /// Peak tilt amplitude in degrees.
     tilt_amplitude_deg: f32,
-    /// Pan contribution applied on the previous tick; subtracted before
-    /// writing the new contribution. Starts at 0 so the first tick's
-    /// output equals the first triangle sample.
+    /// Pan contribution **as actually applied** on the previous tick
+    /// (post-clamp), subtracted before writing the new contribution.
+    /// Storing the *effective* contribution rather than the *intended*
+    /// one keeps diff-and-undo accurate when `Pose::clamped` truncates
+    /// our request — without this, a clamped negative half-cycle would
+    /// leak into the next positive half as a permanent bias, doubling
+    /// the apparent amplitude.
     last_pan_deg: f32,
-    /// Tilt contribution applied on the previous tick.
+    /// Tilt contribution as actually applied on the previous tick. See
+    /// [`Self::last_pan_deg`] — same diff-and-undo correctness reason.
     last_tilt_deg: f32,
 }
 
@@ -147,18 +152,17 @@ impl Modifier for IdleSway {
     fn update(&mut self, avatar: &mut Avatar, now: Instant) {
         let pan = Self::unit_triangle(self.pan_period_ms, now) * self.pan_amplitude_deg;
         let tilt = Self::unit_triangle(self.tilt_period_ms, now) * self.tilt_amplitude_deg;
-        // Diff-and-undo: our contribution to the pose is (pan, tilt); to
-        // compose additively, remove the previous contribution first,
-        // then install the new one. `clamped` defers to the final
-        // compose step (typically EmotionHead) so we don't double-clamp
-        // during the intermediate state.
-        avatar.head_pose = Pose::new(
-            avatar.head_pose.pan_deg - self.last_pan_deg + pan,
-            avatar.head_pose.tilt_deg - self.last_tilt_deg + tilt,
-        )
-        .clamped();
-        self.last_pan_deg = pan;
-        self.last_tilt_deg = tilt;
+        // Diff-and-undo: recover upstream pose by removing our last
+        // *applied* contribution, then add the new request and clamp.
+        // Storing the effective (post-clamp) contribution into
+        // `last_*_deg` keeps the next tick's "undo" honest under
+        // asymmetric clamping — see field docs.
+        let upstream_pan = avatar.head_pose.pan_deg - self.last_pan_deg;
+        let upstream_tilt = avatar.head_pose.tilt_deg - self.last_tilt_deg;
+        let new_pose = Pose::new(upstream_pan + pan, upstream_tilt + tilt).clamped();
+        self.last_pan_deg = new_pose.pan_deg - upstream_pan;
+        self.last_tilt_deg = new_pose.tilt_deg - upstream_tilt;
+        avatar.head_pose = new_pose;
     }
 }
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -124,3 +124,11 @@ path = "examples/aw88298_bench.rs"
 [[example]]
 name = "es7210_bench"
 path = "examples/es7210_bench.rs"
+
+[[example]]
+name = "tilt_extremes"
+path = "examples/tilt_extremes.rs"
+
+[[example]]
+name = "tilt_freewheel"
+path = "examples/tilt_freewheel.rs"

--- a/crates/stackchan-firmware/examples/tilt_extremes.rs
+++ b/crates/stackchan-firmware/examples/tilt_extremes.rs
@@ -1,0 +1,470 @@
+//! Tilt-axis extremes calibration bench.
+//!
+//! Drives the pitch (tilt) servo to a graduated sequence of commanded
+//! angles past the firmware's normal `MAX_TILT_DEG` (±30°) safety
+//! window — up to ±50° — and reads back the live encoder position at
+//! each step. Wherever the readback stops climbing, that's the
+//! effective upward stop; same for downward. Companion to
+//! `examples/bench.rs`, which only exercises the conservative
+//! ±20° trim-discovery range.
+//!
+//! The "stop" we measure is whichever of the two clips the servo
+//! first: the EEPROM `MIN_ANGLE_LIMIT` / `MAX_ANGLE_LIMIT` registers
+//! (logged at boot by `board::bringup`), or the physical hard stop in
+//! the linkage. Compare the SUMMARY line below against the boot-log
+//! angle limits to disambiguate:
+//!
+//! - SUMMARY plateau matches angle-limit raw count → EEPROM is
+//!   clipping; rewrite the limits to widen the window.
+//! - SUMMARY plateau is well inside the angle-limit raw count → it's
+//!   the physical linkage hitting a stop; calibrate `TILT_TRIM_DEG`
+//!   to the observed midpoint or check for mechanical interference.
+//!
+//! ## Workflow
+//!
+//! ```text
+//! source ~/export-esp.sh
+//! just tilt-extremes
+//! ```
+//!
+//! The binary sweeps once and halts; re-flash main firmware with
+//! `just fmr` when done. Output per step:
+//!
+//! ```text
+//! tilt-extremes  cmd=+25.00  raw=597  actual_deg=+24.93  delta=-0.07
+//! ```
+//!
+//! Final SUMMARY line reports the observed `actual_deg` extremes plus
+//! suggested EEPROM angle-limit values + a `TILT_TRIM_DEG` to centre
+//! commanded zero on the mechanical midpoint.
+
+#![no_std]
+#![no_main]
+// Same allowances as `examples/bench.rs`.
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Timer};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use scservo::{ADDR_PRESENT_POSITION, POSITION_CENTER, POSITION_PER_DEGREE};
+use stackchan_core::{Clock, HeadDriver, Pose};
+use stackchan_firmware::{board, clock::HalClock, head};
+
+// esp-println registers the global defmt logger via USB-Serial-JTAG.
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor — see `examples/bench.rs` for the rationale.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("tilt-extremes panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// 32 KiB matches `examples/bench.rs` — no framebuffer here.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Dwell after each commanded angle before reading the encoder. 400 ms
+/// is twice bench's 300 ms — extreme commands need extra settle time
+/// because the servo's interpolation may stall against a hard stop
+/// before the moving-flag clears.
+const DWELL_MS: u64 = 400;
+
+/// Per-`read_position` timeout. 10 ms covers the ~200 µs round-trip
+/// at 1 Mbaud plus the servo's response latency, with margin.
+const READ_TIMEOUT_MS: u64 = 10;
+
+/// "Plateau" threshold in degrees: if successive `actual_deg` readings
+/// differ by less than this, we've hit a stop. 1.0° corresponds to
+/// ~3.4 raw counts — well above encoder noise + interpolation jitter.
+const PLATEAU_DELTA_DEG: f32 = 1.0;
+
+/// Sweep step in degrees. 5° gives 10 samples between 0° and ±50° —
+/// fine enough to localise a stop within the noise budget without
+/// needlessly hammering the servo.
+const STEP_DEG: f32 = 5.0;
+
+/// Outer-bound commanded angle. The Stack-chan tilt servo has ~90°
+/// of mechanical range; setting the probe ceiling to 95° pushes
+/// just past the expected hard stop so the plateau detector reliably
+/// catches it. SCSCL position counts saturate at 0 / 1023 well past
+/// this (~±150°), so the value is safe for the wire protocol.
+const MAX_PROBE_DEG: f32 = 95.0;
+
+/// Step count from 0° to `MAX_PROBE_DEG` inclusive, in one direction.
+/// Hardcoded rather than computed because `f32::ceil` / `f32::abs`
+/// aren't in core no_std without pulling in `libm`. Update if
+/// `MAX_PROBE_DEG` / `STEP_DEG` change — the runtime assert below
+/// catches drift.
+const MAX_STEPS: u32 = 19;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "esp_rtos::main macro requires the `spawner` arg; extremes doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-tilt-extremes v{} — commanded sweep to find tilt mechanical / EEPROM stops",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let mut driver = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await
+    .head;
+
+    // --- Servo health snapshot before the sweep ---------------------------
+    // Reads voltage / temperature / present-position-with-error-byte once,
+    // so the operator can see if the pitch servo has latched a fault
+    // (overload, undervoltage, overheat) that would prevent it from
+    // moving regardless of commanded position. Failures here are non-
+    // fatal — log and proceed.
+    log_health(&mut driver, head::PITCH_SERVO_ID).await;
+
+    // --- Up-sweep: 0° → +MAX_PROBE_DEG, stop early if encoder plateaus -----
+    defmt::info!("tilt-extremes: starting UP sweep (0° → +{=f32}°)", MAX_PROBE_DEG);
+    let upper = sweep(&mut driver, "up", STEP_DEG).await;
+
+    // Return to centre before reversing direction so we don't whip
+    // through 0° at full servo speed.
+    let _ = command(&mut driver, Pose::new(0.0, 0.0)).await;
+    Timer::after(Duration::from_millis(DWELL_MS)).await;
+
+    // --- Down-sweep: 0° → -MAX_PROBE_DEG, same plateau exit -----------------
+    defmt::info!(
+        "tilt-extremes: starting DOWN sweep (0° → -{=f32}°)",
+        MAX_PROBE_DEG
+    );
+    let lower = sweep(&mut driver, "down", -STEP_DEG).await;
+
+    // Centre, log summary, halt.
+    let _ = command(&mut driver, Pose::NEUTRAL).await;
+    Timer::after(Duration::from_millis(DWELL_MS)).await;
+
+    print_summary(lower, upper);
+
+    defmt::info!(
+        "tilt-extremes complete — re-flash main firmware with `just fmr` to resume normal boot"
+    );
+    loop {
+        Timer::after(Duration::from_secs(5)).await;
+    }
+}
+
+/// Drive tilt from 0° outward in `step_deg` increments (positive for
+/// up-sweep, negative for down-sweep) until either the encoder
+/// plateaus or we reach `MAX_PROBE_DEG`. Returns the last *actual*
+/// angle observed before the plateau (or at the last step, if no
+/// plateau was hit).
+async fn sweep(
+    driver: &mut board::HeadDriverImpl,
+    label: &'static str,
+    step_deg: f32,
+) -> f32 {
+    let mut prev_actual_deg: f32 = 0.0;
+    let mut last_actual_deg: f32 = 0.0;
+    let mut cmd_deg: f32 = 0.0;
+    debug_assert!(
+        f32::from(u16::try_from(MAX_STEPS).unwrap_or(u16::MAX))
+            * STEP_DEG
+            >= MAX_PROBE_DEG - f32::EPSILON,
+        "MAX_STEPS out of sync with MAX_PROBE_DEG / STEP_DEG"
+    );
+
+    for i in 0..=MAX_STEPS {
+        // u32 ≤ 10 is exact in f32. step_deg is ±STEP_DEG, so cmd_deg
+        // ranges 0..±MAX_PROBE_DEG inclusive without overshoot.
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "i ≤ MAX_STEPS (10), losslessly representable in f32"
+        )]
+        let i_f = i as f32;
+        cmd_deg = step_deg * i_f;
+
+        if let Err(e) = command(driver, Pose::new(0.0, cmd_deg)).await {
+            defmt::warn!(
+                "tilt-extremes {}: set_pose err at cmd={=f32}: {}",
+                label,
+                cmd_deg,
+                defmt::Debug2Format(&e)
+            );
+            return last_actual_deg;
+        }
+        Timer::after(Duration::from_millis(DWELL_MS)).await;
+
+        let raw = match read_pitch(driver).await {
+            Some(p) => p,
+            None => continue,
+        };
+        let actual_deg = raw_to_deg(raw);
+        let delta = actual_deg - cmd_deg;
+        defmt::info!(
+            "tilt-extremes {}: cmd={=f32}  raw={=u16}  actual_deg={=f32}  delta={=f32}",
+            label,
+            cmd_deg,
+            raw,
+            actual_deg,
+            delta,
+        );
+
+        // Plateau detection: skip the first sample (no prior reading
+        // to compare against) and the centring sample at i=0.
+        if i > 0 && (actual_deg - prev_actual_deg).abs() < PLATEAU_DELTA_DEG {
+            defmt::info!(
+                "tilt-extremes {}: PLATEAU detected at cmd={=f32} (actual={=f32}, prev={=f32}); stopping sweep",
+                label,
+                cmd_deg,
+                actual_deg,
+                prev_actual_deg,
+            );
+            return actual_deg;
+        }
+        prev_actual_deg = actual_deg;
+        last_actual_deg = actual_deg;
+    }
+
+    defmt::info!(
+        "tilt-extremes {}: reached MAX_PROBE_DEG cap (cmd={=f32}, actual={=f32}) without plateau",
+        label,
+        cmd_deg,
+        last_actual_deg,
+    );
+    last_actual_deg
+}
+
+/// Issue a `set_pose` and surface the driver error directly.
+async fn command(
+    driver: &mut board::HeadDriverImpl,
+    pose: Pose,
+) -> Result<(), <board::HeadDriverImpl as HeadDriver>::Error> {
+    driver.set_pose(pose, HalClock.now()).await
+}
+
+/// Read the live pitch encoder *and* the servo's status error byte,
+/// returning `None` (with a logged warn) on transport / timeout
+/// failure so the sweep can keep going. The error byte is logged
+/// inline (with decoded flag names) any time it's non-zero — that's
+/// the canonical "why isn't this servo moving" signal.
+async fn read_pitch(driver: &mut board::HeadDriverImpl) -> Option<u16> {
+    let bus = driver.bus_mut();
+    let mut buf = [0u8; 2];
+    match embassy_time::with_timeout(
+        Duration::from_millis(READ_TIMEOUT_MS),
+        bus.read_memory(head::PITCH_SERVO_ID, ADDR_PRESENT_POSITION, &mut buf),
+    )
+    .await
+    {
+        Ok(Ok(err_byte)) => {
+            if err_byte != 0 {
+                defmt::warn!(
+                    "tilt-extremes: pitch FAULT byte=0x{=u8:02x} ({=str})",
+                    err_byte,
+                    decode_fault_byte(err_byte),
+                );
+            }
+            Some(u16::from_be_bytes(buf))
+        }
+        Ok(Err(e)) => {
+            defmt::warn!(
+                "tilt-extremes: read_memory err: {}",
+                defmt::Debug2Format(&e)
+            );
+            None
+        }
+        Err(_) => {
+            defmt::warn!("tilt-extremes: read_memory timed out");
+            None
+        }
+    }
+}
+
+/// Decode the SCSCL status-packet error byte into a comma-separated
+/// flag name list. Bit definitions per Feetech SCSCL memory-table
+/// documentation. Returns `"OK"` for a zero byte (caller normally
+/// checks before calling, but harmless either way).
+fn decode_fault_byte(b: u8) -> &'static str {
+    // Table-driven would be cleaner with `alloc`, but we want a
+    // `&'static str` for defmt's `{=str}` formatter, so enumerate
+    // the common single- and double-flag combos. Anything past
+    // a few simultaneous flags is exotic enough to warrant looking
+    // at the raw hex.
+    match b {
+        0x00 => "OK",
+        0x01 => "VOLTAGE",
+        0x02 => "ANGLE",
+        0x04 => "OVERHEAT",
+        0x08 => "RANGE",
+        0x10 => "CHECKSUM",
+        0x20 => "OVERLOAD",
+        0x40 => "INSTRUCTION",
+        0x21 => "OVERLOAD+VOLTAGE",
+        0x24 => "OVERLOAD+OVERHEAT",
+        0x25 => "OVERLOAD+OVERHEAT+VOLTAGE",
+        _ => "MULTIPLE (see hex)",
+    }
+}
+
+/// One-shot servo health snapshot: voltage, temperature, and a
+/// position-read that surfaces the error byte. All failures are
+/// logged at `warn` and ignored — this is diagnostic-only.
+async fn log_health(driver: &mut board::HeadDriverImpl, id: u8) {
+    let bus = driver.bus_mut();
+
+    match embassy_time::with_timeout(
+        Duration::from_millis(READ_TIMEOUT_MS),
+        bus.read_voltage(id),
+    )
+    .await
+    {
+        Ok(Ok(v)) => defmt::info!(
+            "tilt-extremes HEALTH: SCServo[{=u8}] voltage = {=u8} (= {=f32} V; servos brown-out below ~5.5 V)",
+            id,
+            v,
+            f32::from(v) / 10.0,
+        ),
+        Ok(Err(e)) => defmt::warn!(
+            "tilt-extremes HEALTH: voltage read err: {}",
+            defmt::Debug2Format(&e)
+        ),
+        Err(_) => defmt::warn!("tilt-extremes HEALTH: voltage read timed out"),
+    }
+
+    match embassy_time::with_timeout(
+        Duration::from_millis(READ_TIMEOUT_MS),
+        bus.read_temperature(id),
+    )
+    .await
+    {
+        Ok(Ok(t)) => defmt::info!(
+            "tilt-extremes HEALTH: SCServo[{=u8}] temperature = {=u8} °C (overheat trip is ~70 °C)",
+            id,
+            t,
+        ),
+        Ok(Err(e)) => defmt::warn!(
+            "tilt-extremes HEALTH: temperature read err: {}",
+            defmt::Debug2Format(&e)
+        ),
+        Err(_) => defmt::warn!("tilt-extremes HEALTH: temperature read timed out"),
+    }
+
+    let mut buf = [0u8; 2];
+    match embassy_time::with_timeout(
+        Duration::from_millis(READ_TIMEOUT_MS),
+        bus.read_memory(id, ADDR_PRESENT_POSITION, &mut buf),
+    )
+    .await
+    {
+        Ok(Ok(err_byte)) => {
+            let raw = u16::from_be_bytes(buf);
+            defmt::info!(
+                "tilt-extremes HEALTH: SCServo[{=u8}] position raw={=u16} ({=f32}°), error byte = 0x{=u8:02x} ({=str})",
+                id,
+                raw,
+                raw_to_deg(raw),
+                err_byte,
+                decode_fault_byte(err_byte),
+            );
+        }
+        Ok(Err(e)) => defmt::warn!(
+            "tilt-extremes HEALTH: status read err: {}",
+            defmt::Debug2Format(&e)
+        ),
+        Err(_) => defmt::warn!("tilt-extremes HEALTH: status read timed out"),
+    }
+}
+
+/// Convert a raw step count into degrees in the firmware's commanded
+/// reference frame: applies `head::TILT_TRIM_DEG` so `actual_deg`
+/// directly compares against `cmd_deg` (delta = 0 when the servo
+/// tracks). Mirrors `head::ScsHead::deg_for` with `direction = +1.0`.
+fn raw_to_deg(raw: u16) -> f32 {
+    let untrimmed = (f32::from(raw) - f32::from(POSITION_CENTER)) / POSITION_PER_DEGREE;
+    untrimmed - head::TILT_TRIM_DEG
+}
+
+/// Inverse of `raw_to_deg` — also applies `head::TILT_TRIM_DEG` so
+/// the operator-facing suggested EEPROM angle-limit raw counts match
+/// what `head::ScsHead::position_for` would actually command.
+fn deg_to_raw(deg: f32) -> u16 {
+    let raw = f32::from(POSITION_CENTER) + (deg + head::TILT_TRIM_DEG) * POSITION_PER_DEGREE;
+    let clamped = raw.clamp(0.0, 1023.0);
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "clamped to [0, 1023] above"
+    )]
+    let pos = clamped as u16;
+    pos
+}
+
+/// Threshold below which the sweep is treated as "no real motion" —
+/// just encoder quantisation noise (≈0.3° per count, so ±1 count
+/// of jitter is already ~0.6° span). Anything tighter than 2° means
+/// the servo never actually moved between the up- and down-extremes
+/// and the SUGGEST line would be nonsense.
+const MIN_SPAN_FOR_SUGGEST_DEG: f32 = 2.0;
+
+/// Emit one `SUMMARY` line + a `SUGGEST` line with EEPROM angle-limit
+/// raw counts and a `TILT_TRIM_DEG` value to paste into `head.rs`.
+/// If the observed span is too small for the SUGGEST math to be
+/// meaningful (servo stuck), prints a STUCK verdict instead so the
+/// operator doesn't paste garbage trim values into the firmware.
+fn print_summary(lower_deg: f32, upper_deg: f32) {
+    let span_deg = upper_deg - lower_deg;
+    let center_deg = (upper_deg + lower_deg) / 2.0;
+
+    defmt::info!(
+        "tilt-extremes SUMMARY: actual range = {=f32}° .. {=f32}° ({=f32}° span); midpoint = {=f32}°",
+        lower_deg,
+        upper_deg,
+        span_deg,
+        center_deg,
+    );
+
+    if span_deg.abs() < MIN_SPAN_FOR_SUGGEST_DEG {
+        defmt::warn!(
+            "tilt-extremes STUCK: encoder span {=f32}° is below the {=f32}° noise floor — the pitch servo is not responding to commanded motion. No calibration values can fix this; check HEALTH log above for fault flags, then inspect linkage / replace servo.",
+            span_deg.abs(),
+            MIN_SPAN_FOR_SUGGEST_DEG,
+        );
+        return;
+    }
+
+    // To make `cmd_deg = 0` produce the mechanical centre, set
+    //   trim = (center_deg - 0) → firmware adds it before scaling.
+    // Inversion sign matches `head::ScsHead::position_for`.
+    let suggested_trim_deg = center_deg;
+    let suggested_min_raw = deg_to_raw(lower_deg);
+    let suggested_max_raw = deg_to_raw(upper_deg);
+
+    defmt::info!(
+        "tilt-extremes SUGGEST: TILT_TRIM_DEG = {=f32}; EEPROM angle-limit raw counts MIN={=u16} MAX={=u16} (compare to boot-log MIN/MAX to tell EEPROM-clip from mech-stop)",
+        suggested_trim_deg,
+        suggested_min_raw,
+        suggested_max_raw,
+    );
+}

--- a/crates/stackchan-firmware/examples/tilt_extremes.rs
+++ b/crates/stackchan-firmware/examples/tilt_extremes.rs
@@ -146,7 +146,10 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
     log_health(&mut driver, head::PITCH_SERVO_ID).await;
 
     // --- Up-sweep: 0° → +MAX_PROBE_DEG, stop early if encoder plateaus -----
-    defmt::info!("tilt-extremes: starting UP sweep (0° → +{=f32}°)", MAX_PROBE_DEG);
+    defmt::info!(
+        "tilt-extremes: starting UP sweep (0° → +{=f32}°)",
+        MAX_PROBE_DEG
+    );
     let upper = sweep(&mut driver, "up", STEP_DEG).await;
 
     // Return to centre before reversing direction so we don't whip
@@ -180,17 +183,12 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
 /// plateaus or we reach `MAX_PROBE_DEG`. Returns the last *actual*
 /// angle observed before the plateau (or at the last step, if no
 /// plateau was hit).
-async fn sweep(
-    driver: &mut board::HeadDriverImpl,
-    label: &'static str,
-    step_deg: f32,
-) -> f32 {
+async fn sweep(driver: &mut board::HeadDriverImpl, label: &'static str, step_deg: f32) -> f32 {
     let mut prev_actual_deg: f32 = 0.0;
     let mut last_actual_deg: f32 = 0.0;
     let mut cmd_deg: f32 = 0.0;
     debug_assert!(
-        f32::from(u16::try_from(MAX_STEPS).unwrap_or(u16::MAX))
-            * STEP_DEG
+        f32::from(u16::try_from(MAX_STEPS).unwrap_or(u16::MAX)) * STEP_DEG
             >= MAX_PROBE_DEG - f32::EPSILON,
         "MAX_STEPS out of sync with MAX_PROBE_DEG / STEP_DEG"
     );
@@ -334,11 +332,8 @@ fn decode_fault_byte(b: u8) -> &'static str {
 async fn log_health(driver: &mut board::HeadDriverImpl, id: u8) {
     let bus = driver.bus_mut();
 
-    match embassy_time::with_timeout(
-        Duration::from_millis(READ_TIMEOUT_MS),
-        bus.read_voltage(id),
-    )
-    .await
+    match embassy_time::with_timeout(Duration::from_millis(READ_TIMEOUT_MS), bus.read_voltage(id))
+        .await
     {
         Ok(Ok(v)) => defmt::info!(
             "tilt-extremes HEALTH: SCServo[{=u8}] voltage = {=u8} (= {=f32} V; servos brown-out below ~5.5 V)",

--- a/crates/stackchan-firmware/examples/tilt_freewheel.rs
+++ b/crates/stackchan-firmware/examples/tilt_freewheel.rs
@@ -1,0 +1,174 @@
+//! Tilt-axis torque-off freewheel diagnostic.
+//!
+//! Disables torque on the pitch (tilt) servo and live-streams the
+//! encoder reading at 5 Hz so the operator can hand-rotate the head
+//! and verify that the servo's internal position sensor is following
+//! the physical motion. Companion to `examples/tilt_extremes.rs`,
+//! which only exercises the *commanded* path.
+//!
+//! ## When to use
+//!
+//! `tilt_extremes` showed the encoder pegged to a single value with
+//! the OVERLOAD fault byte latched. Two failure modes can produce
+//! that pattern, and this binary distinguishes them:
+//!
+//! - **Encoder alive, controller stuck in OVERLOAD** → torque-off
+//!   should clear OVERLOAD on its own, and the encoder reading
+//!   should track the head as you rotate it. Re-run `tilt_extremes`
+//!   after freewheel; the controller often unsticks once the stall
+//!   condition is removed.
+//! - **Encoder dead / shaft–encoder decoupled** → encoder reading
+//!   stays pinned to the same raw value no matter how you move the
+//!   head. Servo replacement is the only fix.
+//!
+//! ## Workflow
+//!
+//! ```text
+//! source ~/export-esp.sh
+//! just tilt-freewheel
+//! ```
+//!
+//! Once `freewheel: torque OFF` appears, slowly rotate the head
+//! through its full physical range while watching the per-sample
+//! `raw=…  deg=…` line. Re-flash main firmware (`just fmr`) when
+//! done — torque stays off until power-cycle.
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Timer};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use scservo::{ADDR_PRESENT_POSITION, POSITION_CENTER, POSITION_PER_DEGREE};
+use stackchan_firmware::{board, head};
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("freewheel panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// 5 Hz — fast enough to track a hand-rotated axis, slow enough to
+/// read the defmt-decoded log in real time.
+const SAMPLE_PERIOD_MS: u64 = 200;
+
+/// Per-`read_memory` timeout. 10 ms covers the ~200 µs round-trip at
+/// 1 Mbaud plus servo response latency.
+const READ_TIMEOUT_MS: u64 = 10;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "esp_rtos::main macro requires the `spawner` arg"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-tilt-freewheel v{} — torque-off live encoder readout",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    let mut delay = Delay;
+    let mut driver = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await
+    .head;
+
+    // Skip an explicit torque-disable write: a known consequence of
+    // a latched OVERLOAD fault is that the servo's reply to the
+    // torque-write packet is mis-framed (extended status bytes), and
+    // the leftover bytes poison the RX FIFO so every subsequent
+    // `read_memory` returns `MalformedResponse`. Since OVERLOAD
+    // already disables motor drive internally (the whole reason
+    // we're here), the head is already back-drivable — we just
+    // read the encoder without sending any further bus traffic.
+    defmt::info!(
+        "freewheel: encoder-only readout on pitch servo (ID {=u8}). Motor is already off-drive due to latched OVERLOAD; rotate head freely.",
+        head::PITCH_SERVO_ID
+    );
+    defmt::info!(
+        "freewheel: sampling pitch position every {=u64} ms; min/max latch across the session. Watch raw= column as you rotate.",
+        SAMPLE_PERIOD_MS
+    );
+
+    let mut min_raw: u16 = u16::MAX;
+    let mut max_raw: u16 = 0;
+
+    loop {
+        Timer::after(Duration::from_millis(SAMPLE_PERIOD_MS)).await;
+
+        let bus = driver.bus_mut();
+        let mut buf = [0u8; 2];
+        let (raw, err_byte) = match embassy_time::with_timeout(
+            Duration::from_millis(READ_TIMEOUT_MS),
+            bus.read_memory(head::PITCH_SERVO_ID, ADDR_PRESENT_POSITION, &mut buf),
+        )
+        .await
+        {
+            Ok(Ok(eb)) => (u16::from_be_bytes(buf), eb),
+            Ok(Err(e)) => {
+                defmt::warn!("freewheel: read err: {}", defmt::Debug2Format(&e));
+                continue;
+            }
+            Err(_) => {
+                defmt::warn!("freewheel: read timed out");
+                continue;
+            }
+        };
+
+        if raw < min_raw {
+            min_raw = raw;
+        }
+        if raw > max_raw {
+            max_raw = raw;
+        }
+
+        let deg = (f32::from(raw) - f32::from(POSITION_CENTER)) / POSITION_PER_DEGREE;
+        if err_byte == 0 {
+            defmt::info!(
+                "freewheel  raw={=u16}  deg={=f32}  min={=u16}  max={=u16}  span={=u16}",
+                raw,
+                deg,
+                min_raw,
+                max_raw,
+                max_raw.saturating_sub(min_raw),
+            );
+        } else {
+            defmt::warn!(
+                "freewheel  raw={=u16}  deg={=f32}  min={=u16}  max={=u16}  span={=u16}  FAULT=0x{=u8:02x}",
+                raw,
+                deg,
+                min_raw,
+                max_raw,
+                max_raw.saturating_sub(min_raw),
+                err_byte,
+            );
+        }
+    }
+}

--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -330,6 +330,9 @@ async fn log_angle_limits(driver: &mut HeadDriverImpl, id: u8) {
     }
 }
 
+/// Enable the servo's torque output, then drain the post-write status
+/// frame so it does not collide with the next command. Logs and
+/// continues on error — a silent servo must not wedge boot.
 async fn enable_torque(driver: &mut HeadDriverImpl, id: u8) {
     let bus = driver.bus_mut();
     match bus.write_torque_enable(id, true).await {

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -58,9 +58,23 @@ const TILT_DIRECTION: f32 = 1.0;
 
 /// Per-unit pan trim, in degrees. Positive = head points rightward at
 /// commanded NEUTRAL. Zero until bench-measured on a real unit.
-const PAN_TRIM_DEG: f32 = 0.0;
+pub const PAN_TRIM_DEG: f32 = 0.0;
 /// Per-unit tilt trim, in degrees. Positive = head aims up at NEUTRAL.
-const TILT_TRIM_DEG: f32 = 0.0;
+/// Combines two corrections:
+///
+/// - **Encoder offset (~+44°):** the pitch servo's internal encoder
+///   zero (raw=512) sits ~44° below physical horizontal on this unit.
+/// - **Anti-droop bias (~+5°):** without a small upward over-command,
+///   `cmd=0` lands at gravity-rest (head visibly drooping ~1° below
+///   level). Adding ~5° pushes the motor's goal high enough to overcome
+///   the front-heavy gravity load and hold the head visibly tilted up
+///   when idle. Bench data: `cmd=+5°` produced actual ≈ +5 raw counts
+///   above rest, so this bias keeps the motor outside its dead-band.
+///
+/// Cleaner long-term: write the SCSCL Position Correction register
+/// (EEPROM `0x1F`) and add a counterweight; re-measure with
+/// `examples/tilt_freewheel.rs`.
+pub const TILT_TRIM_DEG: f32 = 49.0;
 
 /// Move-time sent with every `WritePos`. `SCServo` servos interpolate
 /// internally over this many milliseconds, smoothing out the 50 Hz

--- a/crates/stackchan-firmware/src/imu.rs
+++ b/crates/stackchan-firmware/src/imu.rs
@@ -35,6 +35,14 @@ pub static IMU_SIGNAL: Signal<CriticalSectionRawMutex, Measurement> = Signal::ne
 /// than the chip's internal sampling just returns duplicate values.
 const POLL_PERIOD_MS: u64 = 10;
 
+/// Max number of init attempts before giving up and parking the task.
+/// See `run_imu_loop` for the rationale on why init can fail mid-blob.
+const INIT_MAX_ATTEMPTS: u32 = 3;
+
+/// Cooldown between init attempts so the BMI270 finishes any partial
+/// internal state-machine transition before the next soft-reset.
+const INIT_RETRY_COOLDOWN_MS: u64 = 200;
+
 /// Run the BMI270 init sequence, then loop forever polling samples
 /// and publishing them via [`IMU_SIGNAL`].
 ///
@@ -58,8 +66,6 @@ pub async fn run_imu_loop<I: AsyncI2c>(bus: I) -> ! {
     // the BMI270-recommended recovery — there's no partial-resume
     // path in Bosch's reference. Each attempt starts with a fresh
     // soft-reset, so prior partial state is safely discarded.
-    const INIT_MAX_ATTEMPTS: u32 = 3;
-    const INIT_RETRY_COOLDOWN_MS: u64 = 200;
     let mut init_err = None;
     for attempt in 1..=INIT_MAX_ATTEMPTS {
         match imu.init(&mut delay).await {

--- a/crates/stackchan-sim/tests/head_sway.rs
+++ b/crates/stackchan-sim/tests/head_sway.rs
@@ -96,21 +96,28 @@ fn idle_sway_crosses_zero_on_both_axes() {
         block_on(head.set_pose(avatar.head_pose, now)).expect("RecordingHead is infallible");
     }
 
-    // Both axes must visit both sides of zero over this window.
+    // Pan is symmetric — must visit both sides of zero. Tilt is
+    // asymmetric (`Pose::clamped` pins below-zero tilts to
+    // `MIN_TILT_DEG = 0` because the chassis cutout blocks downward
+    // head travel) so we instead check that tilt visits both the floor
+    // (~0°) and at least one positive angle.
     let (pan_pos, pan_neg) = head
         .records()
         .iter()
         .fold((false, false), |(pos, neg), (_, p)| {
             (pos || p.pan_deg > 0.0, neg || p.pan_deg < 0.0)
         });
-    let (tilt_pos, tilt_neg) = head
+    let (tilt_at_floor, tilt_above_floor) = head
         .records()
         .iter()
-        .fold((false, false), |(pos, neg), (_, p)| {
-            (pos || p.tilt_deg > 0.0, neg || p.tilt_deg < 0.0)
+        .fold((false, false), |(at_floor, above), (_, p)| {
+            (at_floor || p.tilt_deg <= 0.001, above || p.tilt_deg > 0.0)
         });
     assert!(pan_pos && pan_neg, "pan did not cross zero in 33 s");
-    assert!(tilt_pos && tilt_neg, "tilt did not cross zero in 33 s");
+    assert!(
+        tilt_at_floor && tilt_above_floor,
+        "tilt did not visit both the MIN_TILT_DEG floor and a positive value in 33 s"
+    );
 }
 
 #[test]

--- a/justfile
+++ b/justfile
@@ -145,3 +145,22 @@ aw88298-bench:
 es7210-bench:
     cd crates/stackchan-firmware && cargo +esp build --release --example es7210_bench
     {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/es7210_bench{{_serial_suffix}}
+
+# Tilt extremes calibration: drives the pitch servo through 0° → ±50°
+# in 5° steps (5° past `MAX_TILT_DEG`'s safety bound) and reads back
+# the live encoder, stopping the sweep early once readings plateau.
+# Use the SUMMARY/SUGGEST lines to set EEPROM angle limits and
+# `TILT_TRIM_DEG` in `head.rs`. Re-flash main firmware with
+# `just fmr` when done.
+tilt-extremes:
+    cd crates/stackchan-firmware && cargo +esp build --release --example tilt_extremes
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/tilt_extremes{{_serial_suffix}}
+
+# Tilt freewheel diagnostic: disables torque on the pitch servo and
+# live-streams the encoder reading at 5 Hz so the operator can hand-
+# rotate the head and verify whether the internal position sensor is
+# tracking. Use after `tilt-extremes` flags STUCK + OVERLOAD to
+# distinguish "encoder dead" from "controller stuck in OVERLOAD".
+tilt-freewheel:
+    cd crates/stackchan-firmware && cargo +esp build --release --example tilt_freewheel
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/tilt_freewheel{{_serial_suffix}}


### PR DESCRIPTION
## Summary

This branch makes the tilt axis usable on a Stack-chan unit whose pitch-servo encoder slipped past calibration during over-rotation, and lays the foundation for asymmetric (chassis-constrained) tilt mechanisms in general.

Three commits, each independently reviewable:

1. **`feat(core): asymmetric tilt clamp + modifier diff-and-undo correctness`** — Adds `MIN_TILT_DEG` so `Pose::clamped` respects asymmetric tilt ranges (Stack-chan's chassis cutout typically blocks downward travel). Also fixes a latent bug in `IdleSway` and `EmotionHead` where storing the *intended* contribution (instead of the *post-clamp applied* one) causes bias to leak across ticks under any clamping — doubling effective amplitude.
2. **`feat(firmware): tilt_extremes + tilt_freewheel calibration examples`** — Two new example binaries for diagnosing per-unit tilt servo behaviour: `tilt_extremes` runs a commanded sweep with plateau detection, `tilt_freewheel` does encoder-only readout for hand-rotation testing. Both invoked via `just tilt-extremes` / `just tilt-freewheel`.
3. **`fix(firmware): per-unit +49° TILT_TRIM_DEG for offset-encoder unit`** — Sets the per-unit trim on this specific unit. Combines a +44° encoder-offset compensation with a +5° anti-droop bias so the motor breaks out of its dead-band and holds the head visibly horizontal at idle.

## How this was discovered

Owner reported the head slamming down on restart after manually rotating it past its hard stop. Diagnostic flow with the new tools:

- `just fmr` boot log showed `SCServo[2] angle limits MIN=20 MAX=1003` — EEPROM not clipping.
- `just tilt-extremes` showed `actual=42.81°` frozen across every commanded position with `OVERLOAD` latched — looked like a dead encoder.
- `just tilt-freewheel` showed the encoder *did* track manual rotation (span=297 raw counts) — encoder alive, OVERLOAD was clearing once stall removed. The encoder was just offset ~42° relative to physical horizontal.
- Iterative trim tuning landed on +49° (44° offset + 5° anti-droop). Bench sweep confirmed full +90° upward range tracks with sub-1° error.

## Test plan

- [ ] `cargo test --workspace --exclude stackchan-firmware --all-features` — passes locally
- [ ] `cargo clippy --workspace --exclude stackchan-firmware --all-targets -- -D warnings` — passes locally
- [ ] `just fmr` — verify head sits at horizontal at boot, no slam, normal IdleSway pan motion
- [ ] `just tilt-extremes` — verify upward sweep reaches ~+91° with sub-1° tracking error, plateau at ~95° (mechanical stop)