### PR TITLE
docs: AGENTS.md playbook + errors catalog + CLAUDE.md drift fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md
+
+A playbook for AI agents collaborating on `stackchan-kai`. Read this once
+per session before reaching for code. CLAUDE.md is the shared
+human+agent guide; this file is agent-specific.
+
+## At a glance
+
+- **Stack:** `no_std` + `alloc` Rust on ESP32-S3 (CoreS3), embassy executor, defmt logging over USB-Serial-JTAG.
+- **Domain model:** `Avatar` + `Modifier` trait in `stackchan-core` (pure, host-testable). Firmware composes a fixed modifier stack at 30 FPS in `render_task`.
+- **Cross-task communication:** typed `Signal<RawMutex, T>` channels. Sensors publish via `signal()`; consumers drain via `try_take()`. Latest-wins semantics throughout.
+- **Tests:** `stackchan-sim` runs modifiers against `FakeClock` for deterministic golden assertions. Firmware-side tests use on-device benches (`examples/*_bench.rs`).
+
+## Session shapes
+
+Most useful sessions fit one of these shapes. Recognising the shape early
+keeps the work scoped.
+
+### Shape 1: behavior change (modifier authoring)
+1. Read the relevant modifier in `crates/stackchan-core/src/modifiers/`.
+2. Add or change behavior; update the unit tests in the same file.
+3. Add a sim-level integration test in `crates/stackchan-sim/src/lib.rs`.
+4. `just check` — gates pass before flashing.
+5. Optional: `just fmr` to confirm on hardware.
+
+### Shape 2: driver work (one of the 14 driver crates)
+1. Read the crate's README to understand current scope.
+2. Add registers, driver methods, or init steps; keep `embedded-hal-async` boundary clean.
+3. Unit-test what you can on host (packet construction, register encoding).
+4. Add or update a `crates/stackchan-firmware/examples/<chip>_bench.rs` that exercises the new path on hardware.
+5. `just <chip>-bench` to verify on device.
+
+### Shape 3: firmware integration
+1. Identify the `Signal<…, T>` channel(s) the new feature needs.
+2. Producer goes in a per-peripheral task (`src/<chip>.rs`); consumer reads in `render_task`.
+3. Update `Avatar` if the feature surfaces persistent state; remember to extend `frame_eq` only if it's pixel-affecting.
+4. `cargo +esp clippy --release -- -D warnings` from the firmware crate.
+5. Hardware-verify boot and runtime via `just fmr`.
+
+### Shape 4: docs / tooling
+1. CLAUDE.md is shared (humans + agents). AGENTS.md is agent-only. `docs/` is for cross-cutting reference (e.g., `docs/errors.md`).
+2. Per-crate READMEs document API + gotchas — the pre-commit hook reminds you to review them when source changes.
+3. justfile recipes are the project's idiomatic invocation surface — prefer adding a recipe to documenting a long invocation in prose.
+
+## Decision frameworks
+
+- **Ask vs assume:** ask when the change spans multiple PRs, when a public API surface changes, or when a doc rewrite is implied. Otherwise assume and proceed; the user can course-correct.
+- **One PR per feature:** the recent v1.0 polish bundle (#77–#80) shows the cadence. Greptile reviews are tighter on small PRs.
+- **Hardware verification:** required for any firmware-touching PR. Skip only for pure host-side changes (sim tests, doc updates, host crate refactors).
+- **Memory writes:** save hardware quirks, gotchas, and corrections — but never current task state. Use the `feedback` type for behavioral preferences and `project` for unit-specific or repo-specific facts.
+
+## Patterns + idioms
+
+- **Signal drain pattern:** `if let Some(x) = SOME_SIGNAL.try_take() { avatar.x = Some(x); }` — non-blocking, drops misses (the producer's next signal overwrites), runs once per render tick.
+- **`frame_eq` gate:** the render task short-circuits LCD blits when no pixel-affecting field changed. New `Avatar` fields default to *excluded* from `frame_eq` unless they affect drawing.
+- **Per-modifier state:** modifiers own their state (timers, RNG, pending transitions). `update(&mut self, &mut Avatar, now)` is the only mutation surface.
+- **Errors:** typed across the workspace via `thiserror` (host) or `defmt::Format` derives (firmware). See `docs/errors.md`.
+
+## Debugging recipes
+
+### Reading boot logs
+The boot log lives at `/tmp/scfmr.log` after `just fmr` runs in tmux. Key
+anchors to grep for:
+
+```bash
+grep -E "stackchan-firmware v|boot complete|panic|ERROR" /tmp/scfmr.log
+```
+
+A clean boot ends with `boot complete — idle heartbeat` around 1.4 s.
+
+### Filtering chatty steady-state logs
+
+The 1 Hz `head: cmd=… actual=…` and periodic `audio: DmaError(Late)`
+warnings are expected. To watch only state changes:
+
+```bash
+tail -f /tmp/scfmr.log | grep -vE "head: cmd|DmaError\(Late\)|audio: RMS"
+```
+
+For compile-time filtering, set `DEFMT_LOG` before flashing:
+
+```bash
+DEFMT_LOG=info,stackchan_firmware::head=warn just fmr
+```
+
+### Known-noise log lines (do not debug)
+
+These are pre-existing on Andy's specific kit — see memory note on unit hardware:
+
+- `BMM150: not reachable on main I²C — likely wired to BMI270 AUX` — by design on this revision.
+- `BMI270: init attempt 1/3 failed (I2c(I2c(Timeout))); retrying` — known timing wobble, succeeds on retry.
+- `audio: DMA pop error ("DmaError(Late)"); publishing silence and resyncing` — periodic (every ~2 s); the resync logic recovers automatically.
+- `FT6336U: vendor ID 0x01` — non-canonical but register-compatible; the touch driver works.
+
+## Memory + context
+
+The auto-memory store at
+`/home/andy/.ccs/instances/home/projects/-var-home-andy-Git-stackchan-kai/memory/`
+holds accumulated session-spanning context. Read `MEMORY.md` first; it
+indexes feedback (preferences), project (repo-specific facts), and
+reference entries.
+
+Highlights to know at session start:
+
+- USB-Serial-JTAG wedges on rapid back-to-back `espflash` invocations — prefer `just fmr`, use `just reattach` to pick up without reset.
+- ES7210 has no documented chip-ID register and needs MCLK to answer I²C. AW88298 uses 16-bit big-endian registers.
+- The user opts out of proactive `/schedule` offers — don't end replies with "want me to schedule a follow-up?" pitches.
+- Forward-looking PRDs and v2.x vision content go to the user's Obsidian vault, not the public repo. Repo docs stay tactical and present-tense.
+
+## When you're stuck
+
+Report blocking state explicitly: what completed, what's blocking, what
+was attempted, what's needed from the user. Don't loop on the same
+failing command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,35 +1,63 @@
 # stackchan-kai
 
+> AI collaborators: see [AGENTS.md](AGENTS.md) for the dedicated agent playbook
+> (session shapes, debugging recipes, memory pointer). This file is shared
+> between humans and agents; AGENTS.md is agent-specific.
+
 ## Project Structure
 
-Cargo workspace with six crates:
+Cargo workspace with 19 crates, grouped by purpose:
+
+**Domain + sim (host)**
 - `crates/stackchan-core` — `no_std` domain library: `Avatar`, `Eye`, `Mouth`, `Modifier` trait, `Clock` trait, `Emotion`, `Pose`. Pure Rust, no hardware deps.
 - `crates/stackchan-sim` — Headless integration tests that drive `stackchan-core` with a fake clock.
-- `crates/axp2101` — Minimal AXP2101 PMU driver (I²C, embedded-hal-async).
-- `crates/aw9523` — Minimal AW9523 I/O-expander init (I²C, embedded-hal-async). Pulls the LCD reset pin and gates the backlight-boost rail on the CoreS3.
-- `crates/scservo` — Feetech SCServo half-duplex serial driver (UART1, embedded-io-async). Drives the pan/tilt head servos.
-- `crates/stackchan-firmware` — Binary crate. `no_std` + `alloc`. embassy executor on CoreS3.
+- `crates/tracker` — Block-grid motion tracker for the camera path. Pure algorithm; host-testable.
+
+**Driver crates** (`no_std`, embedded-hal-async)
+- `crates/axp2101` — AXP2101 PMU driver (I²C). LDO rails, power-key timing, battery gauge.
+- `crates/aw9523` — AW9523 I/O expander. CoreS3 boot dance: LCD reset pulse, backlight-boost gate.
+- `crates/aw88298` — AW88298 mono Class-D amplifier (I²S TX path).
+- `crates/bm8563` — BM8563 RTC with date-format helper.
+- `crates/bmi270` — BMI270 6-axis IMU (accel + gyro).
+- `crates/bmm150` — BMM150 magnetometer (bench-only on this unit; see hardware quirks).
+- `crates/es7210` — ES7210 4-channel ADC (I²S RX path).
+- `crates/ft6336u` — FT6336U capacitive touch controller.
+- `crates/gc0308` — GC0308 camera SCCB init (LCD_CAM DMA path).
+- `crates/ir-nec` — NEC-protocol IR decoder (RMT peripheral).
+- `crates/ltr553` — LTR-553 ambient-light + proximity sensor.
+- `crates/py32` — PY32 co-processor (servo-power gate, WS2812 LED ring).
+- `crates/scservo` — Feetech SCServo half-duplex serial driver (UART1).
+- `crates/si12t` / `crates/st25r3916` — Scaffolded only.
+
+**Firmware**
+- `crates/stackchan-firmware` — Binary crate. `no_std` + `alloc`. Embassy executor on CoreS3.
 
 ## Build
 
+Prefer just recipes over raw cargo — they encode the project's gates.
+
 ```bash
-cargo test                                  # host-side: core, sim, axp2101, aw9523, scservo
-cargo clippy --workspace --all-targets      # host crates only (firmware excluded from default-members)
+just check                                   # fmt + workspace clippy + host tests (host crates only)
+just ci                                      # check + cargo-deny + workspace doc-lint
+just msrv                                    # MSRV (rust 1.88) build of host crates
 
 # Firmware: requires `source ~/export-esp.sh` first so the `esp` toolchain is on PATH.
-# `just fmr` wraps `cargo +esp build --release` + espflash flash-and-monitor through
-# `sg dialout`; see the justfile for the full recipe set.
 source ~/export-esp.sh
-just fmr
+just check-firmware                          # cargo +esp check
+just clippy-firmware                         # strict clippy (matches CI)
+just build-firmware                          # cargo +esp build --release
+just fmr                                     # flash + monitor in one go
+just reattach                                # attach to a running device without resetting
 ```
+
+Per-bench recipes (each flashes a single example): `just bench`, `just mag-bench`, `just leds-bench`, `just aw88298-bench`, `just es7210-bench`, `just audio-bench`, `just tilt-extremes`, `just tilt-freewheel`. List all: `just`.
 
 ## Flashing from an agent / non-TTY shell
 
 `just fmr` (and any `espflash …--monitor` command) invokes an interactive
 input reader that fails immediately with `× Failed to initialize input
-reader` when stdin is not a TTY — which is the default for any
-agent-spawned bash. Run flash + monitor inside **tmux** so the espflash
-process gets a real PTY:
+reader` when stdin is not a TTY — the default for any agent-spawned bash.
+Run flash + monitor inside **tmux** so the espflash process gets a real PTY:
 
 ```bash
 tmux new-session -d -s scfmr 'bash -l'
@@ -44,7 +72,7 @@ resetting it, use `just reattach` instead of `just fmr`.
 
 ## Pre-commit Hook
 
-`.githooks/pre-commit` runs fmt, clippy (strict), host tests, doctests, workspace check, and a Cargo.lock drift guard. After cloning:
+`.githooks/pre-commit` runs fmt, clippy (strict), host tests, doctests, workspace check, a Cargo.lock drift guard, and a README review reminder. After cloning:
 
 ```bash
 git config core.hooksPath .githooks
@@ -54,39 +82,38 @@ Conventional-commit check at `.githooks/commit-msg`.
 
 ## Architecture
 
-- `stackchan-core` models the avatar as data: `Avatar { left_eye, right_eye, mouth, emotion }` plus a `Modifier` trait with `update(&mut Avatar, now: Instant)`. Time comes from the `Clock` trait so core is deterministic and host-testable.
-- `stackchan-sim` constructs a `stackchan_core::Avatar` + a `FakeClock` and runs a list of `Modifier`s through hand-crafted time sequences. Golden assertions on `Eye::weight`, `Mouth::rotation`, etc.
-- `stackchan-firmware` initializes AXP2101 → AW9523 (releases LCD reset + enables the backlight-boost gate) → SPI LCD via `mipidsi` → SCServo head driver on UART1 → spawns an embassy render task that composes `Avatar::draw(&mut framebuffer)` into `embedded-graphics` primitives, pushes frames at ~30 FPS. `HalClock` wraps embassy-time.
-- `crates/axp2101` is the minimum set of registers (ALDO1/2, BLDO1/2, DLDO1, power-on sequencing) needed for CoreS3 LCD + 3V3 rails.
-- `crates/aw9523` handles the rest of the CoreS3 boot dance: pulses `P1_1` (LCD_RST) and leaves `P1_7` (backlight-boost enable) high so the LCD backlight rail actually comes up.
-- `crates/scservo` is a protocol-correct Feetech driver (checksum + status frame parsing) with golden-packet tests; position readback supports the calibration bench at `crates/stackchan-firmware/examples/bench.rs`.
+- `stackchan-core` models the avatar as data: `Avatar { left_eye, right_eye, mouth, emotion, … }` plus a `Modifier` trait with `update(&mut Avatar, now: Instant)`. Time comes from the `Clock` trait so core is deterministic and host-testable.
+- `stackchan-sim` constructs an `Avatar` + `FakeClock` and runs `Modifier`s through hand-crafted time sequences. Golden assertions on `Eye::weight`, `Mouth::rotation`, etc.
+- `stackchan-firmware` initializes AXP2101 → AW9523 (releases LCD reset + enables backlight-boost) → SPI LCD via `mipidsi` → SCServo head driver on UART1 → spawns embassy tasks for: render (~30 FPS), head (~50 Hz), touch, IR, IMU, ambient, button, LEDs, power, audio (RX RMS + TX queue), camera. Cross-task communication runs through typed `Signal<RawMutex, T>` channels — `try_take` for sensor input (latest-wins), `signal()` for output sinks.
 
 ## Conventions
 
-Commits: conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`, etc.).
+**Commits:** conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `build:`, `ci:`, `perf:`, `style:`, `revert:`). Optional scope: `feat(core):`, `chore(firmware):`. Enforced via `.githooks/commit-msg`.
 
