### PR TITLE
feat: low-battery hysteresis + USB-power aware override

### DIFF
--- a/crates/axp2101/src/lib.rs
+++ b/crates/axp2101/src/lib.rs
@@ -43,6 +43,12 @@ const REG_IRQ_STATUS_1: u8 = 0x49;
 /// estimate. Reads outside that range only happen during transient
 /// chip warm-up and are clamped by [`Axp2101::read_battery_percent`].
 const REG_BAT_GAUGE: u8 = 0xA4;
+/// `PMU_STATUS_1` register address (`0x00`). Bit 5 = `VBUSGD`, set
+/// when the chip detects a valid VBUS voltage on the USB-C input.
+const REG_PMU_STATUS_1: u8 = 0x00;
+/// Bit mask for `VBUSGD` inside `PMU_STATUS_1`. `1` = USB power good
+/// (chip can be charging or simply running off USB).
+const VBUS_GOOD_BIT: u8 = 1 << 5;
 
 /// Maximum value the AXP2101 battery-gauge register reports. Anything
 /// higher is read-back noise during ADC settle and is saturated by
@@ -243,6 +249,22 @@ where
         Ok(true)
     }
 
+    /// Read whether the AXP2101 sees valid VBUS (USB) input voltage.
+    ///
+    /// Returns `true` when the chip's `VBUSGD` flag in `PMU_STATUS_1`
+    /// is set. The flag asserts whenever there's enough voltage on the
+    /// USB-C input for the chip to consider it a valid source —
+    /// independent of whether the unit is actively charging the
+    /// battery, just running off USB, or both.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::I2c`] on bus errors.
+    pub async fn read_usb_power_good(&mut self) -> Result<bool, Error<B::Error>> {
+        let status = self.read_reg(REG_PMU_STATUS_1).await?;
+        Ok(status & VBUS_GOOD_BIT != 0)
+    }
+
     /// Read the AXP2101's battery state-of-charge estimate, in percent.
     ///
     /// Returns a value in <code>0..=[BATTERY_PERCENT_MAX]</code>. The
@@ -432,5 +454,32 @@ mod tests {
         let mut pmic = Axp2101::new(bus);
         let pct = block_on(pmic.read_battery_percent()).unwrap();
         assert_eq!(pct, 0);
+    }
+
+    #[test]
+    fn read_usb_power_good_true_when_vbus_bit_set() {
+        // PMU_STATUS_1 with VBUSGD bit set + some unrelated bits.
+        let bus = MockI2c::new().with_register(REG_PMU_STATUS_1, VBUS_GOOD_BIT | 0x83);
+        let mut pmic = Axp2101::new(bus);
+        let usb_good = block_on(pmic.read_usb_power_good()).unwrap();
+        assert!(usb_good);
+    }
+
+    #[test]
+    fn read_usb_power_good_false_when_vbus_bit_clear() {
+        // PMU_STATUS_1 with everything except VBUSGD set — the read
+        // must isolate the right bit, not key off any-bit-set.
+        let bus = MockI2c::new().with_register(REG_PMU_STATUS_1, !VBUS_GOOD_BIT);
+        let mut pmic = Axp2101::new(bus);
+        let usb_good = block_on(pmic.read_usb_power_good()).unwrap();
+        assert!(!usb_good);
+    }
+
+    #[test]
+    fn read_usb_power_good_zero_register_returns_false() {
+        let bus = MockI2c::new().with_register(REG_PMU_STATUS_1, 0);
+        let mut pmic = Axp2101::new(bus);
+        let usb_good = block_on(pmic.read_usb_power_good()).unwrap();
+        assert!(!usb_good);
     }
 }

--- a/crates/stackchan-core/src/avatar.rs
+++ b/crates/stackchan-core/src/avatar.rs
@@ -247,6 +247,15 @@ pub struct Avatar {
     /// [`Avatar::frame_eq`] — modifiers translate the percentage into
     /// visible state via `Avatar::emotion`, never directly into pixels.
     pub battery_percent: Option<u8>,
+    /// Whether the AXP2101 reports valid USB power on its VBUS input,
+    /// or `None` before the first successful read. Written by the
+    /// firmware power task. `Some(true)` indicates the unit is
+    /// charging or running off USB; consumers (e.g.
+    /// [`super::modifiers::LowBatteryEmotion`]) can suppress
+    /// low-battery behaviour while plugged in. Excluded from
+    /// [`Avatar::frame_eq`] for the same reasons as
+    /// [`Avatar::battery_percent`].
+    pub usb_power_present: Option<bool>,
 }
 
 impl Avatar {
@@ -325,6 +334,8 @@ impl Default for Avatar {
             mag_ut: None,
             // No battery reading until the AXP2101 task publishes one.
             battery_percent: None,
+            // No USB-power reading until the AXP2101 task publishes one.
+            usb_power_present: None,
         }
     }
 }

