### PR TITLE
docs: GitHub Pages engineering handbook under docs/

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,16 @@
+# Jekyll config for the stackchan-kai engineering handbook.
+# GitHub Pages serves from `docs/` on `main` (Settings → Pages).
+title: stackchan-kai
+description: Clean-slate Rust firmware for the M5Stack CoreS3 Stack-chan.
+theme: jekyll-theme-cayman
+markdown: kramdown
+kramdown:
+  syntax_highlighter: rouge
+# Show repo + license footer on every page.
+github:
+  repository_nwo: andymai/stackchan-kai
+  source: docs/
+  zip_url: https://github.com/andymai/stackchan-kai/archive/main.zip
+  tar_url: https://github.com/andymai/stackchan-kai/archive/main.tar.gz
+exclude:
+  - README.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+---
+title: Architecture overview
+---
+
+# Architecture overview
+
+The firmware is a pure data-flow graph: sensors publish to `Signal`
+channels, the render task drains them into `Avatar` fields, a fixed
+modifier stack mutates the `Avatar` once per 30 FPS frame, and output
+sinks (LCD, head servos, LEDs, audio TX) consume the result.
+
+## Boot sequence
+
+```
+esp-hal init
+    │
+    ▼
+internal SRAM + PSRAM heaps (esp-alloc)
+    │
+    ▼
+esp-rtos embassy executor
+    │
+    ▼
+AXP2101 LDOs (LCD rails, power-key timing, BATFET, ADC)
+    │
+    ▼
+AW9523 I/O expander (LCD reset pulse, backlight-boost gate)
+    │
+    ▼
+SPI2 + mipidsi ILI9342C (320×240 RGB565)
+    │
+    ▼
+SCServo on UART1 (head pan/tilt)
+    │
+    ▼
+PY32 co-processor (servo power, WS2812 ring)
+    │
+    ▼
+Spawn embassy tasks → main heartbeat loop
+```
+
+Total time to "boot complete — idle heartbeat" is ~1.4 s on the CoreS3.
+
+## Task graph
+
+The render task is the orchestrator: every other task is either a
+producer (sensor → Signal) or a sink (Signal → hardware).
+
+```
+                  ┌─────────────┐
+   touch ────────▶│             │
+   IR    ────────▶│             │
+   IMU   ────────▶│             │
+   ambient ──────▶│  render     │──▶ LCD (mipidsi blit)
+   power ────────▶│  (30 FPS)   │──▶ pose Signal ──▶ head_task ──▶ SCServo
+   audio RMS ────▶│             │──▶ LED frame Signal ──▶ led_task ──▶ PY32
+   camera ───────▶│             │
+                  └─────────────┘
+                         │
+                         └──▶ heartbeat → watchdog (5s poll)
+```
+
+Each producer publishes via `Signal::signal(value)`. The render task
+drains via `try_take()` once per frame. **Latest-wins semantics**:
+producers signal at any rate, the render task picks up the most recent
+value per frame. Misses are normal and expected — the next signal
+overwrites unread values.
+
+## Modifier stack
+
+The render task runs this canonical sequence per frame:
+
+```
+EmotionTouch → RemoteCommand → PickupReaction → WakeOnVoice
+    → AmbientSleepy → LowBatteryEmotion
+    → EmotionCycle → EmotionStyle → EmotionHead
+    → Blink → Breath
+    → IdleDrift → IdleSway
+    → MouthOpenAudio
+```
+
+Ordering matters: `EmotionTouch` runs first so a tap queued from the
+touch task becomes the active emotion before `EmotionCycle` checks
+the `manual_until` gate. `IdleSway` writes the base `head_pose`;
+`EmotionHead` adds an emotion-keyed bias on top (layered compose).
+
+See the [Modifier authoring guide](modifiers) for how to extend.
+
+## Host simulator
+
+`crates/stackchan-sim` mirrors the firmware's modifier execution
+against a `FakeClock` so the entire avatar behavior is host-testable
+without flashing. The `viz` binary opens a window via `egui` + `winit`
+and runs the canonical modifier stack at wall-clock 30 FPS — drops
+behavior-iteration cycles from ~30 s (build → flash → boot) to <1 s
+(`cargo run --features viz`).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,3 +1,7 @@
+---
+title: Typed-error catalog
+---
+
 # Typed-error catalog
 
 Every driver crate in this workspace exposes a generic `Error<E>` enum.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+---
