### PR TITLE
feat: block-grid motion tracker crate + bench example

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -14,5 +14,6 @@
   "crates/es7210": "0.3.0",
   "crates/gc0308": "0.5.0",
   "crates/si12t": "0.3.0",
-  "crates/st25r3916": "0.3.0"
+  "crates/st25r3916": "0.3.0",
+  "crates/tracker": "0.1.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "scservo",
  "stackchan-core",
  "static_cell",
+ "tracker",
 ]
 
 [[package]]
@@ -1703,6 +1704,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tracker"
+version = "0.1.0"
+dependencies = [
+ "stackchan-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/scservo",
     "crates/si12t",
     "crates/st25r3916",
+    "crates/tracker",
     "crates/stackchan-firmware",
 ]
 default-members = [
@@ -38,6 +39,7 @@ default-members = [
     "crates/scservo",
     "crates/si12t",
     "crates/st25r3916",
+    "crates/tracker",
 ]
 
 [workspace.package]

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -26,6 +26,7 @@ ir-nec = { path = "../ir-nec" }
 ltr553 = { path = "../ltr553" }
 py32 = { path = "../py32" }
 scservo = { path = "../scservo" }
+tracker = { path = "../tracker" }
 embedded-graphics = { workspace = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }

--- a/crates/stackchan-firmware/examples/tracker_bench.rs
+++ b/crates/stackchan-firmware/examples/tracker_bench.rs
@@ -1,0 +1,188 @@
+//! Look-toward-motion tracker bench.
+//!
+//! Standalone firmware binary that brings up only the pieces of the
+//! CoreS3 needed to feed the new `tracker` crate — AXP2101 → AW9523 →
+//! shared I²C0 → GC0308 + LCD\_CAM camera task — and then runs the
+//! [`tracker::Tracker`] over every published camera frame, logging each
+//! decision via defmt. **No servos are commanded** in this bench: the
+//! bench's job is to validate the algorithm and tuning on real hardware
+//! before a follow-up PR wires the tracker into `main.rs`.
+//!
+//! The standard `board::bringup` is reused for the power / I²C dance,
+//! which means the boot-nod gesture still runs once at startup
+//! (servos exercise both axes briefly). After that the head holds at
+//! its rest pose for the duration of the bench.
+//!
+//! Sample log line:
+//!
+//! ```text
+//! tracker-bench: motion=Tracking fired=12 nx=0.42 ny=-0.31 \
+//!                target_pan=2.4 target_tilt=1.6
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
+use embassy_executor::Spawner;
+use embassy_time::{Delay, Duration, Timer};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use stackchan_firmware::{board, camera};
+use tracker::{Motion, Tracker, TrackerConfig};
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// LTO anchor preventing `ESP_APP_DESC` from being stripped by
+/// `lto = "fat"`. See `main.rs` for the full rationale.
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("tracker-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+/// Heap size. The camera task allocates two 150 KiB DMA buffers + two
+/// 150 KiB scratch slots in PSRAM, and a small embassy task arena
+/// + defmt buffers in internal SRAM. 32 KiB internal is plenty for the
+/// latter; PSRAM is registered separately by `psram_allocator!`.
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Camera task entry. Same shape as `main.rs`'s `camera_task` so the
+/// bench reuses the production task.
+#[embassy_executor::task]
+async fn camera_task(peripherals: camera::CameraPeripherals) -> ! {
+    camera::run_camera_task(peripherals).await
+}
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+    esp_alloc::psram_allocator!(peripherals.PSRAM, esp_hal::psram);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "tracker-bench v{} — CoreS3 boot, will stream GC0308 frames into the tracker",
+        env!("CARGO_PKG_VERSION"),
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let camera_periph = camera::CameraPeripherals {
+        lcd_cam: peripherals.LCD_CAM,
+        dma: peripherals.DMA_CH1,
+        i2c: I2cDevice::new(board_io.i2c_bus),
+        pclk: peripherals.GPIO45,
+        href: peripherals.GPIO38,
+        vsync: peripherals.GPIO46,
+        d0: peripherals.GPIO39,
+        d1: peripherals.GPIO40,
+        d2: peripherals.GPIO41,
+        d3: peripherals.GPIO42,
+        d4: peripherals.GPIO15,
+        d5: peripherals.GPIO16,
+        d6: peripherals.GPIO48,
+        d7: peripherals.GPIO47,
+    };
+    if let Err(e) = spawner.spawn(camera_task(camera_periph)) {
+        defmt::panic!("spawn camera_task failed: {}", defmt::Debug2Format(&e));
+    }
+
+    // Force the camera task into streaming mode. The signal is sticky;
+    // we publish it once and the camera task picks it up on its next
+    // wait edge. The bench never publishes `false`, so streaming runs
+    // forever.
+    camera::CAMERA_MODE_SIGNAL.signal(true);
+    defmt::info!("tracker-bench: camera mode forced ON; consuming frames");
+
+    // One Tracker per bench run. Default config matches the QVGA
+    // GC0308 + Stack-chan SCServo head.
+    let mut tracker = Tracker::new(TrackerConfig::DEFAULT);
+
+    // Frame publish rate is ~30 FPS; nominal dt = 33 ms. We could
+    // measure the real interval, but this is fine for the idle-timeout
+    // arithmetic at this scope.
+    const NOMINAL_FRAME_DT_MS: u32 = 33;
+    let mut last_motion: Option<Motion> = None;
+    loop {
+        let frame = camera::CAMERA_FRAME_SIGNAL.wait().await;
+        let outcome = tracker.step(frame, NOMINAL_FRAME_DT_MS);
+
+        // De-noise: only log on motion-class transitions and tracking
+        // updates. The Holding / Returning steady states would otherwise
+        // drown the RTT.
+        let log_now = match outcome.motion {
+            Motion::Tracking | Motion::GlobalEvent => true,
+            other => last_motion != Some(other),
+        };
+        if log_now {
+            log_outcome(&outcome);
+            last_motion = Some(outcome.motion);
+        }
+
+        // Tiny yield so other tasks (audio, button, etc) run.
+        // `Signal::wait` already yielded; this is a paranoia tick to
+        // bound the wakeup rate if the camera ever publishes faster
+        // than 30 FPS.
+        Timer::after(Duration::from_millis(1)).await;
+    }
+}
+
+/// Format the tracker outcome over defmt. Centroid / pose are emitted
+/// as scaled integers because defmt doesn't support `f32` formatters
+/// without the `float` feature, which the firmware's defmt build does
+/// not enable.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "centroid is bounded to [-1, 1] and pose to ±MAX_PAN_DEG / [0, MAX_TILT_DEG]; \
+              i32 trivially holds the * 1000 / * 100 scaled values"
+)]
+fn log_outcome(outcome: &tracker::Outcome) {
+    let motion_label = match outcome.motion {
+        Motion::Warmup => "Warmup",
+        Motion::Tracking => "Tracking",
+        Motion::Holding => "Holding",
+        Motion::Returning => "Returning",
+        Motion::GlobalEvent => "GlobalEvent",
+    };
+    let (cx_milli, cy_milli) = match outcome.centroid {
+        Some((nx, ny)) => ((nx * 1000.0) as i32, (ny * 1000.0) as i32),
+        None => (0, 0),
+    };
+    let pan_centi = (outcome.target.pan_deg * 100.0) as i32;
+    let tilt_centi = (outcome.target.tilt_deg * 100.0) as i32;
+    defmt::info!(
+        "tracker-bench: motion={=str} fired={=u16} centroid=({=i32}/1000, {=i32}/1000) \
+         target_pose=({=i32}/100°, {=i32}/100°)",
+        motion_label,
+        outcome.fired_cells,
+        cx_milli,
+        cy_milli,
+        pan_centi,
+        tilt_centi,
+    );
+}

