### PR TITLE
feat(firmware): audio TX clip queue + low-battery alert beep

### DIFF
--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -26,9 +26,12 @@
 //!    - RX (`run_rms_loop`): pop DMA samples, compute linear RMS over
 //!      each [`RMS_WINDOW_SAMPLES`]-sample window, normalise against
 //!      full-scale i16, publish on [`AUDIO_RMS_SIGNAL`].
-//!    - TX (`run_tx_loop`): push a 1 kHz sine for the boot greeting
-//!      ([`TONE_DURATION_MS`]), then continuous digital silence so the
-//!      AW88298 stays clock-locked.
+//!    - TX (`run_tx_loop`): play queued [`AudioClip`]s back-to-back,
+//!      filling with digital silence between/after clips so the
+//!      AW88298 stays clock-locked. The bring-up enqueues
+//!      [`BOOT_GREETING`] so the speaker says hello at boot;
+//!      higher-level code (e.g. low-battery alerts) enqueues more
+//!      clips via [`try_enqueue_clip`].
 //!
 //! This matches esp-bsp's ordering in `bsp_audio_codec_microphone_init`:
 //! `bsp_audio_init` (spins up I²S + MCLK) runs *before* `es7210_codec_new`.
@@ -42,7 +45,11 @@
 //!   runs without speaker output).
 
 use aw88298::Aw88298;
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex,
+    channel::{Channel, TrySendError},
+    signal::Signal,
+};
 use embassy_time::{Delay, Duration, Timer};
 use es7210::Es7210;
 use esp_hal::{
@@ -116,21 +123,108 @@ const BOOT_VOLUME_DB: i8 = -18;
 /// speaker doesn't pop.
 const TX_SETTLE_MS: u32 = 30;
 
-/// Boot-greeting tone duration. ~½ s is long enough to be unmistakably
-/// audible without becoming annoying on every reboot.
-const TONE_DURATION_MS: u32 = 500;
-
-/// Total samples in the boot-greeting tone burst.
-const TONE_TOTAL_SAMPLES: u32 = SAMPLE_RATE_HZ * TONE_DURATION_MS / 1000;
-
-/// One-cycle sine table, 16 samples = 1 kHz at 16 kHz sample rate.
-/// Amplitude `8192 ≈ -12 dBFS`, picked so the AW88298 output stage
-/// stays well clear of the digital ceiling. Pre-computed at compile
-/// time so the TX feeder is `sin()`-free at runtime (and `libm`-free
-/// in this firmware crate).
-const SINE_TABLE: [i16; 16] = [
+/// One-cycle 1 kHz sine table at 16 kHz sample rate. 16 samples per
+/// cycle. Amplitude `8192 ≈ -12 dBFS`, picked so the AW88298 output
+/// stage stays well clear of the digital ceiling. Pre-computed at
+/// compile time so the TX feeder is `sin()`-free at runtime (and
+/// `libm`-free in this firmware crate).
+const SINE_1KHZ_CYCLE: [i16; 16] = [
     0, 3135, 5793, 7568, 8192, 7568, 5793, 3135, 0, -3135, -5793, -7568, -8192, -7568, -5793, -3135,
 ];
+
+/// One-cycle 2 kHz sine table at 16 kHz sample rate. 8 samples per
+/// cycle. Same -12 dBFS amplitude as [`SINE_1KHZ_CYCLE`]; intended for
+/// alert-style beeps (low-battery, error chirps) where the higher
+/// pitch makes it distinct from the boot greeting.
+const SINE_2KHZ_CYCLE: [i16; 8] = [0, 5793, 8192, 5793, 0, -5793, -8192, -5793];
+
+/// Boot-greeting clip: 500 ms of 1 kHz sine. Plays once at boot via
+/// [`run_audio_task`] enqueueing it into [`AUDIO_TX_QUEUE`].
+///
+/// `500 cycles × 16 samples = 8 000 samples = 500 ms` at the 16 kHz
+/// sample rate. Tweak `cycles` to change duration without touching
+/// the table.
+pub const BOOT_GREETING: AudioClip = AudioClip {
+    samples: &SINE_1KHZ_CYCLE,
+    cycles: 500,
+};
+
+/// Two short 2 kHz beeps separated by silence — the canonical
+/// "low battery" alert. Producers (e.g. main.rs's render loop on a
+/// threshold-crossing detection) enqueue this clip via
+/// [`try_enqueue_clip`].
+///
+/// One full beep = 200 ms = 400 cycles at 8 samples / cycle.
+/// The current encoding is one continuous beep; if hardware listening
+/// suggests two short pulses are clearer, swap the table for
+/// `[beep, gap, beep]` of equivalent total length.
+pub const LOW_BATTERY_ALERT: AudioClip = AudioClip {
+    samples: &SINE_2KHZ_CYCLE,
+    cycles: 400,
+};
+
+/// PCM audio clip queued for TX playback.
+///
+/// Stored as a `&'static [i16]` buffer (one cycle of a tone, or a
+/// pre-baked sample) plus a `cycles` count. The TX feeder plays
+/// through `samples` `cycles` times back-to-back, then transitions
+/// to silence (or the next queued clip).
+///
+/// `cycles = 0` plays nothing — the clip is consumed but produces
+/// zero output samples. Useful for testing the queue without making
+/// noise.
+///
+/// # Examples
+///
+/// ```ignore
+/// // 500 ms of a 1 kHz tone using a 16-sample cycle table.
+/// const TONE: &[i16] = &[/* one 1 kHz cycle at 16 kHz */];
+/// let clip = AudioClip::new(TONE, 500);
+/// audio::AUDIO_TX_QUEUE.try_send(clip).ok();
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct AudioClip {
+    /// Sample buffer. Played through `cycles` times, in order.
+    /// Conventional encoding: 16-bit signed mono at
+    /// [`SAMPLE_RATE_HZ`].
+    pub samples: &'static [i16],
+    /// How many times to loop through `samples`. `1` = one-shot.
+    pub cycles: u32,
+}
+
+impl AudioClip {
+    /// Construct a clip from a sample buffer + cycle count.
+    #[must_use]
+    pub const fn new(samples: &'static [i16], cycles: u32) -> Self {
+        Self { samples, cycles }
+    }
+
+    /// Construct a one-shot clip (plays through `samples` exactly once).
+    #[must_use]
+    pub const fn one_shot(samples: &'static [i16]) -> Self {
+        Self { samples, cycles: 1 }
+    }
+}
+
+/// TX clip queue.
+///
+/// Producers (any task) enqueue [`AudioClip`]s; the audio task plays
+/// them back-to-back, falling back to digital silence when empty.
+/// Capacity 4 fits a few queued alerts without blocking the producer;
+/// when the queue is full, [`try_enqueue_clip`] returns `Err` and the
+/// caller can drop the clip rather than block.
+pub static AUDIO_TX_QUEUE: Channel<CriticalSectionRawMutex, AudioClip, 4> = Channel::new();
+
+/// Enqueue a clip for TX playback. Non-blocking; returns `Err` if the
+/// queue is full so the caller can drop the clip rather than wait.
+///
+/// # Errors
+///
+/// Returns [`TrySendError::Full`] if [`AUDIO_TX_QUEUE`] has 4 clips
+/// already queued.
+pub fn try_enqueue_clip(clip: AudioClip) -> Result<(), TrySendError<AudioClip>> {
+    AUDIO_TX_QUEUE.try_send(clip)
+}
 
 /// Microphone RMS sample, published per render tick.
 ///
@@ -359,10 +453,20 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
         defmt::info!("audio: AW88298 un-muted — speaker live");
     }
 
+    // Enqueue the boot greeting so the TX feeder has audible content
+    // queued up the moment it starts pushing samples. If somehow the
+    // queue is already full (shouldn't be — this is the first
+    // producer) we drop the clip rather than block bring-up.
+    if let Err(e) = try_enqueue_clip(BOOT_GREETING) {
+        defmt::warn!(
+            "audio: failed to enqueue boot greeting ({:?}); silent boot",
+            defmt::Debug2Format(&e)
+        );
+    }
+
     defmt::info!(
-        "audio: bring-up complete — RX RMS loop ({=u32}-sample windows) + TX feeder (boot tone {=u32} ms)",
+        "audio: bring-up complete — RX RMS loop ({=u32}-sample windows) + TX feeder (clip-queue driven)",
         RMS_WINDOW_SAMPLES,
-        TONE_DURATION_MS,
     );
 
     // Both halves are `-> !`, so `join` itself never resolves; the
@@ -479,37 +583,71 @@ fn accumulate(sum_sq: &mut f32, count: &mut u32, sample: i16) {
     *count += 1;
 }
 
-/// TX feeder. Pushes a 1 kHz boot-greeting sine for [`TONE_DURATION_MS`],
-/// then continuous digital silence (zero samples) so the AW88298's I²S
-/// receiver stays locked to the clock domain even when the firmware
-/// isn't producing audio.
+/// In-flight playback of one [`AudioClip`]. Tracks the cursor inside
+/// `samples` and how many full cycles remain.
+struct ClipPlayback {
+    /// Held by reference; the clip itself lives in `.rodata` (or any
+    /// `'static` location).
+    samples: &'static [i16],
+    /// Index of the next sample to emit on a `next_sample()` call.
+    cursor: usize,
+    /// Cycles left to play through `samples`. Decremented to zero
+    /// when the cursor wraps past the end of the slice; once at zero
+    /// the clip is done and `next_sample()` returns `None`.
+    cycles_remaining: u32,
+}
+
+impl ClipPlayback {
+    /// Construct a fresh playback cursor at the start of `clip`.
+    const fn new(clip: AudioClip) -> Self {
+        Self {
+            samples: clip.samples,
+            cursor: 0,
+            cycles_remaining: clip.cycles,
+        }
+    }
+
+    /// Yield the next sample, or `None` if the clip is done. An empty
+    /// `samples` slice or `cycles = 0` yields `None` immediately.
+    fn next_sample(&mut self) -> Option<i16> {
+        if self.cycles_remaining == 0 || self.samples.is_empty() {
+            return None;
+        }
+        let s = self.samples[self.cursor];
+        self.cursor += 1;
+        if self.cursor >= self.samples.len() {
+            self.cursor = 0;
+            self.cycles_remaining -= 1;
+        }
+        Some(s)
+    }
+}
+
+/// TX feeder. Pulls [`AudioClip`]s off [`AUDIO_TX_QUEUE`] and plays
+/// them back-to-back; emits digital silence when the queue is empty
+/// so the AW88298's I²S receiver stays locked to the clock domain.
 ///
-/// Uses `push_with` so the closure produces exactly as many samples as
-/// the DMA tail accepts in this batch — no partial-acceptance bookkeeping
-/// outside the closure, and the sine phase advances 1:1 with samples
-/// actually played.
+/// Mid-batch transitions: when one clip ends partway through a push
+/// buffer, the feeder immediately checks the queue for the next clip
+/// and continues without an audible gap. If nothing is queued, the
+/// remainder of the buffer is filled with zeros and the loop tries
+/// again on the next push.
+///
+/// Uses `push_with` so the closure produces exactly as many samples
+/// as the DMA tail accepts in this batch — no partial-acceptance
+/// bookkeeping outside the closure.
 async fn run_tx_loop<BUFFER>(
     tx_transfer: &mut esp_hal::i2s::master::asynch::I2sWriteDmaTransferAsync<'_, BUFFER>,
 ) -> ! {
-    // Counts down per sample written. When it hits zero we switch to
-    // silence; checked after each `push_with` for the diagnostic log.
-    let mut tone_remaining: u32 = TONE_TOTAL_SAMPLES;
-    let mut sine_phase: usize = 0;
-    let mut announced_silence = false;
+    // The currently-playing clip, if any. `None` = silence.
+    let mut current: Option<ClipPlayback> = None;
 
     loop {
         let result = tx_transfer
             .push_with(|buf: &mut [u8]| {
                 let pairs = buf.len() / 2;
                 for i in 0..pairs {
-                    let sample = if tone_remaining > 0 {
-                        let s = SINE_TABLE[sine_phase];
-                        sine_phase = (sine_phase + 1) % SINE_TABLE.len();
-                        tone_remaining -= 1;
-                        s
-                    } else {
-                        0
-                    };
+                    let sample = next_sample_with_chaining(&mut current);
                     let bytes = sample.to_le_bytes();
                     buf[i * 2] = bytes[0];
                     buf[i * 2 + 1] = bytes[1];
@@ -524,17 +662,31 @@ async fn run_tx_loop<BUFFER>(
                 defmt::Debug2Format(&e)
             );
             Timer::after(Duration::from_millis(10)).await;
-            continue;
-        }
-
-        if !announced_silence && tone_remaining == 0 {
-            defmt::info!(
-                "audio: boot tone done ({=u32} samples); switching to silence",
-                TONE_TOTAL_SAMPLES,
-            );
-            announced_silence = true;
         }
     }
+}
+
+/// Yield one TX sample. If the current clip is exhausted, transition
+/// straight into the next queued clip (if any) so consecutive clips
+/// play without a silence gap. Returns `0` if no clip is playable.
+fn next_sample_with_chaining(current: &mut Option<ClipPlayback>) -> i16 {
+    // Up to two iterations: first attempt with `current`, second
+    // attempt with whatever was just pulled from the queue. Bounded
+    // because each new clip yields at least one sample (or `None` if
+    // its slice is empty / cycles == 0, in which case we fall
+    // through to silence).
+    for _ in 0..2 {
+        if let Some(s) = current.as_mut().and_then(ClipPlayback::next_sample) {
+            return s;
+        }
+        *current = AUDIO_TX_QUEUE.try_receive().ok().map(ClipPlayback::new);
+        if current.is_none() {
+            return 0;
+        }
+    }
+    // Shouldn't reach here for non-degenerate clips. Treat any
+    // pathological zero-yield clip as silence.
+    0
 }
 
 /// Infinite sleep for tasks that have nothing else to do. `-> !` so

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -62,7 +62,8 @@ use stackchan_core::{
     Avatar, Clock, HeadDriver, LedFrame, Modifier,
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
-        IdleDrift, IdleSway, LowBatteryEmotion, MouthOpenAudio, PickupReaction, RemoteCommand,
+        IdleDrift, IdleSway, LOW_BATTERY_THRESHOLD_PERCENT, LowBatteryEmotion, MouthOpenAudio,
+        PickupReaction, RemoteCommand,
     },
     render_leds,
 };
@@ -151,6 +152,10 @@ type LcdDisplay = mipidsi::Display<
 /// trigger a redundant LCD blit because `head_pose` is excluded from
 /// `frame_eq`.
 #[embassy_executor::task]
+#[allow(
+    clippy::too_many_lines,
+    reason = "tick body composes 12+ modifiers + sensor drains + render — splitting fragments the per-frame ordering invariants"
+)]
 async fn render_task(mut display: LcdDisplay) {
     let clock = HalClock;
     let mut fb = Framebuffer::new();
@@ -182,6 +187,12 @@ async fn render_task(mut display: LcdDisplay) {
     let mut mouth_open_audio = MouthOpenAudio::new();
     let mut last_rendered: Option<Avatar> = None;
     let mut led_frame = LedFrame::default();
+    // Tracks the previous battery-percent reading so we can detect a
+    // *downward* crossing of `LOW_BATTERY_THRESHOLD_PERCENT` and fire
+    // the low-battery alert clip exactly once per crossing event.
+    // `None` until the first reading; the boot reading itself never
+    // counts as a crossing.
+    let mut last_battery_percent: Option<u8> = None;
 
     // Pre-compute the blit rect once; it never changes.
     let canvas = Rectangle::new(EgPoint::zero(), Size::new(FB_WIDTH, FB_HEIGHT));
@@ -232,8 +243,30 @@ async fn render_task(mut display: LcdDisplay) {
         // Drain the latest battery-percent reading from the AXP2101
         // power task (1 Hz publish rate). `LowBatteryEmotion` reads
         // `avatar.battery_percent` to decide whether to force Sleepy.
+        // A *downward* crossing of the threshold (e.g. 16% → 14%)
+        // also fires the low-battery alert clip once per crossing —
+        // the audible cue complements the silent emotion change.
         if let Some(percent) = power::BATTERY_PERCENT_SIGNAL.try_take() {
             avatar.battery_percent = Some(percent);
+            if let Some(prev) = last_battery_percent
+                && prev >= LOW_BATTERY_THRESHOLD_PERCENT
+                && percent < LOW_BATTERY_THRESHOLD_PERCENT
+            {
+                if let Err(e) = audio::try_enqueue_clip(audio::LOW_BATTERY_ALERT) {
+                    defmt::warn!(
+                        "audio: low-battery alert dropped, queue full ({:?})",
+                        defmt::Debug2Format(&e)
+                    );
+                } else {
+                    defmt::info!(
+                        "audio: low-battery alert enqueued ({=u8}% → {=u8}%, threshold {=u8}%)",
+                        prev,
+                        percent,
+                        LOW_BATTERY_THRESHOLD_PERCENT,
+                    );
+                }
+            }
+            last_battery_percent = Some(percent);
         }
         // Drain the latest mic-RMS sample from the audio task — the
         // task publishes a fresh `AudioRms(linear)` per ~33 ms window


### PR DESCRIPTION
## Summary
Refactor the TX feeder to consume from an embassy `Channel<AudioClip>` instead of generating the boot tone inline. Producers anywhere in the firmware can now enqueue clips for playback; the feeder plays them back-to-back and falls back to digital silence between/after.

End-to-end demo of the new API: PR #52's low-battery threshold crossing now emits an audible beep alongside the silent emotion change.

## API additions (in `crates/stackchan-firmware/src/audio.rs`)
- `pub struct AudioClip { samples: &'static [i16], cycles: u32 }` — PCM clip with a cycle count for compact tone storage.
- `pub static AUDIO_TX_QUEUE: Channel<_, AudioClip, 4>` — capacity 4 fits a few queued alerts; full-queue producers get `Err` rather than block the audio task.
- `pub fn try_enqueue_clip(clip) -> Result<(), TrySendError<AudioClip>>` — non-blocking enqueue.
- `pub const BOOT_GREETING: AudioClip` — the 1 kHz / 500 ms boot tone, factored out of the previous inline generator.
- `pub const LOW_BATTERY_ALERT: AudioClip` — 200 ms 2 kHz beep using a new 8-sample 2 kHz cycle table; the higher pitch makes it distinct from the boot greeting.

## TX feeder refactor
- New `ClipPlayback` helper holds the cursor + cycles-remaining for one in-flight clip.
- `next_sample_with_chaining` yields the next sample, transparently pulling the next queued clip from `AUDIO_TX_QUEUE` if the current one ends mid-buffer. Bounded loop (max 2 iterations) so a degenerate empty/zero-cycle clip can't infinite-loop the feeder.
- `run_tx_loop` becomes a thin DMA-push loop around the chaining helper. The feeder no longer has a "tone vs silence" state machine; clip presence drives output entirely.

The boot greeting plays exactly the same audibly — it's now just `AUDIO_TX_QUEUE.try_send(BOOT_GREETING)` at the end of bring-up instead of inline generation.

## Low-battery alert wiring (main.rs)
The render loop tracks `last_battery_percent` and detects a downward crossing of `LOW_BATTERY_THRESHOLD_PERCENT` (e.g. 16% → 14%). On crossing it enqueues `LOW_BATTERY_ALERT` once via `audio::try_enqueue_clip`.

The audible cue complements the silent emotion change driven by `LowBatteryEmotion` (PR #52). Crossing only fires once per downward transition; if battery climbs back up and dips again, you get another beep.

## Implementation notes
- **Compact tone storage**: a 500 ms 1 kHz tone is 8000 samples = 16 KB if stored as raw PCM. Stored as `&[i16; 16] × cycles=500` it's 32 bytes + a u32. The TX feeder loops the cycle internally; flash usage stays trivial. Same trick for the 200 ms 2 kHz alert (16 bytes + u32).
- **Mid-batch clip transitions matter**: when clip A ends sample-7-of-128 in a push buffer, ideally clip B (if queued) starts at sample 8. Otherwise there's a perceptible 8 ms silence gap. Pulling the next clip on `None` from the per-sample iterator handles this naturally.
- **Why `Channel<AudioClip>` not `Channel<i16>`**: a per-sample channel at 16 kHz means 16K wakes/second on the executor — a death sentence for any async runtime. Per-clip channel is ~2 sends/sec in practice.

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Firmware release build links
- [x] Host tests pass
- [ ] **Hardware validation**: `just fmr` and confirm:
  - Boot greeting still plays at the same pitch / duration / amplitude as PR #51
  - Plug → unplug → drop battery below 15% triggers a 200 ms 2 kHz beep, distinct from the boot tone
  - "audio: low-battery alert enqueued" log line appears on the threshold crossing
  - No audible artefacts at clip boundaries (gap or click)

PR 2E of the audio stack. Sets up the path for TTS / canned phrases that arrive in pre-baked PCM form on a future PR.