### PR TITLE
docs: clarify v1.0 is a polish milestone, not a stability one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Clean-slate Rust firmware for the M5Stack CoreS3 Stack-chan — `no_std`, embassy, no cloud.**
 
-No AI. No upstream cloud. No C blobs. Just a desk toy that animates a face.
+No vendor cloud. No telemetry. No C blobs. Just a desk toy that animates a face.
 
 [![CI](https://github.com/andymai/stackchan-kai/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/stackchan-kai/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/andymai/stackchan-kai)](https://github.com/andymai/stackchan-kai/releases)
@@ -16,7 +16,7 @@ No AI. No upstream cloud. No C blobs. Just a desk toy that animates a face.
 
 </div>
 
-> **Status:** v0.1.0 shipped 2026-04-23. Public items are currently
+> **Status:** v0.1.0 shipped 2026-04-23. Public items are
 > [Experimental](STABILITY.md#experimental); the v0.x series will iterate the
 > avatar domain model before anything graduates to Stable.
 
@@ -65,8 +65,8 @@ without touching the hardware.
 ## Roadmap
 
 - **RON-configurable appearance** — eye / mouth geometry, palette, per-emotion style
-- **Input-bound behavior** — tap the face to change emotion, point an IR remote to trigger reactions
-- **Other Stack-chan variants** — expand beyond the CoreS3 SKU once v0.1.x stabilizes
+- **Calibration tooling** — host-side bench writes servo + sensor calibration into versioned config
+- **Crash recovery** — panic handler renders an error face and watchdog-reboots cleanly
 
 ## License
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -44,24 +44,31 @@ Experimental APIs graduate to stable by explicit CHANGELOG entry.
 Internal items are `pub(crate)` or `#[doc(hidden)]`. Not part of the supported
 surface.
 
-## Day-one classification (v0.1.0)
+## Day-one classification (v0.1.0 through v1.0)
 
 At v0.1.0, **everything is experimental**. The initial release exists to prove
 the flash + render pipeline end to end; the API surface will churn rapidly
 through v0.2–v0.x as the avatar domain model settles.
 
-Graduations to stable will be called out in dedicated `feat(stabilize):`
-commits, first appearing in a post-v0.x release.
+v1.0 is a **polish milestone** — RON-configurable appearance, host-side
+calibration tooling, crash recovery, codebase TODO sweep — and still ships
+*everything Experimental*. Stabilization is intentionally deferred so the
+API can survive the architectural work planned for v2.x.
+
+Graduations to Stable will be called out in dedicated `feat(stabilize):`
+commits, first appearing at **v2.x** or later.
 
 ## Wrapper crates
 
-`stackchan-firmware` is a binary crate, not a library surface. `axp2101` is a
-standalone driver crate that may publish to crates.io independently; its
-stability is governed by this same policy once v1.0.0 ships.
+`stackchan-firmware` is a binary crate, not a library surface. Standalone
+driver crates (`axp2101`, `aw9523`, `scservo`, `bm8563`, and others) may
+publish to crates.io independently and are governed by this policy under
+their own versioning. Their graduations from Experimental to Stable happen
+on each crate's own cadence, not gated on the workspace version.
 
 ## Cadence commitment
 
-Going forward, once v1.0.0 is reached:
+Once any item graduates to Stable (planned for v2.x or later):
 
 - **Stable surface**: at most one breaking change per 60 days.
 - **Experimental surface**: no such bound.


### PR DESCRIPTION
## Summary

- Tagline accuracy: "No vendor cloud. No telemetry. No C blobs." replaces "No AI. No upstream cloud." — better fits the self-hosted-friendly trajectory.
- Roadmap: drop the speculative "Other Stack-chan variants" line (firmware targets CoreS3 only); add calibration tooling + crash recovery (both shipping toward v1.0).
- STABILITY.md: v1.0 is now explicitly a polish milestone that still ships everything Experimental. Graduations to Stable defer to v2.x.
- STABILITY.md: driver crates (`axp2101`, `aw9523`, `scservo`, `bm8563`, …) graduate on their own cadence, not gated on the workspace version. Cadence commitment now triggers on graduation events.

## Test plan

- [x] `git diff` reviewed line-by-line
- [x] No code changes — pre-commit hooks (fmt / clippy / tests / doctests / Cargo.lock drift) trivially pass
- [ ] CI green