### PR TITLE
feat: WakeOnVoice modifier — sustained mic activity wakes to Happy

### DIFF
--- a/crates/stackchan-core/src/avatar.rs
+++ b/crates/stackchan-core/src/avatar.rs
@@ -256,6 +256,16 @@ pub struct Avatar {
     /// [`Avatar::frame_eq`] for the same reasons as
     /// [`Avatar::battery_percent`].
     pub usb_power_present: Option<bool>,
+    /// Latest microphone RMS amplitude, normalised against full-scale
+    /// i16 (`0.0..=1.0`), or `None` before the audio task publishes
+    /// its first window. Written by the firmware render task draining
+    /// the audio task's signal channel; consumed by both
+    /// [`super::modifiers::MouthOpenAudio`] (visual: mouth opens with
+    /// loudness) and [`super::modifiers::WakeOnVoice`] (emotional:
+    /// sustained voice wakes the avatar to Happy). Excluded from
+    /// [`Avatar::frame_eq`] — modifiers translate RMS into pixels via
+    /// emotion / mouth fields, never directly.
+    pub audio_rms: Option<f32>,
 }
 
 impl Avatar {
@@ -336,6 +346,8 @@ impl Default for Avatar {
             battery_percent: None,
             // No USB-power reading until the AXP2101 task publishes one.
             usb_power_present: None,
+            // No mic RMS reading until the audio task publishes one.
+            audio_rms: None,
         }
     }
 }

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -19,32 +19,39 @@
 //!    `Surprised` with a `manual_until` hold when a pickup / drop is
 //!    detected. Stands down when `manual_until` is already set (so
 //!    explicit touch / remote wins).
-//! 4. [`AmbientSleepy`] — reads `Avatar::ambient_lux`, flips emotion
+//! 4. [`WakeOnVoice`] — reads `Avatar::audio_rms`, flips emotion to
+//!    `Happy` with a `manual_until` hold when sustained voice
+//!    activity is detected. Runs *before* the environmental-override
+//!    group so it can wake the avatar from `Sleepy` (e.g. dark room
+//!    with someone talking, or low-battery while plugged in).
+//!    Respects existing holds set by touch / pickup / remote — those
+//!    still win since they run earlier.
+//! 5. [`AmbientSleepy`] — reads `Avatar::ambient_lux`, flips emotion
 //!    to `Sleepy` with a short `manual_until` hold in dark rooms
 //!    (hysteresis 20/50 lux). Runs after `PickupReaction` so a
 //!    pickup-in-the-dark still surfaces as Surprised rather than
 //!    Sleepy.
-//! 5. [`LowBatteryEmotion`] — reads `Avatar::battery_percent`, forces
+//! 6. [`LowBatteryEmotion`] — reads `Avatar::battery_percent`, forces
 //!    `Sleepy` (with a short `manual_until` hold) when the `SoC` drops
 //!    below a threshold. Runs alongside `AmbientSleepy` as the
 //!    "environmental override" group; touch / pickup / remote still
 //!    win since this respects an existing `manual_until` hold.
-//! 6. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
+//! 7. [`EmotionCycle`] (or application code) — sets `Avatar::emotion`
 //!    when `manual_until` is unset or expired.
-//! 7. [`EmotionStyle`] — translates emotion into style fields, with a
+//! 8. [`EmotionStyle`] — translates emotion into style fields, with a
 //!    linear ease over the transition window.
-//! 8. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
+//! 9. [`Blink`] — drives eye open/closed phase, reading `open_weight` and
 //!    `blink_rate_scale` from the avatar.
-//! 9. [`Breath`] — vertical drift on all features, scaled by
-//!    `breath_depth_scale`.
-//! 10. [`IdleDrift`] — occasional eye-center jitter.
-//! 11. [`IdleSway`] — slow pan/tilt head wander written to
+//! 10. [`Breath`] — vertical drift on all features, scaled by
+//!     `breath_depth_scale`.
+//! 11. [`IdleDrift`] — occasional eye-center jitter.
+//! 12. [`IdleSway`] — slow pan/tilt head wander written to
 //!     `Avatar::head_pose`. Non-visual; drives the firmware's head-update
 //!     task, not the pixel pipeline.
