### PR TITLE
feat: emotion-transition chirps — pickup, wake, low-battery audio cues

### DIFF
--- a/crates/stackchan-core/src/modifiers/pickup_reaction.rs
+++ b/crates/stackchan-core/src/modifiers/pickup_reaction.rs
@@ -71,6 +71,10 @@ pub struct PickupReaction {
     /// pickup is still in progress; cleared when the reading returns
     /// below threshold.
     fired_this_run: bool,
+    /// Set to `true` on the tick the modifier just transitioned from
+    /// not-firing → firing (i.e. wrote `Surprised` and pinned
+    /// `manual_until`). Cleared on the next `update` call.
+    just_fired: bool,
 }
 
 impl PickupReaction {
@@ -80,7 +84,23 @@ impl PickupReaction {
         Self {
             above_since: None,
             fired_this_run: false,
+            just_fired: false,
         }
+    }
+
+    /// `true` on the tick this modifier just transitioned from
+    /// not-firing → firing. Cleared at the start of every `update`,
+    /// so consumers should check it once per render tick after
+    /// `update` runs.
+    ///
+    /// Use this to drive one-shot side effects (e.g. enqueueing a
+    /// pickup chirp) that should accompany the emotional change.
+    /// Note that a pickup blocked by an existing `manual_until` from
+    /// touch / remote does *not* set this flag — there's no
+    /// transition to chirp about.
+    #[must_use]
+    pub const fn just_fired(self) -> bool {
+        self.just_fired
     }
 }
 
@@ -116,6 +136,10 @@ const REST_BAND_SQUARED: core::ops::RangeInclusive<f32> = BELOW_SQUARED..=ABOVE_
 
 impl Modifier for PickupReaction {
     fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        // Clear the edge flag at the start of every tick — it only
+        // ever signals the *current* tick's transition.
+        self.just_fired = false;
+
         let m2 = magnitude_squared(avatar.accel_g);
         // Out-of-rest-band: magnitude outside `(1±k) g` squared.
         let above_threshold = !REST_BAND_SQUARED.contains(&m2);
@@ -161,6 +185,7 @@ impl Modifier for PickupReaction {
         avatar.emotion = PICKUP_EMOTION;
         avatar.manual_until = Some(now + MANUAL_HOLD_MS);
         self.fired_this_run = true;
+        self.just_fired = true;
     }
 }
 
@@ -341,5 +366,49 @@ mod tests {
         pickup.update(&mut avatar, Instant::from_millis(2_000));
         pickup.update(&mut avatar, Instant::from_millis(2_060));
         assert_eq!(avatar.emotion, Emotion::Surprised);
+    }
+
+    #[test]
+    fn just_fired_set_only_on_trigger_tick() {
+        let mut avatar = at_rest();
+        let mut pickup = PickupReaction::new();
+
+        // Pre-trigger: nothing fired yet.
+        set_accel(&mut avatar, 1.8);
+        pickup.update(&mut avatar, Instant::from_millis(0));
+        assert!(!pickup.just_fired());
+        pickup.update(&mut avatar, Instant::from_millis(30));
+        assert!(!pickup.just_fired());
+
+        // Trigger tick (60 ms past the 50 ms debounce).
+        pickup.update(&mut avatar, Instant::from_millis(60));
+        assert!(pickup.just_fired(), "expected fire on trigger tick");
+
+        // Subsequent above-threshold ticks within the same run do
+        // *not* re-fire (fired_this_run is set), so just_fired clears.
+        pickup.update(&mut avatar, Instant::from_millis(100));
+        assert!(!pickup.just_fired());
+    }
+
+    #[test]
+    fn just_fired_not_set_when_blocked_by_existing_hold() {
+        // EmotionTouch has already pinned the avatar with a long hold.
+        // PickupReaction sees the threshold cross + debounce + active
+        // hold, marks fired_this_run as handled, but does not write
+        // a new emotion or set just_fired — there's no transition to
+        // chirp about.
+        let mut avatar = Avatar {
+            emotion: Emotion::Happy,
+            manual_until: Some(Instant::from_millis(30_000)),
+            ..at_rest()
+        };
+        let mut pickup = PickupReaction::new();
+
+        set_accel(&mut avatar, 1.8);
+        pickup.update(&mut avatar, Instant::from_millis(0));
+        pickup.update(&mut avatar, Instant::from_millis(60));
+
+        assert_eq!(avatar.emotion, Emotion::Happy);
+        assert!(!pickup.just_fired());
     }
 }