-PR workflow: every change lands via PR; greptile bot review required. v0.1.0 shipped 2026-04-23 — direct-to-main commits are no longer part of the workflow.
+**Branch naming:** `<type>/<kebab-case-description>`, mirroring the commit type. Examples from history: `docs/claudemd-version-qualifier`, `refactor/rip-mag-data-only`, `feat/sim-host-visualizer`, `chore/prune-info-logs`, `fix/i2c-100khz-py32`.
 
-Parallel work: `git worktree add .worktrees/<branch> <branch>` — `.worktrees/` is gitignored.
+**PR workflow:** every change lands via PR; greptile bot review is the soft convention. v0.1.0 shipped 2026-04-23 — direct-to-main commits are no longer part of the workflow. PR titles match the commit subject; bodies follow the existing Summary + Test plan template.
 
-Type naming — domain-first, no redundant suffixes:
+**Parallel work:** `git worktree add .worktrees/<dirname> <branch>` — `.worktrees/` is gitignored. Always run `gh pr merge` from the main repo path, not from inside a worktree (the `--delete-branch` flag pulls cwd out from under bash).
+
+**Type naming** — domain-first, no redundant suffixes:
 - `Avatar`, `Eye`, `Mouth`, `Emotion` (not `AvatarData`, `EyeState`)
 - `EyePhase::{Open, Closed}` (not `EyeState`); fields use `.phase`
 - `Modifier`, `BlinkModifier`, `BreathModifier` (not `IModifier`, `ModifierImpl`)
 
