### PR TITLE
feat(firmware): RMS sample loop — audio task → mouth pipeline live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,7 @@ dependencies = [
  "ft6336u",
  "ir-nec",
  "ltr553",
+ "micromath",
  "mipidsi",
  "py32",
  "scservo",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -80,6 +80,10 @@ esp-println = { version = "0.17.0", default-features = false, features = [
 
 critical-section = "1.2.0"
 static_cell = "2.1.1"
+# `f32::sqrt` for the audio-task RMS computation. `stackchan-core`
+# already depends on the same major version for `MouthOpenAudio`'s
+# dB mapping; sharing the dep keeps the workspace libm-free.
+micromath = "2"
 
 [lib]
 name = "stackchan_firmware"

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -27,9 +27,9 @@ modifier pipeline at ~30 FPS.
 - `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
 - `src/imu.rs` / `src/mag.rs` — BMI270 / BMM150 tasks publishing to signal channels for the 9-axis data path
 - `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` — per-peripheral tasks
-- `src/audio.rs` — codec bring-up (AW88298 + ES7210) + `AUDIO_RMS_SIGNAL` channel. Task parks until the I²S peripheral wiring lands in a follow-up
+- `src/audio.rs` — I²S0 + codec (AW88298 + ES7210) bring-up, then per-window RMS loop publishing on `AUDIO_RMS_SIGNAL`. Speaker-side (AW88298 TX) still pending
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
-- `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; no I²S / streaming data on the audio pair until PR 2 of the audio stack lands)
+- `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; the streaming I²S path runs only inside `src/audio.rs` in the main firmware)
 
 ## Boot Sequence
 
@@ -119,5 +119,5 @@ port is `/dev/ttyACM1`; override with `just PORT=/dev/ttyACM0 flash`.
 ## Integration
 
 - **Consumes `stackchan-core`** for every domain type (`Avatar`, `Modifier`, `Pose`, `Clock`, `HeadDriver`, `LedFrame`)
-- **Consumes every driver crate in the workspace** — axp2101, aw9523, aw88298, bm8563, bmi270, bmm150, es7210, ft6336u, ir-nec, ltr553, py32, scservo. AW88298 + ES7210 are control-path only for now (chip brought up at benches; no I²S streaming — that lands in the audio-task PR). Scaffolded-only: gc0308, si12t, st25r3916
+- **Consumes every driver crate in the workspace** — axp2101, aw9523, aw88298, bm8563, bmi270, bmm150, es7210, ft6336u, ir-nec, ltr553, py32, scservo. ES7210 streams RX over I²S into the RMS loop in `src/audio.rs`; AW88298 is control-path only for now (TX speaker output still pending). Scaffolded-only: gc0308, si12t, st25r3916
 - **HIL via probe-rs + defmt-test** (planned) — CI runs host tests today; on-device integration tests run on a flash-and-capture rig

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -18,19 +18,17 @@
 //! 3. Small settle delay
 //! 4. Bring up AW88298 (doesn't need MCLK but comes up with the pair)
 //! 5. Bring up ES7210 (now responds — MCLK is flowing)
-//! 6. [TODO PR 2C] enter the sample-processing loop: pop DMA samples,
-//!    compute RMS per ~33 ms window, publish via [`AUDIO_RMS_SIGNAL`]
+//! 6. Enter the sample-processing loop: pop DMA samples, compute
+//!    linear RMS over each [`RMS_WINDOW_SAMPLES`]-sample window
+//!    (~33 ms at 16 kHz, one render frame at 30 FPS), normalise
+//!    against full-scale i16, publish on [`AUDIO_RMS_SIGNAL`].
 //!
 //! This matches esp-bsp's ordering in `bsp_audio_codec_microphone_init`:
 //! `bsp_audio_init` (spins up I²S + MCLK) runs *before* `es7210_codec_new`.
 //!
-//! ## What this PR lands (PR 2B)
-//!
-//! Steps 1–5 above. The task parks after both codecs are up. Sample
-//! processing + RMS publication land in PR 2C, which replaces the park
-//! with a real loop. [`AUDIO_RMS_SIGNAL`] stays at its default
-//! `AudioRms(0.0)` until then — consumer modifiers see a silent mic,
-//! which produces a closed mouth in the downstream binding.
+//! Failures inside the RMS loop log-and-degrade: a DMA pop error
+//! publishes `AudioRms(0.0)` (silent mic → closed mouth downstream)
+//! and resumes after a short backoff rather than parking the task.
 
 use aw88298::Aw88298;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
@@ -42,6 +40,7 @@ use esp_hal::{
     peripherals::{DMA_CH0, GPIO0, GPIO13, GPIO14, GPIO33, GPIO34, I2S0},
     time::Rate,
 };
+use micromath::F32Ext as _;
 
 use crate::board::SharedI2c;
 
@@ -65,6 +64,27 @@ pub const BIT_DEPTH_BITS: u8 = 16;
 /// 8 KiB is a comfortable middle ground and fits in internal SRAM
 /// (DMA-capable) without impacting the PSRAM framebuffer budget.
 const RX_DMA_BYTES: usize = 8 * 1024;
+
+/// RMS analysis window, in samples. ~33 ms at 16 kHz — matches one
+/// render frame at 30 FPS, so the consumer in `main.rs` sees a fresh
+/// value on (almost) every tick.
+const RMS_WINDOW_SAMPLES: u32 = SAMPLE_RATE_HZ * 33 / 1000;
+
+/// Bytes per `pop` from the circular DMA tail. Sample-aligned (×2 = ×16-bit).
+/// 256 bytes ≈ 8 ms of audio: small enough that we don't sit idle
+/// waiting for a giant chunk, large enough to amortise pop overhead.
+const POP_SCRATCH_BYTES: usize = 256;
+
+/// Diagnostic log cadence inside the RMS loop. One info line every
+/// ~2 s of audio (60 windows × 33 ms ≈ 1.98 s) — enough to eyeball mic
+/// activity over RTT without flooding the link.
+const LOG_EVERY_N_WINDOWS: u32 = 60;
+
+/// `i16::MIN.unsigned_abs()² = 32768² = 2³⁰`. Pre-computed because the
+/// per-window normalisation `(mean_sq / FULL_SCALE_SQ).sqrt()` runs
+/// 30 times a second; the value is exact in f32 (mantissa fits 24
+/// bits, this needs 1).
+const FULL_SCALE_SQ: f32 = 32768.0 * 32768.0;
 
 /// Microphone RMS sample, published per render tick.
 ///
@@ -102,8 +122,8 @@ pub struct AudioPeripherals {
     /// Data-in pin (ES7210 → ESP32-S3). CoreS3 schematic: `GPIO14`.
     pub din: GPIO14<'static>,
     /// Data-out pin (ESP32-S3 → AW88298). CoreS3 schematic: `GPIO13`.
-    /// Held even though this PR doesn't stream TX, so PR 2C/3 can
-    /// wire speaker output without another plumbing change.
+    /// Held for future TX streaming (speaker output) — wiring it through
+    /// now avoids another plumbing change when that lands.
     pub dout: GPIO13<'static>,
     /// I²C device handle for the AW88298.
     pub amp_bus: SharedI2c,
@@ -113,12 +133,13 @@ pub struct AudioPeripherals {
 
 /// Audio task entry point.
 ///
-/// Runs the full bring-up sequence (I²S + codecs), then parks
-/// indefinitely. PR 2C replaces the park with the real RMS-processing
-/// loop.
+/// Runs the full bring-up sequence (I²S + codecs), then enters the
+/// per-window RMS loop that pops DMA samples and publishes
+/// [`AUDIO_RMS_SIGNAL`].
 ///
-/// Failures at any step log-and-degrade: audio goes silent (signal
-/// stays at `AudioRms(0.0)`) but the rest of the avatar keeps running.
+/// Failures during bring-up park the task — audio goes silent
+/// (`AudioRms(0.0)`) but the rest of the avatar keeps running.
+/// Failures inside the loop log-and-resync rather than parking.
 pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
     defmt::info!(
         "audio: I²S0 bring-up — {=u32} Hz / {=u8}-bit mono, MCLK {=u32} Hz",
@@ -166,8 +187,9 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
 
     // Start the RX DMA circular transfer. From this point MCLK / BCLK
     // / LRCK are all clocking on their pins; ES7210 can now answer
-    // I²C. The transfer keeps running for the lifetime of the task.
-    let _rx_transfer = match i2s_rx.read_dma_circular_async(rx_buffer) {
+    // I²C. The transfer keeps running for the lifetime of the task —
+    // the RMS loop below pops samples off its tail.
+    let mut rx_transfer = match i2s_rx.read_dma_circular_async(rx_buffer) {
         Ok(t) => t,
         Err(e) => {
             defmt::error!(
@@ -241,8 +263,115 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
         }
     }
 
-    defmt::info!("audio: bring-up complete — I²S RX running, RMS processing TODO (PR 2C)");
-    park_forever().await
+    defmt::info!(
+        "audio: bring-up complete — entering RMS loop ({=u32}-sample / ~33 ms windows)",
+        RMS_WINDOW_SAMPLES,
+    );
+
+    run_rms_loop(&mut rx_transfer).await
+}
+
+/// Per-window RMS computation loop. Pops samples off the running
+/// circular DMA transfer, accumulates `sum(sample²)` for
+/// [`RMS_WINDOW_SAMPLES`] samples, then publishes the normalised RMS
+/// on [`AUDIO_RMS_SIGNAL`].
+///
+/// Pulled out of [`run_audio_task`] mainly to keep that function a
+/// readable bring-up sequence; this fn owns its own state machine
+/// (accumulator, byte-carry, log throttle) and never returns.
+async fn run_rms_loop<BUFFER>(
+    rx_transfer: &mut esp_hal::i2s::master::asynch::I2sReadDmaTransferAsync<'_, BUFFER>,
+) -> ! {
+    let mut scratch = [0u8; POP_SCRATCH_BYTES];
+    // Per-window accumulator. Reset on every publish.
+    let mut sum_sq: f32 = 0.0;
+    let mut count: u32 = 0;
+    // Carries the low byte of an i16 sample whose two bytes straddle a
+    // pop boundary — `chunks_exact(2)` would otherwise drop it.
+    let mut byte_carry: Option<u8> = None;
+    // Wrapping window counter; only used to throttle the diagnostic log.
+    let mut window_no: u32 = 0;
+
+    loop {
+        let n = match rx_transfer.pop(&mut scratch).await {
+            Ok(n) => n,
+            Err(e) => {
+                defmt::warn!(
+                    "audio: DMA pop error ({:?}); publishing silence and resyncing",
+                    defmt::Debug2Format(&e)
+                );
+                AUDIO_RMS_SIGNAL.signal(AudioRms(0.0));
+                sum_sq = 0.0;
+                count = 0;
+                byte_carry = None;
+                Timer::after(Duration::from_millis(10)).await;
+                continue;
+            }
+        };
+        if n == 0 {
+            continue;
+        }
+
+        let mut bytes = &scratch[..n];
+
+        // Reassemble the sample whose low byte was carried over from the
+        // previous pop, if any.
+        if let Some(low) = byte_carry.take() {
+            if let Some((&high, rest)) = bytes.split_first() {
+                accumulate(&mut sum_sq, &mut count, i16::from_le_bytes([low, high]));
+                bytes = rest;
+            } else {
+                byte_carry = Some(low);
+                continue;
+            }
+        }
+
+        let mut chunks = bytes.chunks_exact(2);
+        for pair in &mut chunks {
+            accumulate(
+                &mut sum_sq,
+                &mut count,
+                i16::from_le_bytes([pair[0], pair[1]]),
+            );
+
+            if count >= RMS_WINDOW_SAMPLES {
+                // `count` is bounded by `RMS_WINDOW_SAMPLES` (528 in
+                // the current config) — well below f32's 24-bit mantissa
+                // limit, so the `as f32` cast is exact.
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "count <= RMS_WINDOW_SAMPLES ≪ 2²⁴, exact in f32"
+                )]
+                let mean_sq = sum_sq / (count as f32);
+                // i16::MIN.abs() is one larger than i16::MAX, so a
+                // saturated negative sample can yield rms_norm slightly
+                // above 1.0 (~3e-5). Clamp so consumers can rely on the
+                // documented [0, 1] contract.
+                let rms_norm = (mean_sq / FULL_SCALE_SQ).sqrt().min(1.0);
+                AUDIO_RMS_SIGNAL.signal(AudioRms(rms_norm));
+
+                sum_sq = 0.0;
+                count = 0;
+                window_no = window_no.wrapping_add(1);
+
+                if window_no.is_multiple_of(LOG_EVERY_N_WINDOWS) {
+                    defmt::info!("audio: RMS {=f32} (linear, full-scale = 1.0)", rms_norm);
+                }
+            }
+        }
+
+        // Stash an odd trailing byte for the next pop.
+        byte_carry = chunks.remainder().first().copied();
+    }
+}
+
+/// Add one i16 sample's contribution to the running window accumulator.
+/// `f32::from(i16)` is exact (24-bit mantissa > 16-bit range).
+#[inline]
+fn accumulate(sum_sq: &mut f32, count: &mut u32, sample: i16) {
+    let s = f32::from(sample);
+    *sum_sq += s * s;
+    *count += 1;
 }
 
 /// Infinite sleep for tasks that have nothing else to do. `-> !` so

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -227,10 +227,10 @@ async fn render_task(mut display: LcdDisplay) {
         if let Some(ut) = mag::MAG_SIGNAL.try_take() {
             avatar.mag_ut = Some(ut);
         }
-        // Drain the latest mic-RMS sample from the audio task. Stays
-        // at `AudioRms(0.0)` (closed mouth) until PR 2C wires the RX
-        // DMA sample loop — wiring the consumer now so the modifier
-        // is active and tested on real hardware from day one.
+        // Drain the latest mic-RMS sample from the audio task — the
+        // task publishes a fresh `AudioRms(linear)` per ~33 ms window
+        // (one render frame at 30 FPS). `try_take` is non-blocking and
+        // misses are fine: latest-wins matches mic semantics.
         if let Some(rms) = audio::AUDIO_RMS_SIGNAL.try_take() {
             mouth_open_audio.set_rms(rms.0);
         }
@@ -419,9 +419,8 @@ async fn mag_task(shared_i2c: SharedI2c) -> ! {
 
 /// Audio task. Owns the I²S0 peripheral + DMA, runs the full bring-up
 /// sequence (I²S MCLK first so ES7210 can answer I²C, then both
-/// codecs), and (in PR 2C) will compute mic RMS per render window
-/// publishing to [`audio::AUDIO_RMS_SIGNAL`]. Today parks after
-/// bring-up.
+/// codecs), then computes mic RMS per ~33 ms window and publishes on
+/// [`audio::AUDIO_RMS_SIGNAL`].
 #[embassy_executor::task]
 async fn audio_task(peripherals: audio::AudioPeripherals) -> ! {
     audio::run_audio_task(peripherals).await


### PR DESCRIPTION
## Summary
- Replaces `park_forever()` after audio bring-up with `run_rms_loop()`: pops circular-DMA tail, reassembles LE i16 samples across pop boundaries, accumulates `sum(s²)` over 528-sample windows (~33 ms ≈ one render frame at 30 FPS), publishes normalised RMS on `AUDIO_RMS_SIGNAL`.
- Closes the audio→mouth path end-to-end: mic → ES7210 → I²S DMA → RMS → `Signal` → `MouthOpenAudio.set_rms` → `mouth.mouth_open` → growing pink ellipse on the LCD. Consumer side was already wired up in PR 2B; this PR unparks the producer.
- Adds `micromath = "2"` to firmware `Cargo.toml` for `f32::sqrt` (matches the dep `stackchan-core` already pulls in for `MouthOpenAudio`'s dB mapping).
- Throttles a diagnostic info log to once per ~2 s of audio so the mic level is eyeball-able over RTT without flooding the link.
- README updated: `src/audio.rs` no longer parks; ES7210 streams RX into the RMS loop; AW88298 TX (speaker) still pending.

## Implementation notes
- **`Signal` not `Channel`**: latest-wins matches mic semantics — if the render task lags, the next mouth opening should reflect *current* mic level, not queued history.
- **Sample alignment across pops**: I²S DMA fills in descriptor-sized chunks, so a 16-bit sample's two bytes can straddle pop boundaries. `byte_carry: Option<u8>` reassembles them — without it, `chunks_exact(2)` silently drops the half-sample and corrupts every subsequent sample.
- **`(mean_sq / FULL_SCALE_SQ).sqrt().min(1.0)`**: dividing first keeps intermediates small. The `.min(1.0)` clamp covers the ~3e-5 overshoot from `i16::MIN.abs() > i16::MAX` so consumers can rely on the documented `[0, 1]` contract.
- **`run_rms_loop` is a separate fn**: keeps `run_audio_task` a readable bring-up sequence; the loop owns its own state machine (accumulator, byte carry, log throttle).

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Host tests + doc tests pass
- [x] Firmware release build links
- [ ] **Hardware validation**: `just fmr` and confirm the periodic `audio: RMS …` log shows ~0.001–0.01 in silence and ~0.05–0.3 with normal speech; mouth ellipse visibly opens when speaking

PR 2C of the audio stack. PR 2B landed I²S0 + codec bring-up in #34/#36. Speaker output (AW88298 TX) and any envelope/AGC tuning live in follow-up work.