### PR TITLE
feat: low-battery sleepy emotion — AXP2101 SoC reader, power task, modifier

### DIFF
--- a/crates/axp2101/README.md
+++ b/crates/axp2101/README.md
@@ -14,12 +14,13 @@ status: stable
 `no_std` async driver for the X-Powers AXP2101 power-management IC on
 the M5Stack CoreS3. Scope is the minimum needed to boot the LCD rails
 *and* configure the chip not to auto-shutdown on idle, plus one-shot
-power-key IRQ helpers for the hardware button. Battery-state readout
-and charging config are left for future releases.
+power-key IRQ helpers for the hardware button and a battery
+state-of-charge reader. Charge-current / voltage readout and full
+charging config are left for future releases.
 
 ## Key Files
 
-- `src/lib.rs` — `ADDRESS`, register + bit constants, `CORES3_INIT_SEQUENCE` (the full `M5Unified` register sequence as a `[(reg, value)]` slice), `Axp2101` struct, `init_cores3`, `read_reg` / `write_reg`, power-key IRQ helpers, mock-I²C golden-sequence tests
+- `src/lib.rs` — `ADDRESS`, register + bit constants, `CORES3_INIT_SEQUENCE` (the full `M5Unified` register sequence as a `[(reg, value)]` slice), `Axp2101` struct, `init_cores3`, `read_reg` / `write_reg`, power-key IRQ helpers, `read_battery_percent`, mock-I²C tests
 
 ## Bus + Addressing
 

--- a/crates/axp2101/src/lib.rs
+++ b/crates/axp2101/src/lib.rs
@@ -38,6 +38,16 @@ const REG_IRQ_EN_1: u8 = 0x41;
 /// `IRQ_STATUS_1` register address (`0x49`). Flags for power-key
 /// events; write-1-to-clear.
 const REG_IRQ_STATUS_1: u8 = 0x49;
+/// `BAT_GAUGE` register address (`0xA4`). Reads as 0..=100, the
+/// AXP2101's internal coulomb-counter / OCV-blend state-of-charge
+/// estimate. Reads outside that range only happen during transient
+/// chip warm-up and are clamped by [`Axp2101::read_battery_percent`].
+const REG_BAT_GAUGE: u8 = 0xA4;
+
+/// Maximum value the AXP2101 battery-gauge register reports. Anything
+/// higher is read-back noise during ADC settle and is saturated by
+/// [`Axp2101::read_battery_percent`].
+pub const BATTERY_PERCENT_MAX: u8 = 100;
 
 /// Bit for "short-press" in AXP2101's `IRQ_EN_1` / `IRQ_STATUS_1`
 /// registers (release after a brief hold, < 1 s).
@@ -232,6 +242,28 @@ where
             .await?;
         Ok(true)
     }
+
+    /// Read the AXP2101's battery state-of-charge estimate, in percent.
+    ///
+    /// Returns a value in <code>0..=[BATTERY_PERCENT_MAX]</code>. The
+    /// chip's gauge register can transiently report values above 100
+    /// during ADC settling immediately after `init_cores3` enables
+    /// battery detect; this method saturates instead of surfacing the
+    /// physically-meaningless reading.
+    ///
+    /// Note: the `SoC` estimate is only meaningful once the AXP2101
+    /// has observed at least one charge / discharge transition since
+    /// power-up — on a freshly-powered unit it can read 0% for several
+    /// seconds before stabilising. Callers that poll this on a
+    /// schedule should expect the early values to be noisy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::I2c`] on bus errors.
+    pub async fn read_battery_percent(&mut self) -> Result<u8, Error<B::Error>> {
+        let raw = self.read_reg(REG_BAT_GAUGE).await?;
+        Ok(raw.min(BATTERY_PERCENT_MAX))
+    }
 }
 
 #[cfg(test)]