--- a/crates/stackchan-core/src/modifiers/low_battery.rs
+++ b/crates/stackchan-core/src/modifiers/low_battery.rs
@@ -3,16 +3,31 @@
 //!
 //! ## Detection shape
 //!
-//! Reads `avatar.battery_percent` each tick. Single-threshold check
-//! (no hysteresis); the AXP2101's internal `SoC` estimate is already
-//! smoothed and the threshold is conservative enough that bouncing
-//! across the boundary should be rare in practice. If hardware
-//! observation shows flicker, swap to a two-threshold variant
-//! mirroring [`super::AmbientSleepy`].
+//! Reads `avatar.battery_percent` each tick. Two-threshold hysteresis
+//! mirrors [`super::AmbientSleepy`]:
+//!
+//! - **Enter low:** percent below [`LOW_BATTERY_ENTER_PERCENT`] while
+//!   not already low.
+//! - **Exit low:** percent above [`LOW_BATTERY_EXIT_PERCENT`] while
+//!   currently low. Clears this modifier's own state so autonomy
+//!   resumes immediately on the next tick.
+//! - Between the two thresholds, the modifier holds its current
+//!   state — preventing flicker if the chip's `SoC` estimate is
+//!   noisy near the trigger.
 //!
 //! Unknown battery (`battery_percent = None`, i.e. the power task
 //! hasn't published a reading yet) is treated as "no information"
-//! and never triggers the override.
+//! and never transitions either way.
+//!
+//! ## USB-power suppression
+//!
+//! Even when the percent is below the enter threshold, the modifier
+//! stands down if `avatar.usb_power_present == Some(true)`. The
+//! reasoning: the unit is charging (or running off USB), so going
+//! "sleepy" is the wrong UX — it should look attentive while plugged
+//! in even with a depleted battery. Unknown USB state
+//! (`usb_power_present = None`) is treated as not-charging, so a
+//! pre-first-read tick still allows the override.
 //!
 //! ## Coordination with the other emotion modifiers
 //!
@@ -24,9 +39,9 @@
 //!
 //! When the modifier fires, it sets a [`LOW_BATTERY_HOLD_MS`] hold.
 //! Subsequent ticks short-circuit on the active hold; once it expires
-//! and the battery is still low, the next tick re-fires and sets a
-//! fresh hold. So Sleepy effectively rolls forward in
-//! [`LOW_BATTERY_HOLD_MS`]-sized chunks, mirroring `AmbientSleepy`.
+//! and the battery is still low (and not on USB), the next tick
+//! re-fires and sets a fresh hold. So Sleepy effectively rolls forward
+//! in [`LOW_BATTERY_HOLD_MS`]-sized chunks, mirroring `AmbientSleepy`.
 //!
 //! [`Avatar::manual_until`]: crate::avatar::Avatar::manual_until
 
@@ -40,7 +55,27 @@ use crate::emotion::Emotion;
 /// 15% is "still has time to find a charger but should stop being cute
 /// about it" — chosen so the avatar's behaviour change is a usable
 /// hint that the unit needs power, not a panic state.
-pub const LOW_BATTERY_THRESHOLD_PERCENT: u8 = 15;
+pub const LOW_BATTERY_ENTER_PERCENT: u8 = 15;
+
+/// Battery percent above which the modifier exits low-battery state.
+///
+/// 20% is the hysteresis upper bound: charging back to ≥ 20% releases
+/// the override. The 5-percentage-point gap is wide enough to absorb
+/// the AXP2101's typical reporting noise (1–2% LSB jitter under the
+/// CoreS3's discharge curve) without flicker.
+pub const LOW_BATTERY_EXIT_PERCENT: u8 = 20;
+
+/// Backwards-compat alias for the old single-threshold const.
+///
+/// Kept so downstream code that imported
+/// [`LOW_BATTERY_THRESHOLD_PERCENT`] (e.g. firmware's threshold-
+/// crossing detector for the alert beep) keeps compiling; new code
+/// should use the explicit `ENTER` / `EXIT` consts.
+#[deprecated(
+    since = "0.6.0",
+    note = "use LOW_BATTERY_ENTER_PERCENT or LOW_BATTERY_EXIT_PERCENT"
+)]
+pub const LOW_BATTERY_THRESHOLD_PERCENT: u8 = LOW_BATTERY_ENTER_PERCENT;
 
 /// How long the low-battery hold pins Sleepy once set, in ms.
 ///
