### PR TITLE
chore(firmware): downgrade boot-path register-dump info logs to debug

### DIFF
--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -479,7 +479,7 @@ pub struct AudioPeripherals {
               the I²S → codec → TX ordering invariants for negligible benefit"
 )]
 pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
-    defmt::info!(
+    defmt::debug!(
         "audio: I²S0 bring-up — {=u32} Hz / {=u8}-bit mono, MCLK {=u32} Hz",
         SAMPLE_RATE_HZ,
         BIT_DEPTH_BITS,
@@ -544,7 +544,7 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
             park_forever().await;
         }
     };
-    defmt::info!("audio: I²S RX DMA running — MCLK / BCLK / LRCK clocking");
+    defmt::debug!("audio: I²S RX DMA running — MCLK / BCLK / LRCK clocking");
 
     // MCLK settle. ES7210 datasheet says "a few ms" but empirically
     // (and per esp-adf), the chip can take longer to latch the clock
@@ -554,7 +554,7 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
     let mut delay = Delay;
     let mut amp = Aw88298::new(p.amp_bus);
     match amp.init(&mut delay).await {
-        Ok(()) => defmt::info!(
+        Ok(()) => defmt::debug!(
             "audio: AW88298 ready — I²S 16 kHz mono, muted, boost off (un-mute deferred)"
         ),
         Err(e) => {
@@ -620,7 +620,7 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
             defmt::Debug2Format(&e)
         );
     } else {
-        defmt::info!(
+        defmt::debug!(
             "audio: AW88298 volume set to {=i8} dB (boot default)",
             BOOT_VOLUME_DB
         );
@@ -638,7 +638,7 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
             run_rms_loop(&mut rx_transfer).await
         }
     };
-    defmt::info!("audio: I²S TX DMA running — feeding silence");
+    defmt::debug!("audio: I²S TX DMA running — feeding silence");
 
     Timer::after(Duration::from_millis(u64::from(TX_SETTLE_MS))).await;
 
@@ -915,12 +915,12 @@ async fn park_forever() -> ! {
 /// Purely diagnostic. Silent on addresses that don't respond; chatty
 /// (one info log per ACK) on addresses that do.
 async fn scan_i2c_bus<B: embedded_hal_async::i2c::I2c>(bus: &mut B) {
-    defmt::info!("audio: I²C bus scan starting (0x08..=0x77)");
+    defmt::debug!("audio: I²C bus scan starting (0x08..=0x77)");
     let mut found: u32 = 0;
     for addr in 0x08_u8..=0x77 {
         let mut buf = [0u8; 1];
         if bus.write_read(addr, &[0x00], &mut buf).await.is_ok() {
-            defmt::info!(
+            defmt::debug!(
                 "audio: I²C 0x{=u8:02X} ACK (first byte @ reg 0x00 = 0x{=u8:02X})",
                 addr,
                 buf[0]
@@ -928,5 +928,5 @@ async fn scan_i2c_bus<B: embedded_hal_async::i2c::I2c>(bus: &mut B) {
             found += 1;
         }
     }
-    defmt::info!("audio: I²C bus scan complete — {=u32} devices ACKed", found);
+    defmt::debug!("audio: I²C bus scan complete — {=u32} devices ACKed", found);
 }

--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -315,7 +315,7 @@ async fn log_angle_limits(driver: &mut HeadDriverImpl, id: u8) {
         Ok(_err_byte) => {
             let min = (u16::from(buf[0]) << 8) | u16::from(buf[1]);
             let max = (u16::from(buf[2]) << 8) | u16::from(buf[3]);
-            defmt::info!(
+            defmt::debug!(
                 "SCServo[{=u8}]: angle limits MIN={=u16} MAX={=u16} (pos counts; full range is 0..=1023)",
                 id,
                 min,
@@ -336,7 +336,7 @@ async fn log_angle_limits(driver: &mut HeadDriverImpl, id: u8) {
 async fn enable_torque(driver: &mut HeadDriverImpl, id: u8) {
     let bus = driver.bus_mut();
     match bus.write_torque_enable(id, true).await {
-        Ok(()) => defmt::info!("SCServo[{=u8}]: torque enabled", id),
+        Ok(()) => defmt::debug!("SCServo[{=u8}]: torque enabled", id),
         Err(e) => defmt::warn!(
             "SCServo[{=u8}]: torque-enable failed: {}",
             id,

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -161,7 +161,7 @@ type LcdDisplay = mipidsi::Display<
 async fn render_task(mut display: LcdDisplay) {
     let clock = HalClock;
     let mut fb = Framebuffer::new();
-    defmt::info!(
+    defmt::debug!(
         "framebuffer allocated in PSRAM: {=u32}x{=u32} Rgb565",
         FB_WIDTH,
         FB_HEIGHT


### PR DESCRIPTION
## Summary
v1.0 polish — quiet the boot path so steady-state info lines surface real signals. Strict scope: only redundant chip-version / register-dump / implementation-step lines move to `debug!`.

## What stays at info
- Every `task: {period} ms tick, ...` spawn announcement
- Every chip-detection signal: `SCServo[N]: present`, `BMI270: detected`, `FT6336U: vendor ID`, `LTR-553: init complete`
- Every state-transition: `boot-nod: yes nod start/complete`, `AW88298 un-muted — speaker live`, `audio: bring-up complete`
- Every runtime info: `head: cmd=… actual=…`, `audio: RMS …`, `audio: low-battery alert enqueued`, `AXP2101: battery N%, USB true`
- The canonical anchors: `stackchan-firmware vX — CoreS3 boot`, `ILI9342C ready`, `boot @ RTC`, `boot complete — idle heartbeat`

## What moves to debug
- `audio.rs` × 8 — I²S0 bring-up config dump, RX/TX DMA running implementation steps, AW88298 ready register-state dump, volume register-write step, I²C bus scan triplet (start, per-ACK loop, complete)
- `board.rs` × 2 — SCServo angle-limits register dump (× 2 servos), torque-enabled paired step (× 2 servos)
- `main.rs` × 1 — framebuffer-allocated init detail

## Test plan
- [x] Pre-commit: fmt + workspace clippy + host tests (all green)
- [x] `cargo +esp clippy --release -- -D warnings` clean
- [x] `just fmr` boot-verified on hardware: clean boot through `boot complete — idle heartbeat` at 1402 ms, info-line count down ~25%, head + audio + camera + IMU all healthy, no panic, all critical diagnostics still present
- [ ] Greptile review