+title: stackchan-kai engineering handbook
+---
+
+# stackchan-kai engineering handbook
+
+Reference docs for the [stackchan-kai](https://github.com/andymai/stackchan-kai)
+codebase — `no_std` Rust firmware for the M5Stack CoreS3 Stack-chan,
+plus the host-side simulator + 14 driver crates that compose it.
+
+This handbook complements the in-repo guides:
+
+- **[CLAUDE.md](https://github.com/andymai/stackchan-kai/blob/main/CLAUDE.md)** — shared human + AI orientation: build commands, conventions, hardware notes.
+- **[AGENTS.md](https://github.com/andymai/stackchan-kai/blob/main/AGENTS.md)** — agent-specific playbook: session shapes, debugging recipes, memory pointer.
+
+## Pages
+
+- [Architecture overview](architecture) — the firmware's task graph, the modifier stack, and how the host sim mirrors it.
+- [Modifier authoring guide](modifiers) — how to add a new behavior to the avatar without breaking the canonical stack ordering.
+- [Signal channels](signals) — the typed `Signal<…, T>` pattern that wires sensors to the render task.
+- [Typed-error catalog](errors) — every driver crate's `Error<E>` enum, with what each variant means and what to do about it.
+
+## Source layout
+
+```
+crates/
+├── stackchan-core   # Pure no_std domain library (Avatar, Modifier, Pose, Clock)
+├── stackchan-sim    # Host-side simulator (FakeClock, Framebuffer, viz binary)
+├── stackchan-firmware  # CoreS3 firmware binary (embassy + esp-rtos)
+├── tracker          # Block-grid motion tracker for the camera path
+└── 14 driver crates # axp2101, aw9523, aw88298, bm8563, bmi270, bmm150,
+                    # es7210, ft6336u, gc0308, ir-nec, ltr553, py32,
+                    # scservo, si12t, st25r3916
+```
+
+## Stability model
+
+`stackchan-kai` is `v0.x` until v1.0 ships its polish milestone.
+v1.0 will not graduate any items to **Stable** — that's deferred to
+v2.x so the API can survive the architectural work planned there. See
+[STABILITY.md](https://github.com/andymai/stackchan-kai/blob/main/STABILITY.md)
+for the full graduation rules.
+
+Standalone driver crates (axp2101, aw9523, scservo, bm8563, etc.)
+graduate on their own cadence, not gated on the workspace version.

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -1,0 +1,102 @@
+---
+title: Modifier authoring guide
+---
+
+# Modifier authoring guide
+
+A `Modifier` is a state machine that mutates the `Avatar` once per
+frame. Modifiers compose by ordering — the canonical stack runs in a
+fixed sequence in `render_task`, with each later modifier observing
+the cumulative effect of all earlier ones.
+
+## The trait
+
+```rust
+pub trait Modifier {
+    fn update(&mut self, avatar: &mut Avatar, now: Instant);
+}
+```
+
+That's the entire surface. Modifiers own their state (timers, RNG,
+pending transitions) — `update` is the only mutation surface. Time
+flows in via `Instant` (a wrapper around `embassy_time::Instant` on
+firmware, `FakeClock`-driven on host).
+
+## Steps to add a new modifier
+
+1. **Choose the file.** New modifiers go under
+   `crates/stackchan-core/src/modifiers/<your_name>.rs`.
+
+2. **Implement the state machine.** Pattern:
+
+   ```rust
+   pub struct YourModifier {
+       // state fields — timers, RNG, last-value
+   }
+
+   impl YourModifier {
+       #[must_use]
+       pub const fn new() -> Self { /* ... */ }
+   }
+
+   impl Modifier for YourModifier {
+       fn update(&mut self, avatar: &mut Avatar, now: Instant) {
+           // Read avatar fields the modifier is aware of.
+           // Mutate avatar fields the modifier owns.
+       }
+   }
+   ```
+
+3. **Add unit tests.** Each modifier file has a `mod tests` at the
+   bottom that exercises edge cases against `Instant::from_millis(...)`
+   sequences. Pattern: assert specific avatar fields after a known
+   tick sequence.
+
+4. **Wire into `render_task`.** Open `crates/stackchan-firmware/src/main.rs`,
+   construct your modifier alongside the others, and call
+   `your_modifier.update(&mut avatar, now)` in the canonical order.
+   Update the boot info-line listing modifiers in the modifier stack.
+
+5. **Add a sim integration test.** In
+   `crates/stackchan-sim/src/lib.rs`'s `integration_tests` mod, add a
+   test that drives the new modifier through a realistic time sequence.
+   Use `FakeClock` for deterministic time.
+
+6. **Update the boot-log golden.** If your modifier produces a new
+   info-line at startup (e.g. "your-modifier: enabled"), add the
+   substring to `tests/golden/boot.txt`.
+
+## Reading vs writing avatar fields
+
+Avatar fields fall into two buckets:
+
+**Pixel-affecting** — fields that change the rendered face: `left_eye`,
+`right_eye`, `mouth`, `emotion`, `eye_curve`, `mouth_curve`,
+`cheek_blush`, etc. These are listed in `Avatar::frame_eq`. New
+pixel-affecting fields **must** be added to `frame_eq` so the render
+task's dirty-check works correctly.
+
+**Non-pixel** — sensor inputs and motor outputs: `head_pose`,
+`accel_g`, `gyro_dps`, `ambient_lux`, `battery_percent`, `audio_rms`,
+etc. These are *excluded* from `frame_eq` because they don't directly
+affect drawn pixels. Modifiers translate them into pixel-affecting
+state (e.g. `LowBatteryEmotion` reads `battery_percent` and writes
+`emotion`).
+
+## When ordering matters
+
+The canonical stack ordering is non-trivial. Examples:
+
+- `EmotionTouch` → `EmotionCycle` — touch must run first so a manual
+  tap-set emotion overrides cycle's auto-rotation gate.
+- `EmotionStyle` → `Blink` / `Breath` — style sets baseline weights;
+  blink/breath add subtle modulation on top.
+- `IdleDrift` (eye position) → `IdleSway` (head pose) — eye drift is
+  pixel-affecting and runs in the visual stack; sway is motor-only and
+  runs after.
+- `MouthOpenAudio` runs last so audio-driven mouth-open isn't
+  overwritten by a stale `Blink` write.
+
+When in doubt, mirror the order in `render_task` exactly and add a
+`stackchan-sim` integration test that asserts the visible behavior
+(eyes don't walk off-screen, mouth doesn't oscillate at 60 Hz, etc.).

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,0 +1,73 @@
+---
+title: Signal channels
+---
+
+# Signal channels
+
+Cross-task communication runs through typed `Signal<RawMutex, T>`
+channels — `embassy_sync::signal::Signal`. Each channel has exactly
+one producer and one consumer, latest-wins semantics, and never
+blocks.
+
+## The pattern
+
+```rust
+// Producer side (per-peripheral task):
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+
+pub static SOMETHING_SIGNAL: Signal<CriticalSectionRawMutex, ValueType>
+    = Signal::new();
+
+// Inside the producer's loop:
+SOMETHING_SIGNAL.signal(my_value);
+
+// Consumer side (render task):
+if let Some(value) = SOMETHING_SIGNAL.try_take() {
+    avatar.something = Some(value);
+}
+```
+
+## Why `try_take` and not `wait`
+
+The render task drains every signal once per 30 FPS frame. Using
+`signal.wait()` would block until a value arrives — the render task
+can't afford to block. `try_take()` is non-blocking: returns `Some(v)`
+if a value is waiting (and consumes it), `None` otherwise. Dropped
+values are fine because the next `signal()` overwrites the channel
+with the latest reading.
+
+This shape works because every signal we care about is a
+**latest-wins** observation: "what's the current ambient lux?" not
+"how many lux readings have I missed?". The exception is event-driven
+signals (`TAP_SIGNAL`, `REMOTE_SIGNAL`); for those, a missed signal
+means a missed tap, but they fire so rarely (sub-Hz) that the render
+task's 33 ms tick virtually never coincides with the signal write.
+
+## Catalog
+
+| Signal | Producer | Consumer | Cadence |
+|---|---|---|---|
+| `audio::AUDIO_RMS_SIGNAL` | audio task RX RMS loop | render → `MouthOpenAudio` + `WakeOnVoice` | ~33 ms |
+| `touch::TAP_SIGNAL` | touch task / button task | render → `EmotionTouch` | event |
+| `ir::REMOTE_SIGNAL` | IR RMT task | render → `RemoteCommand` | event |
+| `imu::IMU_SIGNAL` | IMU polling | render → `avatar.accel_g`, `gyro_dps` | 10 ms |
+| `ambient::AMBIENT_LUX_SIGNAL` | LTR-553 polling | render → `avatar.ambient_lux` | 500 ms |
+| `power::POWER_STATUS_SIGNAL` | AXP2101 polling | render → `avatar.battery_percent` | 1000 ms |
+| `head::POSE_SIGNAL` | render task | head task → SCServo | 33 ms |
+| `head::HEAD_POSE_ACTUAL_SIGNAL` | head task readback | render → `avatar.head_pose_actual` | 1000 ms |
+| `leds::LED_FRAME_SIGNAL` | render task | led task → PY32 | 33 ms |
+| `camera::CAMERA_FRAME_SIGNAL` | camera DMA task | render task → blit | gated |
+| `camera::CAMERA_MODE_SIGNAL` | button task | render + camera tasks | event |
+| `camera::CAMERA_CAPTURE_REQUEST` | render task | camera task | event |
+
+## Watchdog supervision
+
+The watchdog task (see `src/watchdog.rs`) doesn't peek the signals —
+that would race the render task's drain. Instead, each periodic
+producer increments an `AtomicU32` heartbeat counter once per loop
+iteration, and the watchdog polls those counters every 5 s. When a
+counter doesn't advance enough relative to its expected cadence, the
+watchdog logs `WARN watchdog: channel '<name>' silent`. See
+[architecture](architecture) for the full task graph and watchdog
+placement.


### PR DESCRIPTION
## Summary
PR 6 of the AI dev UX bundle. With Pages configured to serve from `/docs` on `main`, Jekyll renders the markdown directly — no mdBook build step or workflow required. Adds the foundational handbook pages so future-Andy (or future-AI) lands on a real handbook instead of a generic README link.

### New pages
- **`docs/_config.yml`** — Jekyll site config (Cayman theme, kramdown + rouge highlighter, repo + license footer)
- **`docs/index.md`** — landing page with cross-links to CLAUDE.md + AGENTS.md and pointers to the four sub-pages
- **`docs/architecture.md`** — boot sequence, task graph, modifier stack ordering rationale, host simulator overview
- **`docs/modifiers.md`** — 6-step guide for adding a new behavior to the avatar, with the pixel-affecting vs non-pixel field bucket discussion and the canonical-stack ordering examples
- **`docs/signals.md`** — the typed `Signal<…, T>` pattern, why `try_take` instead of `wait`, full channel catalog (12 signals documented with producer/consumer/cadence), watchdog placement note

Plus a Jekyll front-matter on the existing `docs/errors.md` so it renders with a proper page title.

The handbook complements (not replaces) CLAUDE.md + AGENTS.md — those stay in the repo root for in-context loading. The handbook is the external-facing surface; in-repo docs are the daily-reference surface.

## Test plan
- [x] Pre-commit gates green (no Rust changes; doc-only)
- [x] `_config.yml` syntax-validated against jekyll-theme-cayman conventions
- [ ] Visual check on github.com/andymai/stackchan-kai once Pages re-builds (auto-deploys on merge to main)
- [ ] Greptile review

## Coordinated PRs in this bundle
PR 6 of 8. Others: docs (#81 ✓), tooling (#82 ✓), viz (#83 — CI re-running), boot-log golden (#84 ✓), watchdog (#85), static analysis breadth (G), Nix flake (H).