-Unsafe code: denied at the workspace level. The firmware crate explicitly allows unsafe for linker-defined symbols and register-map pointers, gated behind per-module `#![allow(unsafe_code)]` with a comment explaining why.
+**Unsafe code:** denied at the workspace level. The firmware crate explicitly allows unsafe for linker-defined symbols and register-map pointers, gated behind per-module `#![allow(unsafe_code)]` with a comment explaining why.
 
-No `unwrap()` / `expect()` in library code. Use `?` with typed errors (`thiserror` for host; `defmt::Format` derives on firmware errors).
+**No `unwrap()` / `expect()` in library code.** Use `?` with typed errors (`thiserror` for host; `defmt::Format` derives on firmware errors). See [docs/errors.md](docs/errors.md) for the typed-error catalog.
 
 ## Hardware notes
 
 - CoreS3: ESP32-S3 dual-core Xtensa, 8 MB PSRAM, 16 MB flash.
 - AXP2101 at I²C address `0x34`. Must be initialized before LCD SPI pins have power.
-- ILI9342C LCD, 320×240, over SPI2. Backlight on AXP2101 DLDO1.
+- ILI9342C LCD, 320×240, over SPI2. Backlight on AXP2101 BLDO1 (gated through AW9523 `P1_7`).
 - PSRAM heap via `esp-alloc`; internal SRAM reserved for ISR/real-time.
