### PR TITLE
feat(firmware): time-of-day boot greeting via BM8563 RTC

### DIFF
--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -28,10 +28,11 @@
 //!      full-scale i16, publish on [`AUDIO_RMS_SIGNAL`].
 //!    - TX (`run_tx_loop`): play queued [`AudioClip`]s back-to-back,
 //!      filling with digital silence between/after clips so the
-//!      AW88298 stays clock-locked. The bring-up enqueues
-//!      [`BOOT_GREETING`] so the speaker says hello at boot;
-//!      higher-level code (e.g. low-battery alerts) enqueues more
-//!      clips via [`try_enqueue_clip`].
+//!      AW88298 stays clock-locked. Higher-level code (e.g. main.rs's
+//!      RTC-aware boot greeting, low-battery alerts, pickup chirps)
+//!      enqueues clips via [`try_enqueue_clip`] and the typed
+//!      [`try_enqueue_wake_chirp`] / [`try_enqueue_pickup_chirp`] /
+//!      [`try_enqueue_low_battery_alert`] helpers.
 //!
 //! This matches esp-bsp's ordering in `bsp_audio_codec_microphone_init`:
 //! `bsp_audio_init` (spins up I²S + MCLK) runs *before* `es7210_codec_new`.
@@ -149,8 +150,9 @@ const SINE_4KHZ_CYCLE: [i16; 4] = [0, 8192, 0, -8192];
 /// hears two distinct pulses rather than one long tone.
 const SILENCE_CYCLE: [i16; 8] = [0; 8];
 
-/// Boot-greeting clip: 500 ms of 1 kHz sine. Plays once at boot via
-/// [`run_audio_task`] enqueueing it into [`AUDIO_TX_QUEUE`].
+/// Default boot greeting: 500 ms of 1 kHz sine. Used when the RTC
+/// is unavailable (no battery / chip missing) and as the daytime
+/// (12:00–17:59) variant in the time-of-day selector.
 ///
 /// `500 cycles × 16 samples = 8 000 samples = 500 ms` at the 16 kHz
 /// sample rate. Tweak `cycles` to change duration without touching
@@ -159,6 +161,50 @@ pub const BOOT_GREETING: AudioClip = AudioClip {
     samples: &SINE_1KHZ_CYCLE,
     cycles: 500,
 };
+
+/// Morning greeting (05:00–11:59): a brighter 2 kHz / 300 ms tone.
+/// Higher pitch + shorter duration than the default — more "wake up"
+/// than "settle in".
+pub const BOOT_GREETING_MORNING: AudioClip = AudioClip {
+    samples: &SINE_2KHZ_CYCLE,
+    cycles: 600,
+};
+
+/// Evening greeting (18:00–22:59): the default 1 kHz tone but
+/// slightly longer (700 ms) for a warmer feel.
+pub const BOOT_GREETING_EVENING: AudioClip = AudioClip {
+    samples: &SINE_1KHZ_CYCLE,
+    cycles: 700,
+};
+
+/// Night greeting (23:00–04:59): a single short, soft beep — 200 ms
+/// of 1 kHz. Quiet enough not to wake a sleeping household.
+pub const BOOT_GREETING_NIGHT: AudioClip = AudioClip {
+    samples: &SINE_1KHZ_CYCLE,
+    cycles: 200,
+};
+
+/// Pick the boot greeting clip for a given clock hour (`0..=23`).
+///
+/// - Morning (05–11): [`BOOT_GREETING_MORNING`]
+/// - Day (12–17): [`BOOT_GREETING`] (default)
+/// - Evening (18–22): [`BOOT_GREETING_EVENING`]
+/// - Night (23, 00–04): [`BOOT_GREETING_NIGHT`]
+///
+/// Hours outside `0..=23` (which the BM8563 should never produce)
+/// fall back to the default daytime greeting.
+#[must_use]
+pub const fn boot_greeting_for_hour(hour: u8) -> AudioClip {
+    match hour {
+        5..=11 => BOOT_GREETING_MORNING,
+        18..=22 => BOOT_GREETING_EVENING,
+        23 | 0..=4 => BOOT_GREETING_NIGHT,
+        // 12..=17 (default daytime) + any out-of-range hour (the
+        // BM8563 caps at 23, so this branch covers spec-compliant
+        // and degenerate-input alike).
+        _ => BOOT_GREETING,
+    }
+}
 
 /// Single-clip "wake" chirp: 100 ms of 1 kHz sine. Audibly soft but
 /// distinct from the boot greeting (which is 5× longer); enqueued
