### PR TITLE
fix(gc0308): plain code-format private timing constants in pub docs

### DIFF
--- a/crates/gc0308/src/lib.rs
+++ b/crates/gc0308/src/lib.rs
@@ -58,7 +58,7 @@ pub const CHIP_ID: u8 = 0x9B;
 /// real hardware.
 pub const REG_CHIP_ID: u8 = 0x00;
 
-/// `RESET_RELATED` register. Writing [`SOFT_RESET_PAYLOAD`] issues a
+/// `RESET_RELATED` register. Writing `SOFT_RESET_PAYLOAD` issues a
 /// software reset (clears registers + holds in reset until the table
 /// is reprogrammed).
 pub const REG_RESET: u8 = 0xFE;
@@ -248,12 +248,12 @@ impl<B: I2c> Gc0308<B> {
     /// Full power-on bring-up.
     ///
     /// Steps:
-    /// 1. Wait [`POWER_ON_DELAY_MS`] for the analog rails to settle.
+    /// 1. Wait `POWER_ON_DELAY_MS` for the analog rails to settle.
     /// 2. Read and validate the chip ID.
-    /// 3. Issue a software reset and wait [`SOFT_RESET_DELAY_MS`].
+    /// 3. Issue a software reset and wait `SOFT_RESET_DELAY_MS`.
     /// 4. Apply [`DEFAULT_REGS`] verbatim (sensor analog setup,
     ///    AEC/AGC/AWB defaults, gamma curves).
-    /// 5. Wait [`DEFAULTS_SETTLE_MS`] for the AAA algorithms to latch.
+    /// 5. Wait `DEFAULTS_SETTLE_MS` for the AAA algorithms to latch.
     ///
     /// On exit the chip is producing valid frames at full VGA. Callers
     /// typically follow up with [`Gc0308::set_format`],


### PR DESCRIPTION
## Summary

\`cargo doc\` with \`-D warnings\` errors on \`[\`X\`]\` intra-doc-links that resolve to private items. Four references in \`gc0308/src/lib.rs\` (\`SOFT_RESET_PAYLOAD\`, \`POWER_ON_DELAY_MS\`, \`SOFT_RESET_DELAY_MS\`, \`DEFAULTS_SETTLE_MS\`) point at crate-private timing / payload constants that don't belong in the public API surface — strip the brackets so the names render as plain inline code instead. Existing main is failing CI on this; #63 + #64 are blocked behind it.

## Test plan

- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p gc0308 --all-features\` builds clean