-- `/dev/ttyACM1` is the CoreS3 USB-JTAG on Andy's machine (may shuffle with `/dev/ttyACM0` which is his Pikatea macropad — check with `udevadm info` first).
+- `/dev/ttyACM1` is the CoreS3 USB-Serial-JTAG on Andy's machine (may shuffle with `/dev/ttyACM0` — check `udevadm info` first).
 - Serial access requires `sg dialout -c '...'` wrapper on the host until `dialout` group is in the active shell's supplementary groups.
-- Logs travel over RTT via the USB-JTAG probe; `probe-rs run --chip esp32s3` is the canonical flash + log path (wired up as the `cargo run` runner in the firmware crate).
+- Logs travel as `defmt`-encoded bytes over the ESP32-S3 USB-Serial-JTAG peripheral; `espflash --monitor --log-format defmt` decodes on the host. No RTT probe required.
 
 ## Config + assets
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,124 @@
+# Typed-error catalog
+
+Every driver crate in this workspace exposes a generic `Error<E>` enum.
+The `E` parameter is the underlying transport error (I²C, SPI, or UART),
+which the firmware wraps with `Debug2Format` for `defmt` logging.
+
+This page summarises every variant across the workspace so a new
+contributor (or an AI agent debugging a panic trace) can map an error
+log line to its root cause without grepping the source.
+
+## Common pattern: transport vs protocol
+
+Most drivers split errors into two categories:
+
+- **Transport** — the bus rejected the operation. Bus glitch, missing
+  pull-up, chip-not-present, wrong address. Carries the inner bus error
+  (e.g. `embedded_hal_async::i2c::ErrorKind::ArbitrationLoss`).
+- **Protocol** — the chip answered but the response was wrong. Bad
+  chip-ID, malformed packet, checksum mismatch, value out of range.
+  Carries the offending byte(s) so logs are self-describing.
+
+Recovery hint: transport errors usually warrant a retry; protocol errors
+usually mean a wiring or firmware bug and should not be retried blindly.
+
+## Per-crate catalog
+
+### `axp2101::Error<E>`
+PMU init / battery gauge.
+- `I2c(E)` — bus error.
+
+### `aw9523::Error<E>`
+I/O expander init.
+- `I2c(E)` — bus error.
+
+### `aw88298::Error<E>`
+Mono Class-D amplifier (TX path).
+- `I2c(E)` — bus error.
+- `BadChipId(u16)` — `CHIPID` register didn't return expected ID. AW88298 uses 16-bit big-endian registers; raw value is in the variant.
+
+### `bm8563::Error<E>`
+RTC.
+- `I2c(E)` — bus error.
+- `VoltageLow` — `VL` flag set; backup battery dropped, current time unreliable. Treat as "unset."
+
+### `bmi270::Error<E>`
+6-axis IMU.
+- `I2c(E)` — bus error.
+- `BadChipId(u8)` — wrong device, bus glitch, or held in reset.
+- `NotDetected` — neither primary nor secondary I²C address answered.
+- `InitTimeout` — config blob upload didn't finish; usually truncation or defective part.
+
+### `bmm150::Error<E>`
+Magnetometer.
+- `I2c(E)` — bus error.
+- `ChipId { expected, actual }` — caller targeted the wrong address or part is damaged.
+- `NotDetected` — both candidate addresses failed to respond.
+- `Overflow` — reading exceeded ADC dynamic range; retry or ignore the sample.
+
+### `es7210::Error<E>`
+4-channel ADC (RX path).
+- `I2c(E)` — bus error.
+- `BadChipId(u8, u8)` — `(CHIP_ID1, CHIP_ID2)` mismatch. ES7210 needs MCLK to answer I²C — see memory note on audio codec quirks.
+
+### `ft6336u::Error<E>`
+Capacitive touch.
+- `I2c(E)` — bus error.
+
+### `gc0308::Error<E>`
+Camera SCCB.
+- `I2c(E)` — SCCB (I²C-compatible) bus error.
+- `BadChipId(u8)` — wrong device or wiring issue.
+
+### `ltr553::Error<E>`
+Ambient + proximity.
+- `I2c(E)` — bus error.
+- `BadPartId(u8)` — `PART_ID` upper nibble mismatch; common cause is a related Lite-On part with a different lux formula.
+
+### `py32::Error<E>`
+Co-processor (servo power gate, LED ring).
+- `I2c(E)` — bus error.
+- `InvalidPin(u8)` — caller passed pin outside `0..=13`.
+- `TooManyLeds(usize)` — caller passed more than `MAX_LEDS` pixels.
+
+### `scservo::Error<E>`
+Half-duplex serial servo bus.
+- `Uart(E)` — UART transport error.
+- `PayloadTooLarge` — write exceeded `MAX_DATA_BYTES`; v1 write surface never reaches this.
+- `NoResponse` — UART closed before full response (rare on open-ended serial; usually a hung slave).
+- `MalformedResponse` — wrong header bytes or response ID mismatch.
+- `ChecksumMismatch` — packet arrived but checksum failed.
+- `PositionOutOfRange(u16)` — position above `POSITION_MAX` (1023); the servo would mis-interpret high bits.
+- `BroadcastNotAllowed` — caller used `BROADCAST_ID` on an operation requiring a response.
+
+### `si12t::Error<E>`
+Scaffolded only.
+- `I2c(E)` — bus error.
+- `BadIdentity` — placeholder; register surface not filled in.
+
+### `st25r3916::Error<E>`
+NFC reader IC, scaffolded.
+- `Spi(E)` — bus error.
+- `BadIcIdentity(u8)` — `IC_IDENTITY` mismatch.
+
+### `ir-nec`
+No `Error` enum — decoder returns `Option<NecCommand>` and treats noise as "no decode" rather than an error.
+
+## Firmware-side error wrapping
+
+`stackchan-firmware` does not introduce its own typed-error enum. Init
+failures inside `#[esp_rtos::main]` panic via `defmt::panic!` because
+there's no caller to bubble to. Per-task failures are logged with
+`defmt::warn!` or `defmt::error!` and the task continues, parks
+forever, or restarts depending on severity (see each `src/<chip>.rs`).
+
+## Adding a new error variant
+
+When adding a variant to a driver crate's `Error`:
+
+1. Document **what triggered** it and **what to do about it** in the
+   doc-comment — the catalog above relies on this to stay accurate.
+2. Carry the offending value (`u8`, `u16`, etc.) when it aids
+   debugging. Logs that just say "bad chip ID" without the byte are
+   hard to triage.
+3. Update this catalog in the same PR.