-//! 12. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
+//! 13. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top of the
 //!     sway. Runs **after** `IdleSway` so bias composes additively rather
 //!     than fighting for absolute control of the pose.
-//! 13. [`MouthOpenAudio`] — reads `Avatar::mouth.weight` preserved by
+//! 14. [`MouthOpenAudio`] — reads `Avatar::mouth.weight` preserved by
 //!     earlier modifiers, writes `Avatar::mouth.mouth_open` from
 //!     microphone RMS via a dB-mapped attack/release envelope. Runs
 //!     last in the visual stack so emotion geometry stays the static
@@ -65,6 +72,7 @@ mod low_battery;
 mod mouth_open_audio;
 mod pickup_reaction;
 mod remote_command;
+mod wake_on_voice;
 
 pub use ambient_sleepy::{AMBIENT_HOLD_MS, AmbientSleepy, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX};
 pub use blink::Blink;
@@ -88,6 +96,7 @@ pub use mouth_open_audio::{
 };
 pub use pickup_reaction::{PICKUP_DEBOUNCE_MS, PICKUP_DEVIATION_G, PickupReaction};
 pub use remote_command::{RemoteCommand, RemoteMapping};
+pub use wake_on_voice::{WAKE_HOLD_MS, WAKE_RMS_THRESHOLD, WAKE_SUSTAIN_TICKS, WakeOnVoice};
 
 use crate::avatar::Avatar;
 use crate::clock::Instant;

