### PR TITLE
docs: drop stale v0.1.0 qualifier from CLAUDE.md hardcoded-geometry note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,4 @@ No `unwrap()` / `expect()` in library code. Use `?` with typed errors (`thiserro
 
 ## Config + assets
 
-None yet. v0.1.0 avatar geometry is hardcoded in `stackchan-core::avatar`. Later releases may add RON-configurable appearance.
+None yet. Avatar geometry is hardcoded in `stackchan-core::avatar`. Later releases may add RON-configurable appearance.


### PR DESCRIPTION
## Summary
- One-line surgical edit to `CLAUDE.md:93`: drop the `v0.1.0` qualifier from the hardcoded-avatar-geometry note. Substance is unchanged (geometry is still hardcoded at v0.9.7) — leading the sentence with `v0.1.0` made it read as current-version state instead of historical context.
- Complements PR #76 (which intentionally locked the `v0.1.0 shipped 2026-04-23` status lines in README + STABILITY); this is the one remaining version reference that drifted.

## Test plan
- [x] Greptile review (no behavior change, doc-only)
- [ ] CI passes (no Rust changes; commit-msg hook + workflow files only)