### PR DESCRIPTION
## Summary
First of a 5-themed AI dev UX bundle. Three coordinated doc additions:

**CLAUDE.md modernization** — fixes confirmed-stale claims:
- `six crates` → 19 crates grouped by purpose (the original was accurate at v0.1.0; never updated as the workspace grew)
- `probe-rs run --chip esp32s3 is the canonical flash + log path` → `defmt-encoded bytes over USB-Serial-JTAG, espflash --monitor --log-format defmt`. Reflects the audio/camera-era flash path.
- Recommends `just check` over raw cargo as idiomatic
- Adds branch-naming convention + worktree-footgun warning
- Cross-links to AGENTS.md + docs/errors.md

**AGENTS.md** — new dedicated AI-collaborator playbook (separate from CLAUDE.md which stays shared). Session shapes, decision frameworks, patterns + idioms, debugging recipes (incl. defmt filter snippets and known-noise log catalog for this unit), memory pointer with key persistent-context highlights.

**docs/errors.md** — typed-error catalog covering all 14 driver crates with the transport vs protocol split. Each variant explains what triggered it + what to do about it. Helps debug a defmt error log without grepping the source.

## Test plan
- [x] Pre-commit gates green (fmt + clippy + tests + doctests + Cargo.lock guard + README review reminder)
- [x] No source code changes; pure doc additions
- [ ] Greptile review

## Coordinated PRs in this bundle
This is PR 1 of 5. Companions: tooling + just dev recipes (B), host visualizer (C), boot-log regression guard (D), embassy task watchdog (E). Plus aspirational follow-ups: mdBook (F), static analysis breadth (G), Nix flake (H).