--- a/crates/stackchan-core/src/modifiers/wake_on_voice.rs
+++ b/crates/stackchan-core/src/modifiers/wake_on_voice.rs
@@ -60,9 +60,9 @@ pub const WAKE_HOLD_MS: u64 = 5_000;
 /// Modifier that watches [`Avatar::audio_rms`] and writes `Happy`
 /// when sustained voice is detected.
 ///
-/// State is a single u8 counter; the modifier holds no allocation
-/// and is `Copy` so callers can stash it on the stack alongside the
-/// other modifier instances.
+/// State is a small struct (counter + edge flag); the modifier holds
+/// no allocation and is `Copy` so callers can stash it on the stack
+/// alongside the other modifier instances.
 #[derive(Debug, Clone, Copy)]
 pub struct WakeOnVoice {
     /// Linear-RMS threshold above which a tick counts as loud.
@@ -73,6 +73,11 @@ pub struct WakeOnVoice {
     /// Running counter of consecutive loud ticks. Reset on any quiet
     /// tick or after the wake fires.
     consecutive_loud: u8,
+    /// Set to `true` on the tick the wake transitions from
+    /// not-firing → firing; cleared on the next `update` call.
+    /// Callers (e.g. firmware enqueueing a wake chirp) read this
+    /// once per tick after `update`.
+    just_fired: bool,
 }
 
 impl WakeOnVoice {
@@ -84,6 +89,7 @@ impl WakeOnVoice {
             threshold: WAKE_RMS_THRESHOLD,
             sustain_ticks: WAKE_SUSTAIN_TICKS,
             consecutive_loud: 0,
+            just_fired: false,
         }
     }
 
@@ -94,7 +100,20 @@ impl WakeOnVoice {
             threshold,
             sustain_ticks,
             consecutive_loud: 0,
+            just_fired: false,
         }
+    }
+
+    /// `true` on the tick this modifier just transitioned from
+    /// not-firing → firing. Cleared at the start of every `update`
+    /// call, so consumers should check it once per render tick after
+    /// `update` runs.
+    ///
+    /// Use this to drive one-shot side effects (e.g. enqueueing an
+    /// audio chirp) that should accompany the emotional change.
+    #[must_use]
+    pub const fn just_fired(self) -> bool {
+        self.just_fired
     }
 
     /// Exposed for tests: current loud-tick counter.