--- a/crates/tracker/CHANGELOG.md
+++ b/crates/tracker/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/crates/tracker/Cargo.toml
+++ b/crates/tracker/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tracker"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "no_std block-grid motion tracker that turns RGB565 camera frames into pan/tilt head poses for the Stack-chan."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+# `Pose` lives in stackchan-core so the tracker can publish poses
+# directly into the firmware's existing `POSE_SIGNAL` plumbing without
+# a marshalling layer.
+stackchan-core = { path = "../stackchan-core" }

--- a/crates/tracker/README.md
+++ b/crates/tracker/README.md
@@ -1,0 +1,87 @@
+---
+crate: tracker
+role: Block-grid motion tracker (RGB565 → head Pose)
+bus: none (pure algorithm)
+transport: in-memory frame slices
+no_std: true
+unsafe: forbidden
+status: experimental (v0.x)
+---
+
+# tracker
+
+`no_std` block-grid motion tracker for the Stack-chan camera. Consumes
+raw RGB565 QVGA frames, computes inter-frame motion via per-block luma
+deltas, and emits a target `stackchan_core::Pose` for the head servos.
+Pure algorithm — no I/O, no allocation, host-testable from canned
+fixture frames.
+
+## Key Files
+
+- `src/lib.rs` — `TrackerConfig`, `Tracker`, `Outcome`, `Motion`,
+  control-law (P-gain + dead zone + per-step slew + idle-timeout
+  return-to-centre), inline unit tests on synthesised frames
+- `src/luma.rs` — RGB565 → 8-bit luma approximation
+  (`(R8 + 2·G8 + B8) >> 2`), `fill_block_luma` reduction over a
+  configurable `blocks_x` × `blocks_y` grid (≤ 16 × 16)
+
+## Algorithm
+
+For each step:
+
+1. **Per-block mean luma.** Reduce the frame into a small grid (default
+   8 × 6 → 40 × 40 pixel cells over QVGA). Luma uses a fast
+   shifts-only Rec. 601 approximation.
+2. **Per-block delta vs. previous frame.** A block whose normalised
+   delta exceeds `block_threshold` "fires".
+3. **Centroid of fired cells.** Mapped to `[-1, 1]` per axis.
+4. **Reject global events.** If too many cells fire (default > 70%),
+   the frame is treated as a lighting flip and the pose held.
+5. **Dead zone + P-gain + slew clamp.** Centroid is converted to a pan
+   / tilt delta via the configured camera FOV; small offsets pass
+   through the dead zone untouched, the rest are scaled by `p_gain`
+   and clamped to `±max_step_deg`.
+6. **Idle timeout.** After `idle_timeout_ms` of no motion the target
+   pose slews back toward `Pose::NEUTRAL` at `idle_step_deg` per step.
+7. **`Pose::clamped`.** Final assignment routes through the
+   stackchan-core safe-range clamp (asymmetric tilt — see
+   `stackchan_core::head`).
+
+## Sign Conventions
+
+Inherited from `stackchan_core::head`:
+
+- `+pan_deg` → head turns *right* from the viewer's POV.
+- `+tilt_deg` → head nods *up* (chin rises). `MIN_TILT_DEG = 0`, so
+  the tracker can ask for a downward look but `Pose::clamped` pins
+  it to level.
+- Centroid `nx > 0` ⇒ motion right of frame centre ⇒ pan delta `> 0`.
+- Centroid `ny > 0` ⇒ motion below frame centre ⇒ tilt delta `< 0`
+  (head nods down) — clamped to 0 in practice.
+
+## Coupling
+
+- Depends on `stackchan-core` *only* for `Pose` and the safe-range
+  constants. No firmware deps; runs unchanged on host.
+- The firmware's `examples/tracker_bench.rs` exercises this crate
+  end-to-end against the live GC0308 + LCD\_CAM camera task and logs
+  proposed poses without driving any servo.
+
+## Tuning
+
+Defaults live in `TrackerConfig::DEFAULT` and are tuned for QVGA
+GC0308 + Stack-chan SCServo head on a CoreS3. Edit per axis as
+needed; the bench logs centroid + fired-cell counts every step so
+empirical tuning is straightforward.
+
+## Limitations
+
+- Frame-difference detection localises to the **midpoint** of motion,
+  not the new position — fast left-to-right travel of an object will
+  fire blocks at *both* ends, biasing the centroid toward the centre.
+  For Stack-chan use (people entering frame, slow scene-rate change)
+  this works well; longer-term, a running-mean background subtraction
+  would track moving objects more accurately.
+- 8 × 6 grid resolution puts angular resolution at ~7° per cell on a
+  62° H FOV — fine enough for slow head tracking, coarse for precise
+  saccades.

