### PR TITLE
feat(firmware): embassy task watchdog supervisor

### DIFF
--- a/crates/stackchan-firmware/src/ambient.rs
+++ b/crates/stackchan-firmware/src/ambient.rs
@@ -49,6 +49,7 @@ pub async fn run_ambient_loop<I: AsyncI2c>(bus: I) -> ! {
 
     let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
     loop {
+        crate::watchdog::AMBIENT.beat();
         match als.read_ambient().await {
             Ok(reading) => {
                 AMBIENT_LUX_SIGNAL.signal(reading.lux);

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -705,6 +705,13 @@ async fn run_rms_loop<BUFFER>(
     const LOG_EVERY_N_DMA_ERRS: u32 = 200;
 
     loop {
+        // Watchdog heartbeat fires once per audio-task iteration, not
+        // once per completed RMS window. The DmaError(Late) path
+        // recovers via `continue` without producing an RMS sample, but
+        // the audio task itself is still alive — that's what the
+        // watchdog cares about. Producing-RMS-correctly is a separate
+        // concern that surfaces via the `audio: RMS …` debug logs.
+        crate::watchdog::AUDIO.beat();
         let n = match rx_transfer.pop(&mut scratch).await {
             Ok(n) => {
                 consecutive_dma_errs = 0;

--- a/crates/stackchan-firmware/src/imu.rs
+++ b/crates/stackchan-firmware/src/imu.rs
@@ -101,6 +101,7 @@ pub async fn run_imu_loop<I: AsyncI2c>(bus: I) -> ! {
 
     let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
     loop {
+        crate::watchdog::IMU.beat();
         match imu.read_measurement().await {
             Ok(m) => IMU_SIGNAL.signal(m),
             Err(e) => defmt::warn!("BMI270: read failed: {}", defmt::Debug2Format(&e)),

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -31,3 +31,4 @@ pub mod leds;
 pub mod power;
 pub mod touch;
 pub mod wallclock;
+pub mod watchdog;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 
 use stackchan_firmware::{
     ambient, audio, board, button, camera, clock, framebuffer, head, imu, ir, leds, power, touch,
-    wallclock,
+    wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -464,6 +464,7 @@ async fn head_task(mut driver: HeadDriverImpl) {
         HEAD_PERIOD_MS.saturating_mul(u64::from(POSITION_POLL_EVERY)),
     );
     loop {
+        watchdog::HEAD.beat();
         if let Some(next) = head::POSE_SIGNAL.try_take() {
             current = next;
         }
@@ -582,6 +583,14 @@ async fn audio_task(peripherals: audio::AudioPeripherals) -> ! {
 #[embassy_executor::task]
 async fn camera_task(peripherals: camera::CameraPeripherals) -> ! {
     camera::run_camera_task(peripherals).await
+}
+
+/// Watchdog supervisor. Polls per-channel heartbeat counters (audio,
+/// IMU, ambient, power, head) every 5 s and warns when any falls
+/// silent. See `src/watchdog.rs` for the cadence-aware logic.
+#[embassy_executor::task]
+async fn watchdog_task() -> ! {
+    watchdog::run_watchdog_loop().await
 }
 
 #[esp_rtos::main]
@@ -704,6 +713,9 @@ async fn main(spawner: Spawner) -> ! {
     }
     if let Err(e) = spawner.spawn(power_task(I2cDevice::new(board_io.i2c_bus))) {
         defmt::panic!("spawn power_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(watchdog_task()) {
+        defmt::panic!("spawn watchdog_task failed: {}", defmt::Debug2Format(&e));
     }
 
     // Audio subsystem. The task owns I²S0 + DMA + audio pins and

--- a/crates/stackchan-firmware/src/power.rs
+++ b/crates/stackchan-firmware/src/power.rs
@@ -65,6 +65,7 @@ pub async fn run_power_loop<I: AsyncI2c>(bus: I) -> ! {
     // (otherwise this would log every poll tick).
     let mut last_published: Option<PowerStatus> = None;
     loop {
+        crate::watchdog::POWER.beat();
         let Some(status) = read_status(&mut pmic).await else {
             ticker.next().await;
             continue;

--- a/crates/stackchan-firmware/src/watchdog.rs
+++ b/crates/stackchan-firmware/src/watchdog.rs
@@ -1,0 +1,140 @@
+//! Embassy task watchdog: per-channel heartbeat counters that surface
+//! silent task deaths.
+//!
+//! Each periodic producer task (audio RMS loop, IMU, ambient, power,
+//! head) calls [`Channel::beat`] once per loop iteration. Every
+//! [`WATCHDOG_PERIOD_MS`], the watchdog task reads each counter, diffs
+//! against the previous poll, and emits a `defmt::warn!` if the actual
+//! delta falls below the channel's expected minimum.
+//!
+//! Why heartbeats instead of peeking the existing `Signal<…, T>`
+//! channels: `Signal` is single-consumer (each `try_take` is destructive),
+//! so a watchdog drain would race the render task that's already
+//! consuming the same signal. Heartbeats sidestep the race entirely.
+//!
+//! The cost is one `AtomicU32::fetch_add(1, Relaxed)` per producer
+//! iteration — a few cycles, no embassy task wake, no contention with
+//! the existing Signal semantics.
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use embassy_time::{Duration, Ticker};
+
+/// How often the watchdog task wakes to check every channel. 5 s gives
+/// even the slowest producer (1 Hz power task) a comfortable margin —
+/// 5 expected beats per window — while still flagging a wedged task
+/// within roughly 5 s of the symptom appearing.
+const WATCHDOG_PERIOD_MS: u64 = 5_000;
+
+/// One monitored producer task.
+///
+/// Cadence-aware: `min_per_window` is the smallest beat count we accept
+/// inside a [`WATCHDOG_PERIOD_MS`] poll window before we consider the
+/// channel silent. Set conservatively (~50% of nominal) to absorb
+/// scheduler jitter without false-positives.
+pub struct Channel {
+    /// Human-readable name surfaced in the warning log.
+    name: &'static str,
+    /// Total beats since boot. Producer increments via [`Channel::beat`].
+    counter: AtomicU32,
+    /// Counter value at the previous watchdog poll. The watchdog task
+    /// swaps this in `check_and_reset`.
+    last_polled: AtomicU32,
+    /// Minimum beats expected per [`WATCHDOG_PERIOD_MS`] window.
+    min_per_window: u32,
+}
+
+impl Channel {
+    /// Construct a heartbeat channel for a producer task.
+    const fn new(name: &'static str, min_per_window: u32) -> Self {
+        Self {
+            name,
+            counter: AtomicU32::new(0),
+            last_polled: AtomicU32::new(0),
+            min_per_window,
+        }
+    }
+
+    /// Producer-side: increment the heartbeat counter. Call once per
+    /// producer-task loop iteration. `Relaxed` because the watchdog
+    /// only needs eventual visibility, not strict ordering.
+    pub fn beat(&self) {
+        self.counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Watchdog-side: read the current counter, swap it into
+    /// `last_polled`, and return the delta + whether it's below the
+    /// `min_per_window` threshold.
+    fn check_and_reset(&self) -> (u32, bool) {
+        let now = self.counter.load(Ordering::Relaxed);
+        let prev = self.last_polled.swap(now, Ordering::Relaxed);
+        let delta = now.wrapping_sub(prev);
+        let stale = delta < self.min_per_window;
+        (delta, stale)
+    }
+}
+
+// ---- Channel statics --------------------------------------------------------
+//
+// `min_per_window` values are derived from each producer's nominal
+// cadence × WATCHDOG_PERIOD_MS, halved to absorb jitter:
+//   audio  RMS @ ~33 ms  → ~151 nominal → min 75
+//   imu    @ 10 ms       → 500 nominal  → min 300
+//   ambient @ 500 ms     → 10 nominal   → min 5
+//   power  @ 1000 ms     → 5 nominal    → min 3
+//   head   @ 20 ms       → 250 nominal  → min 150
+
+/// Audio RX-RMS loop. Beats once per published [`AudioRms`] sample
+/// (~one per 33 ms window).
+pub static AUDIO: Channel = Channel::new("audio", 75);
+/// BMI270 IMU polling loop. Beats once per 10 ms iteration.
+pub static IMU: Channel = Channel::new("imu", 300);
+/// LTR-553 ambient-light polling loop. Beats once per 500 ms iteration.
+pub static AMBIENT: Channel = Channel::new("ambient", 5);
+/// AXP2101 battery + USB-power polling loop. Beats once per 1 s iteration.
+pub static POWER: Channel = Channel::new("power", 3);
+/// `SCServo` head-update loop. Beats once per 20 ms command tick.
+pub static HEAD: Channel = Channel::new("head", 150);
+
+/// Iterate every channel and warn on staleness. Internal helper, but
+/// exposed for unit testability.
+fn check_all() {
+    let channels: &[&Channel] = &[&AUDIO, &IMU, &AMBIENT, &POWER, &HEAD];
+    for ch in channels {
+        let (delta, stale) = ch.check_and_reset();
+        if stale {
+            defmt::warn!(
+                "watchdog: channel '{=str}' silent — saw {=u32} beats in {=u64} ms (expected ≥ {=u32})",
+                ch.name,
+                delta,
+                WATCHDOG_PERIOD_MS,
+                ch.min_per_window,
+            );
+        }
+    }
+}
+
+/// Embassy task entry point. Spawned once from `main.rs`. Runs the
+/// supervisor poll forever; never panics, never returns.
+pub async fn run_watchdog_loop() -> ! {
+    let mut ticker = Ticker::every(Duration::from_millis(WATCHDOG_PERIOD_MS));
+    defmt::info!(
+        "watchdog task: {=u64} ms tick, monitoring 5 channels (audio, imu, ambient, power, head)",
+        WATCHDOG_PERIOD_MS,
+    );
+    // Discard the first window — boot ordering means several producers
+    // haven't beaten yet at this point, and a false-positive flood on
+    // boot trains the operator to ignore the warnings.
+    ticker.next().await;
+    let _ = (
+        AUDIO.check_and_reset(),
+        IMU.check_and_reset(),
+        AMBIENT.check_and_reset(),
+        POWER.check_and_reset(),
+        HEAD.check_and_reset(),
+    );
+    loop {
+        ticker.next().await;
+        check_all();
+    }
+}


### PR DESCRIPTION
## Summary
PR 5 of the AI dev UX bundle. Surfaces silent task deaths that would otherwise manifest only as unexplained behavior gaps (eyes go still, audio mouth stops syncing, head freezes). The watchdog logs a `WARN` per silent channel every 5 s, naming the wedged producer.

### `crates/stackchan-firmware/src/watchdog.rs`
New module exposing a `Channel` struct with per-producer atomic heartbeat counters, plus `run_watchdog_loop` that polls every channel each 5 s and warns on counters that didn't advance enough.

Cadence-aware: each channel has a `min_per_window` derived from its nominal cadence × 50% jitter margin:
- `audio` @ ~33 ms → 75 min/window
- `imu` @ 10 ms → 300 min/window
- `ambient` @ 500 ms → 5 min/window
- `power` @ 1000 ms → 3 min/window
- `head` @ 20 ms → 150 min/window

### Heartbeat placement
One `Channel::beat()` per producer-task loop iteration:
- **`audio.rs`** — at the top of the RX RMS loop, *before* the DmaError recovery branch. Detects "audio task wedged" not "RMS production failed" — the device's expected `DmaError(Late)` noise doesn't trigger false positives. (First implementation placed the beat after a successful RMS window; that misfired because DmaError prevented windows from completing.)
- **`imu.rs`** / **`ambient.rs`** / **`power.rs`** — at the top of each loop body.
- **`main.rs::head_task`** — at the top of the 50 Hz command loop.

### Why heartbeats vs peeking signals
`Signal<…, T>` is single-consumer (`try_take` is destructive), so a watchdog drain would race the render task that's already consuming the same signal. Heartbeats sidestep the race entirely. Cost: one `fetch_add(1, Relaxed)` per producer iteration — a few cycles, no embassy task wake.

### Implementation note
Uses `AtomicU32` because xtensa-esp32s3 doesn't expose 64-bit atomics natively. Counter overflow at 2³² beats = ~497 days at 100 Hz, more than enough.

## Test plan
- [x] `cargo +esp clippy --release -- -D warnings` clean
- [x] `just fmr` boot-verified: clean boot through "boot complete" at 1401 ms, watchdog spawn line at 1306 ms
- [x] 30+ s of steady-state running showed zero watchdog warnings — all 5 producer tasks healthy
- [x] Negative case verified: original audio beat placement (after DmaError-gated RMS window) correctly fired `watchdog: channel 'audio' silent` warnings every 5 s, confirming the supervisor logic is sound
- [ ] Greptile review

## Coordinated PRs in this bundle
PR 5 of 8. Others: docs (#81 ✓), tooling (#82 ✓), viz (#83 — CI re-running after policy fix), boot-log golden (#84 ✓ merged), gh-pages docs site (F), static analysis breadth (G), Nix flake (H).