@@ -537,17 +583,10 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
         defmt::info!("audio: AW88298 un-muted — speaker live");
     }
 
-    // Enqueue the boot greeting so the TX feeder has audible content
-    // queued up the moment it starts pushing samples. If somehow the
-    // queue is already full (shouldn't be — this is the first
-    // producer) we drop the clip rather than block bring-up.
-    if let Err(e) = try_enqueue_clip(BOOT_GREETING) {
-        defmt::warn!(
-            "audio: failed to enqueue boot greeting ({:?}); silent boot",
-            defmt::Debug2Format(&e)
-        );
-    }
-
+    // The boot greeting is enqueued by main.rs after it reads the RTC
+    // (so the time-of-day variant can be chosen). If the RTC isn't
+    // available main falls back to BOOT_GREETING. Either way the TX
+    // queue is the single source of TX content from here on.
     defmt::info!(
         "audio: bring-up complete — RX RMS loop ({=u32}-sample windows) + TX feeder (clip-queue driven)",
         RMS_WINDOW_SAMPLES,

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -636,12 +636,26 @@ async fn main(spawner: Spawner) -> ! {
         defmt::panic!("spawn audio_task failed: {}", defmt::Debug2Format(&e));
     }
 
-    // One-shot wall-clock read for the boot log. Single I²C round-trip;
-    // failures are warn-only (logged inside `wallclock::read_and_format`).
-    let mut rtc_buf = [0u8; 19];
+    // One-shot wall-clock read. Drives both the boot-log timestamp
+    // and the time-of-day boot greeting. RTC failures are warn-only
+    // (logged inside `wallclock::read_datetime`); we fall back to
+    // the default daytime greeting when no reading is available.
     let rtc_bus = I2cDevice::new(board_io.i2c_bus);
-    if let Some(stamp) = wallclock::read_and_format(rtc_bus, &mut rtc_buf).await {
-        defmt::info!("boot @ {=str} (RTC)", stamp);
+    let boot_clip = wallclock::read_datetime(rtc_bus)
+        .await
+        .map_or(audio::BOOT_GREETING, |dt| {
+            let mut rtc_buf = [0u8; 19];
+            defmt::info!(
+                "boot @ {=str} (RTC)",
+                bm8563::format_datetime(dt, &mut rtc_buf),
+            );
+            audio::boot_greeting_for_hour(dt.hours)
+        });
+    if let Err(e) = audio::try_enqueue_clip(boot_clip) {
+        defmt::warn!(
+            "audio: boot greeting dropped, queue full ({:?})",
+            defmt::Debug2Format(&e)
+        );
     }
 
     defmt::info!("boot complete — idle heartbeat");

--- a/crates/stackchan-firmware/src/wallclock.rs
+++ b/crates/stackchan-firmware/src/wallclock.rs
@@ -1,27 +1,27 @@
-//! BM8563 wall-clock read, used to timestamp a single boot log line.
+//! BM8563 wall-clock read, used to timestamp a single boot log line
+//! and select the time-of-day boot greeting.
 //!
 //! The `defmt` timestamp stays as `embassy_time::Instant::now()` in
 //! milliseconds — that's what the embassy / defmt integration expects.
-//! This module exists only to give the boot log an absolute time
-//! ("boot @ 2026-04-24 13:37:05") so post-reboot logs can be
-//! correlated without maintaining a side channel on the host.
+//! This module exists to give the boot log an absolute time ("boot @
+//! 2026-04-24 13:37:05") so post-reboot logs can be correlated, and
+//! to surface the current hour so the audio task can pick a
+//! morning / day / evening / night greeting (see
+//! [`crate::audio::boot_greeting_for_hour`]).
 //!
-//! No attempt to keep a running wall-clock: the one caller today
-//! pays for one I²C round-trip at boot. YAGNI until we grow a second
-//! caller.
+//! No attempt to keep a running wall-clock: callers today pay for
+//! one I²C round-trip at boot. YAGNI until we grow a regular polling
+//! consumer.
 
-use bm8563::{Bm8563, format_datetime};
+use bm8563::{Bm8563, DateTime};
 use embedded_hal_async::i2c::I2c as AsyncI2c;
 
-/// Read + format the current wall time from the RTC.
+/// Read the current wall time from the RTC.
 ///
-/// Writes into `buffer` in `YYYY-MM-DD HH:MM:SS` form (19 ASCII bytes)
-/// and returns the filled string slice, or `None` if the RTC was
-/// unreachable / unreliable.
-///
-/// Using a caller-provided buffer keeps the allocator out of the hot
-/// path.
-pub async fn read_and_format<I: AsyncI2c>(bus: I, buffer: &mut [u8; 19]) -> Option<&str> {
+/// Returns `None` if the RTC was unreachable / unreliable. Errors are
+/// logged at `warn` so boot diagnostics surface without coupling
+/// callers to the BM8563 error type.
+pub async fn read_datetime<I: AsyncI2c>(bus: I) -> Option<DateTime> {
     let mut rtc = Bm8563::new(bus);
     if let Err(e) = rtc.init().await {
         defmt::warn!(
@@ -30,14 +30,13 @@ pub async fn read_and_format<I: AsyncI2c>(bus: I, buffer: &mut [u8; 19]) -> Opti
         );
         return None;
     }
-    match rtc.read_datetime().await {
-        Ok(dt) => Some(format_datetime(dt, buffer)),
-        Err(e) => {
+    rtc.read_datetime()
+        .await
+        .inspect_err(|e| {
             defmt::warn!(
                 "BM8563: read failed ({}); boot log will omit wall-clock",
-                defmt::Debug2Format(&e),
+                defmt::Debug2Format(e),
             );
-            None
-        }
-    }
+        })
+        .ok()
 }


### PR DESCRIPTION
## Summary
The boot tone now varies by clock hour, picked at boot from the BM8563 RTC reading.

| Hour range | Variant | Pitch | Duration |
|------------|---------|-------|----------|
| 05:00–11:59 | Morning | 2 kHz | 300 ms — bright "wake up" feel |
| 12:00–17:59 | Day (default) | 1 kHz | 500 ms — original |
| 18:00–22:59 | Evening | 1 kHz | 700 ms — warmer, slightly longer |
| 23:00–04:59 | Night | 1 kHz | 200 ms — short and quiet |

If the RTC is unreachable / no battery / chip missing, falls back to the default daytime greeting silently (warn-logged on the failed read inside `wallclock`).

## Architecture change
Previously the audio task auto-enqueued `BOOT_GREETING` at the end of its bring-up. Now the audio task leaves the TX queue empty after bring-up and main.rs enqueues the time-aware greeting once it has the RTC reading. This:
- Decouples application-level audio policy (which greeting?) from the audio-stack bring-up sequence (just wires the speaker).
- Means the audio task is generic — any caller can be the first producer to the queue.
- Keeps the TX feeder fed at the same wall-clock time as before (RTC read takes ~10 ms, audio bring-up takes ~250 ms; the clip is in the queue well before the feeder pulls it).

## Refactor
- `wallclock::read_and_format` → `wallclock::read_datetime`. Returns `Option<DateTime>` so callers can both format the timestamp for the boot log AND extract the hour for the greeting selector, without an extra I²C round-trip. main.rs calls `bm8563::format_datetime` directly for the log line.
- New `audio::boot_greeting_for_hour(u8) -> AudioClip` selector exposes the time-of-day mapping; `const fn` so it can be evaluated at compile time when the input is a literal.
- Three new public clip consts: `BOOT_GREETING_MORNING`, `BOOT_GREETING_EVENING`, `BOOT_GREETING_NIGHT`. `BOOT_GREETING` retained as the daytime default and the no-RTC fallback.

## Test plan
- [x] `cargo fmt --check`
- [x] Host clippy: `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings`
- [x] Firmware clippy: `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings`
- [x] Firmware release build links
- [x] Host tests + doc tests pass
- [ ] **Hardware validation**: `just fmr` and confirm:
  - Boot at different times of day produces different chimes (or temporarily set the RTC at boot to test each variant)
  - With RTC battery removed (or chip missing): default daytime greeting still plays + warn log line appears
  - "boot @ YYYY-MM-DD HH:MM:SS (RTC)" log line still appears when the RTC is healthy