--- a/crates/stackchan-core/src/modifiers/wake_on_voice.rs
+++ b/crates/stackchan-core/src/modifiers/wake_on_voice.rs
@@ -1,0 +1,343 @@
+//! `WakeOnVoice`: flips `Avatar::emotion` to `Happy` when the
+//! microphone observes sustained voice activity.
+//!
+//! ## Detection shape
+//!
+//! Watches `avatar.audio_rms` (linear, `0.0..=1.0`, normalised against
+//! full-scale i16). A tick "counts as loud" when the RMS exceeds
+//! [`WAKE_RMS_THRESHOLD`]. Once the consecutive loud-tick count
+//! reaches [`WAKE_SUSTAIN_TICKS`] the modifier triggers: emotion goes
+//! to `Happy` and `manual_until` is pinned forward by
+//! [`WAKE_HOLD_MS`].
+//!
+//! Falling below the threshold for any tick resets the counter — the
+//! detector requires *uninterrupted* loudness, not cumulative. This
+//! keeps it robust against single-frame transients (a cough, a chair
+//! squeak) that would otherwise drift the counter upward.
+//!
+//! Unknown audio (`audio_rms = None`, before the first publish) is
+//! treated as silence and never triggers.
+//!
+//! ## Coordination with the other emotion modifiers
+//!
+//! Unlike [`super::AmbientSleepy`] / [`super::LowBatteryEmotion`],
+//! this modifier is intended to *override* a sleepy state on voice
+//! activity — so it does **not** respect an existing
+//! [`Avatar::manual_until`] hold. It runs early in the modifier chain
+//! (right after the explicit-input modifiers but before the
+//! environmental-override group) and writes its own `manual_until`
+//! that the environmental modifiers will then respect.
+//!
+//! Touch / pickup / remote inputs still win because they run first
+//! and set their own holds before this modifier sees the avatar.
+//!
+//! [`Avatar::manual_until`]: crate::avatar::Avatar::manual_until
+
+use super::Modifier;
+use crate::avatar::Avatar;
+use crate::clock::Instant;
+use crate::emotion::Emotion;
+
+/// Linear RMS threshold for the "loud" classification. `0.05 ≈ -26
+/// dBFS`, well above ambient room noise on the CoreS3 mic but below
+/// normal speaking volume at typical desktop distance.
+pub const WAKE_RMS_THRESHOLD: f32 = 0.05;
+
+/// Consecutive loud ticks required to fire the wake.
+///
+/// At a 30 FPS render cadence (33 ms / tick), 10 ticks ≈ 330 ms —
+/// long enough to ignore single coughs / chair squeaks, short enough
+/// that the avatar reacts within a single spoken word.
+pub const WAKE_SUSTAIN_TICKS: u8 = 10;
+
+/// How long the wake hold pins `Happy` once set, in ms.
+///
+/// 5 s mirrors the other environmental holds. Within the window the
+/// modifier short-circuits its own re-fire; once expired, a still-
+/// loud audio stream rolls a fresh hold forward.
+pub const WAKE_HOLD_MS: u64 = 5_000;
+
+/// Modifier that watches [`Avatar::audio_rms`] and writes `Happy`
+/// when sustained voice is detected.
+///
+/// State is a single u8 counter; the modifier holds no allocation
+/// and is `Copy` so callers can stash it on the stack alongside the
+/// other modifier instances.
+#[derive(Debug, Clone, Copy)]
+pub struct WakeOnVoice {
+    /// Linear-RMS threshold above which a tick counts as loud.
+    pub threshold: f32,
+    /// Consecutive-loud-ticks required to trigger the wake. Saturates
+    /// at `u8::MAX` so an extremely-long sustained input doesn't wrap.
+    pub sustain_ticks: u8,
+    /// Running counter of consecutive loud ticks. Reset on any quiet
+    /// tick or after the wake fires.
+    consecutive_loud: u8,
+}
+
+impl WakeOnVoice {
+    /// Construct with the default thresholds ([`WAKE_RMS_THRESHOLD`] /
+    /// [`WAKE_SUSTAIN_TICKS`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            threshold: WAKE_RMS_THRESHOLD,
+            sustain_ticks: WAKE_SUSTAIN_TICKS,
+            consecutive_loud: 0,
+        }
+    }
+
+    /// Construct with custom threshold + sustain.
+    #[must_use]
+    pub const fn with_config(threshold: f32, sustain_ticks: u8) -> Self {
+        Self {
+            threshold,
+            sustain_ticks,
+            consecutive_loud: 0,
+        }
+    }
+
+    /// Exposed for tests: current loud-tick counter.
+    #[cfg(test)]
+    const fn consecutive_loud(self) -> u8 {
+        self.consecutive_loud
+    }
+}
+
+impl Default for WakeOnVoice {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for WakeOnVoice {
+    fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        let Some(rms) = avatar.audio_rms else {
+            // No reading yet — treat as silent, reset counter.
+            self.consecutive_loud = 0;
+            return;
+        };
+
+        if rms > self.threshold {
+            self.consecutive_loud = self.consecutive_loud.saturating_add(1);
+        } else {
+            // Any quiet tick resets — we want sustained loudness, not
+            // cumulative.
+            self.consecutive_loud = 0;
+            return;
+        }
+
+        if self.consecutive_loud < self.sustain_ticks {
+            return;
+        }
+
+        // Threshold-and-sustain met. If a hold is already active,
+        // don't extend it on every tick (mirrors AmbientSleepy's
+        // rolling-hold behaviour); once it expires, the next still-
+        // loud tick rolls a new one.
+        if let Some(until) = avatar.manual_until
+            && now < until
+        {
+            return;
+        }
+
+        avatar.emotion = Emotion::Happy;
+        avatar.manual_until = Some(now + WAKE_HOLD_MS);
+        // Reset so the next wake requires a fresh sustained period
+        // rather than firing every tick within a single loud burst.
+        self.consecutive_loud = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loud_avatar() -> Avatar {
+        Avatar {
+            audio_rms: Some(0.3),
+            ..Avatar::default()
+        }
+    }
+
+    fn quiet_avatar() -> Avatar {
+        Avatar {
+            audio_rms: Some(0.001),
+            ..Avatar::default()
+        }
+    }
+
+    #[test]
+    fn no_reading_keeps_counter_zero() {
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = Avatar::default(); // audio_rms = None
+        for t in 0..20 {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(wake.consecutive_loud(), 0);
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+    }
+
+    #[test]
+    fn quiet_keeps_counter_zero() {
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = quiet_avatar();
+        for t in 0..20 {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(wake.consecutive_loud(), 0);
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+    }
+
+    #[test]
+    fn loud_below_sustain_does_not_fire() {
+        // sustain_ticks - 1 loud ticks should NOT trigger.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert!(avatar.manual_until.is_none());
+    }
+
+    #[test]
+    fn sustained_loud_triggers_happy() {
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS)) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        // Hold deadline = now + WAKE_HOLD_MS at the firing tick.
+        let firing_now = Instant::from_millis((u64::from(WAKE_SUSTAIN_TICKS) - 1) * 33);
+        assert_eq!(avatar.manual_until, Some(firing_now + WAKE_HOLD_MS));
+    }
+
+    #[test]
+    fn quiet_tick_resets_counter_mid_burst() {
+        // 9 loud ticks, one quiet (resets), then 9 more loud — should
+        // not yet fire because each run is below sustain.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        avatar.audio_rms = Some(0.001); // quiet
+        wake.update(
+            &mut avatar,
+            Instant::from_millis((u64::from(WAKE_SUSTAIN_TICKS) - 1) * 33),
+        );
+        assert_eq!(wake.consecutive_loud(), 0);
+        avatar.audio_rms = Some(0.3); // loud again
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
+            wake.update(
+                &mut avatar,
+                Instant::from_millis((u64::from(WAKE_SUSTAIN_TICKS) + t) * 33),
+            );
+        }
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+    }
+
+    #[test]
+    fn fires_only_once_per_sustained_burst() {
+        // After firing, the modifier resets its counter. Continued
+        // loudness within the hold window short-circuits at the
+        // manual_until check; only after the hold expires AND a
+        // fresh sustain accumulates does it fire again.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        // First fire.
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS)) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        let first_deadline = avatar.manual_until;
+        // Continue loud through the hold window. Counter should
+        // accumulate but the hold should suppress re-firing.
+        for t in (u64::from(WAKE_SUSTAIN_TICKS))..(u64::from(WAKE_SUSTAIN_TICKS) + 30) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(avatar.manual_until, first_deadline);
+    }
+
+    #[test]
+    fn manual_hold_from_other_modifier_blocks_wake() {
+        // PickupReaction has already claimed the avatar with Surprised
+        // and a long hold. WakeOnVoice still sees sustained loud
+        // ticks but stands down — explicit input wins.
+        let mut wake = WakeOnVoice::new();
+        let pickup_deadline = Instant::from_millis(30_000);
+        let mut avatar = Avatar {
+            emotion: Emotion::Surprised,
+            manual_until: Some(pickup_deadline),
+            ..loud_avatar()
+        };
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) + 5) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(avatar.emotion, Emotion::Surprised);
+        assert_eq!(avatar.manual_until, Some(pickup_deadline));
+    }
+
+    #[test]
+    fn voice_overrides_sleepy_when_hold_expired() {
+        // AmbientSleepy set Sleepy + a hold; the hold has expired.
+        // WakeOnVoice should fire on sustained loud audio and write
+        // Happy with a fresh hold.
+        let mut wake = WakeOnVoice::new();
+        let expired = Instant::from_millis(0);
+        let mut avatar = Avatar {
+            emotion: Emotion::Sleepy,
+            manual_until: Some(expired),
+            ..loud_avatar()
+        };
+        // Tick at well past the expiry.
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS)) {
+            wake.update(&mut avatar, Instant::from_millis(10_000 + t * 33));
+        }
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(avatar.manual_until > Some(expired));
+    }
+
+    #[test]
+    fn counter_saturates_does_not_wrap() {
+        // 300 loud ticks (well past u8::MAX) should not panic and
+        // should keep the modifier in a consistent state.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        for t in 0..300_u64 {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        // Either fired and reset, or held in saturating state.
+        // The contract: no panic and the avatar emotion is one of the
+        // expected values (Happy after fire, default Neutral never).
+        assert!(matches!(avatar.emotion, Emotion::Happy));
+    }
+
+    #[test]
+    fn custom_config_takes_effect() {
+        // Lower sustain count fires faster.
+        let mut wake = WakeOnVoice::with_config(0.05, 3);
+        let mut avatar = loud_avatar();
+        for t in 0..3 {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(avatar.emotion, Emotion::Happy);
+    }
+
+    #[test]
+    fn at_threshold_does_not_count_as_loud() {
+        // The check is `rms > threshold`, so exactly-at-threshold is
+        // treated as quiet. Pin this so it doesn't drift to `>=`.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = Avatar {
+            audio_rms: Some(WAKE_RMS_THRESHOLD),
+            ..Avatar::default()
+        };
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) + 5) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert_eq!(avatar.emotion, Emotion::Neutral);
+        assert_eq!(wake.consecutive_loud(), 0);
+    }
+}

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -63,7 +63,7 @@ use stackchan_core::{
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
         IdleDrift, IdleSway, LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT,
-        LowBatteryEmotion, MouthOpenAudio, PickupReaction, RemoteCommand,
+        LowBatteryEmotion, MouthOpenAudio, PickupReaction, RemoteCommand, WakeOnVoice,
     },
     render_leds,
 };
