### PR TITLE
chore: boot-log regression guard — golden + verify-boot recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,6 +57,15 @@ check:
 doc-drift:
     @bash scripts/check-doc-drift.sh {{ if env_var_or_default("STRICT", "") == "1" { "--strict" } else { "" } }}
 
+# Boot-log regression guard — diff /tmp/scfmr.log (last `just fmr` /
+# `just fmr-agent` flash) against `tests/golden/boot.txt`. Reports
+# missing golden lines (regression) and unexpected WARN/ERROR lines
+# (new noise) with known-noise filtered. Run after every flash to catch
+# silent regressions. Pass `--update` to rewrite the golden from the
+# current live log when boot output changes intentionally.
+verify-boot *args:
+    @bash scripts/check-boot.sh {{args}}
+
 # Everything the CI host job runs (adds doc-lint + cargo-deny).
 ci: check
     cargo deny check

--- a/scripts/check-boot.sh
+++ b/scripts/check-boot.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-boot.sh — diff live boot log against tests/golden/boot.txt.
+#
+# Reports:
+#   1. Golden lines that didn't appear in the live log (regression!)
+#   2. Unexpected ERROR or WARN lines (new noise!)
+#
+# Known-noise (DmaError(Late), BMI270 retry, BMM150 not reachable, etc.)
+# is filtered before the WARN/ERROR scan — these are documented in
+# AGENTS.md as expected for this unit.
+#
+# Usage:
+#   just verify-boot          # check /tmp/scfmr.log
+#   just verify-boot --update # rewrite the golden from /tmp/scfmr.log
+set -euo pipefail
+
+GOLDEN="tests/golden/boot.txt"
+LIVE="${SCFMR_LOG:-/tmp/scfmr.log}"
+
+# Color when interactive.
+if [ -t 1 ]; then
+    G=$'\033[32m'; Y=$'\033[33m'; R=$'\033[31m'; D=$'\033[2m'; N=$'\033[0m'
+else
+    G=""; Y=""; R=""; D=""; N=""
+fi
+
+if [ "${1:-}" = "--update" ]; then
+    echo "${Y}check-boot:${N} --update mode rebuilds the golden file from $LIVE."
+    echo "Review the diff and commit the result."
+    echo
+    if [ ! -f "$LIVE" ]; then
+        echo "${R}check-boot:${N} no live log at $LIVE — flash first (just fmr-agent)" >&2
+        exit 1
+    fi
+    # Extract every "info" line from the live log, strip the timestamp
+    # prefix and source-location suffix, dedupe, sort by first
+    # appearance.
+    grep "INFO" "$LIVE" \
+        | sed -E 's/^[0-9]+ ms \[INFO \] //; s/ \(stackchan_firmware [^)]+\)$//' \
+        | awk '!seen[$0]++' \
+        > "$GOLDEN.candidate"
+    echo "${G}check-boot:${N} candidate written to $GOLDEN.candidate. Review and:"
+    echo "  diff $GOLDEN $GOLDEN.candidate"
+    echo "  mv $GOLDEN.candidate $GOLDEN  # if you accept the new state"
+    exit 0
+fi
+
+if [ ! -f "$GOLDEN" ]; then
+    echo "${R}check-boot:${N} golden file missing at $GOLDEN" >&2
+    exit 1
+fi
+if [ ! -f "$LIVE" ]; then
+    echo "${R}check-boot:${N} live log missing at $LIVE — flash first (just fmr-agent)" >&2
+    exit 1
+fi
+
+# Phase 1: golden lines that didn't appear.
+missing=0
+echo "Checking for missing golden lines:"
+while IFS= read -r line; do
+    case "$line" in ''|'#'*) continue ;; esac
+    if ! grep -qF "$line" "$LIVE"; then
+        printf "  %s✗%s missing: %s\n" "$R" "$N" "$line"
+        missing=$((missing + 1))
+    fi
+done < "$GOLDEN"
+if [ "$missing" -eq 0 ]; then
+    printf "  %s✓%s all golden lines present\n" "$G" "$N"
+fi
+
+# Phase 2: unexpected WARN / ERROR lines (after filtering known noise).
+echo
+echo "Checking for unexpected WARN/ERROR lines:"
+unexpected=$(grep -E "\[(WARN|ERROR)\]" "$LIVE" \
+    | grep -vE "DmaError\(Late\)" \
+    | grep -vE "BMI270: init attempt [0-9]+/3 failed" \
+    | grep -vE "BMM150: not reachable on main I" \
+    | grep -vE "BMM150: NotDetected" || true)
+
+if [ -z "$unexpected" ]; then
+    printf "  %s✓%s no unexpected WARN/ERROR (after known-noise filter)\n" "$G" "$N"
+else
+    echo "$unexpected" | head -20 | sed "s/^/  ${Y}!${N} /"
+    unexpected_count=$(echo "$unexpected" | wc -l)
+    printf "  %s%d unexpected line(s) total%s\n" "$Y" "$unexpected_count" "$N"
+fi
+
+echo
+if [ "$missing" -gt 0 ]; then
+    printf "%scheck-boot: FAIL — %d missing golden line(s).%s\n" "$R" "$missing" "$N" >&2
+    printf "%s             update the golden if the change is intentional: just verify-boot --update%s\n" "$D" "$N" >&2
+    exit 1
+fi
+printf "%scheck-boot: PASS%s\n" "$G" "$N"