@@ -112,6 +131,10 @@ impl Default for WakeOnVoice {
 
 impl Modifier for WakeOnVoice {
     fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+        // Clear the edge flag at the start of every tick — it only
+        // ever signals the *current* tick's transition.
+        self.just_fired = false;
+
         let Some(rms) = avatar.audio_rms else {
             // No reading yet — treat as silent, reset counter.
             self.consecutive_loud = 0;
@@ -146,6 +169,7 @@ impl Modifier for WakeOnVoice {
         // Reset so the next wake requires a fresh sustained period
         // rather than firing every tick within a single loud burst.
         self.consecutive_loud = 0;
+        self.just_fired = true;
     }
 }
 
@@ -323,6 +347,62 @@ mod tests {
             wake.update(&mut avatar, Instant::from_millis(t * 33));
         }
         assert_eq!(avatar.emotion, Emotion::Happy);
+    }
+
+    #[test]
+    fn just_fired_set_on_trigger_tick_only() {
+        // Sustained loudness fires on the Nth tick. just_fired is
+        // true on that tick, false on the (N+1)th.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+            assert!(!wake.just_fired(), "fired early on tick {t}");
+        }
+        // Trigger tick.
+        wake.update(
+            &mut avatar,
+            Instant::from_millis((u64::from(WAKE_SUSTAIN_TICKS) - 1) * 33),
+        );
+        assert!(wake.just_fired(), "did not fire on threshold tick");
+        // Next tick: still loud, but inside hold window — not a fresh
+        // fire, so just_fired clears.
+        wake.update(
+            &mut avatar,
+            Instant::from_millis(u64::from(WAKE_SUSTAIN_TICKS) * 33),
+        );
+        assert!(!wake.just_fired(), "stuck-fired across consecutive ticks");
+    }
+
+    #[test]
+    fn just_fired_clears_when_quiet_tick_resets_counter() {
+        // A quiet tick mid-burst resets the counter and zeroes
+        // just_fired (which was already false).
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = loud_avatar();
+        wake.update(&mut avatar, Instant::from_millis(0));
+        avatar.audio_rms = Some(0.001);
+        wake.update(&mut avatar, Instant::from_millis(33));
+        assert!(!wake.just_fired());
+        assert_eq!(wake.consecutive_loud(), 0);
+    }
+
+    #[test]
+    fn just_fired_not_set_when_blocked_by_manual_hold() {
+        // Sustained loud audio under an existing manual hold should
+        // *not* set just_fired — emotion / hold are unchanged so
+        // there's no transition to chirp about.
+        let mut wake = WakeOnVoice::new();
+        let mut avatar = Avatar {
+            emotion: Emotion::Surprised,
+            manual_until: Some(Instant::from_millis(30_000)),
+            ..loud_avatar()
+        };
+        for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) + 5) {
+            wake.update(&mut avatar, Instant::from_millis(t * 33));
+        }
+        assert!(!wake.just_fired());
+        assert_eq!(avatar.emotion, Emotion::Surprised);
     }
 
     #[test]

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -138,6 +138,17 @@ const SINE_1KHZ_CYCLE: [i16; 16] = [
 /// pitch makes it distinct from the boot greeting.
 const SINE_2KHZ_CYCLE: [i16; 8] = [0, 5793, 8192, 5793, 0, -5793, -8192, -5793];
 
+/// One-cycle 4 kHz sine table at 16 kHz sample rate. 4 samples per
+/// cycle (the highest pitch we can produce cleanly without going
+/// past the Nyquist limit). Used as the top of the
+/// [`PICKUP_CHIRP`] rising sweep.
+const SINE_4KHZ_CYCLE: [i16; 4] = [0, 8192, 0, -8192];
+
+/// 8-sample silence cycle for [`AudioClip`]-encoded gaps. Used between
+/// successive beeps in [`try_enqueue_low_battery_alert`] so the user
+/// hears two distinct pulses rather than one long tone.
+const SILENCE_CYCLE: [i16; 8] = [0; 8];
+
 /// Boot-greeting clip: 500 ms of 1 kHz sine. Plays once at boot via
 /// [`run_audio_task`] enqueueing it into [`AUDIO_TX_QUEUE`].
 ///
@@ -149,18 +160,42 @@ pub const BOOT_GREETING: AudioClip = AudioClip {
     cycles: 500,
 };
 
-/// Two short 2 kHz beeps separated by silence — the canonical
-/// "low battery" alert. Producers (e.g. main.rs's render loop on a
-/// threshold-crossing detection) enqueue this clip via
-/// [`try_enqueue_clip`].
+/// Single-clip "wake" chirp: 100 ms of 1 kHz sine. Audibly soft but
+/// distinct from the boot greeting (which is 5× longer); enqueued
+/// when [`stackchan_core::modifiers::WakeOnVoice`] just fired.
 ///
-/// One full beep = 200 ms = 400 cycles at 8 samples / cycle.
-/// The current encoding is one continuous beep; if hardware listening
-/// suggests two short pulses are clearer, swap the table for
-/// `[beep, gap, beep]` of equivalent total length.
-pub const LOW_BATTERY_ALERT: AudioClip = AudioClip {
+/// `100 cycles × 16 samples = 1 600 samples = 100 ms`.
+pub const WAKE_CHIRP: AudioClip = AudioClip {
+    samples: &SINE_1KHZ_CYCLE,
+    cycles: 100,
+};
+
+/// First leg of the pickup chirp: 50 ms of 2 kHz.
+const PICKUP_CHIRP_LO: AudioClip = AudioClip {
     samples: &SINE_2KHZ_CYCLE,
-    cycles: 400,
+    cycles: 100,
+};
+/// Second leg of the pickup chirp: 50 ms of 4 kHz. Played
+/// back-to-back with [`PICKUP_CHIRP_LO`] for an upward sweep that
+/// matches the "Surprised!" emotion fire from
+/// [`stackchan_core::modifiers::PickupReaction`].
+const PICKUP_CHIRP_HI: AudioClip = AudioClip {
+    samples: &SINE_4KHZ_CYCLE,
+    cycles: 200,
+};
+
+/// Single beep used inside [`try_enqueue_low_battery_alert`]. 100 ms
+/// of 2 kHz; two of these separated by silence form the full alert.
+const LOW_BATTERY_BEEP: AudioClip = AudioClip {
+    samples: &SINE_2KHZ_CYCLE,
+    cycles: 200,
+};
+/// 80 ms gap between the two low-battery beeps. Silence stored as a
+/// short cycle table looped many times — keeps the tx feeder code
+/// uniform (everything goes through clip playback).
+const LOW_BATTERY_GAP: AudioClip = AudioClip {
+    samples: &SILENCE_CYCLE,
+    cycles: 160,
 };
 
 /// PCM audio clip queued for TX playback.
@@ -224,6 +259,55 @@ pub static AUDIO_TX_QUEUE: Channel<CriticalSectionRawMutex, AudioClip, 4> = Chan
 /// already queued.
 pub fn try_enqueue_clip(clip: AudioClip) -> Result<(), TrySendError<AudioClip>> {
     AUDIO_TX_QUEUE.try_send(clip)
+}
+
+/// Enqueue the canonical low-battery alert: two 100 ms 2 kHz beeps
+/// separated by an 80 ms gap. Three queued clips total.
+///
+/// Best-effort: if the queue fills mid-sequence, the partially-queued
+/// alert plays as far as it got and the helper returns the failure.
+/// The render-loop caller logs once and continues; partial alerts
+/// are unlikely in practice (the queue starts empty between fires).
+///
+/// # Errors
+///
+/// Returns the first [`TrySendError::Full`] encountered. Earlier
+/// clips that did fit are not rolled back — they will play.
+pub fn try_enqueue_low_battery_alert() -> Result<(), TrySendError<AudioClip>> {
+    AUDIO_TX_QUEUE.try_send(LOW_BATTERY_BEEP)?;
+    AUDIO_TX_QUEUE.try_send(LOW_BATTERY_GAP)?;
+    AUDIO_TX_QUEUE.try_send(LOW_BATTERY_BEEP)?;
+    Ok(())
+}
+
+/// Enqueue the wake chirp: 100 ms of 1 kHz. One queued clip.
+///
+/// Pair with [`stackchan_core::modifiers::WakeOnVoice::just_fired`]
+/// to play a confirmation tone the same tick the modifier flips
+/// emotion to `Happy`.
+///
+/// # Errors
+///
+/// Returns [`TrySendError::Full`] if [`AUDIO_TX_QUEUE`] is full.
+pub fn try_enqueue_wake_chirp() -> Result<(), TrySendError<AudioClip>> {
+    AUDIO_TX_QUEUE.try_send(WAKE_CHIRP)
+}
+
+/// Enqueue the pickup chirp: 50 ms of 2 kHz then 50 ms of 4 kHz —
+/// an upward sweep that matches the "Surprised!" emotion fire from
+/// [`stackchan_core::modifiers::PickupReaction`]. Two queued clips.
+///
+/// Best-effort, same partial-queue caveat as
+/// [`try_enqueue_low_battery_alert`].
+///
+/// # Errors
+///
+/// Returns the first [`TrySendError::Full`] encountered. The first
+/// clip, if it queued successfully, will play.
+pub fn try_enqueue_pickup_chirp() -> Result<(), TrySendError<AudioClip>> {
+    AUDIO_TX_QUEUE.try_send(PICKUP_CHIRP_LO)?;
+    AUDIO_TX_QUEUE.try_send(PICKUP_CHIRP_HI)?;
+    Ok(())
 }
 
 /// Microphone RMS sample, published per render tick.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -258,14 +258,14 @@ async fn render_task(mut display: LcdDisplay) {
                 }
             } else if status.battery_percent < LOW_BATTERY_ENTER_PERCENT && !status.usb_power {
                 alert_armed_for_low = true;
-                if let Err(e) = audio::try_enqueue_clip(audio::LOW_BATTERY_ALERT) {
+                if let Err(e) = audio::try_enqueue_low_battery_alert() {
                     defmt::warn!(
-                        "audio: low-battery alert dropped, queue full ({:?})",
+                        "audio: low-battery alert (partially) dropped ({:?})",
                         defmt::Debug2Format(&e)
                     );
                 } else {
                     defmt::info!(
-                        "audio: low-battery alert enqueued ({=u8}%, enter < {=u8}%)",
+                        "audio: low-battery alert enqueued (2 beeps, {=u8}%, enter < {=u8}%)",
                         status.battery_percent,
                         LOW_BATTERY_ENTER_PERCENT,
                     );
@@ -286,7 +286,23 @@ async fn render_task(mut display: LcdDisplay) {
         emotion_touch.update(&mut avatar, now);
         remote.update(&mut avatar, now);
         pickup.update(&mut avatar, now);
+        if pickup.just_fired()
+            && let Err(e) = audio::try_enqueue_pickup_chirp()
+        {
+            defmt::warn!(
+                "audio: pickup chirp (partially) dropped ({:?})",
+                defmt::Debug2Format(&e)
+            );
+        }
         wake_on_voice.update(&mut avatar, now);
+        if wake_on_voice.just_fired()
+            && let Err(e) = audio::try_enqueue_wake_chirp()
+        {
+            defmt::warn!(
+                "audio: wake chirp dropped, queue full ({:?})",
+                defmt::Debug2Format(&e)
+            );
+        }
         ambient_sleepy.update(&mut avatar, now);
         low_battery.update(&mut avatar, now);
         cycle.update(&mut avatar, now);


### PR DESCRIPTION
## Summary
Closes the audio feedback loop for user-visible emotion changes: each time `PickupReaction` or `WakeOnVoice` fires, the speaker plays a distinctive short chirp confirming the avatar registered the event. The low-battery alert is upgraded from one continuous beep to two short pulses for clarity.

Demo flow: walk in front of the avatar in a dark room (Sleepy from `AmbientSleepy`) — sustained voice → **wake chirp + Happy emotion**. Pick the avatar up mid-conversation — **pickup chirp + Surprised**. Battery drops below 15% on battery power — **two short 2 kHz beeps + Sleepy**.

## stackchan-core
- `PickupReaction.just_fired() -> bool` and `WakeOnVoice.just_fired() -> bool` — edge-trigger flags set on the tick the modifier transitions from not-firing → firing, cleared at the top of every subsequent `update`. Importantly, blocked fires (existing `manual_until` from a stronger modifier) do *not* set the flag — there's no transition to chirp about, so consumers don't false-fire side effects.
- 5 new unit tests covering: trigger-tick set, next-tick clear, mid-burst quiet reset (WakeOnVoice), and manual-hold suppression (both modifiers).

## stackchan-firmware
- New cycle tables: 4 kHz (4 samples/cycle, the highest pitch we can emit cleanly without crossing Nyquist) and an 8-sample silence cycle for clip-encoded gaps.
- New chirps:
  - `WAKE_CHIRP`: 100 ms of 1 kHz. Single clip.
  - `PICKUP_CHIRP_LO` + `PICKUP_CHIRP_HI`: 50 ms 2 kHz → 50 ms 4 kHz upward sweep matching the "Surprised!" emotion fire.
  - `LOW_BATTERY_BEEP` + `LOW_BATTERY_GAP`: 100 ms 2 kHz / 80 ms silence / 100 ms 2 kHz, replacing the previous single 200 ms beep.
- Public helpers `try_enqueue_wake_chirp`, `try_enqueue_pickup_chirp`, `try_enqueue_low_battery_alert` push the right clip(s) into `AUDIO_TX_QUEUE` in one call. Best-effort under partial-queue-full; any clips that did fit will play.
- `main.rs`: after `pickup.update` and `wake_on_voice.update`, check `just_fired()` and enqueue the matching chirp via let-chain. The previous threshold-crossing low-battery alert keeps its detection logic but now uses the 2-beep helper for distinctness.

## Implementation notes
- **Why expose `just_fired()` instead of an `OnFire` callback / channel**: the modifier already runs once per tick on the main task. A bool flag is zero-overhead, requires no allocation or signal plumbing, and matches the existing "consumer reads modifier state after `update`" pattern. Callbacks would tangle the modifier with audio (firmware-only) and break the host-testability convention.
- **Why a public `LOW_BATTERY_BEEP` is private but the helper is public**: external callers should think in terms of "play the alert", not "play a beep then a gap then a beep". Exposing only the sequencing helper keeps the API stable if we later swap the encoding (e.g., a longer first beep with rising pitch).
- **`try_enqueue_*` helpers are best-effort under partial-queue-full**: if the queue accepts the first clip but not the second, the first clip plays and the helper returns `Err`. The render-loop callers log once and continue. The capacity-4 queue plus the 1 Hz max trigger rate (battery polling) means partial alerts are unlikely in practice.

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Firmware release build links
- [x] Host tests: 163 core (was 158; +5); all doc tests pass
- [ ] **Hardware validation**: `just fmr` and confirm:
  - Pick up the avatar: ascending 2 kHz → 4 kHz sweep, ~100 ms total
  - Speak for ~½ s in front of mic: 100 ms 1 kHz wake chirp + Happy emotion
  - Drop battery below 15% (or temporarily lower the threshold for testing): two distinct 100 ms 2 kHz beeps with an 80 ms gap
  - Boot greeting unchanged (1 kHz / 500 ms)
  - No chirp re-fires during sustained pickup / sustained voice (just_fired clears next tick)