### PR TITLE
fix(ci): release-please env stops failing when no PR was created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,9 +67,17 @@ jobs:
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          # Pass the raw release-please-action `pr` JSON through env and
+          # parse with jq inside the shell. Going via
+          # `${{ fromJSON(...).number }}` here renders at template time
+          # — even with `if: steps.release.outputs.pr` skipping the
+          # step, GH still evaluates the env: block, and `fromJSON("")`
+          # errors when no PR was created/updated this run (e.g. a
+          # `docs:` push with nothing releasable).
+          PR_DATA: ${{ steps.release.outputs.pr }}
           REPO: ${{ github.repository }}
         run: |
+          PR_NUMBER=$(jq -r .number <<<"$PR_DATA")
           gh pr review "$PR_NUMBER" \
             --approve \
             --body "Auto-approved by release pipeline." \
@@ -79,9 +87,10 @@ jobs:
         if: steps.release.outputs.pr
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          PR_DATA: ${{ steps.release.outputs.pr }}
           REPO: ${{ github.repository }}
         run: |
+          PR_NUMBER=$(jq -r .number <<<"$PR_DATA")
           gh pr merge "$PR_NUMBER" \
             --auto --squash \
             --repo "$REPO"


### PR DESCRIPTION
## Summary

Auto-approve and auto-merge steps used \`PR_NUMBER: \${{ fromJSON(steps.release.outputs.pr).number }}\` in their \`env:\` blocks. Even with \`if: steps.release.outputs.pr\` gating the step, GitHub Actions evaluates \`env:\` templates at render time — so \`fromJSON("")\` errored on every release-please run that didn't open or update a PR (any \`docs:\` / \`ci:\` / \`chore:\` push, plus the no-op runs immediately after a release PR auto-merges). Recent failures: \`9a4e6f6\` (post-#74 docs merge), \`1993d08\` (post-#67 release-PR auto-merge).

Fix: pass the raw JSON through \`env:\` unchanged and parse with \`jq\` inside the shell. The \`if:\` still gates whether the step runs; the \`env:\` just no-ops to an empty string when there's nothing to release, so template rendering can't fail.

## Test plan

- [x] YAML parses cleanly
- [ ] Next no-content release-please run (\`docs:\` / \`ci:\` / \`chore:\` push) shows the workflow as success instead of failure
- [ ] Next content release-please run still successfully auto-approves + auto-merges (regression check on the happy path)