--- a/tests/golden/boot.txt
+++ b/tests/golden/boot.txt
@@ -1,0 +1,47 @@
+# Golden boot log — expected info-line set after a clean firmware boot.
+#
+# This file is the canonical "what does a healthy boot look like" record.
+# `scripts/check-boot.sh` greps the live log (default /tmp/scfmr.log)
+# for each line below and reports any line that didn't appear, plus any
+# unexpected `WARN`/`ERROR` lines. Timestamps are stripped before
+# comparison, so timing variation between flashes doesn't trigger drift.
+#
+# Lines beginning with `#` are comments. Each non-comment line is a
+# substring match — the live log line must contain the golden text
+# verbatim. Use this for boot-up signals only; don't try to capture
+# steady-state log lines (head: cmd= etc.) here.
+#
+# Update this file when:
+#   - A new task spawns at boot and prints a "task: {period} ms tick" line
+#   - A new chip-detection signal is added (e.g. "FOO: detected at 0xNN")
+#   - A bring-up implementation step graduates from `debug` to `info`
+#
+# When boot output changes deliberately, run:
+#   just verify-boot --update   (writes whatever is in /tmp/scfmr.log)
+# Review the diff carefully before committing.
+
+stackchan-firmware v
+AXP2101: CoreS3 power defaults applied
+AW9523: CoreS3 defaults applied
+PY32: servo power enabled
+SCServo bus ready on UART1
+SCServo[1]: present
+SCServo[2]: present
+boot-nod: yes nod start
+boot-nod: complete
+ILI9342C ready — spawning render task
+idle drift seed:
+head task:
+render task:
+boot @
+boot complete — idle heartbeat
+FT6336U: vendor ID
+touch task:
+LTR-553: init complete
+BMI270: detected at
+audio: ES7210 ready
+audio: AW88298 un-muted — speaker live
+audio: bring-up complete
+camera: GC0308 SCCB init complete
+camera: PSRAM buffers allocated
+LED ring: boot fade complete


### PR DESCRIPTION
## Summary
PR 4 of the AI dev UX bundle. Catches silent boot regressions on every flash without manual log scanning.

### `tests/golden/boot.txt`
Canonical "what does a healthy boot look like" record. 26 substring matches covering every spawn line, chip-detection signal, and bring-up state-transition the firmware emits on a clean boot.

### `scripts/check-boot.sh`
Diffs a live log (default `/tmp/scfmr.log`) against the golden:
- **Phase 1**: every golden substring must appear in the live log; missing lines fail with exit 1.
- **Phase 2**: every unexpected `WARN`/`ERROR` line is reported, with known-noise filtered (DmaError(Late), BMI270 retry, BMM150 not reachable on this unit — these match the AGENTS.md known-noise catalog).
- `--update` mode regenerates the golden from the live log so the user can review the diff before committing.

### `just verify-boot [--update]`
Wraps the script. Run after every flash.

## Test plan
- [x] End-to-end verified: fresh `just fmr` flash → `just verify-boot` → **PASS** (all 26 golden lines present, no unexpected warnings)
- [x] Negative case: ran against a stale log (missing `idle drift seed:` because the flashed firmware predated PR #79); script correctly detected the regression with non-zero exit
- [x] Pre-commit gates green
- [ ] Greptile review

## Coordinated PRs in this bundle
PR 4 of 8. Others: docs (#81 ✓ merged), tooling (#82 ✓ merged), viz (#83), watchdog (E), gh-pages docs site (F), static analysis breadth (G), Nix flake (H).