@@ -51,30 +86,54 @@ pub const LOW_BATTERY_THRESHOLD_PERCENT: u8 = 15;
 pub const LOW_BATTERY_HOLD_MS: u64 = 5_000;
 
 /// Modifier that watches [`Avatar::battery_percent`] and forces
-/// `Emotion::Sleepy` below a threshold.
+/// `Emotion::Sleepy` below a threshold, with hysteresis and USB-power
+/// suppression.
 ///
-/// Stateless — purely reads the current battery field and writes
-/// emotion. The threshold is configurable per-instance so apps can
-/// dial the trigger up or down without recompiling the core crate.
+/// Thresholds are configurable per-instance so apps can dial them up
+/// or down without recompiling the core crate.
 #[derive(Debug, Clone, Copy)]
 pub struct LowBatteryEmotion {
-    /// Trigger threshold; sleepy fires when `battery_percent < threshold`.
-    pub threshold_percent: u8,
+    /// Lower threshold (`<`): transitions out of healthy into low.
+    pub enter_threshold_percent: u8,
+    /// Upper threshold (`>`): transitions out of low back into healthy.
+    pub exit_threshold_percent: u8,
+    /// Hysteresis state: `true` once we've crossed below the enter
+    /// threshold, `false` once we've crossed back above the exit
+    /// threshold. Drives the actual override decision each tick.
+    is_low: bool,
 }
 
 impl LowBatteryEmotion {
-    /// Construct with the default threshold ([`LOW_BATTERY_THRESHOLD_PERCENT`]).
+    /// Construct with the default thresholds
+    /// ([`LOW_BATTERY_ENTER_PERCENT`] / [`LOW_BATTERY_EXIT_PERCENT`]).
     #[must_use]
     pub const fn new() -> Self {
         Self {
-            threshold_percent: LOW_BATTERY_THRESHOLD_PERCENT,
+            enter_threshold_percent: LOW_BATTERY_ENTER_PERCENT,
+            exit_threshold_percent: LOW_BATTERY_EXIT_PERCENT,
+            is_low: false,
         }
     }
 
-    /// Construct with a custom threshold.
+    /// Construct with custom thresholds. `exit_threshold_percent`
+    /// should normally be greater than `enter_threshold_percent` for
+    /// real hysteresis; the modifier doesn't enforce this so unusual
+    /// configurations (single-threshold by setting them equal) work
+    /// without ceremony.
     #[must_use]
-    pub const fn with_threshold(threshold_percent: u8) -> Self {
-        Self { threshold_percent }
+    pub const fn with_thresholds(enter_threshold_percent: u8, exit_threshold_percent: u8) -> Self {
+        Self {
+            enter_threshold_percent,
+            exit_threshold_percent,
+            is_low: false,
+        }
+    }
+
+    /// Exposed for tests: whether the modifier currently believes the
+    /// battery is in the low state.
+    #[cfg(test)]
+    const fn is_low(self) -> bool {
+        self.is_low
     }
 }
 
@@ -91,8 +150,22 @@ impl Modifier for LowBatteryEmotion {
             return;
         };
 
-        if percent >= self.threshold_percent {
-            // Battery healthy; defer to the autonomy stack.
+        // Hysteresis: update our internal "is_low" belief.
+        if !self.is_low && percent < self.enter_threshold_percent {
+            self.is_low = true;
+        } else if self.is_low && percent > self.exit_threshold_percent {
+            self.is_low = false;
+        }
+
+        if !self.is_low {
+            return;
+        }
+
+        // USB power present — the unit is charging or running off USB.
+        // Going "sleepy" while plugged in is the wrong UX; suppress.
+        // Unknown USB state (None) falls through and lets the override
+        // fire, so a still-booting power task doesn't block the cue.
+        if avatar.usb_power_present == Some(true) {
             return;
         }
 
@@ -201,25 +274,93 @@ mod tests {
     }
 
     #[test]
-    fn threshold_boundary_at_exactly_threshold_does_not_fire() {
-        // The check is `percent < threshold`, so exactly-at-threshold
-        // is considered healthy. Pin this so it doesn't drift.
+    fn enter_threshold_boundary_at_exactly_threshold_does_not_fire() {
+        // The check is `percent < enter_threshold`, so
+        // exactly-at-threshold is considered healthy.
         let mut modifier = LowBatteryEmotion::new();
         let mut avatar = Avatar {
-            battery_percent: Some(LOW_BATTERY_THRESHOLD_PERCENT),
+            battery_percent: Some(LOW_BATTERY_ENTER_PERCENT),
             emotion: Emotion::Happy,
             ..Avatar::default()
         };
         modifier.update(&mut avatar, Instant::ZERO);
         assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(!modifier.is_low());
+    }
+
+    #[test]
+    fn enter_threshold_boundary_one_below_fires() {
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(LOW_BATTERY_ENTER_PERCENT - 1),
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+        assert!(modifier.is_low());
+    }
+
+    #[test]
+    fn hysteresis_holds_low_state_within_band() {
+        // Once below the enter threshold, the modifier stays low until
+        // the percent crosses *above* the exit threshold — even if it
+        // climbs above the enter threshold along the way.
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(10),
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::from_millis(0));
+        assert!(modifier.is_low());
+
+        // Climb to mid-band: still low.
+        avatar.battery_percent = Some(17);
+        modifier.update(&mut avatar, Instant::from_millis(LOW_BATTERY_HOLD_MS + 1));
+        assert!(modifier.is_low());
+
+        // Climb just above exit threshold: still low (need *above*, not at).
+        avatar.battery_percent = Some(LOW_BATTERY_EXIT_PERCENT);
+        modifier.update(
+            &mut avatar,
+            Instant::from_millis(2 * LOW_BATTERY_HOLD_MS + 1),
+        );
+        assert!(modifier.is_low());
+
+        // Climb past exit: clears.
+        avatar.battery_percent = Some(LOW_BATTERY_EXIT_PERCENT + 1);
+        modifier.update(
+            &mut avatar,
+            Instant::from_millis(3 * LOW_BATTERY_HOLD_MS + 1),
+        );
+        assert!(!modifier.is_low());
+    }
+
+    #[test]
+    fn usb_power_suppresses_low_battery_override() {
+        // Battery is below threshold but USB is plugged in — modifier
+        // tracks "is_low" but does not write Sleepy.
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(5),
+            usb_power_present: Some(true),
+            emotion: Emotion::Happy,
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::ZERO);
+        assert!(modifier.is_low());
+        assert_eq!(avatar.emotion, Emotion::Happy);
         assert!(avatar.manual_until.is_none());
     }
 
     #[test]
-    fn threshold_boundary_one_below_fires() {
+    fn unknown_usb_state_lets_override_fire() {
+        // `usb_power_present = None` (pre-first-read) shouldn't block
+        // the modifier; we'd rather show low-battery once and correct
+        // later than miss the cue.
         let mut modifier = LowBatteryEmotion::new();
         let mut avatar = Avatar {
-            battery_percent: Some(LOW_BATTERY_THRESHOLD_PERCENT - 1),
+            battery_percent: Some(5),
+            usb_power_present: None,
             ..Avatar::default()
         };
         modifier.update(&mut avatar, Instant::ZERO);
@@ -227,14 +368,48 @@ mod tests {
     }
 
     #[test]
-    fn custom_threshold_takes_effect() {
-        let mut modifier = LowBatteryEmotion::with_threshold(50);
+    fn unplugging_usb_releases_suppression() {
+        // Plugged in, low battery → no override.
+        // Unplug while still low → override fires on the next tick.
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(5),
+            usb_power_present: Some(true),
+            ..Avatar::default()
+        };
+        modifier.update(&mut avatar, Instant::from_millis(0));
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert!(modifier.is_low());
+
+        // Unplug.
+        avatar.usb_power_present = Some(false);
+        modifier.update(&mut avatar, Instant::from_millis(1_000));
+        assert_eq!(avatar.emotion, Emotion::Sleepy);
+    }
+
+    #[test]
+    fn custom_thresholds_take_effect() {
+        let mut modifier = LowBatteryEmotion::with_thresholds(50, 60);
         let mut avatar = Avatar {
             battery_percent: Some(40),
             ..Avatar::default()
         };
         modifier.update(&mut avatar, Instant::ZERO);
         assert_eq!(avatar.emotion, Emotion::Sleepy);
+        assert!(modifier.is_low());
+
+        // Climb to between custom enter/exit: still low.
+        avatar.battery_percent = Some(55);
+        modifier.update(&mut avatar, Instant::from_millis(LOW_BATTERY_HOLD_MS + 1));
+        assert!(modifier.is_low());
+
+        // Climb past custom exit: clears.
+        avatar.battery_percent = Some(61);
+        modifier.update(
+            &mut avatar,
+            Instant::from_millis(2 * LOW_BATTERY_HOLD_MS + 1),
+        );
+        assert!(!modifier.is_low());
     }
 
     #[test]
@@ -265,5 +440,39 @@ mod tests {
         modifier.update(&mut avatar, later);
         assert_eq!(avatar.manual_until, Some(later + LOW_BATTERY_HOLD_MS));
         assert!(avatar.manual_until > first_deadline);
+    }
+
+    #[test]
+    fn hysteresis_band_walk_does_not_flicker() {
+        // Walking up and down inside the dead-band should not cause
+        // emotion thrash. Specifically: enter low, climb into band,
+        // dip back below enter, climb again — emotion stays Sleepy
+        // throughout (after the initial trigger).
+        let mut modifier = LowBatteryEmotion::new();
+        let mut avatar = Avatar {
+            battery_percent: Some(10),
+            ..Avatar::default()
+        };
+
+        // Step the time past each hold window so the modifier
+        // re-fires; otherwise the manual_until short-circuit
+        // would mask any real change of behaviour.
+        let mut t = 1_000u64;
+        let step = LOW_BATTERY_HOLD_MS + 1;
+
+        for percent in [10, 17, 14, 18, 13, 19, 12] {
+            avatar.battery_percent = Some(percent);
+            modifier.update(&mut avatar, Instant::from_millis(t));
+            assert!(
+                modifier.is_low(),
+                "percent={percent} flipped is_low off mid-band"
+            );
+            assert_eq!(
+                avatar.emotion,
+                Emotion::Sleepy,
+                "percent={percent} drove emotion off Sleepy"
+            );
+            t += step;
+        }
     }
 }

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -75,7 +75,14 @@ pub use emotion_style::EmotionStyle;
 pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
-pub use low_battery::{LOW_BATTERY_HOLD_MS, LOW_BATTERY_THRESHOLD_PERCENT, LowBatteryEmotion};
+#[allow(
+    deprecated,
+    reason = "re-exporting deprecated alias for downstream compat"
+)]
+pub use low_battery::LOW_BATTERY_THRESHOLD_PERCENT;
+pub use low_battery::{
+    LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT, LOW_BATTERY_HOLD_MS, LowBatteryEmotion,
+};
 pub use mouth_open_audio::{
     DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthOpenAudio,
 };

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -62,8 +62,8 @@ use stackchan_core::{
     Avatar, Clock, HeadDriver, LedFrame, Modifier,
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
-        IdleDrift, IdleSway, LOW_BATTERY_THRESHOLD_PERCENT, LowBatteryEmotion, MouthOpenAudio,
-        PickupReaction, RemoteCommand,
+        IdleDrift, IdleSway, LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT,
+        LowBatteryEmotion, MouthOpenAudio, PickupReaction, RemoteCommand,
     },
     render_leds,
 };