--- a/crates/tracker/src/lib.rs
+++ b/crates/tracker/src/lib.rs
@@ -1,0 +1,671 @@
+//! # tracker
+//!
+//! Block-grid motion tracker for the Stack-chan camera. Consumes raw
+//! RGB565 camera frames, computes inter-frame motion via per-block luma
+//! deltas, and emits a target [`Pose`] for the head servos. Pure
+//! algorithm — no I/O, no allocation, host-testable.
+//!
+//! ## Pipeline
+//!
+//! 1. Convert each pixel to an 8-bit luma estimate (Rec. 601 weights).
+//! 2. Sum luma into a small grid of blocks (configurable, ≤ 16×16).
+//! 3. Compare the new grid to the previous frame's grid. A block whose
+//!    normalised delta exceeds [`TrackerConfig::block_threshold`] fires.
+//! 4. If the count of fired cells is above [`TrackerConfig::min_fired_cells`]
+//!    and below [`TrackerConfig::max_fired_fraction`] (the latter
+//!    rejects whole-frame events like the lights flipping on), compute
+//!    the centroid of the fired cells and translate it to a pan/tilt
+//!    delta via the configured camera FOV.
+//! 5. Apply a dead zone, proportional gain, and per-step slew limit;
+//!    accumulate into a target [`Pose`]; clamp via [`Pose::clamped`].
+//! 6. If no motion is seen for [`TrackerConfig::idle_timeout_ms`], slew
+//!    the target back toward [`Pose::NEUTRAL`].
+//!
+//! ## Coordinates
+//!
+//! Frames are assumed to be column-major-byte-pairs in big-endian
+//! RGB565 (the `LCD_CAM` peripheral's default byte order). Pixel `(x, y)`
+//! lives at byte offset `(y * width + x) * 2`. The tracker does not
+//! validate orientation; mirrored cameras can be corrected via the
+//! [`TrackerConfig::flip_x`] / [`TrackerConfig::flip_y`] flags.
+//!
+//! ## Stability
+//!
+//! Experimental as of v0.1.0.
+
+#![cfg_attr(not(test), no_std)]
+#![deny(unsafe_code)]
+
+mod luma;
+
+pub use luma::{BYTES_PER_PIXEL, MAX_BLOCKS, MAX_BLOCKS_X, MAX_BLOCKS_Y, fill_block_luma};
+
+use stackchan_core::Pose;
+
+/// Configuration for [`Tracker`].
+///
+/// All fields are public so callers can tune individual parameters
+/// from the workspace [`TrackerConfig::DEFAULT`].
+#[derive(Debug, Clone, Copy)]
+pub struct TrackerConfig {
+    /// Frame width in pixels. Must equal the source DMA buffer width.
+    pub frame_width: u16,
+    /// Frame height in pixels.
+    pub frame_height: u16,
+    /// Horizontal blocks in the analysis grid. ≤ [`MAX_BLOCKS_X`].
+    pub blocks_x: u16,
+    /// Vertical blocks in the analysis grid. ≤ [`MAX_BLOCKS_Y`].
+    pub blocks_y: u16,
+    /// Pixel skip factor inside a block (1 = read every pixel,
+    /// 2 = read every other pixel in both axes). Larger values trade
+    /// a small amount of accuracy for ~`step²` less memory bandwidth.
+    pub subsample_step: u8,
+    /// Camera horizontal field of view in degrees. GC0308 with the
+    /// CoreS3 lens is roughly 62°.
+    pub fov_h_deg: f32,
+    /// Camera vertical field of view in degrees. ~49° on the same lens.
+    pub fov_v_deg: f32,
+    /// Per-block delta threshold in normalised luma units `[0.0, 1.0]`.
+    /// A block with `|curr - prev| / 255` above this fires.
+    pub block_threshold: f32,
+    /// Minimum fired-cell count required to count as "real" motion.
+    /// Rejects single-block sensor noise.
+    pub min_fired_cells: u16,
+    /// If more than this fraction of cells fire on a single frame the
+    /// event is treated as a global lighting change and ignored.
+    pub max_fired_fraction: f32,
+    /// Proportional gain on centroid-offset error in `[0.0, 1.0]`.
+    /// `1.0` jumps the head all the way to centre the target on every
+    /// frame; `0.4` damps the loop pleasantly given typical servo lag.
+    pub p_gain: f32,
+    /// Dead-zone half-width as a fraction of frame size, applied
+    /// independently per axis. A normalised centroid offset within
+    /// `±dead_zone` produces no motion.
+    pub dead_zone: f32,
+    /// Maximum pose-delta per [`Tracker::step`] call, per axis, in
+    /// degrees. Caps angular velocity to keep the loop stable when the
+    /// servos can't keep up with the commanded rate.
+    pub max_step_deg: f32,
+    /// Idle timeout in milliseconds. After this much "no motion" the
+    /// tracker begins slewing back to [`Pose::NEUTRAL`].
+    pub idle_timeout_ms: u32,
+    /// Per-step slew while idle, in degrees per axis. The default
+    /// produces a calm return at 30 FPS.
+    pub idle_step_deg: f32,
+    /// Mirror the centroid horizontally before mapping to pan. Use when
+    /// the camera image is left-right reversed relative to the head's
+    /// pan direction (e.g. lens / sensor mounted upside-down).
+    pub flip_x: bool,
+    /// Mirror vertically. Use when the image is upside-down relative
+    /// to the head's tilt direction.
+    pub flip_y: bool,
+}
+
+impl TrackerConfig {
+    /// Defaults tuned for QVGA GC0308 → `SCServo` head on a CoreS3.
+    ///
+    /// 8×6 grid (40×40 pixel blocks), 5 % per-block luma threshold,
+    /// 70 % global-event ceiling, P=0.4, ±10 % dead zone, 4 °/frame
+    /// slew, 3 s idle timeout, 1 °/step return-to-centre.
+    pub const DEFAULT: Self = Self {
+        frame_width: 320,
+        frame_height: 240,
+        blocks_x: 8,
+        blocks_y: 6,
+        subsample_step: 2,
+        fov_h_deg: 62.0,
+        fov_v_deg: 49.0,
+        block_threshold: 0.05,
+        min_fired_cells: 2,
+        max_fired_fraction: 0.70,
+        p_gain: 0.4,
+        dead_zone: 0.10,
+        max_step_deg: 4.0,
+        idle_timeout_ms: 3_000,
+        idle_step_deg: 1.0,
+        flip_x: false,
+        flip_y: false,
+    };
+}
+
+/// Outcome of one [`Tracker::step`] call.
+///
+/// Returned for diagnostic logging in the bench example and for unit
+/// tests. The new target pose is always available as [`Outcome::target`];
+/// [`Outcome::motion`] distinguishes the *why*.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Outcome {
+    /// Number of grid cells whose per-block delta exceeded the threshold.
+    /// Capped at `blocks_x * blocks_y`.
+    pub fired_cells: u16,
+    /// Normalised centroid in `[-1.0, 1.0]` per axis when motion was
+    /// detected, else `None`. `(0, 0)` means the centre of the frame.
+    pub centroid: Option<(f32, f32)>,
+    /// Classification of this step.
+    pub motion: Motion,
+    /// New target pose after this step. Always within
+    /// [`Pose::clamped`]'s safe range.
+    pub target: Pose,
+}
+
+/// Why the tracker chose this pose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Motion {
+    /// Not enough information to act yet — the tracker is buffering its
+    /// first frame. Target pose is unchanged.
+    Warmup,
+    /// Real motion detected; the target pose was nudged toward it.
+    Tracking,
+    /// No motion this step but still inside the idle timeout window;
+    /// target pose held.
+    Holding,
+    /// Idle long enough to be slewing back toward [`Pose::NEUTRAL`].
+    Returning,
+    /// Too many cells fired this frame — likely a global lighting
+    /// change. Target pose held.
+    GlobalEvent,
+}
+
+/// Block-grid motion tracker.
+///
+/// Holds the previous-frame block grid and the running target pose.
+/// One [`Tracker`] per camera; not `Sync` (the firmware uses one task
+/// per camera so this is fine — see `examples/tracker_bench.rs`).
+pub struct Tracker {
+    /// Active configuration. Captured at construction time and not
+    /// re-validated on every step.
+    config: TrackerConfig,
+    /// Previous frame's per-block mean luma in `[0, 255]`. Indexed as
+    /// `prev_grid[y * blocks_x + x]`. Length is `blocks_x * blocks_y`.
+    prev_grid: [u8; MAX_BLOCKS],
+    /// Whether [`Self::prev_grid`] holds a real previous frame.
+    /// `false` until the first [`Self::step`].
+    have_prev: bool,
+    /// Running commanded target pose. Always inside the [`Pose::clamped`]
+    /// safe range.
+    target_pose: Pose,
+    /// Accumulated time since motion was last detected, in
+    /// milliseconds. Saturates at `u32::MAX`.
+    idle_ms: u32,
+}
+
+impl Tracker {
+    /// Build a tracker from a config.
+    ///
+    /// Out-of-range grid sizes are silently clamped to
+    /// `[1, MAX_BLOCKS_X]` × `[1, MAX_BLOCKS_Y]`; other values are
+    /// trusted. Caller is expected to seed [`TrackerConfig`] from
+    /// [`TrackerConfig::DEFAULT`] and tweak the few fields they care
+    /// about.
+    #[must_use]
+    pub const fn new(config: TrackerConfig) -> Self {
+        Self {
+            config,
+            prev_grid: [0; MAX_BLOCKS],
+            have_prev: false,
+            target_pose: Pose::NEUTRAL,
+            idle_ms: 0,
+        }
+    }
+
+    /// Borrow the active config.
+    #[must_use]
+    pub const fn config(&self) -> &TrackerConfig {
+        &self.config
+    }
+
+    /// Most-recently commanded target pose.
+    #[must_use]
+    pub const fn target_pose(&self) -> Pose {
+        self.target_pose
+    }
+
+    /// Forget the previous frame and reset the target to `NEUTRAL`.
+    /// The next [`Self::step`] will report [`Motion::Warmup`].
+    pub const fn reset(&mut self) {
+        self.have_prev = false;
+        self.target_pose = Pose::NEUTRAL;
+        self.idle_ms = 0;
+    }
+
+    /// Process one frame.
+    ///
+    /// `frame` must hold at least
+    /// `frame_width * frame_height * BYTES_PER_PIXEL` bytes of big-endian
+    /// RGB565. Frames smaller than that produce a warmup result with
+    /// the target pose unchanged.
+    ///
+    /// `dt_ms` is the wall-clock interval since the previous step.
+    /// Used for the idle-timeout / return-to-centre logic. Pass the
+    /// real delta when available, or a constant nominal frame period
+    /// (e.g. 33 ms at 30 FPS) when not.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        clippy::similar_names,
+        reason = "block-grid arithmetic: cell counts ≤ MAX_BLOCKS (256) so \
+                  usize→u32 / u32→f32 casts cannot lose information; the \
+                  f32→u16 casts are bounded by inputs that have already been \
+                  clamped to [0, 255] / [0, total_cells]; per-axis \
+                  `nx`/`ny`/`*_eff` pairs are the algorithm's natural names"
+    )]
+    pub fn step(&mut self, frame: &[u8], dt_ms: u32) -> Outcome {
+        let cfg = &self.config;
+        let bx = clamp_blocks(cfg.blocks_x, MAX_BLOCKS_X);
+        let by = clamp_blocks(cfg.blocks_y, MAX_BLOCKS_Y);
+        let total = usize::from(bx) * usize::from(by);
+
+        let need = usize::from(cfg.frame_width) * usize::from(cfg.frame_height) * BYTES_PER_PIXEL;
+        if frame.len() < need {
+            return Outcome {
+                fired_cells: 0,
+                centroid: None,
+                motion: Motion::Warmup,
+                target: self.target_pose,
+            };
+        }
+
+        let mut curr_grid = [0u8; MAX_BLOCKS];
+        fill_block_luma(
+            frame,
+            cfg.frame_width,
+            cfg.frame_height,
+            bx,
+            by,
+            cfg.subsample_step.max(1),
+            &mut curr_grid,
+        );
+
+        if !self.have_prev {
+            self.prev_grid[..total].copy_from_slice(&curr_grid[..total]);
+            self.have_prev = true;
+            return Outcome {
+                fired_cells: 0,
+                centroid: None,
+                motion: Motion::Warmup,
+                target: self.target_pose,
+            };
+        }
+
+        let threshold_u = ((cfg.block_threshold.clamp(0.0, 1.0)) * 255.0) as u16;
+        let max_fired = ((cfg.max_fired_fraction.clamp(0.0, 1.0)) * total as f32) as u16;
+        let mut fired_cells: u16 = 0;
+        let mut sum_x: u32 = 0;
+        let mut sum_y: u32 = 0;
+        for iy in 0..usize::from(by) {
+            for ix in 0..usize::from(bx) {
+                let idx = iy * usize::from(bx) + ix;
+                let curr = u16::from(curr_grid[idx]);
+                let prev = u16::from(self.prev_grid[idx]);
+                let delta = curr.abs_diff(prev);
+                if delta > threshold_u {
+                    fired_cells += 1;
+                    sum_x += ix as u32;
+                    sum_y += iy as u32;
+                }
+            }
+        }
+        // Roll the previous grid forward unconditionally — even on a
+        // global-event frame we want next frame's delta to be against
+        // the new state.
+        self.prev_grid[..total].copy_from_slice(&curr_grid[..total]);
+
+        if fired_cells > max_fired {
+            // Treat as global event. Hold pose, reset idle timer so we
+            // don't immediately start returning to centre on lighting
+            // flickers (likely the user just walked into the room).
+            self.idle_ms = 0;
+            return Outcome {
+                fired_cells,
+                centroid: None,
+                motion: Motion::GlobalEvent,
+                target: self.target_pose,
+            };
+        }
+
+        if fired_cells < cfg.min_fired_cells {
+            return self.no_motion_outcome(dt_ms, fired_cells);
+        }
+
+        // Centroid in block-index space, then normalised to [-1, 1].
+        let (cell_cx, cell_cy) = (
+            (sum_x as f32) / f32::from(fired_cells),
+            (sum_y as f32) / f32::from(fired_cells),
+        );
+        // Centre of a block-index axis of length N is at (N-1)/2;
+        // dividing by that maps the index-space centroid to [-1, 1].
+        let half_x = (f32::from(bx) - 1.0) * 0.5;
+        let half_y = (f32::from(by) - 1.0) * 0.5;
+        let mut nx = (cell_cx - half_x) / half_x.max(0.5);
+        let mut ny = (cell_cy - half_y) / half_y.max(0.5);
+        if cfg.flip_x {
+            nx = -nx;
+        }
+        if cfg.flip_y {
+            ny = -ny;
+        }
+
+        // Apply dead zone per axis.
+        let dz = cfg.dead_zone.clamp(0.0, 0.99);
+        let nx_eff = if nx.abs() < dz { 0.0 } else { nx };
+        let ny_eff = if ny.abs() < dz { 0.0 } else { ny };
+
+        // Map normalised offset to angle delta via half-FOV * P.
+        // Sign convention:
+        //   nx > 0 → motion is right-of-centre → head should pan right
+        //                                        → +pan_deg
+        //   ny > 0 → motion is below centre    → head should tilt down
+        //                                        → -tilt_deg
+        // (Recall: positive tilt = nod up.)
+        let pan_delta =
+            (nx_eff * cfg.fov_h_deg * 0.5 * cfg.p_gain).clamp(-cfg.max_step_deg, cfg.max_step_deg);
+        let tilt_delta =
+            (-ny_eff * cfg.fov_v_deg * 0.5 * cfg.p_gain).clamp(-cfg.max_step_deg, cfg.max_step_deg);
+
+        self.target_pose = Pose::new(
+            self.target_pose.pan_deg + pan_delta,
+            self.target_pose.tilt_deg + tilt_delta,
+        )
+        .clamped();
+        self.idle_ms = 0;
+
+        Outcome {
+            fired_cells,
+            centroid: Some((nx, ny)),
+            motion: Motion::Tracking,
+            target: self.target_pose,
+        }
+    }
+
+    /// Helper: build the outcome for a "no motion this frame" step.
+    /// Splits the idle-timeout / return-to-centre logic out of
+    /// [`Self::step`] for readability.
+    const fn no_motion_outcome(&mut self, dt_ms: u32, fired_cells: u16) -> Outcome {
+        self.idle_ms = self.idle_ms.saturating_add(dt_ms);
+        if self.idle_ms < self.config.idle_timeout_ms {
+            return Outcome {
+                fired_cells,
+                centroid: None,
+                motion: Motion::Holding,
+                target: self.target_pose,
+            };
+        }
+        let step = self.config.idle_step_deg.max(0.0);
+        self.target_pose = Pose::new(
+            slew_toward(self.target_pose.pan_deg, 0.0, step),
+            slew_toward(self.target_pose.tilt_deg, 0.0, step),
+        )
+        .clamped();
+        Outcome {
+            fired_cells,
+            centroid: None,
+            motion: Motion::Returning,
+            target: self.target_pose,
+        }
+    }
+}
+
+/// Step `value` toward `target` by at most `step` units.
+const fn slew_toward(value: f32, target: f32, step: f32) -> f32 {
+    let diff = target - value;
+    if diff.abs() <= step {
+        target
+    } else if diff > 0.0 {
+        value + step
+    } else {
+        value - step
+    }
+}
+
+/// Clamp a configured grid extent into `[1, max]`.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "max is one of MAX_BLOCKS_X / MAX_BLOCKS_Y, both ≤ 16, fits trivially in u16"
+)]
+const fn clamp_blocks(requested: u16, max: usize) -> u16 {
+    if requested == 0 {
+        1
+    } else if (requested as usize) > max {
+        max as u16
+    } else {
+        requested
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "tests assert exact-match outputs of our own arithmetic; \
+              unwrap and panic-on-mismatch are fine on synthesised fixtures"
+)]
+mod tests {
+    use super::*;
+
+    /// Build a 320×240 RGB565 frame filled with a single luma value.
+    fn flat_frame(luma: u8) -> alloc::vec::Vec<u8> {
+        // RGB565 luma ≈ G channel; pick a green value matching `luma`.
+        // For a uniform frame we just need every pixel identical, so
+        // any encoding is fine — set R=G=B from `luma`.
+        let r5 = u16::from(luma >> 3) & 0x1F;
+        let g6 = u16::from(luma >> 2) & 0x3F;
+        let b5 = u16::from(luma >> 3) & 0x1F;
+        let pixel = (r5 << 11) | (g6 << 5) | b5;
+        let hi = (pixel >> 8) as u8;
+        let lo = (pixel & 0xFF) as u8;
+        let mut v = alloc::vec::Vec::with_capacity(320 * 240 * 2);
+        for _ in 0..(320 * 240) {
+            v.push(hi);
+            v.push(lo);
+        }
+        v
+    }
+
+    /// Paint a rectangular bright patch onto an existing frame.
+    fn paint_patch(frame: &mut [u8], x0: usize, y0: usize, w: usize, h: usize, luma: u8) {
+        let r5 = u16::from(luma >> 3) & 0x1F;
+        let g6 = u16::from(luma >> 2) & 0x3F;
+        let b5 = u16::from(luma >> 3) & 0x1F;
+        let pixel = (r5 << 11) | (g6 << 5) | b5;
+        let hi = (pixel >> 8) as u8;
+        let lo = (pixel & 0xFF) as u8;
+        for y in y0..(y0 + h) {
+            for x in x0..(x0 + w) {
+                let idx = (y * 320 + x) * 2;
+                frame[idx] = hi;
+                frame[idx + 1] = lo;
+            }
+        }
+    }
+
+    extern crate alloc;
+
+    #[test]
+    fn warmup_holds_neutral() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let f = flat_frame(64);
+        let out = t.step(&f, 33);
+        assert_eq!(out.motion, Motion::Warmup);
+        assert_eq!(out.target, Pose::NEUTRAL);
+    }
+
+    #[test]
+    fn no_motion_holds_pose_until_idle_timeout() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let f = flat_frame(64);
+        let _ = t.step(&f, 33); // warmup
+        // Same frame again: no motion. Should be Holding for the first
+        // 3 s (idle_timeout_ms = 3000 in DEFAULT).
+        let out = t.step(&f, 33);
+        assert_eq!(out.motion, Motion::Holding);
+        assert_eq!(out.target, Pose::NEUTRAL);
+    }
+
+    #[test]
+    fn idle_timeout_returns_toward_neutral() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        // Seed the target away from NEUTRAL so the return-to-centre
+        // slew has somewhere to slew *to*. Field access works because
+        // the test lives inside the crate.
+        t.target_pose = Pose::new(20.0, 10.0);
+
+        let blank = flat_frame(64);
+        let _ = t.step(&blank, 33); // warmup, prev grid populated
+
+        // 4 s of no-motion steps at 33 ms each → past the 3 s timeout.
+        let mut last_target = t.target_pose;
+        for _ in 0..130 {
+            let out = t.step(&blank, 33);
+            last_target = out.target;
+        }
+        assert!(
+            last_target.pan_deg.abs() < 20.0,
+            "expected pan to slew below seed, got {}",
+            last_target.pan_deg,
+        );
+        assert!(
+            last_target.tilt_deg.abs() < 10.0,
+            "expected tilt to slew below seed, got {}",
+            last_target.tilt_deg,
+        );
+    }
+
+    #[test]
+    fn patch_appears_right_pans_head_right() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+
+        // Frame 1: blank (warmup).
+        let blank = flat_frame(20);
+        let _ = t.step(&blank, 33);
+
+        // Frame 2: bright 80×80 patch on the right edge. Fired cells
+        // are exactly where the new content appeared — block columns
+        // 6-7 — so the centroid lives there too.
+        let mut f2 = flat_frame(20);
+        paint_patch(&mut f2, 240, 80, 80, 80, 230);
+        let out = t.step(&f2, 33);
+
+        match out.motion {
+            Motion::Tracking => {}
+            other => panic!("expected Tracking, got {other:?}"),
+        }
+        let (nx, _ny) = out.centroid.unwrap();
+        assert!(nx > 0.0, "expected centroid right-of-centre, got nx={nx}");
+        assert!(out.target.pan_deg > 0.0);
+        assert!(out.target.pan_deg <= TrackerConfig::DEFAULT.max_step_deg);
+    }
+
+    #[test]
+    fn patch_appears_high_tilts_head_up() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let blank = flat_frame(20);
+        let _ = t.step(&blank, 33);
+
+        // 80×80 patch up high (top of frame), centred horizontally.
+        let mut f2 = flat_frame(20);
+        paint_patch(&mut f2, 120, 0, 80, 80, 230);
+        let out = t.step(&f2, 33);
+
+        assert_eq!(out.motion, Motion::Tracking);
+        let (_nx, ny) = out.centroid.unwrap();
+        assert!(ny < 0.0, "expected centroid above centre, got ny={ny}");
+        // Negative ny → tilt up → positive tilt_deg.
+        assert!(
+            out.target.tilt_deg > 0.0,
+            "expected upward tilt, got tilt_deg={}",
+            out.target.tilt_deg,
+        );
+    }
+
+    #[test]
+    fn patch_appears_low_clamps_tilt_to_zero() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let blank = flat_frame(20);
+        let _ = t.step(&blank, 33);
+
+        let mut f2 = flat_frame(20);
+        paint_patch(&mut f2, 120, 160, 80, 80, 230);
+        let out = t.step(&f2, 33);
+
+        assert_eq!(out.motion, Motion::Tracking);
+        let (_nx, ny) = out.centroid.unwrap();
+        assert!(ny > 0.0, "expected centroid below centre, got ny={ny}");
+        // Positive ny would command negative tilt (look down), but
+        // MIN_TILT_DEG = 0 so Pose::clamped pins it at 0.
+        assert_eq!(out.target.tilt_deg, 0.0);
+    }
+
+    #[test]
+    fn global_lighting_change_is_rejected() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let dark = flat_frame(10);
+        let bright = flat_frame(220);
+        let _ = t.step(&dark, 33); // warmup
+        let out = t.step(&bright, 33);
+        assert_eq!(
+            out.motion,
+            Motion::GlobalEvent,
+            "expected GlobalEvent on whole-frame brightness flip, got {:?}",
+            out.motion,
+        );
+        assert_eq!(out.target, Pose::NEUTRAL);
+    }
+
+    #[test]
+    fn dead_zone_suppresses_centred_motion() {
+        let mut cfg = TrackerConfig::DEFAULT;
+        cfg.dead_zone = 0.5; // wide dead zone for the test
+        let mut t = Tracker::new(cfg);
+
+        let blank = flat_frame(20);
+        let _ = t.step(&blank, 33);
+
+        // Patch appears centred — fired cells cluster around the frame
+        // centre, so the normalised centroid sits inside the wide dead
+        // zone and the target pose isn't nudged.
+        let mut f2 = flat_frame(20);
+        paint_patch(&mut f2, 130, 90, 60, 60, 230);
+        let out = t.step(&f2, 33);
+
+        assert_eq!(out.motion, Motion::Tracking);
+        assert_eq!(out.target, Pose::NEUTRAL);
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let f = flat_frame(64);
+        let _ = t.step(&f, 33);
+        t.reset();
+        let out = t.step(&f, 33);
+        assert_eq!(out.motion, Motion::Warmup);
+    }
+
+    #[test]
+    fn target_pose_saturates_at_pan_clamp() {
+        // Alternate blank ↔ patch-far-right so every transition fires
+        // cells exclusively on the right side of the frame, biasing
+        // pan deltas positive every step. Verify pan saturates at
+        // MAX_PAN_DEG instead of running away.
+        let mut t = Tracker::new(TrackerConfig::DEFAULT);
+        let blank = flat_frame(20);
+        let mut patch_right = flat_frame(20);
+        paint_patch(&mut patch_right, 240, 80, 80, 80, 230);
+
+        let _ = t.step(&blank, 33);
+        for _ in 0..50 {
+            let _ = t.step(&patch_right, 33);
+            let _ = t.step(&blank, 33);
+        }
+        // Should have hit the pan clamp.
+        assert!(
+            (t.target_pose().pan_deg - stackchan_core::MAX_PAN_DEG).abs() < 0.01,
+            "expected pan saturated at MAX_PAN_DEG, got {}",
+            t.target_pose().pan_deg,
+        );
+        assert!(t.target_pose().tilt_deg <= stackchan_core::MAX_TILT_DEG);
+        assert!(t.target_pose().tilt_deg >= stackchan_core::MIN_TILT_DEG);
+    }
+}

