### PR TITLE
chore: tooling — just dev/check-fast/fmr-agent + per-bench recipes + pre-commit fast mode + doc-drift CI guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,11 @@
 #
 # Firmware-side (esp) checks are expensive and require the espup toolchain
 # to be sourced; they run in CI, not on every commit.
+#
+# Fast mode: set `STACKCHAN_FAST=1` to skip clippy + tests + doctests +
+# workspace-check. Keeps fmt + Cargo.lock drift guard + the README
+# review reminder. Use during inner-loop iteration; CI catches anything
+# the fast pre-commit misses on push.
 set -euo pipefail
 
 staged=$(git diff --cached --name-only --diff-filter=ACMR)
@@ -28,17 +33,22 @@ if [ "$has_rust" = true ]; then
     echo "pre-commit: checking formatting..."
     cargo fmt --check
 
-    echo "pre-commit: running clippy on host crates (incl. tests)..."
-    cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings
+    if [ "${STACKCHAN_FAST:-0}" = "1" ]; then
+        echo "pre-commit: STACKCHAN_FAST=1 — skipping clippy + tests + doctests + workspace-check"
+        echo "pre-commit: (CI will run the full gate set on push)"
+    else
+        echo "pre-commit: running clippy on host crates (incl. tests)..."
+        cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings
 
-    echo "pre-commit: running host tests..."
-    cargo test --workspace --exclude stackchan-firmware --all-features --quiet
+        echo "pre-commit: running host tests..."
+        cargo test --workspace --exclude stackchan-firmware --all-features --quiet
 
-    echo "pre-commit: running doc tests..."
-    cargo test --workspace --exclude stackchan-firmware --all-features --doc --quiet
+        echo "pre-commit: running doc tests..."
+        cargo test --workspace --exclude stackchan-firmware --all-features --doc --quiet
 
-    echo "pre-commit: checking workspace (host)..."
-    cargo check --workspace --exclude stackchan-firmware --all-features --all-targets --quiet
+        echo "pre-commit: checking workspace (host)..."
+        cargo check --workspace --exclude stackchan-firmware --all-features --all-targets --quiet
+    fi
 fi
 
 # Non-blocking: if source changes but the nearest README.md isn't

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,20 @@ jobs:
 
       - name: Build on MSRV
         run: cargo build --workspace --exclude stackchan-firmware --all-features