@@ -187,12 +187,13 @@ async fn render_task(mut display: LcdDisplay) {
     let mut mouth_open_audio = MouthOpenAudio::new();
     let mut last_rendered: Option<Avatar> = None;
     let mut led_frame = LedFrame::default();
-    // Tracks the previous battery-percent reading so we can detect a
-    // *downward* crossing of `LOW_BATTERY_THRESHOLD_PERCENT` and fire
-    // the low-battery alert clip exactly once per crossing event.
-    // `None` until the first reading; the boot reading itself never
-    // counts as a crossing.
-    let mut last_battery_percent: Option<u8> = None;
+    // Hysteresis state for the low-battery alert beep. Mirrors the
+    // emotion-side `LowBatteryEmotion` modifier: the beep fires once
+    // when the battery transitions from healthy to low, and re-arms
+    // only when the percent climbs back above the *exit* threshold.
+    // Starts `false`; the boot reading itself only fires the beep if
+    // we boot already below the enter threshold (and unplugged).
+    let mut alert_armed_for_low: bool = false;
 
     // Pre-compute the blit rect once; it never changes.
     let canvas = Rectangle::new(EgPoint::zero(), Size::new(FB_WIDTH, FB_HEIGHT));
@@ -240,18 +241,22 @@ async fn render_task(mut display: LcdDisplay) {
         if let Some(ut) = mag::MAG_SIGNAL.try_take() {
             avatar.mag_ut = Some(ut);
         }
-        // Drain the latest battery-percent reading from the AXP2101
-        // power task (1 Hz publish rate). `LowBatteryEmotion` reads
-        // `avatar.battery_percent` to decide whether to force Sleepy.
-        // A *downward* crossing of the threshold (e.g. 16% → 14%)
-        // also fires the low-battery alert clip once per crossing —
-        // the audible cue complements the silent emotion change.
-        if let Some(percent) = power::BATTERY_PERCENT_SIGNAL.try_take() {
-            avatar.battery_percent = Some(percent);
-            if let Some(prev) = last_battery_percent
-                && prev >= LOW_BATTERY_THRESHOLD_PERCENT
-                && percent < LOW_BATTERY_THRESHOLD_PERCENT
-            {
+        // Drain the latest power status from the AXP2101 task (1 Hz).
+        // `LowBatteryEmotion` reads `avatar.battery_percent` and
+        // `avatar.usb_power_present` for hysteresis + USB suppression.
+        // The alert beep mirrors the modifier's hysteresis: arm on a
+        // downward enter-threshold crossing (and only when not on USB
+        // power), re-arm only after climbing past the exit threshold.
+        if let Some(status) = power::POWER_STATUS_SIGNAL.try_take() {
+            avatar.battery_percent = Some(status.battery_percent);
+            avatar.usb_power_present = Some(status.usb_power);
+
+            if alert_armed_for_low {
+                if status.battery_percent > LOW_BATTERY_EXIT_PERCENT {
+                    alert_armed_for_low = false;
+                }
+            } else if status.battery_percent < LOW_BATTERY_ENTER_PERCENT && !status.usb_power {
+                alert_armed_for_low = true;
                 if let Err(e) = audio::try_enqueue_clip(audio::LOW_BATTERY_ALERT) {
                     defmt::warn!(
                         "audio: low-battery alert dropped, queue full ({:?})",
@@ -259,14 +264,12 @@ async fn render_task(mut display: LcdDisplay) {
                     );
                 } else {
                     defmt::info!(
-                        "audio: low-battery alert enqueued ({=u8}% → {=u8}%, threshold {=u8}%)",
-                        prev,
-                        percent,
-                        LOW_BATTERY_THRESHOLD_PERCENT,
+                        "audio: low-battery alert enqueued ({=u8}%, enter < {=u8}%)",
+                        status.battery_percent,
+                        LOW_BATTERY_ENTER_PERCENT,
                     );
                 }
             }
-            last_battery_percent = Some(percent);
         }
         // Drain the latest mic-RMS sample from the audio task — the
         // task publishes a fresh `AudioRms(linear)` per ~33 ms window

--- a/crates/stackchan-firmware/src/power.rs
+++ b/crates/stackchan-firmware/src/power.rs
@@ -1,39 +1,53 @@
 //! AXP2101 battery / power-monitor polling task.
 //!
-//! Polls the PMIC's state-of-charge gauge at 1 Hz and publishes the
-//! latest percentage on [`BATTERY_PERCENT_SIGNAL`]. The render task
-//! drains the signal into `avatar.battery_percent`, where
-//! [`stackchan_core::modifiers::LowBatteryEmotion`] picks it up and
-//! flips emotion to Sleepy when the `SoC` drops below threshold.
+//! Polls the PMIC at 1 Hz for battery `SoC` percent and USB-power
+//! presence, publishing both as one [`PowerStatus`] struct on
+//! [`POWER_STATUS_SIGNAL`]. The render task drains it into
+//! `avatar.battery_percent` and `avatar.usb_power_present`, where
+//! [`stackchan_core::modifiers::LowBatteryEmotion`] picks up both:
+//! the percent drives the hysteresis state machine, and the USB-good
+//! bit suppresses the Sleepy override while the unit is charging.
 //!
 //! The AXP2101 is already initialised (`init_cores3`) by the main
 //! boot sequence — this task only consumes the chip via reads and
 //! never touches LDO / battery-detect config.
 //!
 //! Failure mode: I²C read errors log at `warn` and we keep polling.
-//! A persistently-failing AXP2101 means `BATTERY_PERCENT_SIGNAL`
-//! never publishes, so `avatar.battery_percent` stays `None` and the
+//! A persistently-failing AXP2101 means `POWER_STATUS_SIGNAL` never
+//! publishes, so the avatar fields stay `None` and the
 //! `LowBatteryEmotion` modifier silently no-ops. Other power-related
 //! features (LDO rails) are unaffected — the chip itself is fine,
-//! just the gauge readback isn't reaching the avatar.
+//! just the gauge / VBUS readback isn't reaching the avatar.
 
 use axp2101::Axp2101;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, Ticker};
 use embedded_hal_async::i2c::I2c as AsyncI2c;
 
-/// Latest battery state-of-charge in percent, `0..=100`.
+/// Snapshot of the AXP2101 power state, published once per poll tick.
 ///
-/// Single producer (this task) → single consumer (the render task's
-/// drain at the top of each tick). Latest-wins matches the consumer's
-/// need: a render task that misses one publish should see the next
-/// one, not a backlog.
-pub static BATTERY_PERCENT_SIGNAL: Signal<CriticalSectionRawMutex, u8> = Signal::new();
+/// `usb_power` reflects the chip's `VBUSGD` flag; it asserts whenever
+/// the USB-C input has a valid voltage, regardless of whether the
+/// charger is actively pushing current.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PowerStatus {
+    /// Battery state-of-charge in percent (`0..=100`).
+    pub battery_percent: u8,
+    /// `true` when valid USB voltage is present.
+    pub usb_power: bool,
+}
+
+/// Latest [`PowerStatus`] reading, single-producer (this task) →
+/// single-consumer (the render task's drain at the top of each tick).
+///
+/// Latest-wins matches the consumer's need: a render task that misses
+/// one publish should see the next one, not a backlog.
+pub static POWER_STATUS_SIGNAL: Signal<CriticalSectionRawMutex, PowerStatus> = Signal::new();
 
 /// Poll cadence. The AXP2101's gauge register only changes on the
 /// minute-scale during normal discharge — 1 Hz is luxurious for
 /// charge-tracking and lets the modifier react within ~1 s of a
-/// threshold crossing without spamming the I²C bus.
+/// threshold crossing or USB plug/unplug without spamming the bus.
 const POLL_PERIOD_MS: u64 = 1_000;
 
 /// Run the AXP2101 battery-monitor loop forever. `init_cores3` must
@@ -42,29 +56,61 @@ const POLL_PERIOD_MS: u64 = 1_000;
 pub async fn run_power_loop<I: AsyncI2c>(bus: I) -> ! {
     let mut pmic = Axp2101::new(bus);
     defmt::info!(
-        "AXP2101 power monitor: polling battery gauge @ {=u64} ms tick",
+        "AXP2101 power monitor: polling battery + USB @ {=u64} ms tick",
         POLL_PERIOD_MS,
     );
 
     let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
-    let mut last_published: Option<u8> = None;
+    // Track last-published so the diagnostic log emits only on change
+    // (otherwise this would log every poll tick).
+    let mut last_published: Option<PowerStatus> = None;
     loop {
-        match pmic.read_battery_percent().await {
-            Ok(percent) => {
-                BATTERY_PERCENT_SIGNAL.signal(percent);
-                // Log only when the value changes by a noticeable
-                // amount, otherwise this would emit one info per
-                // second. 1% steps are plenty for human inspection.
-                if last_published != Some(percent) {
-                    defmt::info!("AXP2101: battery {=u8}%", percent);
-                    last_published = Some(percent);
-                }
-            }
-            Err(e) => defmt::warn!(
-                "AXP2101: battery-gauge read failed ({:?})",
-                defmt::Debug2Format(&e),
-            ),
+        let Some(status) = read_status(&mut pmic).await else {
+            ticker.next().await;
+            continue;
+        };
+
+        POWER_STATUS_SIGNAL.signal(status);
+
+        if last_published != Some(status) {
+            defmt::info!(
+                "AXP2101: battery {=u8}%, USB {=bool}",
+                status.battery_percent,
+                status.usb_power,
+            );
+            last_published = Some(status);
         }
+
         ticker.next().await;
     }
+}
+
+/// Read both battery and USB-power state in one tick, returning
+/// `None` on any I²C failure. Logged-and-degraded inside the helper
+/// so the caller's loop body stays tight.
+async fn read_status<B: AsyncI2c>(pmic: &mut Axp2101<B>) -> Option<PowerStatus> {
+    let battery_percent = pmic
+        .read_battery_percent()
+        .await
+        .inspect_err(|e| {
+            defmt::warn!(
+                "AXP2101: battery-gauge read failed ({:?})",
+                defmt::Debug2Format(e),
+            );
+        })
+        .ok()?;
+    let usb_power = pmic
+        .read_usb_power_good()
+        .await
+        .inspect_err(|e| {
+            defmt::warn!(
+                "AXP2101: USB-power read failed ({:?})",
+                defmt::Debug2Format(e),
+            );
+        })
+        .ok()?;
+    Some(PowerStatus {
+        battery_percent,
+        usb_power,
+    })
 }


### PR DESCRIPTION
## Summary
Promotes the simple single-threshold low-battery override (PR #52) to a hysteresis state machine that also suppresses while plugged in. End-to-end vertical: AXP2101 reader → power task → Avatar fields → modifier → firmware alert beep.

## Behaviour matrix
| Battery | USB present | Previous emotion | New behaviour                      |
|---------|-------------|------------------|------------------------------------|
| 14% (entering) | unplugged | Neutral / cycle | → Sleepy + alert beep         |
| 14% | plugged in        | Neutral / cycle | unchanged (cycle continues)        |
| 17% (between thresholds, was low) | unplugged | Sleepy | stays Sleepy (hysteresis) |
| 21% (exiting) | unplugged | Sleepy           | autonomy resumes; alert re-arms  |
| 5% (already low) | plugged → unplug | Neutral | → Sleepy on next tick           |
| 5% (already low) | unplug → plug | Sleepy | → autonomy resumes immediately   |

## Crate changes

### axp2101 (+49 LOC)
- `read_usb_power_good() -> bool` reads bit 5 (`VBUSGD`) of PMU_STATUS_1. Returns `true` whenever the chip sees valid USB voltage, regardless of whether the charger is actively pushing current.
- 3 new tests: bit set with surrounding-bit noise, bit clear with all other bits set, zero-register baseline.

### stackchan-core
- `Avatar.usb_power_present: Option<bool>` — sibling to `battery_percent`, same `None`-until-first-publish convention, same exclusion from `frame_eq`.
- `LowBatteryEmotion`:
  - Two-threshold hysteresis (`enter < 15`, `exit > 20`) replaces the single-threshold check, mirroring `AmbientSleepy`.
  - `is_low: bool` state for the modifier's belief (used in tests; could be exposed if needed later).
  - USB-power suppression: when `avatar.usb_power_present == Some(true)` and the battery is below threshold, the modifier still updates its hysteresis state but skips the Sleepy override. Plugging in releases the cue on the next tick.
  - 5 new tests: hysteresis dead-band hold, USB suppression, unknown-USB-fallback, unplugging releases, and a band-walk flicker check that walks the percent up and down inside the hysteresis dead-band and asserts emotion never thrashes.
- `LOW_BATTERY_THRESHOLD_PERCENT` is now a `#[deprecated]` alias for `LOW_BATTERY_ENTER_PERCENT`. New public consts `LOW_BATTERY_ENTER_PERCENT` / `LOW_BATTERY_EXIT_PERCENT`. Out-of-tree code that imported the old name keeps compiling with a deprecation warning.

### stackchan-firmware
- `power.rs`: replaces `BATTERY_PERCENT_SIGNAL: Signal<u8>` with `POWER_STATUS_SIGNAL: Signal<PowerStatus>` carrying `{ battery_percent, usb_power }`. The poll loop reads both registers per tick. `read_status` is factored into a helper using `inspect_err` for log-and-degrade so the loop body stays a tight `let-else`.
- `main.rs`: drains both fields into the avatar; the alert-beep detector becomes a small hysteresis state machine of its own (`alert_armed_for_low`) mirroring the modifier's enter/exit thresholds and respecting USB suppression — no beep when the percent dips below threshold while plugged in.

## Why hysteresis
The user-facing concern: AXP2101's `SoC` register has 1–2% LSB jitter on the CoreS3's discharge curve, and a single threshold at 15% would let a percent that's "really" 14.5% bounce between 14 and 15. With the avatar visibly toggling Sleepy ↔ autonomy on every bounce, that becomes annoying fast. 5-percentage-point dead-band absorbs the noise; the band-walk flicker test pins the invariant.

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Firmware release build links
- [x] Host tests: 136 core (was 131; +5), 10 axp2101 (was 7; +3); all doc tests pass
- [ ] **Hardware validation**: `just fmr` and confirm:
  - Boot with USB plugged in: percent + `USB true` log line, no Sleepy override at low battery
  - Boot unplugged at low battery: Sleepy + alert beep within ~1 s
  - Plug in while Sleepy: returns to autonomy on the next tick
  - Walk the percent up and down through 14-19%: no emotion thrash, no repeated alert beeps