@@ -244,16 +276,26 @@ mod tests {
     use core::cell::RefCell;
     use embedded_hal_async::i2c::{Operation, SevenBitAddress};
 
-    /// Host-side I²C mock that records every transaction payload in order.
+    /// Host-side I²C mock. Records every write payload in order and
+    /// answers reads from a per-register canned-value table. Reads
+    /// against unmapped registers return `0`.
     struct MockI2c {
         transactions: RefCell<Vec<(u8, Vec<u8>)>>,
+        read_responses: RefCell<Vec<(u8, u8)>>,
     }
 
     impl MockI2c {
         fn new() -> Self {
             Self {
                 transactions: RefCell::new(Vec::new()),
+                read_responses: RefCell::new(Vec::new()),
             }
+        }
+
+        /// Stage a value to return when the driver reads `reg`.
+        fn with_register(self, reg: u8, value: u8) -> Self {
+            self.read_responses.borrow_mut().push((reg, value));
+            self
         }
     }
 
@@ -267,11 +309,34 @@ mod tests {
             address: SevenBitAddress,
             operations: &mut [Operation<'_>],
         ) -> Result<(), Self::Error> {
+            // For a `write_read`, the operation list is `[Write(reg),
+            // Read(buf)]`. Track the most-recent write so the read can
+            // look up the canned value for that register.
+            let mut last_write_reg: Option<u8> = None;
             for op in operations {
-                if let Operation::Write(buf) = op {
-                    self.transactions.borrow_mut().push((address, buf.to_vec()));
+                match op {
+                    Operation::Write(buf) => {
+                        self.transactions.borrow_mut().push((address, buf.to_vec()));
+                        if let Some(&reg) = buf.first() {
+                            last_write_reg = Some(reg);
+                        }
+                    }
+                    Operation::Read(buf) => {
+                        let value = last_write_reg
+                            .and_then(|reg| {
+                                self.read_responses
+                                    .borrow()
+                                    .iter()
+                                    .rev()
+                                    .find(|(r, _)| *r == reg)
+                                    .map(|(_, v)| *v)
+                            })
+                            .unwrap_or(0);
+                        if let Some(slot) = buf.first_mut() {
+                            *slot = value;
+                        }
+                    }
                 }
-                // Reads and write-reads never issued by the driver under test.
             }
             Ok(())
         }
@@ -339,5 +404,33 @@ mod tests {
     fn into_inner_releases_bus() {
         let pmic = Axp2101::new(MockI2c::new());
         let _bus: MockI2c = pmic.into_inner();
+    }
+
+    #[test]
+    fn read_battery_percent_returns_register_value() {
+        let bus = MockI2c::new().with_register(REG_BAT_GAUGE, 73);
+        let mut pmic = Axp2101::new(bus);
+        let pct = block_on(pmic.read_battery_percent()).unwrap();
+        assert_eq!(pct, 73);
+    }
+
+    #[test]
+    fn read_battery_percent_saturates_above_max() {
+        // Some chips have been observed reporting 0xFF during ADC settle
+        // immediately after init. The driver clamps to BATTERY_PERCENT_MAX.
+        let bus = MockI2c::new().with_register(REG_BAT_GAUGE, 0xFF);
+        let mut pmic = Axp2101::new(bus);
+        let pct = block_on(pmic.read_battery_percent()).unwrap();
+        assert_eq!(pct, BATTERY_PERCENT_MAX);
+    }
+
+    #[test]
+    fn read_battery_percent_passes_zero_through() {
+        // A genuinely-flat battery reads 0; the driver must not
+        // mis-clamp this up.
+        let bus = MockI2c::new().with_register(REG_BAT_GAUGE, 0);
+        let mut pmic = Axp2101::new(bus);
+        let pct = block_on(pmic.read_battery_percent()).unwrap();
+        assert_eq!(pct, 0);
     }
 }

--- a/crates/stackchan-core/src/avatar.rs
+++ b/crates/stackchan-core/src/avatar.rs
@@ -240,6 +240,13 @@ pub struct Avatar {
     /// it yet (data-only landing). Excluded from [`Avatar::frame_eq`]
     /// — the raw field never affects pixels directly.
     pub mag_ut: Option<(f32, f32, f32)>,
+    /// Battery state-of-charge in percent (`0..=100`), or `None`
+    /// before the first successful AXP2101 gauge read. Written by
+    /// the firmware power task; consumed by
+    /// [`super::modifiers::LowBatteryEmotion`]. Excluded from
+    /// [`Avatar::frame_eq`] — modifiers translate the percentage into
+    /// visible state via `Avatar::emotion`, never directly into pixels.
+    pub battery_percent: Option<u8>,
 }
 
 impl Avatar {
@@ -316,6 +323,8 @@ impl Default for Avatar {
             ambient_lux: None,
             // No magnetometer reading until the BMM150 task publishes one.
             mag_ut: None,
+            // No battery reading until the AXP2101 task publishes one.
+            battery_percent: None,
         }
     }
 }

--- a/crates/stackchan-core/src/modifiers/low_battery.rs
+++ b/crates/stackchan-core/src/modifiers/low_battery.rs
@@ -1,0 +1,269 @@
+//! `LowBatteryEmotion`: forces `Emotion::Sleepy` when the AXP2101's
+//! reported battery state-of-charge drops below a threshold.
+//!
+//! ## Detection shape
+//!
+//! Reads `avatar.battery_percent` each tick. Single-threshold check
+//! (no hysteresis); the AXP2101's internal `SoC` estimate is already
+//! smoothed and the threshold is conservative enough that bouncing
+//! across the boundary should be rare in practice. If hardware
+//! observation shows flicker, swap to a two-threshold variant
+//! mirroring [`super::AmbientSleepy`].
+//!
+//! Unknown battery (`battery_percent = None`, i.e. the power task
+//! hasn't published a reading yet) is treated as "no information"
+//! and never triggers the override.
+//!
+//! ## Coordination with the other emotion modifiers
+//!
+//! Like [`super::PickupReaction`] and [`super::AmbientSleepy`], this
+//! modifier respects an existing [`Avatar::manual_until`] hold — if
+//! touch, a pickup, or any other explicit input has already claimed
+//! the emotion, we stand down. Low battery is *background state*: it
+//! shouldn't override a user's deliberate interaction.
+//!
+//! When the modifier fires, it sets a [`LOW_BATTERY_HOLD_MS`] hold.
+//! Subsequent ticks short-circuit on the active hold; once it expires
+//! and the battery is still low, the next tick re-fires and sets a
+//! fresh hold. So Sleepy effectively rolls forward in
+//! [`LOW_BATTERY_HOLD_MS`]-sized chunks, mirroring `AmbientSleepy`.
+//!
+//! [`Avatar::manual_until`]: crate::avatar::Avatar::manual_until
+
+use super::Modifier;
+use crate::avatar::Avatar;
+use crate::clock::Instant;
+use crate::emotion::Emotion;
+
+/// Battery percent below which `Emotion::Sleepy` is forced.
+///
+/// 15% is "still has time to find a charger but should stop being cute
+/// about it" — chosen so the avatar's behaviour change is a usable
+/// hint that the unit needs power, not a panic state.
+pub const LOW_BATTERY_THRESHOLD_PERCENT: u8 = 15;
+
+/// How long the low-battery hold pins Sleepy once set, in ms.
+///
+/// Short (5 s) by design: the modifier re-sets the hold on every
+/// low-battery tick, so the effective behaviour is "Sleepy while
+/// battery low, resume within 5 s of charging back above the
+/// threshold." Mirrors [`super::AMBIENT_HOLD_MS`].
+pub const LOW_BATTERY_HOLD_MS: u64 = 5_000;
+
+/// Modifier that watches [`Avatar::battery_percent`] and forces
+/// `Emotion::Sleepy` below a threshold.
+///
+/// Stateless — purely reads the current battery field and writes
+/// emotion. The threshold is configurable per-instance so apps can
+/// dial the trigger up or down without recompiling the core crate.
+#[derive(Debug, Clone, Copy)]
+pub struct LowBatteryEmotion {
+    /// Trigger threshold; sleepy fires when `battery_percent < threshold`.
+    pub threshold_percent: u8,
+}
+
+impl LowBatteryEmotion {
+    /// Construct with the default threshold ([`LOW_BATTERY_THRESHOLD_PERCENT`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            threshold_percent: LOW_BATTERY_THRESHOLD_PERCENT,
+        }
+    }
+
+    /// Construct with a custom threshold.
+    #[must_use]
+    pub const fn with_threshold(threshold_percent: u8) -> Self {
+        Self { threshold_percent }
+    }
+}
+
+impl Default for LowBatteryEmotion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for LowBatteryEmotion {
+    fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        let Some(percent) = avatar.battery_percent else {
+            // No reading yet — nothing to do.
+            return;
+        };
+
+        if percent >= self.threshold_percent {
+            // Battery healthy; defer to the autonomy stack.
+            return;
+        }
+
+        // Another modifier (touch, pickup, remote) has already claimed
+        // the emotion. Stand down — low battery is background state,
+        // explicit input wins.
+        if let Some(until) = avatar.manual_until
+            && now < until
+        {
+            return;
+        }
+
+        avatar.emotion = Emotion::Sleepy;
+        // Set a fresh hold. Subsequent ticks within the hold window
+        // short-circuit at the manual_until check above; once the
+        // hold expires, the next low-battery tick rolls a new one.
+        avatar.manual_until = Some(now + LOW_BATTERY_HOLD_MS);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: avatar with a healthy battery, well above the threshold.
+    fn healthy_avatar() -> Avatar {
+        Avatar {
+            battery_percent: Some(80),
+            ..Avatar::default()
+        }
+    }
+
+    /// Helper: avatar with a low battery, well below the threshold.
+    fn low_battery_avatar() -> Avatar {
+        Avatar {
+            battery_percent: Some(5),
+            ..Avatar::default()
+        }
+    }
+
+    #[test]
+    fn no_battery_reading_does_nothing() {
+        let mut modifier = LowBatteryEmotion::new();
+        // battery_percent = None
+        let mut avatar = Avatar {
+            emotion: Emotion::Happy,
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn healthy_battery_does_nothing() {
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            emotion: Emotion::Happy,
+            ..healthy_avatar()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn low_battery_forces_sleepy() {
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            emotion: Emotion::Happy,
+            ..low_battery_avatar()
+        };
+        let now = Instant::from_millis(1_000);
+        modifier.update(&mut avatar, now);
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+        assert_eq!(avatar.manual_until, Some(now + LOW_BATTERY_HOLD_MS));
+    }
+
+    #[test]
+    fn manual_hold_suppresses_low_battery_override() {
+        let mut modifier = LowBatteryEmotion::new();
+        let hold_deadline = Instant::from_millis(10_000);
+        let mut avatar = Avatar {
+            // Claimed by e.g. PickupReaction.
+            emotion: Emotion::Surprised,
+            manual_until: Some(hold_deadline),
+            ..low_battery_avatar()
+        };
+        modifier.update(&mut avatar, Instant::from_millis(5_000));
+        // Hold still active — modifier stands down.
+        assert_eq!(avatar.emotion, Emotion::Surprised);
+        assert_eq!(avatar.manual_until, Some(hold_deadline));
+    }
+
+    #[test]
+    fn expired_manual_hold_lets_low_battery_through() {
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            manual_until: Some(Instant::from_millis(1_000)),
+            ..low_battery_avatar()
+        };
+        let now = Instant::from_millis(2_000);
+        modifier.update(&mut avatar, now);
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+        assert_eq!(avatar.manual_until, Some(now + LOW_BATTERY_HOLD_MS));
+    }
+
+    #[test]
+    fn threshold_boundary_at_exactly_threshold_does_not_fire() {
+        // The check is `percent < threshold`, so exactly-at-threshold
+        // is considered healthy. Pin this so it doesn't drift.
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(LOW_BATTERY_THRESHOLD_PERCENT),
+            emotion: Emotion::Happy,
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn threshold_boundary_one_below_fires() {
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(LOW_BATTERY_THRESHOLD_PERCENT - 1),
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+    }
+
+    #[test]
+    fn custom_threshold_takes_effect() {
+        let mut modifier = LowBatteryEmotion::with_threshold(50);
+        let mut avatar = Avatar {
+            battery_percent: Some(40),
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+    }
+
+    #[test]
+    fn second_tick_within_hold_window_does_not_refresh_deadline() {
+        // Mirrors AmbientSleepy: once the modifier sets a hold, it
+        // short-circuits on subsequent ticks until the hold expires.
+        // The hold rolls forward in [LOW_BATTERY_HOLD_MS]-sized
+        // chunks, not on every tick.
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = low_battery_avatar();
+        modifier.update(&mut avatar, Instant::from_millis(1_000));
+        let first_deadline = avatar.manual_until;
+        // Tick again 1 s later — well within the 5 s hold window.
+        modifier.update(&mut avatar, Instant::from_millis(2_000));
+        assert_eq!(avatar.manual_until, first_deadline);
+    }
+
+    #[test]
+    fn rolls_hold_forward_after_expiry() {
+        // After the first hold expires, a still-low battery should
+        // re-fire the modifier and set a fresh hold.
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = low_battery_avatar();
+        modifier.update(&mut avatar, Instant::from_millis(1_000));
+        let first_deadline = avatar.manual_until;
+        // Tick after the hold has expired.
+        let later = Instant::from_millis(1_000 + LOW_BATTERY_HOLD_MS + 1);
+        modifier.update(&mut avatar, later);
+        assert_eq!(avatar.manual_until, Some(later + LOW_BATTERY_HOLD_MS));
+        assert!(avatar.manual_until > first_deadline);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -24,22 +24,27 @@
 //!    (hysteresis 20/50 lux). Runs after `PickupReaction` so a
 //!    pickup-in-the-dark still surfaces as Surprised rather than
 //!    Sleepy.
-//! 5. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
+//! 5. [`LowBatteryEmotion`] — reads `Avatar::battery_percent`, forces
+//!    `Sleepy` (with a short `manual_until` hold) when the `SoC` drops
+//!    below a threshold. Runs alongside `AmbientSleepy` as the
+//!    "environmental override" group; touch / pickup / remote still
+//!    win since this respects an existing `manual_until` hold.
+//! 6. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
 //!    when `manual_until` is unset or expired.
-//! 6. [`EmotionStyle`] — translates emotion into style fields, with a
+//! 7. [`EmotionStyle`] — translates emotion into style fields, with a
 //!    linear ease over the transition window.
-//! 7. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
+//! 8. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
 //!    `blink_rate_scale` from the avatar.
-//! 8. [`Breath`] — vertical drift on all features, scaled by
+//! 9. [`Breath`] — vertical drift on all features, scaled by
 //!    `breath_depth_scale`.
-//! 9. [`IdleDrift`] — occasional eye-center jitter.
-//! 10. [`IdleSway`] — slow pan/tilt head wander written to
+//! 10. [`IdleDrift`] — occasional eye-center jitter.
+//! 11. [`IdleSway`] — slow pan/tilt head wander written to
 //!     `Avatar::head_pose`. Non-visual; drives the firmware's head-update
 //!     task, not the pixel pipeline.
-//! 11. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
+//! 12. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
 //!     sway. Runs **after** `IdleSway` so bias composes additively rather
 //!     than fighting for absolute control of the pose.
-//! 12. [`MouthOpenAudio`] — reads `Avatar::mouth.weight` preserved by
+//! 13. [`MouthOpenAudio`] — reads `Avatar::mouth.weight` preserved by
 //!     earlier modifiers, writes `Avatar::mouth.mouth_open` from
 //!     microphone RMS via a dB-mapped attack/release envelope. Runs
 //!     last in the visual stack so emotion geometry stays the static
@@ -56,6 +61,7 @@ mod emotion_style;
 mod emotion_touch;
 mod idle_drift;
 mod idle_sway;
+mod low_battery;
 mod mouth_open_audio;
 mod pickup_reaction;
 mod remote_command;
@@ -69,6 +75,7 @@ pub use emotion_style::EmotionStyle;
 pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
+pub use low_battery::{LOW_BATTERY_HOLD_MS, LOW_BATTERY_THRESHOLD_PERCENT, LowBatteryEmotion};
 pub use mouth_open_audio::{
     DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthOpenAudio,
 };

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -26,7 +26,7 @@ modifier pipeline at ~30 FPS.
 - `src/clock.rs` — `HalClock` wraps `embassy_time::Instant` to implement `stackchan_core::Clock`
 - `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
 - `src/imu.rs` / `src/mag.rs` — BMI270 / BMM150 tasks publishing to signal channels for the 9-axis data path
-- `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` — per-peripheral tasks
+- `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` / `src/power.rs` — per-peripheral tasks
 - `src/audio.rs` — I²S0 + codec bring-up, then RX RMS loop (publishing on `AUDIO_RMS_SIGNAL`) + TX feeder (1 kHz boot greeting then silence) running concurrently via `embassy_futures::join`
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
 - `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; the streaming I²S path runs only inside `src/audio.rs` in the main firmware)

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -28,5 +28,6 @@ pub mod imu;
 pub mod ir;
 pub mod leds;
 pub mod mag;
+pub mod power;
 pub mod touch;
 pub mod wallclock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -25,7 +25,8 @@
 extern crate alloc;
 
 use stackchan_firmware::{
-    ambient, audio, board, button, clock, framebuffer, head, imu, ir, leds, mag, touch, wallclock,
+    ambient, audio, board, button, clock, framebuffer, head, imu, ir, leds, mag, power, touch,
+    wallclock,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -61,7 +62,7 @@ use stackchan_core::{
     Avatar, Clock, HeadDriver, LedFrame, Modifier,
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
-        IdleDrift, IdleSway, MouthOpenAudio, PickupReaction, RemoteCommand,
+        IdleDrift, IdleSway, LowBatteryEmotion, MouthOpenAudio, PickupReaction, RemoteCommand,
     },
     render_leds,
 };
@@ -166,6 +167,7 @@ async fn render_task(mut display: LcdDisplay) {
     let mut remote = RemoteCommand::new();
     let mut pickup = PickupReaction::new();
     let mut ambient_sleepy = AmbientSleepy::new();
+    let mut low_battery = LowBatteryEmotion::new();
     let mut cycle = EmotionCycle::new();
     let mut style = EmotionStyle::new();
     let mut blink = Blink::new();
@@ -186,7 +188,7 @@ async fn render_task(mut display: LcdDisplay) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + AmbientSleepy + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + MouthOpenAudio",
+        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + MouthOpenAudio",
         FRAME_PERIOD_MS
     );
 
@@ -227,6 +229,12 @@ async fn render_task(mut display: LcdDisplay) {
         if let Some(ut) = mag::MAG_SIGNAL.try_take() {
             avatar.mag_ut = Some(ut);
         }
+        // Drain the latest battery-percent reading from the AXP2101
+        // power task (1 Hz publish rate). `LowBatteryEmotion` reads
+        // `avatar.battery_percent` to decide whether to force Sleepy.
+        if let Some(percent) = power::BATTERY_PERCENT_SIGNAL.try_take() {
+            avatar.battery_percent = Some(percent);
+        }
         // Drain the latest mic-RMS sample from the audio task — the
         // task publishes a fresh `AudioRms(linear)` per ~33 ms window
         // (one render frame at 30 FPS). `try_take` is non-blocking and
@@ -238,6 +246,7 @@ async fn render_task(mut display: LcdDisplay) {
         remote.update(&mut avatar, now);
         pickup.update(&mut avatar, now);
         ambient_sleepy.update(&mut avatar, now);
+        low_battery.update(&mut avatar, now);
         cycle.update(&mut avatar, now);
         style.update(&mut avatar, now);
         blink.update(&mut avatar, now);
@@ -417,6 +426,14 @@ async fn mag_task(shared_i2c: SharedI2c) -> ! {
     mag::run_mag_loop(shared_i2c).await
 }
 
+/// AXP2101 battery-monitor task. Polls the gauge register at 1 Hz
+/// and publishes the `SoC` percent on [`power::BATTERY_PERCENT_SIGNAL`]
+/// for the render task to drain into `avatar.battery_percent`.
+#[embassy_executor::task]
+async fn power_task(shared_i2c: SharedI2c) -> ! {
+    power::run_power_loop(shared_i2c).await
+}
+
 /// Audio task. Owns the I²S0 peripheral + DMA. Runs full bring-up
 /// (I²S MCLK first so ES7210 can answer I²C, both codecs over I²C,
 /// AW88298 volume + un-mute, then RX + TX DMA), then runs the RX RMS
@@ -536,6 +553,9 @@ async fn main(spawner: Spawner) -> ! {
     }
     if let Err(e) = spawner.spawn(mag_task(I2cDevice::new(board_io.i2c_bus))) {
         defmt::panic!("spawn mag_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(power_task(I2cDevice::new(board_io.i2c_bus))) {
+        defmt::panic!("spawn power_task failed: {}", defmt::Debug2Format(&e));
     }
 
     // Audio subsystem. The task owns I²S0 + DMA + audio pins and

--- a/crates/stackchan-firmware/src/power.rs
+++ b/crates/stackchan-firmware/src/power.rs
@@ -1,0 +1,70 @@
+//! AXP2101 battery / power-monitor polling task.
+//!
+//! Polls the PMIC's state-of-charge gauge at 1 Hz and publishes the
+//! latest percentage on [`BATTERY_PERCENT_SIGNAL`]. The render task
+//! drains the signal into `avatar.battery_percent`, where
+//! [`stackchan_core::modifiers::LowBatteryEmotion`] picks it up and
+//! flips emotion to Sleepy when the `SoC` drops below threshold.
+//!
+//! The AXP2101 is already initialised (`init_cores3`) by the main
+//! boot sequence — this task only consumes the chip via reads and
+//! never touches LDO / battery-detect config.
+//!
+//! Failure mode: I²C read errors log at `warn` and we keep polling.
+//! A persistently-failing AXP2101 means `BATTERY_PERCENT_SIGNAL`
+//! never publishes, so `avatar.battery_percent` stays `None` and the
+//! `LowBatteryEmotion` modifier silently no-ops. Other power-related
+//! features (LDO rails) are unaffected — the chip itself is fine,
+//! just the gauge readback isn't reaching the avatar.
+
+use axp2101::Axp2101;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Duration, Ticker};
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+
+/// Latest battery state-of-charge in percent, `0..=100`.
+///
+/// Single producer (this task) → single consumer (the render task's
+/// drain at the top of each tick). Latest-wins matches the consumer's
+/// need: a render task that misses one publish should see the next
+/// one, not a backlog.
+pub static BATTERY_PERCENT_SIGNAL: Signal<CriticalSectionRawMutex, u8> = Signal::new();
+
+/// Poll cadence. The AXP2101's gauge register only changes on the
+/// minute-scale during normal discharge — 1 Hz is luxurious for
+/// charge-tracking and lets the modifier react within ~1 s of a
+/// threshold crossing without spamming the I²C bus.
+const POLL_PERIOD_MS: u64 = 1_000;
+
+/// Run the AXP2101 battery-monitor loop forever. `init_cores3` must
+/// have already run on this bus — that's wired up in the main boot
+/// sequence before any task spawns.
+pub async fn run_power_loop<I: AsyncI2c>(bus: I) -> ! {
+    let mut pmic = Axp2101::new(bus);
+    defmt::info!(
+        "AXP2101 power monitor: polling battery gauge @ {=u64} ms tick",
+        POLL_PERIOD_MS,
+    );
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    let mut last_published: Option<u8> = None;
+    loop {
+        match pmic.read_battery_percent().await {
+            Ok(percent) => {
+                BATTERY_PERCENT_SIGNAL.signal(percent);
+                // Log only when the value changes by a noticeable
+                // amount, otherwise this would emit one info per
+                // second. 1% steps are plenty for human inspection.
+                if last_published != Some(percent) {
+                    defmt::info!("AXP2101: battery {=u8}%", percent);
+                    last_published = Some(percent);
+                }
+            }
+            Err(e) => defmt::warn!(
+                "AXP2101: battery-gauge read failed ({:?})",
+                defmt::Debug2Format(&e),
+            ),
+        }
+        ticker.next().await;
+    }
+}


### PR DESCRIPTION
## Summary
Full vertical feature: extend the `axp2101` crate with a battery state-of-charge reader, add an embassy power-monitor task to firmware, surface SoC on `Avatar`, and add a `LowBatteryEmotion` modifier that forces Sleepy when SoC drops below a threshold.

End-to-end: AXP2101 → power_task → BATTERY_PERCENT_SIGNAL → render task drain → Avatar.battery_percent → LowBatteryEmotion → Avatar.emotion = Sleepy.

## Crate changes

### axp2101 (+101 LOC)
- `read_battery_percent() -> u8` reads register `0xA4` (BAT_GAUGE), saturates at `BATTERY_PERCENT_MAX = 100` to absorb the chip's occasional out-of-range reading during ADC settle after init.
- Test mock extended to handle `Read` operations + per-register canned responses (driver-tests previously only verified writes).
- 3 new tests: value pass-through, saturation, zero passes through.

### stackchan-core (+278 LOC)
- `Avatar.battery_percent: Option<u8>` — `None` until first publish, excluded from `frame_eq` (modifier translates SoC into emotion, not pixels). Mirrors the `ambient_lux` / `mag_ut` field pattern.
- New `LowBatteryEmotion` modifier (`crates/stackchan-core/src/modifiers/low_battery.rs`):
  - Default threshold 15%, hold duration 5 s.
  - Single-threshold check (no hysteresis — per the spec; can swap to hysteresis later if hardware shows flicker around the threshold).
  - Respects `Avatar.manual_until` so touch / pickup / remote still win — low battery is *background state*.
  - 9 unit tests covering the matrix.
- Updated canonical-stack doc in `modifiers/mod.rs` to slot `LowBatteryEmotion` as step 5 (alongside `AmbientSleepy` in the "environmental override" group).

### stackchan-firmware (+97 LOC)
- New `power.rs` module: `run_power_loop` polls the AXP2101 gauge at 1 Hz and publishes on `BATTERY_PERCENT_SIGNAL`. Logs an info line only when the value changes (avoids spamming RTT every second).
- `main.rs`: spawn `power_task` alongside the other shared-I²C consumers, drain `BATTERY_PERCENT_SIGNAL` into `avatar.battery_percent` in the render loop, instantiate `LowBatteryEmotion`, slot `low_battery.update` between `ambient_sleepy` and `cycle`.

## Behaviour
- At 16% battery: avatar continues normal autonomy (above threshold).
- At 14%: modifier fires on the next tick → emotion locks to Sleepy with a 5 s `manual_until` hold. While SoC stays low the hold rolls forward in 5 s chunks (the modifier short-circuits within the hold window and re-fires once it expires — same pattern as `AmbientSleepy`).
- Plug in USB → SoC climbs → once it crosses back above 15%, the next post-hold tick releases and `EmotionCycle` resumes.
- Touch / pickup / remote still wins: any modifier that sets `manual_until` first claims the emotion for its hold duration before LowBatteryEmotion checks.

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Firmware release build links
- [x] Host tests pass: 131 unit (was 121), all doc tests pass
- [ ] **Hardware validation**: `just fmr` and confirm:
  - `AXP2101: battery N%` log line appears within ~1 s of boot
  - Plugging / unplugging USB shows the percent moving in sensible directions
  - Holding the threshold flag low (drop the unit to ~14% or set a temporary higher threshold for testing) flips the avatar to Sleepy