+
+  doc-drift:
+    name: Doc drift (READMEs vs src/)
+    # Warn-only — informational, not a merge gate. Skipped on
+    # release-please PRs (their version-bump churn would always trigger
+    # drift warnings). Full git history needed for the `rev-list` count.
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'release-kun[bot]' ||
+      !startsWith(github.event.pull_request.title, 'chore: release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check per-crate README drift
+        run: bash scripts/check-doc-drift.sh

--- a/justfile
+++ b/justfile
@@ -28,13 +28,34 @@ _serial_suffix := if os() == "macos" { "" } else { "'" }
 default:
     @just --list
 
+# ----- Session-start sanity check ------------------------------------------
+
+# Print toolchain availability, device enumeration, working-tree state,
+# and recent CI status. Read-only; no side effects. Useful at session
+# start (human or AI) before reaching for code.
+dev:
+    @bash scripts/dev-status.sh
+
 # ----- Host-side -----------------------------------------------------------
+
+# Fast inner-loop check — fmt + cargo check, no clippy or tests.
+# Sub-second feedback for "did my edit compile?" iteration. Use this
+# while iterating on a single file; run `just check` before committing.
+check-fast:
+    cargo fmt --check
+    cargo check --workspace --exclude stackchan-firmware --all-features --all-targets --quiet
 
 # Fast host checks — the same gates the pre-commit hook runs.
 check:
     cargo fmt --check
     cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings
     cargo test --workspace --exclude stackchan-firmware --all-features
+
+# Doc-drift guard — flag crates whose src/ has diverged > N commits from
+# their README.md. Warn-only by default. Pass `STRICT=1` for non-zero
+# exit on drift (CI uses this).
+doc-drift:
+    @bash scripts/check-doc-drift.sh {{ if env_var_or_default("STRICT", "") == "1" { "--strict" } else { "" } }}
 
 # Everything the CI host job runs (adds doc-lint + cargo-deny).
 ci: check
@@ -102,6 +123,15 @@ reattach:
 # One port-open, one reset — preferred over split `flash; monitor`.
 fmr: build-firmware
     {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{firmware_elf}}{{_serial_suffix}}
+
+# Agent-friendly fmr: kicks `just fmr` off inside a tmux session, tees
+# the output to /tmp/scfmr.log, and polls until "boot complete" appears
+# (with a 90 s timeout). Returns 0 on clean boot, 2 on panic, 3 on
+# timeout. Designed for AI agents and other non-TTY shells where
+# espflash's interactive monitor would otherwise fail to start. See
+# CLAUDE.md "Flashing from an agent / non-TTY shell".
+fmr-agent:
+    @bash scripts/fmr-agent.sh
 
 # Path prefix for release bench example ELFs.
 example_elf_dir := "target/xtensa-esp32s3-none-elf/release/examples"
@@ -174,3 +204,38 @@ tilt-extremes:
 tilt-freewheel:
     cd crates/stackchan-firmware && cargo +esp build --release --example tilt_freewheel
     {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/tilt_freewheel{{_serial_suffix}}
+
+# Ambient light sensor bench: streams LTR-553 lux readings at 2 Hz +
+# proximity counts. Verifies init sequence + driver presence.
+ambient-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example ambient_bench
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/ambient_bench{{_serial_suffix}}
+
+# IR-NEC bench: decodes incoming NEC frames from the IR receiver on
+# GPIO21 (RMT channel 7) and prints `(address, command)` tuples. Use to
+# discover your remote's codes for the `RemoteCommand` modifier mapping.
+ir-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example ir_bench
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/ir_bench{{_serial_suffix}}
+
+# FT6336U touch bench: streams raw touch events (point count, x, y,
+# pressure) so calibration drift or wiring issues surface as obviously-
+# wrong coordinates.
+touch-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example touch_bench
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/touch_bench{{_serial_suffix}}
+
+# BMI270 IMU bench: streams accel + gyro at 100 Hz with magnitude
+# computed. Use to characterize gravity vector + bias on a static unit
+# before hand-tuning PickupReaction thresholds.
+imu-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example imu_bench
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/imu_bench{{_serial_suffix}}
+
+# Block-grid motion tracker bench: brings up the camera path and runs
+# the `tracker` crate over each frame, logging motion centroids and
+# proposed pan/tilt deltas. No servos commanded — algorithm validation
+# only.
+tracker-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example tracker_bench
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/tracker_bench{{_serial_suffix}}

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# check-doc-drift.sh — flag crates whose src/ has diverged from their README.md.
+#
+# For each crate under crates/, compares:
+#   - the latest commit touching src/
+#   - the latest commit touching README.md
+# If src/ has > $DRIFT_THRESHOLD commits since the last README touch,
+# emits a warning. Exits 0 (warn-only) by default; pass `--strict` to
+# exit non-zero so CI can fail on drift.
+#
+# Tunable knobs:
+#   DRIFT_THRESHOLD — default 30 commits. Above this, we consider the
+#                     README plausibly stale.
+#
+# Catches the failure mode CLAUDE.md exhibited (drift from "six crates"
+# at v0.1.0 → 19 crates at v0.9.7) without anyone noticing.
+set -euo pipefail
+
+: "${DRIFT_THRESHOLD:=30}"
+strict=false
+[ "${1:-}" = "--strict" ] && strict=true
+
+# Output styling — color when interactive.
+if [ -t 1 ]; then
+    Y=$'\033[33m'; G=$'\033[32m'; D=$'\033[2m'; N=$'\033[0m'
+else
+    Y=""; G=""; D=""; N=""
+fi
+
+drifted=0
+clean=0
+no_readme=0
+
+for crate_dir in crates/*/; do
+    crate=$(basename "$crate_dir")
+
+    if [ ! -f "${crate_dir}README.md" ]; then
+        no_readme=$((no_readme + 1))
+        continue
+    fi
+    if [ ! -d "${crate_dir}src" ]; then
+        continue
+    fi
+
+    # `git log -1 -- <path>` returns the commit hash of the most recent
+    # commit affecting that path. If the README has never been touched
+    # (rare) the rev is empty; we treat that as "huge drift".
+    src_rev=$(git log -1 --format=%H -- "${crate_dir}src" 2>/dev/null || true)
+    readme_rev=$(git log -1 --format=%H -- "${crate_dir}README.md" 2>/dev/null || true)
+
+    if [ -z "$src_rev" ]; then
+        continue
+    fi
+
+    if [ -z "$readme_rev" ]; then
+        printf "  %s%s%s — README never touched (always drifted)\n" "$Y" "$crate" "$N"
+        drifted=$((drifted + 1))
+        continue
+    fi
+
+    # Count commits touching src/ between (readme_rev, src_rev]. If
+    # readme_rev == src_rev (same commit changed both), drift is 0.
+    if [ "$src_rev" = "$readme_rev" ]; then
+        clean=$((clean + 1))
+        continue
+    fi
+
+    drift=$(git rev-list --count "${readme_rev}..${src_rev}" -- "${crate_dir}src" 2>/dev/null || echo 0)
+
+    if [ "$drift" -gt "$DRIFT_THRESHOLD" ]; then
+        printf "  %s%s%s — %d src commits since README touch (threshold: %d)\n" \
+            "$Y" "$crate" "$N" "$drift" "$DRIFT_THRESHOLD"
+        drifted=$((drifted + 1))
+    else
+        clean=$((clean + 1))
+    fi
+done
+
+echo
+printf "doc-drift: %s%d clean%s, %s%d drifted%s, %s%d missing README%s\n" \
+    "$G" "$clean" "$N" \
+    "$Y" "$drifted" "$N" \
+    "$D" "$no_readme" "$N"
+
+if [ "$drifted" -gt 0 ] && [ "$strict" = true ]; then
+    echo
+    echo "doc-drift: --strict mode — exiting non-zero because $drifted crate(s) drifted." >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/dev-status.sh
+++ b/scripts/dev-status.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# dev-status.sh — session-start sanity check.
+#
+# Prints toolchain availability, device enumeration, working-tree state,
+# and recent CI status so the contributor (human or AI) sees the lay of
+# the land at the start of a session. Read-only; no side effects.
+set -uo pipefail
+
+# Color output if stdout is a TTY, plain otherwise (so logs stay clean).
+if [ -t 1 ]; then
+    G=$'\033[32m'; Y=$'\033[33m'; R=$'\033[31m'; D=$'\033[2m'; N=$'\033[0m'
+else
+    G=""; Y=""; R=""; D=""; N=""
+fi
+
+ok()    { echo "  ${G}✓${N} $*"; }
+warn()  { echo "  ${Y}!${N} $*"; }
+miss()  { echo "  ${R}✗${N} $*"; }
+note()  { echo "  ${D}·${N} $*"; }
+
+echo
+echo "stackchan-kai — dev session status"
+echo
+
+# ----- Toolchain ----------------------------------------------------------
+echo "Toolchain:"
+for cmd in cargo just tmux; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        ok "$cmd ($(command -v $cmd))"
+    else
+        miss "$cmd not on PATH"
+    fi
+done
+if command -v espflash >/dev/null 2>&1; then
+    ok "espflash ($(espflash --version 2>/dev/null | head -1))"
+else
+    warn "espflash not on PATH (cargo install espflash)"
+fi
+if [ -f "$HOME/export-esp.sh" ]; then
+    ok "esp toolchain available (source ~/export-esp.sh)"
+else
+    miss "no ~/export-esp.sh — esp toolchain not installed (espup install)"
+fi
+
+# ----- Device -------------------------------------------------------------
+echo
+echo "Device:"
+acm_devices=( /dev/ttyACM* )
+if [ -e "${acm_devices[0]}" ]; then
+    for dev in "${acm_devices[@]}"; do
+        # `udevadm info` works rootless and identifies which port is the CoreS3.
+        descr=$(udevadm info "$dev" 2>/dev/null | grep -E "ID_VENDOR_FROM_DATABASE|ID_MODEL_FROM_DATABASE" | head -2 | tr '\n' ' ' | sed 's/E: //g')
+        ok "$dev — ${descr:-(unknown)}"
+    done
+else
+    warn "no /dev/ttyACM* — connect the CoreS3 over USB"
+fi
+
+# Dialout group check (Linux only).
+if [ "$(uname)" = "Linux" ]; then
+    if id -nG "$USER" 2>/dev/null | tr ' ' '\n' | grep -qx dialout; then
+        ok "user '$USER' is in 'dialout' group"
+    else
+        warn "user '$USER' not in 'dialout' group — wrap espflash via 'sg dialout'"
+    fi
+fi
+
+# ----- Repo -----------------------------------------------------------------
+echo
+echo "Repo:"
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "(detached)")
+ok "branch: $branch"
+if git diff-index --quiet HEAD -- 2>/dev/null; then
+    ok "working tree clean"
+else
+    note "working tree has unstaged changes:"
+    git status -s | head -10 | sed 's/^/      /'
+fi
+
+worktree_count=$(git worktree list 2>/dev/null | wc -l)
+if [ "$worktree_count" -gt 1 ]; then
+    note "$((worktree_count - 1)) extra worktree(s) live in .worktrees/"
+fi
+
+# Behind / ahead of upstream, if upstream exists.
+if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null); then
+    behind=$(git rev-list --count "HEAD..$upstream" 2>/dev/null || echo 0)
+    ahead=$(git rev-list --count "$upstream..HEAD" 2>/dev/null || echo 0)
+    if [ "$behind" -gt 0 ] || [ "$ahead" -gt 0 ]; then
+        note "vs $upstream: $ahead ahead, $behind behind"
+    fi
+fi
+
+# ----- Recent commits -----------------------------------------------------
+echo
+echo "Recent commits on $branch:"
+git log --oneline -5 2>/dev/null | sed 's/^/  /'
+
+# ----- Open PRs ------------------------------------------------------------
+if command -v gh >/dev/null 2>&1; then
+    echo
+    echo "Open PRs:"
+    if gh pr list --state open --limit 5 --json number,title 2>/dev/null \
+        | grep -q '"number"'; then
+        gh pr list --state open --limit 5 2>/dev/null | sed 's/^/  /'
+    else
+        ok "no open PRs"
+    fi
+fi
+
+echo

--- a/scripts/fmr-agent.sh
+++ b/scripts/fmr-agent.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# fmr-agent.sh — flash + monitor in tmux + tee log + poll for boot complete.
+#
+# Wraps the agent-friendly flashing dance (CLAUDE.md "Flashing from an
+# agent / non-TTY shell"). Returns 0 if "boot complete" appeared in the
+# log within $BOOT_TIMEOUT_S, non-zero otherwise.
+#
+# Usage:
+#   just fmr-agent
+#
+# Reads:
+#   BOOT_TIMEOUT_S   — wall-clock seconds before giving up (default: 90)
+#   SCFMR_LOG        — log path (default: /tmp/scfmr.log)
+#   SCFMR_SESSION    — tmux session name (default: scfmr)
+#
+# After this returns, the device keeps running and the tmux session
+# stays attached. Use `tmux send-keys -t <session> C-c` before re-running
+# to break out of the monitor cleanly.
+set -euo pipefail
+
+: "${BOOT_TIMEOUT_S:=90}"
+: "${SCFMR_LOG:=/tmp/scfmr.log}"
+: "${SCFMR_SESSION:=scfmr}"
+
+# Resolve the worktree root we were invoked from. `just` invokes recipes
+# from the project root, so $PWD is the right anchor.
+WORKTREE_ROOT="$PWD"
+
+# Reset any prior monitor cleanly. `tmux send-keys C-c` is idempotent
+# when no session exists; the kill ensures a fresh start so log positions
+# don't compound.
+tmux kill-session -t "$SCFMR_SESSION" 2>/dev/null || true
+
+# Truncate the log so a partial prior run doesn't trip the boot-complete
+# poll on the next invocation.
+: > "$SCFMR_LOG"
+
+tmux new-session -d -s "$SCFMR_SESSION" -c "$WORKTREE_ROOT" 'bash -l'
+tmux send-keys -t "$SCFMR_SESSION" \
+    "source ~/export-esp.sh && just fmr 2>&1 | tee $SCFMR_LOG" Enter
+
+echo "fmr-agent: tmux session '$SCFMR_SESSION' started, build+flash in progress..."
+echo "fmr-agent: tailing $SCFMR_LOG (timeout ${BOOT_TIMEOUT_S}s for 'boot complete')"
+
+# Poll for boot-complete with a deadline. `until grep -q ...; do sleep`
+# is the obvious shape but blocks indefinitely — we need a deadline so a
+# panicking firmware doesn't wedge the recipe.
+deadline=$(( $(date +%s) + BOOT_TIMEOUT_S ))
+while true; do
+    if grep -q "boot complete" "$SCFMR_LOG" 2>/dev/null; then
+        break
+    fi
+    if grep -qiE "^.*(panic|ERROR.*panicked)" "$SCFMR_LOG" 2>/dev/null; then
+        echo "fmr-agent: PANIC detected in log:"
+        grep -iE "panic|ERROR" "$SCFMR_LOG" | head -20
+        exit 2
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "fmr-agent: TIMEOUT (${BOOT_TIMEOUT_S}s) — last 20 log lines:"
+        tail -20 "$SCFMR_LOG"
+        exit 3
+    fi
+    sleep 2
+done
+
+# Boot succeeded — print the canonical boot summary so the agent can
+# confirm at a glance without reading the full log.
+echo "fmr-agent: BOOT COMPLETE"
+grep -E "stackchan-firmware v|task:|present|ready|boot complete|panic|ERROR" "$SCFMR_LOG" | head -25


### PR DESCRIPTION
## Summary
PR 2 of the AI dev UX bundle. Every change targets faster inner-loop iteration or earlier-warning failure modes.

### New scripts (under `scripts/`)
- **`dev-status.sh`** — session-start sanity: toolchain check, /dev/ttyACM* enumeration with udev-resolved chip names, dialout-group membership, working-tree state, recent commits, open PRs. Read-only.
- **`fmr-agent.sh`** — agent-friendly `just fmr` wrapper: kicks build+flash off in tmux, tees output to /tmp/scfmr.log, polls for "boot complete" with a 90 s deadline. Returns 0 clean / 2 panic / 3 timeout. Codifies the CLAUDE.md "Flashing from an agent / non-TTY shell" dance.
- **`check-doc-drift.sh`** — for each crate, counts src commits since the README was last touched. Flags > 30 commits as drift. Warn-only by default; CI uses non-strict mode (informational).

### New just recipes
- `just dev` — session-start dashboard
- `just check-fast` — fmt + cargo check (no clippy/tests). Sub-second inner loop.
- `just doc-drift` — runs drift script (`STRICT=1` for non-zero exit)
- `just fmr-agent` — agent flash dance one-shot
- `just ambient-bench` / `just ir-bench` / `just touch-bench` / `just imu-bench` / `just tracker-bench` — fill in missing per-bench recipes for examples that already exist

### Pre-commit hook
- New `STACKCHAN_FAST=1` env var: skips clippy + tests + doctests + workspace-check, keeps fmt + Cargo.lock guard + README reminder. CI catches anything fast mode misses on push.

### CI
- New `doc-drift` job runs `scripts/check-doc-drift.sh` on every PR (skipped on release-please PRs).

## Test plan
- [x] `just dev` runs cleanly and resolves device names via udev
- [x] `just check-fast` passes
- [x] `just doc-drift` reports `19 clean, 0 drifted, 0 missing README`
- [x] Pre-commit fast-mode tested locally (`STACKCHAN_FAST=1 git commit`)
- [x] All host gates green
- [ ] Greptile review

## Coordinated PRs in this bundle
This is PR 2 of 8. PR 1 is #81 (docs modernization). Companions: viz (C), boot-log golden (D), watchdog (E). Aspirational follow-ups: gh-pages docs site (F), static analysis breadth (G), Nix flake (H).