--- a/crates/tracker/src/luma.rs
+++ b/crates/tracker/src/luma.rs
@@ -1,0 +1,207 @@
+//! RGB565 → per-block luma reduction.
+//!
+//! Splits a frame into a `blocks_x` × `blocks_y` grid of equal-sized
+//! cells and writes the mean luma per cell into a caller-provided
+//! output array. Pure arithmetic, no allocation, no borrows of the
+//! frame outlive the call.
+//!
+//! ## Coordinate convention
+//!
+//! Pixels are laid out row-major: byte index for pixel `(x, y)` is
+//! `(y * width + x) * BYTES_PER_PIXEL`. Each pixel is two bytes,
+//! big-endian (the `LCD_CAM` peripheral's default emit order — high
+//! byte first).
+//!
+//! ## Luma approximation
+//!
+//! `y ≈ (R8 + 2·G8 + B8) >> 2` — adds-and-shifts only, ~5 ops per
+//! pixel. Visually close enough to true Rec. 601 for motion-detection
+//! purposes (the tracker compares deltas, not absolute values, so the
+//! extra precision of full-weight Rec. 601 multiplies isn't worth the
+//! cycles).
+
+/// RGB565 = 2 bytes per pixel.
+pub const BYTES_PER_PIXEL: usize = 2;
+
+/// Maximum supported horizontal grid extent.
+///
+/// Bigger = more arithmetic per frame and more `prev_grid` state.
+/// 16 columns over a 320 px frame is one cell every 20 px — finer
+/// than necessary for centroid localisation given typical servo and
+/// motion lag.
+pub const MAX_BLOCKS_X: usize = 16;
+
+/// Maximum supported vertical grid extent.
+pub const MAX_BLOCKS_Y: usize = 16;
+
+/// Maximum total cells. The tracker reserves a fixed-size buffer of
+/// this length for the previous-frame grid.
+pub const MAX_BLOCKS: usize = MAX_BLOCKS_X * MAX_BLOCKS_Y;
+
+/// Compute the per-block mean luma for one frame.
+///
+/// `frame` must be at least `width * height * BYTES_PER_PIXEL` bytes
+/// of big-endian RGB565. `blocks_x` × `blocks_y` cells (≤ [`MAX_BLOCKS_X`] /
+/// [`MAX_BLOCKS_Y`]) of width `floor(width / blocks_x)` and height
+/// `floor(height / blocks_y)` are scanned. `subsample_step` skips
+/// pixels inside each block: `1` reads every pixel, `2` every other
+/// pixel in both axes.
+///
+/// `out[0 .. blocks_x * blocks_y]` is filled with mean luma values in
+/// `[0, 255]`; entries past that range are untouched.
+///
+/// Pixels outside the integer-divisible region (when `width` or
+/// `height` doesn't divide evenly) are silently dropped — the
+/// algorithm doesn't need exact area parity since fired-cell counting
+/// is on a per-block basis.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "block_w/block_h are bounded by frame dims (≤ u16::MAX); the \
+              `as u16` / `as u8` casts on luma sums are explicitly clamped \
+              by /(pixel count) so the value fits."
+)]
+pub fn fill_block_luma(
+    frame: &[u8],
+    width: u16,
+    height: u16,
+    blocks_x: u16,
+    blocks_y: u16,
+    subsample_step: u8,
+    out: &mut [u8],
+) {
+    if blocks_x == 0 || blocks_y == 0 {
+        return;
+    }
+    let bx = usize::from(blocks_x);
+    let by = usize::from(blocks_y);
+    let w = usize::from(width);
+    let h = usize::from(height);
+    let block_w = w / bx;
+    let block_h = h / by;
+    if block_w == 0 || block_h == 0 {
+        return;
+    }
+    let step = usize::from(subsample_step.max(1));
+
+    for iy in 0..by {
+        for ix in 0..bx {
+            let x0 = ix * block_w;
+            let y0 = iy * block_h;
+            let mut sum: u32 = 0;
+            let mut count: u32 = 0;
+            let mut y = y0;
+            while y < y0 + block_h {
+                let row_off = y * w * BYTES_PER_PIXEL;
+                let mut x = x0;
+                while x < x0 + block_w {
+                    let off = row_off + x * BYTES_PER_PIXEL;
+                    // Bounds check folded in: `off + 1 < frame.len()`.
+                    if off + 1 < frame.len() {
+                        let hi = frame[off];
+                        let lo = frame[off + 1];
+                        let pixel = (u16::from(hi) << 8) | u16::from(lo);
+                        sum += u32::from(luma_from_rgb565(pixel));
+                        count += 1;
+                    }
+                    x += step;
+                }
+                y += step;
+            }
+            let cell_idx = iy * bx + ix;
+            if cell_idx < out.len() {
+                out[cell_idx] = sum.checked_div(count).unwrap_or(0) as u8;
+            }
+        }
+    }
+}
+
+/// Approximate luma from one RGB565 pixel.
+///
+/// `y ≈ (R8 + 2·G8 + B8) / 4` — fast, surprisingly faithful for motion
+/// purposes. R5 / B5 expand to 8-bit by replicating the top 3 bits;
+/// G6 expands by replicating the top 2 bits.
+#[inline]
+#[must_use]
+pub const fn luma_from_rgb565(pixel: u16) -> u8 {
+    let r5 = ((pixel >> 11) & 0x1F) as u32;
+    let g6 = ((pixel >> 5) & 0x3F) as u32;
+    let b5 = (pixel & 0x1F) as u32;
+    let r8 = (r5 << 3) | (r5 >> 2);
+    let g8 = (g6 << 2) | (g6 >> 4);
+    let b8 = (b5 << 3) | (b5 >> 2);
+    let y = (r8 + 2 * g8 + b8) >> 2;
+    // y is bounded by (255 + 2*255 + 255)/4 = 255.
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "y is computed with weights summing to 4; max value 255 fits in u8"
+    )]
+    let y_u8 = y as u8;
+    y_u8
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::unwrap_used,
+    reason = "tests assert exact integer outputs"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn luma_extremes() {
+        // Pure black RGB565 = 0x0000 → luma 0.
+        assert_eq!(luma_from_rgb565(0x0000), 0);
+        // Pure white RGB565 = 0xFFFF → luma 255.
+        assert_eq!(luma_from_rgb565(0xFFFF), 255);
+    }
+
+    #[test]
+    fn block_luma_uniform_frame() {
+        // 16×16 RGB565, all pixels 0xFFFF → every block should be 255.
+        let mut frame = alloc::vec::Vec::with_capacity(16 * 16 * 2);
+        for _ in 0..(16 * 16) {
+            frame.push(0xFF);
+            frame.push(0xFF);
+        }
+        let mut out = [0u8; MAX_BLOCKS];
+        fill_block_luma(&frame, 16, 16, 4, 4, 1, &mut out);
+        for cell in &out[..16] {
+            assert_eq!(*cell, 255);
+        }
+    }
+
+    #[test]
+    fn block_luma_split_frame() {
+        // Left half of a 16×16 frame is white, right half black.
+        // With a 2×1 grid we expect block 0 = ~255, block 1 = 0.
+        let mut frame = alloc::vec::Vec::with_capacity(16 * 16 * 2);
+        for y in 0..16 {
+            for x in 0..16 {
+                let (hi, lo) = if x < 8 {
+                    (0xFFu8, 0xFFu8)
+                } else {
+                    (0x00, 0x00)
+                };
+                let _ = y; // silence unused warning if optimised away
+                frame.push(hi);
+                frame.push(lo);
+            }
+        }
+        let mut out = [0u8; MAX_BLOCKS];
+        fill_block_luma(&frame, 16, 16, 2, 1, 1, &mut out);
+        assert_eq!(out[0], 255);
+        assert_eq!(out[1], 0);
+    }
+
+    #[test]
+    fn fill_skips_when_grid_zero() {
+        let frame = [0u8; 32];
+        let mut out = [42u8; MAX_BLOCKS];
+        fill_block_luma(&frame, 4, 4, 0, 4, 1, &mut out);
+        // Untouched (still 42) because blocks_x == 0 short-circuits.
+        assert_eq!(out[0], 42);
+    }
+
+    extern crate alloc;
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,6 +50,9 @@
     "crates/st25r3916": {
       "package-name": "st25r3916"
     },
