### PR TITLE
refactor: seed IdleDrift from the chip's hardware RNG

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -31,6 +31,7 @@ use stackchan_firmware::{
 
 use board::{HeadDriverImpl, SharedI2c};
 use clock::HalClock;
+use core::num::NonZeroU32;
 use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Ticker, Timer};
@@ -46,6 +47,7 @@ use esp_hal::{
     Blocking,
     clock::CpuClock,
     gpio::{Level, Output, OutputConfig},
+    rng::Rng,
     spi::{
         Mode as SpiMode,
         master::{Config as SpiConfig, Spi},
@@ -158,7 +160,7 @@ type LcdDisplay = mipidsi::Display<
     clippy::too_many_lines,
     reason = "tick body composes 12+ modifiers + sensor drains + render — splitting fragments the per-frame ordering invariants"
 )]
-async fn render_task(mut display: LcdDisplay) {
+async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let clock = HalClock;
     let mut fb = Framebuffer::new();
     defmt::info!(
@@ -180,11 +182,11 @@ async fn render_task(mut display: LcdDisplay) {
     let mut style = EmotionStyle::new();
     let mut blink = Blink::new();
     let mut breath = Breath::new();
-    // Fixed seed keeps boot-to-boot drifts identical; a future RNG-backed
-    // source (e.g. reading a voltage-derived seed from the AXP2101) can
-    // swap in without touching the task shape.
-    let mut drift =
-        IdleDrift::with_seed(const { core::num::NonZeroU32::new(0xDEAD_BEEF).unwrap() });
+    // Seed comes from the ESP32-S3 hardware RNG (`esp_hal::rng::Rng`),
+    // sampled once at boot in `main()` before this task spawns. Each
+    // boot produces a distinct drift sequence — eyes don't fall into
+    // the same micro-pattern after a power cycle.
+    let mut drift = IdleDrift::with_seed(drift_seed);
     let mut sway = IdleSway::new();
     let mut emotion_head = EmotionHead::new();
     let mut mouth_open_audio = MouthOpenAudio::new();
@@ -676,7 +678,18 @@ async fn main(spawner: Spawner) -> ! {
     };
     defmt::info!("ILI9342C ready — spawning render task");
 
-    if let Err(e) = spawner.spawn(render_task(display)) {
+    // Sample the chip's hardware RNG once for IdleDrift's xorshift32
+    // seed. xorshift32 forbids zero, so re-roll on the (1 in 2^32)
+    // chance we hit it — the loop almost always exits first try.
+    let rng = Rng::new();
+    let drift_seed = loop {
+        if let Some(s) = NonZeroU32::new(rng.random()) {
+            break s;
+        }
+    };
+    defmt::info!("idle drift seed: {=u32:#010x}", drift_seed.get());
+
+    if let Err(e) = spawner.spawn(render_task(display, drift_seed)) {
         defmt::panic!("spawn render_task failed: {}", defmt::Debug2Format(&e));
     }
     if let Err(e) = spawner.spawn(head_task(board_io.head)) {

--- a/crates/stackchan-sim/src/lib.rs
+++ b/crates/stackchan-sim/src/lib.rs
@@ -249,6 +249,52 @@ mod integration_tests {
         }
     }
 
+    /// Two `IdleDrift`s seeded with distinct values must produce
+    /// distinct eye-position sequences. This is the host-side guard
+    /// for the firmware boot path that samples `esp_hal::rng::Rng`
+    /// once per boot — if seed propagation broke (e.g. a future
+    /// refactor of `IdleDrift::with_seed` quietly ignored its arg),
+    /// every boot would produce identical drift sequences and this
+    /// test would fail.
+    #[test]
+    fn distinct_seeds_produce_distinct_drift_sequences() {
+        // 7 ticks × `DEFAULT_INTERVAL_MS` (4 s) = 7 drift events.
+        // Two unrelated seeds — using compile-time non-zero literals
+        // sidesteps the test-only `unwrap` surface.
+        let seed_a = core::num::NonZeroU32::new(0x1234_5678).unwrap();
+        let seed_b = core::num::NonZeroU32::new(0xCAFE_BABE).unwrap();
+        let mut drift_a = IdleDrift::with_seed(seed_a);
+        let mut drift_b = IdleDrift::with_seed(seed_b);
+
+        let mut avatar_a = Avatar::default();
+        let mut avatar_b = Avatar::default();
+        let clock = FakeClock::new();
+
+        let interval_ms = 4_000_u64; // matches IdleDrift::DEFAULT_INTERVAL_MS
+        let mut diverged = false;
+        for i in 0..7 {
+            // Tick exactly at each drift boundary so an offset is
+            // applied on every iteration after the scheduling tick.
+            let now = stackchan_core::Instant::from_millis(i * interval_ms);
+            drift_a.update(&mut avatar_a, now);
+            drift_b.update(&mut avatar_b, now);
+            if avatar_a.left_eye.center != avatar_b.left_eye.center {
+                diverged = true;
+                break;
+            }
+        }
+        // Use clock to keep `FakeClock` import consistent with the
+        // surrounding tests; advancing here is a no-op but keeps the
+        // test shape uniform if a future Modifier consults the clock
+        // outside its `update` arg.
+        clock.advance(interval_ms * 7);
+
+        assert!(
+            diverged,
+            "two distinct IdleDrift seeds produced identical eye sequences over 7 drift ticks"
+        );
+    }
+
     #[test]
     fn blink_frequency_over_one_minute() {
         let clock = FakeClock::new();


### PR DESCRIPTION
## Summary
- `IdleDrift` was seeded with the fixed `0xDEAD_BEEF` xorshift32 seed at every boot, so the eye-drift sequence was identical from one power cycle to the next.
- This PR samples `esp_hal::rng::Rng` once in `main()` before spawning the render task, derives a `NonZeroU32` seed (with a re-roll loop for the 1-in-2³² zero case), passes it into `render_task`, and uses it via the existing `IdleDrift::with_seed` API.
- Boot log now includes `idle drift seed: 0x{seed:08x}` so the seed used is visible per boot. Verified on hardware: `idle drift seed: 0x393dcb35` at 1306 ms.
- Drops the misleading aspirational comment at `main.rs:183` that talked about reading "a voltage-derived seed from the AXP2101" — the AXP2101 doesn't expose a noise register; the hardware RNG was always the right entropy source.

## Test plan
- [x] New unit-style host test in `stackchan-sim`: `distinct_seeds_produce_distinct_drift_sequences` runs two `IdleDrift`s with `0x12345678` and `0xCAFEBABE` over 7 drift ticks and asserts the eye positions diverge. Catches the "future refactor accidentally ignores the seed argument" failure mode without needing hardware.
- [x] `cargo test -p stackchan-sim --lib distinct_seeds` passes
- [x] Pre-commit gates: fmt, full workspace clippy, all host tests, doctests
- [x] `cargo +esp clippy --release -- -D warnings` clean
- [x] `just fmr` boot-verified on hardware: clean boot through "boot complete — idle heartbeat" at 1402 ms, RNG seed printed, all 14 modifiers running, no panic
- [ ] Greptile review