@@ -173,6 +173,7 @@ async fn render_task(mut display: LcdDisplay) {
     let mut pickup = PickupReaction::new();
     let mut ambient_sleepy = AmbientSleepy::new();
     let mut low_battery = LowBatteryEmotion::new();
+    let mut wake_on_voice = WakeOnVoice::new();
     let mut cycle = EmotionCycle::new();
     let mut style = EmotionStyle::new();
     let mut blink = Blink::new();
@@ -200,7 +201,7 @@ async fn render_task(mut display: LcdDisplay) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + MouthOpenAudio",
+        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + WakeOnVoice + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + MouthOpenAudio",
         FRAME_PERIOD_MS
     );
 
@@ -274,13 +275,18 @@ async fn render_task(mut display: LcdDisplay) {
         // Drain the latest mic-RMS sample from the audio task — the
         // task publishes a fresh `AudioRms(linear)` per ~33 ms window
         // (one render frame at 30 FPS). `try_take` is non-blocking and
-        // misses are fine: latest-wins matches mic semantics.
+        // misses are fine: latest-wins matches mic semantics. Both
+        // `MouthOpenAudio` (visual) and `WakeOnVoice` (emotional)
+        // consume this — the former via its internal `set_rms`, the
+        // latter via reading `avatar.audio_rms` in `update`.
         if let Some(rms) = audio::AUDIO_RMS_SIGNAL.try_take() {
             mouth_open_audio.set_rms(rms.0);
+            avatar.audio_rms = Some(rms.0);
         }
         emotion_touch.update(&mut avatar, now);
         remote.update(&mut avatar, now);
         pickup.update(&mut avatar, now);
+        wake_on_voice.update(&mut avatar, now);
         ambient_sleepy.update(&mut avatar, now);
         low_battery.update(&mut avatar, now);
         cycle.update(&mut avatar, now);


### PR DESCRIPTION
## Summary
Adds a voice-activity-detection modifier that flips emotion to `Happy` (with a 5 s `manual_until` hold) when the microphone observes sustained voice activity. Composes with the existing audio + emotion stacks: someone talking to the avatar in a dark room (`Sleepy` from `AmbientSleepy`) now wakes it up to `Happy`.

## Behaviour
| Scenario | Before this PR | After this PR |
|----------|----------------|---------------|
| Quiet room | Cycle / autonomy | Cycle / autonomy |
| Single cough or chair squeak | Cycle / autonomy | Cycle / autonomy (single-tick transient ignored) |
| Sustained speech (~½ s) | Cycle / autonomy | → Happy (5 s hold) |
| Sustained speech in dark room | Sleepy (AmbientSleepy holds) | → Happy (WakeOnVoice overrides) |
| Sustained speech while held / picked up | Surprised (PickupReaction holds) | Surprised (explicit input still wins) |
| Sustained speech on low battery (unplugged) | Sleepy (LowBatteryEmotion holds) | → Happy (WakeOnVoice runs first in chain and claims `manual_until`) |

## stackchan-core
- `Avatar.audio_rms: Option<f32>` — linear mic RMS (`0.0..=1.0`), `None` until first publish. Sibling to the existing sensor fields, excluded from `frame_eq`.
- New `WakeOnVoice` modifier:
  - **Threshold:** `rms > 0.05` (≈ -26 dBFS), well above ambient room noise but below normal speaking volume.
  - **Sustain:** ≥ 10 consecutive loud ticks (~330 ms at 30 FPS) — long enough to ignore single transients, short enough to react within one spoken word.
  - **Reset:** any quiet tick zeroes the counter — uninterrupted, not cumulative.
  - **Trigger:** writes `Happy` + pins `manual_until = now + 5 s`. Subsequent loud ticks within the hold short-circuit; the next loud tick after expiry rolls a fresh hold.
  - **Coordination:** runs *before* `AmbientSleepy` / `LowBatteryEmotion` so it can override their Sleepy claim. Runs *after* `EmotionTouch` / `RemoteCommand` / `PickupReaction` which still win since they set their own holds first.
  - 11 unit tests covering the matrix.
- Updated canonical-stack doc with the new step #4 placement.

## stackchan-firmware
- The render task drains `audio::AUDIO_RMS_SIGNAL` into both `mouth_open_audio.set_rms` (existing visual mouth animation) and `avatar.audio_rms` (new modifier consumer). Same source, two sinks.
- Instantiates `WakeOnVoice::new()` and slots `wake_on_voice.update` between `pickup.update` and `ambient_sleepy.update`.

## Notes on architecture
**Why a separate `audio_rms` field instead of refactoring `MouthOpenAudio` to share state**: `MouthOpenAudio` consumes RMS via an internal setter (`set_rms`) and applies an attack/release envelope before mapping to mouth open-amount. Refactoring it to read `avatar.audio_rms` would require changing 13 unit tests and the modifier's API; out of scope for this PR. Two sinks at the firmware drain site is additive and safe; a follow-up can unify the path if desired.

**Why `Happy` instead of a new `Curious` variant**: the `Emotion` enum is a small fixed set today; adding a variant means updating drawing code, emotion-cycle iteration order, the `EmotionStyle` translator, head-bias mappings, and tests across the entire visual stack. `Happy` is the closest existing fit for "someone is engaging with me" and produces a visibly responsive avatar.

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Firmware release build links
- [x] Host tests: 158 core (was 147; +11), 10 axp2101; all doc tests pass
- [ ] **Hardware validation**: `just fmr` and confirm:
  - Speaking at normal volume for ~½ s flips the avatar to Happy
  - Within 5 s of going silent, autonomy resumes (back to cycle)
  - Coughing or briefly tapping the desk does NOT trigger the wake
  - In a dark room (Sleepy from AmbientSleepy), speaking wakes to Happy
  - Threshold may need tuning based on actual ES7210 mic gain — adjust `WAKE_RMS_THRESHOLD` and re-flash if false positives or missed triggers