+    "crates/tracker": {
+      "package-name": "tracker"
+    },
     "crates/stackchan-firmware": {
       "package-name": "stackchan-firmware"
     }


### PR DESCRIPTION
## Summary

- New `crates/tracker` `no_std` crate consumes RGB565 camera frames, computes inter-frame motion via per-block luma deltas, and emits a target `stackchan_core::Pose` for the head servos. Pure algorithm — no I/O, no allocation. 14 host-side unit tests on synthesised RGB565 fixtures.
- New `examples/tracker_bench.rs` runs the full pipeline against the live GC0308 + LCD\_CAM camera task and logs proposed poses + decision diagnostics over RTT. **Does not command any servo** — bench-first rollout before a follow-up PR wires the tracker into `main.rs`.
- Workspace registration (root `Cargo.toml`, `release-please-config.json`, `.release-please-manifest.json`); firmware crate gains a `tracker = { path = "../tracker" }` dep.

## Algorithm

Per step:
1. **Block-grid luma reduction** — 8×6 cells over QVGA (40×40 px each), fast shifts-only Rec. 601 approximation \`y ≈ (R8 + 2·G8 + B8) / 4\`.
2. **Per-block delta vs. previous frame.** Above 5 % luma → cell fires.
3. **Centroid of fired cells**, normalised to \`[-1, 1]\` per axis.
4. **Reject global events** (> 70 % cells fire → lighting flip; pose held).
5. **Dead zone + P-gain + slew clamp** — centroid → pan/tilt delta via configured FOV (62°×49°), accumulates into a target \`Pose\`, routes through \`Pose::clamped\` (asymmetric tilt safe range).
6. **Idle timeout** — after 3 s of no motion, slew back toward \`Pose::NEUTRAL\` at 1°/step.

All knobs live on \`TrackerConfig\`; \`TrackerConfig::DEFAULT\` is tuned for the QVGA GC0308 + Stack-chan SCServo head on a CoreS3.

## Limitation

Frame-difference detection localises to the *midpoint* of motion, not the new position — fast travel of an object will fire blocks at both ends, biasing the centroid centre-ward. Fine for the typical Stack-chan use case (people entering frame, slow scene change). A follow-up could swap to running-mean background subtraction for sharper tracking; the bench will let us decide whether that's worth doing before main.rs wiring.

## Test plan

- [x] \`cargo test -p tracker\` — 14 unit tests pass on host
- [x] \`cargo clippy -p tracker --all-targets\` clean
- [x] \`cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --exclude stackchan-firmware --all-features\` clean
- [x] \`cargo fmt --check\` clean
- [ ] \`source ~/export-esp.sh && cargo +esp build --release --example tracker_bench\` (firmware-side; CI will run this)
- [ ] Flash \`tracker_bench\` to a CoreS3, wave at the camera, confirm RTT logs show sensible centroid + Pose deltas (next session, after merge)