### PR TITLE
docs: drop Claude Code Skills mention, de-meta public copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 **Clean-slate Rust firmware for the M5Stack CoreS3 Stack-chan — `no_std`, embassy, no cloud.**
 
-A small NPC engine in `no_std` Rust that animates a desk-toy face. No vendor cloud. No telemetry. No C blobs.
-
 [![CI](https://github.com/andymai/stackchan-kai/actions/workflows/ci.yml/badge.svg)](https://github.com/andymai/stackchan-kai/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/andymai/stackchan-kai)](https://github.com/andymai/stackchan-kai/releases)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
@@ -15,10 +13,6 @@ A small NPC engine in `no_std` Rust that animates a desk-toy face. No vendor clo
 [Stability](./STABILITY.md) · [Changelog](./CHANGELOG.md) · [Justfile](./justfile) · [Handbook](https://andymai.github.io/stackchan-kai/)
 
 </div>
-
-> **Status:** v0.1.0 shipped 2026-04-23. Public items are
-> [Experimental](STABILITY.md#experimental); the v0.x series will iterate
-> the engine domain model before anything graduates to Stable.
 
 ## Flash it
 
@@ -46,10 +40,9 @@ without touching the hardware.
 
 ## The engine
 
-`stackchan-core` is a small NPC engine: an [`Entity`] component bag
-(face, motor, perception, voice, mind, events, input, tick) animated by
-a [`Director`] that sorts behaviors into phases and ticks them each
-frame.
+`stackchan-core` models the avatar as data: an [`Entity`] (face, motor,
+perception, voice, mind, events, input, tick) plus a [`Director`] that
+sorts `Modifier`s by phase and ticks them each frame.
 
 ```rust
 use stackchan_core::{Director, Entity, Instant, modifiers::Blink};
@@ -64,49 +57,32 @@ for ms in (0..10_000).step_by(33) {
 }
 ```
 
-Two trait families:
-
-- **`Modifier`** — per-frame state mutator. The 14 stock animation
-  behaviors (Blink, Breath, IdleDrift, IdleSway, EmotionStyle,
-  EmotionTouch, EmotionCycle, RemoteCommand, PickupReaction,
-  WakeOnVoice, AmbientSleepy, LowBatteryEmotion, EmotionHead,
-  MouthOpenAudio) all live here.
-- **`Skill`** — discoverable capability with a `name` + `description`
-  pair (modeled on Claude Code Skills) that doubles as trigger
-  guidance. Trait surface only today; zero implementations shipped.
-
-Modifiers register with a phase (`Affect` / `Expression` / `Motion` /
-`Audio` today; `Perception` / `Cognition` / `Speech` / `Output`
-reserved with numeric gaps for future insertion). The Director sorts
-once by `(phase, priority, registration_order)` and ticks each
-modifier per frame. See the [architecture overview](https://andymai.github.io/stackchan-kai/architecture)
-and the [modifier authoring guide](https://andymai.github.io/stackchan-kai/modifiers)
-for the full picture.
+Each `Modifier` declares a phase (`Affect`, `Expression`, `Motion`,
+`Audio`) and a priority; the Director sorts once and ticks per frame.
+The 14 stock modifiers cover blinking, breathing, idle drift, head
+sway, emotion transitions, touch / IR / voice / ambient / battery
+reactions, and audio-driven mouth motion. See the
+[architecture overview](https://andymai.github.io/stackchan-kai/architecture)
+and [modifier authoring guide](https://andymai.github.io/stackchan-kai/modifiers)
+for the details.
 
 ## Features
 
-- **Animated face** — five emotions, 300 ms eased transitions, blink / breath / idle-drift modifiers at double-buffered 30 FPS
-- **Head motion** — Feetech SCServo pan/tilt driver with a calibration bench (`just bench`)
+- **Animated face** — five emotions, 300 ms eased transitions, blink / breath / idle-drift at double-buffered 30 FPS
+- **Head motion** — Feetech SCServo pan/tilt with a calibration bench (`just bench`)
 - **9-axis sensing** — BMI270 accel + gyro, BMM150 magnetometer (compensated µT, live bench via `just mag-bench`)
 - **Local inputs** — FT6336U touch, LTR-553 ambient + proximity, NEC IR decoder
 - **Timekeeping + peripherals** — BM8563 RTC, PY32 co-processor, WS2812 neck LED ring (`just leds-bench`)
-- **Reactive emotion engine** — touch / pickup / voice / ambient / battery all drive the face through the same Director pipeline
-- **Host-side sim** — full Director runs on the host with pixel-golden tests + an `egui` visualiser (`cargo run -p stackchan-sim --bin viz --features viz`); behaviour iteration drops from ~30 s build cycles to <1 s
+- **Host-side sim** — runs the full modifier stack on the host with pixel-golden tests + an `egui` visualiser (`cargo run -p stackchan-sim --bin viz --features viz`); cuts behaviour iteration from ~30 s build cycles to under a second
 - **Safe by default** — no `unwrap` in library code, typed errors throughout, `unsafe` denied workspace-wide
 
 ## Non-goals
 
-- **No voice agent or LLM.** This is not a xiaozhi replacement.
-- **No cloud or telemetry.** Zero outbound network calls today.
-- **No C/C++ in the firmware binary.** Drivers are written directly against datasheets.
-- **No Wi-Fi / BLE yet.** The networking stack is out of scope for v0.x.
-- **Not an M5Unified port.** Only the desk-toy surface area is covered.
-
-## Roadmap
-
-- **RON-configurable appearance** — eye / mouth geometry, palette, per-emotion style
-- **Calibration tooling** — host-side bench writes servo + sensor calibration into versioned config
-- **Crash recovery** — panic handler renders an error face and watchdog-reboots cleanly
+- No voice agent or LLM. This is not a xiaozhi replacement.
+- No cloud or telemetry. Zero outbound network calls.
+- No C/C++ in the firmware binary. Drivers are written directly against datasheets.
+- No Wi-Fi or BLE.
+- Not an M5Unified port. Only the desk-toy surface area is covered.
 
 ## License
 

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -1,36 +1,24 @@
-//! [`Director`] — the orchestrator that ticks an [`Entity`] each frame.
+//! [`Director`] — orchestrator that ticks an [`Entity`] each frame.
 //!
-//! The "AI Director" is canonical in NPC AI literature (Left 4 Dead's
-//! director is the textbook example): a meta-orchestrator that decides
-//! what an NPC does and when, by composing smaller behaviors. Our
-//! [`Director`] does exactly that — it owns a registry of [`Modifier`]s
-//! (per-frame mutators) and [`Skill`]s (Claude-Code-Skill-style
-//! discoverable capabilities), and per-frame:
+//! Per frame, the Director:
 //!
-//! 1. Stamps `entity.tick` (now / `dt_ms` / frame counter).
+//! 1. Stamps `entity.tick` (now, `dt_ms`, frame counter).
 //! 2. Clears `entity.events` (one-frame fire flags).
-//! 3. Runs each registered modifier in `(phase, priority, registration_order)`
-//!    order.
-//! 4. Polls each registered skill's `should_fire` and invokes those
-//!    that match.
+//! 3. Runs each registered modifier in `(phase, priority,
+//!    registration_order)` order.
+//! 4. Polls each registered skill's `should_fire` and invokes the
+//!    matching ones.
 //!
-//! ## Modifier vs Skill
-//!
-//! - **Modifiers** are per-frame face/motor/affect mutators. They live
-//!   in declared [`Phase`]s and produce visible output (eye position,
-//!   head pose, mouth open). The 14 v0.x modifiers all migrate here.
-//! - **Skills** are discoverable capabilities that fire when their
-//!   `should_fire` predicate matches. They write to mind / voice /
-//!   events only (never face / motor — that's modifier territory).
-//!   Today: zero skills shipped. Surface ready for v2.x.
-//!
-//! ## Storage shape
+//! Modifiers are per-frame face / motor / affect mutators living in
+//! declared [`Phase`]s; skills are longer-running capabilities with
+//! `should_fire` + `invoke`. Skills don't write `face` or `motor`
+//! directly (see [`crate::skill`]).
 //!
 //! Modifiers and skills are held as `&'a mut dyn Modifier` / `&'a mut
-//! dyn Skill` references in fixed-capacity [`heapless::Vec`]s. Caller
-//! (firmware `render_task` or sim) owns the modifier instances as
-//! locals; Director only borrows. This keeps `stackchan-core`
-//! `no_std` + alloc-free.
+//! dyn Skill` references in fixed-capacity [`heapless::Vec`]s. The
+//! caller (firmware `render_task` or sim) owns the instances as
+//! locals; the Director only borrows. The crate stays `no_std` and
+//! alloc-free.
 //!
 //! [`Entity`]: crate::entity::Entity
 //! [`Modifier`]: crate::modifier::Modifier
@@ -44,8 +32,7 @@ use crate::events::Events;
 use crate::modifier::Modifier;
 use crate::skill::{Skill, SkillStatus};
 
-/// Maximum number of modifiers a [`Director`] can hold. Sized for the
-/// 14 stock modifiers + ample headroom for third-party additions.
+/// Maximum number of modifiers a [`Director`] can hold.
 pub const MODIFIER_CAP: usize = 32;
 
 /// Maximum number of skills a [`Director`] can hold.
@@ -53,58 +40,47 @@ pub const SKILL_CAP: usize = 16;
 
 /// Phases of the per-frame tick.
 ///
-/// `#[repr(u8)]` with explicit numeric gaps of 10 leaves room for v2.x
-/// phases (e.g. `PostPerception = 15`) to slot in without renumbering
-/// existing variants. Modifiers are sorted by `(phase, priority,
-/// registration_order)` before execution.
+/// `#[repr(u8)]` with numeric gaps of 10 leaves room to insert phases
+/// between existing variants without renumbering. Modifiers are sorted
+/// by `(phase, priority, registration_order)` before execution.
 ///
-/// ## Why these phases
+/// Sensors observe the world, cognition picks an intent, emotion
+/// follows, speech queues, expression renders, motion executes, audio
+/// drives the visual envelope, and output ships the frame.
 ///
-/// The phase order encodes the canonical NPC tick: sensors observe the
-/// world; cognition picks an intent; emotion (affect) follows; speech
-/// queues; expression renders; motion executes; audio drives the visual
-/// envelope; output ships the frame.
-///
-/// Today, modifier population:
+/// Population:
 /// - `Affect` (7): `EmotionTouch`, `RemoteCommand`, `PickupReaction`,
 ///   `WakeOnVoice`, `AmbientSleepy`, `LowBatteryEmotion`, `EmotionCycle`
 /// - `Expression` (4): `EmotionStyle`, Blink, Breath, `IdleDrift`
 /// - `Motion` (2): `IdleSway`, `EmotionHead`
 /// - `Audio` (1): `MouthOpenAudio`
-/// - `Perception` / `Cognition` / `Speech` / `Output`: empty (stubs for v2.x)
+/// - `Perception` / `Cognition` / `Speech` / `Output`: empty
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Phase {
-    /// Sensors → world model. Empty today: firmware drains Signal
-    /// channels into `entity.perception` *before* `Director::run`.
-    /// Future modifiers in this phase would do post-sensor smoothing,
-    /// gaze-target tracking, etc.
+    /// Sensors → world model. Empty: the firmware drains Signal
+    /// channels into `entity.perception` before `Director::run`.
     Perception = 10,
-    /// World model + memory → intent. Empty today; v2.x: an adapter
-    /// modifier reads from a `MindBridge` Signal channel that an
-    /// async firmware task fills with results from a LAN-host LLM.
+    /// World model + memory → intent. Empty.
     Cognition = 20,
-    /// Intent + sensors → emotion. Where the 7 emotion-driving
-    /// modifiers run. Touch / Remote / Pickup / Voice run first
-    /// (input-edge driven); Ambient / `LowBattery` (environmental
-    /// overrides) next; `EmotionCycle` (autonomous advance) last.
+    /// Intent + sensors → emotion. Touch / Remote / Pickup / Voice
+    /// run first (input-edge driven); Ambient / `LowBattery`
+    /// (environmental overrides) next; `EmotionCycle` (autonomous
+    /// advance) last.
     Affect = 30,
-    /// Intent → speech queue. Empty today; v2.x: a TTS feeder modifier
-    /// translates `mind.intent` into `voice.speech_queue` payloads.
+    /// Intent → speech queue. Empty.
     Speech = 40,
-    /// Emotion → face style. Where `EmotionStyle` picks
-    /// curve/scale/blush, then Blink / Breath / `IdleDrift` add their
-    /// per-frame deltas.
+    /// Emotion → face style. `EmotionStyle` picks curve / scale /
+    /// blush; Blink / Breath / `IdleDrift` add per-frame deltas.
     Expression = 50,
-    /// Intent + emotion → pose. `IdleSway` writes a baseline; `EmotionHead`
-    /// adds an emotion-keyed bias on top.
+    /// Intent + emotion → pose. `IdleSway` writes a baseline;
+    /// `EmotionHead` adds an emotion-keyed bias on top.
     Motion = 60,
-    /// Audio-driven visual updates. `MouthOpenAudio` drives `mouth.mouth_open`
-    /// from the mic RMS.
+    /// Audio-driven visual updates. `MouthOpenAudio` drives
+    /// `mouth.mouth_open` from the mic RMS.
     Audio = 70,
-    /// Face → frame, pose → servos. Empty for modifiers; the firmware's
-    /// render task does the actual draw + servo command after `Director::run`
-    /// returns.
+    /// Face → frame, pose → servos. Empty for modifiers; the render
+    /// task does the draw + servo command after `Director::run`.
     Output = 80,
 }
 
@@ -130,13 +106,10 @@ pub enum FieldGroup {
 /// Fine-grained identifiers for the entity's mutable surface.
 ///
 /// Modifiers declare their `reads` / `writes` via `&'static [Field]`
-/// slices on [`ModifierMeta`]; the Director can use these to detect
-/// conflicts at registration time (today: declarative only; v2.x:
-/// actual enforcement).
-///
-/// Granularity is per-leaf-field so different sub-fields of the same
-/// component (e.g. `LeftEyePhase` vs `LeftEyeWeight`) don't false-flag
-/// as conflicts.
+/// slices on [`ModifierMeta`]. Today the slices are documentation;
+/// debug-mode enforcement after each `update` is planned. Per-leaf
+/// granularity (e.g. `LeftEyePhase` vs `LeftEyeWeight`) keeps
+/// sub-fields of the same component from false-flagging as conflicts.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Field {
@@ -257,59 +230,45 @@ impl Field {
 /// `const META: ModifierMeta = ...` in each modifier's impl.
 #[derive(Debug)]
 pub struct ModifierMeta {
-    /// Stable identifier — typically the impl's type name (e.g. `"Blink"`).
+    /// Stable identifier — typically the impl's type name.
     pub name: &'static str,
-    /// Human/LLM-readable description: what this modifier does in one
-    /// sentence. Used by introspection tools and (v2.x) the LAN-host
-    /// cognition bridge to reason about active behavior.
+    /// One-sentence description of what this modifier does. Read by
+    /// humans and (eventually) a dispatcher.
     pub description: &'static str,
-    /// Which phase this modifier runs in. Determines coarse ordering.
+    /// Phase this modifier runs in. Determines coarse ordering.
     pub phase: Phase,
-    /// Tiebreaker for modifiers within the same phase. Lower priority
-    /// runs first; default `0`.
+    /// Intra-phase tiebreaker. Lower priority runs first; default `0`.
     pub priority: i8,
-    /// Fields this modifier reads. Today: documentation only; v2.x:
-    /// enforced via debug-mode assertions.
+    /// Fields this modifier reads.
     pub reads: &'static [Field],
-    /// Fields this modifier writes. Today: documentation only; v2.x:
-    /// enforced.
+    /// Fields this modifier writes.
     pub writes: &'static [Field],
 }
 
-/// Static metadata for a [`Skill`] type. Modeled on Claude Code Skills:
-/// a stable `name` plus a `description` that doubles as trigger
-/// guidance for LLM-driven dispatch in v2.x.
+/// Static metadata for a [`Skill`] type: a stable `name` plus a
+/// `description` consumable by a dispatcher.
 #[derive(Debug)]
 pub struct SkillMeta {
-    /// Stable identifier (e.g. `"BootGreeting"`).
+    /// Stable identifier.
     pub name: &'static str,
-    /// Trigger guidance + action summary. Read by humans and (v2.x)
-    /// LLMs to decide when this skill applies.
+    /// Trigger guidance + action summary.
     pub description: &'static str,
     /// Arbitration priority among overlapping skills. Higher wins.
     pub priority: u8,
     /// Fields this skill is allowed to write. By convention, skills
-    /// only touch `Mind` / `Voice` / `Events` — `Face` and `Motor`
-    /// are modifier territory. Documentation-only enforcement today.
+    /// touch `Mind` / `Voice` / `Events` — `Face` and `Motor` are
+    /// modifier territory.
     pub writes: &'static [Field],
 }
 
 /// The orchestrator. Holds borrowed modifier + skill registries; ticks
 /// the entity each frame.
-///
-/// ## Lifetime
-///
-/// `'a` is the lifetime of the modifier / skill instances. Caller owns
-/// them as locals (typically in firmware `render_task` or sim
-/// scaffolding) and registers `&'a mut dyn` references with the
-/// Director. Director's lifetime ≤ caller's locals.
 /// One entry in the modifier registry. Pairs the modifier reference
-/// with a registration counter so the sort is stable on `(phase,
-/// priority)` ties — `core::slice::sort_unstable_by_key` (which is
-/// what we use, since stable sort isn't in `core`) needs an explicit
-/// secondary key for deterministic ordering.
+/// with a registration counter; needed because `core` only provides
+/// `sort_unstable_by_key`, so stability on `(phase, priority)` ties
+/// requires an explicit secondary key.
 struct ModifierSlot<'a> {
-    /// 0-based registration order. Set when `add_modifier` is called.
+    /// 0-based registration order, assigned by `add_modifier`.
     registered_at: u16,
     /// The modifier itself.
     modifier: &'a mut dyn Modifier,
@@ -337,10 +296,8 @@ impl core::fmt::Display for RegistryFull {
 
 /// The orchestrator that ticks an [`Entity`] each frame.
 ///
-/// `'a` is the lifetime of the modifier / skill instances. Caller owns
-/// them as locals (typically in firmware `render_task` or sim
-/// scaffolding) and registers `&'a mut dyn` references with the
-/// Director. Director's lifetime ≤ caller's locals.
+/// `'a` is the lifetime of the modifier / skill instances; the caller
+/// owns them as locals and registers `&'a mut dyn` references.
 pub struct Director<'a> {
     /// Registered modifiers, sorted by `(phase, priority,
     /// registered_at)` on first `run()` call.
@@ -418,19 +375,16 @@ impl<'a> Director<'a> {
     ///    returns true.
     pub fn run(&mut self, entity: &mut Entity, now: Instant) {
         if !self.sorted {
-            // `core::slice::sort_unstable_by_key` is the no_std-friendly
-            // sort. Stability comes from including `registered_at` in the
-            // key — distinct slots can never produce equal keys, so the
-            // unstable sort produces a deterministic order matching
-            // `(phase, priority, registration order)`.
+            // `sort_unstable_by_key` is the no_std-friendly sort.
+            // Stability comes from including `registered_at` in the
+            // key: distinct slots can never produce equal keys, so the
+            // result matches `(phase, priority, registration_order)`.
             self.modifiers.as_mut_slice().sort_unstable_by_key(|slot| {
                 let meta = slot.modifier.meta();
                 (meta.phase, meta.priority, slot.registered_at)
             });
-            // Skills sort by `priority` *descending* (higher fires
-            // first) — opposite of modifiers, where lower = earlier.
-            // Negate the priority to get a descending sort from
-            // sort_unstable_by_key.
+            // Skills sort by priority descending (higher fires first),
+            // opposite of modifiers.
             self.skills
                 .as_mut_slice()
                 .sort_unstable_by_key(|s| core::cmp::Reverse(s.meta().priority));
@@ -448,24 +402,19 @@ impl<'a> Director<'a> {
             frame: self.frame,
         };
 
-        // Start-of-frame clear of one-frame fire flags. Modifiers populate
-        // events during their pass; firmware reads them after run() returns.
+        // Clear one-frame fire flags. Modifiers populate events during
+        // their pass; firmware reads them after `run()` returns.
         entity.events = Events::default();
 
-        // Modifier pass.
         for slot in &mut self.modifiers {
             slot.modifier.update(entity);
         }
 
-        // Skill pass. Each frame, every registered skill's `should_fire`
-        // is polled; matches are `invoke`d. Continuing skills will be
-        // re-invoked next frame as long as `should_fire` keeps matching.
         for s in &mut self.skills {
             if s.should_fire(entity) {
+                // `should_fire` is the only gate; `SkillStatus::Done`
+                // vs `Continuing` is reserved for skill state-tracking.
                 let _status: SkillStatus = s.invoke(entity);
-                // SkillStatus::Done vs Continuing semantics will matter
-                // in v2.x when skill state-tracking arrives. Today,
-                // should_fire is the gate.
             }
         }
 

--- a/crates/stackchan-core/src/entity.rs
+++ b/crates/stackchan-core/src/entity.rs
@@ -1,37 +1,24 @@
-//! Top-level entity model: the NPC.
+//! The NPC entity, composed of sub-components.
 //!
-//! [`Entity`] composes the entity's six concerns into named
-//! sub-components: [`Face`] (visual), [`Motor`] (motion), [`Perception`]
-//! (sensors), [`Voice`] (speech I/O), [`Mind`] (brain), [`Events`]
-//! (one-frame fire flags). A seventh field, [`Tick`], is bookkeeping
-//! that [`crate::Director`] stamps each frame.
+//! [`Entity`] groups [`Face`] (visual), [`Motor`] (motion),
+//! [`Perception`] (sensors), [`Voice`] (speech I/O), [`Mind`] (brain),
+//! [`Input`] (pending firmware → modifier inputs), and [`Events`]
+//! (one-frame fire flags). [`Tick`] is bookkeeping that
+//! [`crate::Director`] stamps each frame.
 //!
-//! ## Why "Entity" and not "Avatar"
-//!
-//! `Avatar` (v0.x) implied "visual representation" — a face animator.
-//! StackChan's roadmap is an AI-powered NPC: conversation, memory,
-//! intent, dialogue. The visual face is one component of the entity,
-//! not the whole thing. The rename + decomposition keeps the type
-//! system aligned with the domain ontology.
-//!
-//! ## Modifier vs Skill access patterns
-//!
-//! - **Modifiers** ([`crate::Modifier`]) take `&mut Entity` and can
-//!   touch any sub-component, but conventionally each modifier writes
-//!   only the components matching its [`crate::director::Phase`].
-//! - **Skills** ([`crate::Skill`]) take `&mut Entity` but **must
-//!   not** write to `face` or `motor` directly — they write to
-//!   `mind` / `voice` / `events`, and modifiers in
-//!   [`crate::director::Phase::Expression`] / [`crate::director::Phase::Motion`]
-//!   translate intent/affect into rendered face + physical motion.
-//!   This is the single most important architectural invariant for
-//!   NPC composition.
+//! Modifiers can touch any sub-component, but conventionally each
+//! modifier writes only the components matching its
+//! [`crate::director::Phase`]. Skills don't write `face` or `motor`
+//! directly — they write `mind` / `voice` / `events`, and modifiers in
+//! [`crate::director::Phase::Expression`] / [`crate::director::Phase::Motion`]
+//! translate that intent into rendered face and physical motion.
 //!
 //! [`Face`]: crate::face::Face
 //! [`Motor`]: crate::motor::Motor
 //! [`Perception`]: crate::perception::Perception
 //! [`Voice`]: crate::voice::Voice
 //! [`Mind`]: crate::mind::Mind
+//! [`Input`]: crate::input::Input
 //! [`Events`]: crate::events::Events
 
 use crate::clock::Instant;
@@ -45,29 +32,27 @@ use crate::voice::Voice;
 
 /// Per-frame timing stamped on [`Entity`] by [`crate::Director::run`].
 ///
-/// Modifiers read `entity.tick.now` instead of taking a `now: Instant`
-/// argument — keeps the `Modifier::update` signature single-arg and
-/// makes `dt_ms` / `frame` available for time-derivative work.
+/// Modifiers read `entity.tick.now` instead of taking `now: Instant`
+/// as an argument; `dt_ms` and `frame` are available for time-derivative
+/// work.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Tick {
-    /// Wall time (or simulated time) this frame.
+    /// Wall (or simulated) time this frame.
     pub now: Instant,
-    /// Milliseconds since the previous `App::run` call. `0` on the first
-    /// frame (no previous reference).
+    /// Milliseconds since the previous `Director::run`. `0` on the
+    /// first frame.
     pub dt_ms: u32,
-    /// Monotonic frame counter, starting at `1` after the first
-    /// `App::run` call. Useful as a cheap change-detection key for
-    /// future skills that want "wake me when X changed."
+    /// Monotonic frame counter, `1` after the first `Director::run`.
     pub frame: u64,
 }
 
 /// The composed entity: a single NPC.
 ///
-/// `Eq` is intentionally not derived because [`Face`] contains an
-/// `f32` (`Mouth::mouth_open`) and [`Motor`] contains `Pose`s with
-/// `f32` fields. Use `==` (`PartialEq`) for tests; the renderer uses
+/// `Eq` is not derived because [`Face`] contains `f32` fields
+/// (`Mouth::mouth_open`) and [`Motor`] contains `Pose`s with `f32`
+/// fields. Use `PartialEq` for tests; the renderer uses
 /// [`Entity::frame_eq`] for its dirty-check (visual fields only).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Entity {
     /// Visual surface. Read by the renderer.
     pub face: Face,
@@ -75,51 +60,26 @@ pub struct Entity {
     pub motor: Motor,
     /// Raw sensor readings. Populated by firmware Signal drains.
     pub perception: Perception,
-    /// Speech I/O. Modifiers set `voice.chirp_request` to trigger
-    /// firmware audio enqueue.
+    /// Speech I/O. Modifiers set `voice.chirp_request` to trigger an
+    /// audio enqueue.
     pub voice: Voice,
-    /// Cognitive layer (affect, autonomy, plus v2.x stubs).
+    /// Cognitive layer (affect, autonomy).
     pub mind: Mind,
-    /// Pending inputs the modifier graph consumes (tap edges, IR
-    /// pairs). Set by firmware drains; cleared by the consuming
-    /// modifier. **Not** cleared by the Director at frame start.
+    /// Pending firmware → modifier inputs (tap edges, IR pairs). Set
+    /// by firmware drains; cleared by the consuming modifier. Not
+    /// cleared by the Director at frame start.
     pub input: Input,
-    /// One-frame fire flags. Cleared at frame start by [`crate::Director::run`].
+    /// One-frame fire flags. Cleared by [`crate::Director::run`].
     pub events: Events,
     /// Per-frame timing. Stamped by [`crate::Director::run`].
     pub tick: Tick,
 }
 
-impl Default for Entity {
-    /// The neutral resting NPC: default face, neutral pose, no sensor
-    /// readings yet, no chirps pending, neutral mind, no events fired,
-    /// zeroed tick.
-    fn default() -> Self {
-        Self {
-            face: Face::default(),
-            motor: Motor::default(),
-            perception: Perception::default(),
-            voice: Voice::default(),
-            input: Input::default(),
-            mind: Mind::default(),
-            events: Events::default(),
-            tick: Tick::default(),
-        }
-    }
-}
-
 impl Entity {
-    /// Visual-state equality used by the firmware's render-loop
-    /// dirty-check: `true` iff `self` and `other` would render to the
-    /// same pixels. Compares only [`Self::face`]; sensor / motor /
-    /// mind / voice / events / tick state is excluded — those can
-    /// change without producing pixel differences (the LCD is rigidly
-    /// mounted to the head, modifiers translate sensor changes into
-    /// face changes via emotion, etc.).
-    ///
-    /// This is dramatically simpler than v0.x's `Avatar::frame_eq`
-    /// (which had to enumerate 10 visual fields) — the component
-    /// model gives us this for free.
+    /// Visual-state equality used by the render loop's dirty-check:
+    /// `true` iff `self` and `other` would render to the same pixels.
+    /// Compares only [`Self::face`]; sensor / motor / mind / voice /
+    /// events / tick state is excluded.
     #[must_use]
     pub fn frame_eq(&self, other: &Self) -> bool {
         self.face == other.face

--- a/crates/stackchan-core/src/events.rs
+++ b/crates/stackchan-core/src/events.rs
@@ -1,34 +1,22 @@
-//! One-frame fire flags propagating modifier-detected edges to the
-//! firmware's render loop.
+//! One-frame fire flags from modifiers to the firmware's render loop.
 //!
-//! [`Events`] is reserved for one-frame edge signals that don't fit the
-//! richer [`crate::voice::Voice`] surface. Today it's empty — chirp
-//! edges (pickup, wake, low-battery alert) all flow through
-//! [`crate::voice::Voice::chirp_request`], which carries the chirp
-//! *kind* alongside the edge.
+//! [`Events`] is currently empty: chirp edges flow through
+//! [`crate::voice::Voice::chirp_request`] instead, which carries the
+//! chirp kind alongside the edge. This struct stays as the slot for
+//! signals that aren't audio requests.
 //!
-//! ## Lifecycle
+//! [`crate::Director::run`] clears `entity.events` at the start of each
+//! frame, before any modifier runs. Modifiers set fields when their
+//! state machine fires an edge; the firmware reads them after the
+//! modifier pass; the next frame clears again.
 //!
-//! [`crate::Director::run`] **clears** `entity.events` at the start of
-//! each frame, before any modifier runs. Modifiers set fields to `true`
-//! when their state machine fires an edge. The firmware reads them
-//! after the modifier pass; on the next frame, the Director clears them
-//! again.
-//!
-//! No modifier should ever read `entity.events.*` from the *current*
-//! frame — they're firmware-facing signals, not inter-modifier
-//! communication. (Inter-modifier coordination flows through
-//! [`crate::mind::Affect`] / [`crate::mind::Autonomy`] /
-//! [`crate::voice::Voice`].)
+//! Modifiers don't read `entity.events.*` from the current frame —
+//! these are firmware-facing signals, not inter-modifier coordination.
+//! Inter-modifier coordination flows through [`crate::mind::Affect`] /
+//! [`crate::mind::Autonomy`] / [`crate::voice::Voice`].
 
 /// One-frame fire flags. Cleared by [`crate::Director::run`] at frame
-/// start; set by modifiers; read by firmware between modifier pass
-/// and post-render work.
-///
-/// Empty today — every modifier-emitted edge currently maps to a
-/// [`crate::voice::ChirpKind`] on `entity.voice.chirp_request`. New
-/// fields land here when a future signal *isn't* an audio request:
-/// for example, "skill X just completed" notifications, or a debug
-/// "modifier Y short-circuited" introspection bit.
+/// start; set by modifiers; read by firmware between the modifier
+/// pass and post-render work.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Events {}

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -1,24 +1,15 @@
 //! Visual surface of the entity: the rendered face.
 //!
-//! [`Face`] groups the eye / mouth geometry plus the emotion-driven
+//! [`Face`] groups the eye and mouth geometry plus the emotion-driven
 //! [`Style`] that shapes how those primitives are drawn. It owns
 //! everything the renderer needs to produce a frame; non-visual state
-//! (sensors, motor pose, mind/affect, voice queue) lives elsewhere on
-//! [`Entity`].
-//!
-//! The split exists because v0.x packed all of these into a single
-//! `Avatar` struct, which made it impossible to express domain
-//! boundaries in the type system: a mod that "tweaks the face" had to
-//! reach across motor + sensor fields too. With `Face` as a sub-component
-//! of [`Entity`], modifiers in [`Phase::Expression`] borrow only the
-//! visual surface they actually mutate.
+//! (sensors, motor pose, mind, voice) lives elsewhere on [`Entity`].
 //!
 //! All coordinates are in an abstract 320×240 framebuffer space so the
-//! domain logic stays resolution-agnostic until the pixel pipeline needs
-//! a concrete resolution.
+//! domain logic stays resolution-agnostic until the pixel pipeline
+//! needs a concrete resolution.
 //!
 //! [`Entity`]: crate::entity::Entity
-//! [`Phase::Expression`]: crate::director::Phase::Expression
 
 /// A 2D integer point in framebuffer space.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -1,40 +1,28 @@
-//! Pending inputs that modifiers consume on the frame they're set.
+//! Pending firmware → modifier inputs.
 //!
-//! [`Input`] is the firmware's "what just happened" channel into the
-//! modifier graph. Unlike [`crate::events::Events`] (one-frame fire
-//! flags that the [`Director`](crate::Director) clears at frame start),
-//! `Input` carries pending requests that survive across frames until
-//! a modifier explicitly consumes them.
+//! [`Input`] carries requests from firmware tasks that the modifier
+//! graph consumes. Unlike [`crate::events::Events`] (one-frame fire
+//! flags cleared by the [`Director`](crate::Director) at frame start),
+//! `Input` survives across frames until a modifier consumes it.
 //!
-//! ## Producer / consumer pattern
+//! Producer side: a firmware task drains a Signal channel and writes
+//! the relevant `Input` field (e.g. the touch task writes
+//! `entity.input.tap_pending = true`).
 //!
-//! - **Producer** (firmware tasks): drain a Signal channel, set the
-//!   relevant `Input` field. e.g. the touch task drains `TAP_SIGNAL`
-//!   and writes `entity.input.tap_pending = true`.
-//! - **Consumer** (modifier `update`): on each tick, check the field.
-//!   If set, take + clear it (e.g. `tap_pending = false`,
-//!   `remote_pending = None`) and apply the effect.
-//!
-//! This replaces the v0.x imperative-method pattern (`emotion_touch.tap()`,
-//! `remote_command.queue(addr, cmd)`, `mouth_open_audio.set_rms(rms)`)
-//! which couldn't coexist with the [`Director`](crate::Director)
-//! borrowing each modifier mutably for the duration of the registry.
-//! Inputs flow through `Entity` instead — the same channel as everything
-//! else.
+//! Consumer side: the modifier checks the field each tick, and if set,
+//! reads + clears it.
 
 /// Pending inputs the modifier graph consumes.
 ///
-/// Persistent across frames: the [`Director`](crate::Director) does NOT
-/// clear `Input` at frame start. Modifiers explicitly consume by
-/// setting fields back to their default (`false` / `None`).
+/// Persistent across frames: the [`Director`](crate::Director) does
+/// not clear `Input`. Modifiers consume explicitly by setting fields
+/// back to their default.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Input {
-    /// Tap edge from a touch sensor or button. Consumed by
-    /// [`crate::modifiers::EmotionTouch`]: it advances emotion + sets
-    /// the autonomy hold, then clears this flag.
+    /// Tap edge from the touch sensor or power button. Consumed by
+    /// [`crate::modifiers::EmotionTouch`].
     pub tap_pending: bool,
     /// Most recent decoded IR-remote `(address, command)` pair.
-    /// Consumed by [`crate::modifiers::RemoteCommand`] which looks the
-    /// pair up in its mapping table, sets emotion, and clears this.
+    /// Consumed by [`crate::modifiers::RemoteCommand`].
     pub remote_pending: Option<(u16, u8)>,
 }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -1,27 +1,14 @@
 //! # stackchan-core
 //!
-//! `no_std` domain library for the StackChan NPC. Models the entity as
-//! a composition of typed sub-components ([`Entity`] = `{ face, motor,
-//! perception, voice, mind, events, tick }`) animated by two trait
-//! families:
+//! `no_std` engine for the StackChan NPC. An [`Entity`] holds the state
+//! (face, motor, perception, voice, mind, events, input, tick); a
+//! [`Director`] sorts [`Modifier`]s by [`director::Phase`] + priority
+//! and ticks them each frame.
 //!
-//! - [`Modifier`] — per-frame state mutators (the 14 stock animation
-//!   behaviors live here).
-//! - [`Skill`] — Claude-Code-Skill-style discoverable capabilities
-//!   (trait surface only today; v2.x).
+//! [`Skill`] is a longer-running NPC capability with `name` +
+//! `description` metadata shaped for a future dispatcher.
 //!
-//! Behaviors register with a [`Director`] which sorts modifiers by
-//! [`director::Phase`] + priority and runs them each frame. The phase
-//! enum encodes the canonical NPC tick order (Perception → Cognition →
-//! Affect → Speech → Expression → Motion → Audio → Output).
-//!
-//! The crate has no hardware, OS, or allocation dependencies — it's the
-//! platform-independent heart of the firmware.
-//!
-//! ## Stability
-//!
-//! Everything in this crate is **experimental** as of v0.x. See the
-//! top-level `STABILITY.md`.
+//! No hardware, OS, or allocation dependencies.
 //!
 //! ## Example
 //!
@@ -33,7 +20,6 @@
 //! let mut director = Director::new();
 //! director.add_modifier(&mut blink).expect("registry has room");
 //!
-//! // Advance simulated time; the blink modifier animates the eyes.
 //! for ms in (0..10_000).step_by(33) {
 //!     director.run(&mut entity, Instant::from_millis(ms));
 //! }
@@ -71,8 +57,6 @@ pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
 pub use input::Input;
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use mind::{Affect, Autonomy, Mind, OverrideSource};
-// Intent / Attention / Memory are v2.x stub markers; reach via
-// `crate::mind::*` until they have real shape.
 pub use modifier::Modifier;
 pub use motor::Motor;
 pub use perception::Perception;

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -1,26 +1,19 @@
-//! Cognitive layer of the entity: emotion, autonomy, intent, attention,
-//! memory.
+//! Cognitive layer of the entity.
 //!
-//! [`Mind`] is the brain. Today it carries [`Affect`] (current emotion)
-//! and [`Autonomy`] (manual-override gating); [`Intent`], [`Attention`],
-//! and [`Memory`] are stub marker types reserved for v2.x. Modifiers in
-//! [`Phase::Affect`] write to `mind.affect.emotion` and
-//! `mind.autonomy.manual_until`; modifiers in [`Phase::Expression`] and
-//! [`Phase::Motion`] read `mind.affect.emotion` to choose a face style
-//! and head-bias; future skills will write to `mind.intent` to drive
-//! both expression and speech.
+//! [`Mind`] holds [`Affect`] (current emotion) and [`Autonomy`]
+//! (manual-override gating). [`Intent`], [`Attention`], and [`Memory`]
+//! are placeholder marker types reserved for future use. Modifiers in
+//! [`Phase::Affect`] write `mind.affect.emotion` and
+//! `mind.autonomy.manual_until`; modifiers in [`Phase::Expression`]
+//! and [`Phase::Motion`] read `mind.affect.emotion` to choose a face
+//! style and head bias.
 //!
-//! ## Design rationale
-//!
-//! The split between `Affect` (what the entity *feels*) and `Autonomy`
-//! (whether autonomous drivers are allowed to override) is deliberate.
-//! In v0.x both lived flat on `Avatar`, which conflated "current
-//! emotion" with "manual override is active." The cleaner shape: an
-//! emotion driver always proposes; `Autonomy::manual_until` decides
-//! whether the proposal is accepted. The new
-//! [`Autonomy::source`] field will let v2.x skills do layered overrides
-//! (a "conversation" skill can override `Source::LowBattery` but not
-//! `Source::Pickup`) without touching the autonomy gate's expiry.
+//! Splitting `Affect` (what the entity feels) from `Autonomy` (whether
+//! autonomous drivers are allowed to override) lets emotion drivers
+//! always propose a value; `Autonomy::manual_until` decides whether
+//! the proposal is accepted. The [`Autonomy::source`] field lets
+//! priority-based override management distinguish a touch hold from a
+//! low-battery hold.
 //!
 //! [`Phase::Affect`]: crate::director::Phase::Affect
 //! [`Phase::Expression`]: crate::director::Phase::Expression
@@ -30,24 +23,16 @@ use crate::clock::Instant;
 use crate::emotion::Emotion;
 
 /// The entity's current felt state.
-///
-/// Today: the discrete [`Emotion`] enum from the v0.x model. v2.x will
-/// extend this with continuous valence/arousal axes for richer
-/// dimensional affect models without breaking modifiers that read
-/// [`Self::emotion`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Affect {
     /// Current emotional expression. Set by `Phase::Affect` modifiers
-    /// (touch input, IR remote, voice activity, ambient light, battery
-    /// state, autonomous cycler); consumed by `EmotionStyle` and
-    /// `EmotionHead` to translate into face/style and head-bias.
+    /// (touch, IR, voice, ambient, battery, autonomous cycler);
+    /// consumed by `EmotionStyle` and `EmotionHead`.
     pub emotion: Emotion,
-    // v2.x: pub valence: f32, pub arousal: f32,
 }
 
-/// Where an autonomy override originated. Lets future skills do
-/// priority-based override management ("conversation skill may
-/// override `LowBattery` but not `Pickup`").
+/// Where an autonomy override originated. Lets layered override
+/// management distinguish hold sources.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OverrideSource {
@@ -68,80 +53,48 @@ pub enum OverrideSource {
 /// Autonomy gating: lets an explicit driver pin emotion against the
 /// autonomous cycler.
 ///
-/// `manual_until = Some(t)` means "autonomous drivers stand down until
-/// the clock reaches `t`." `EmotionCycle` checks this before
-/// advancing; touch / remote / pickup / voice / environmental
-/// overrides all set this when they take control.
+/// `manual_until = Some(t)` means autonomous drivers stand down until
+/// the clock reaches `t`. `EmotionCycle` checks this before advancing;
+/// touch / remote / pickup / voice / environmental overrides set this
+/// when they take control.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Autonomy {
     /// Deadline until which autonomous emotion drivers should defer.
-    /// `None` = autonomy active (default).
+    /// `None` = autonomy active.
     pub manual_until: Option<Instant>,
-    /// Which kind of override is currently holding the gate. `None`
-    /// when `manual_until` is `None`. v2.x: skills consult this for
-    /// layered override management.
+    /// Which kind of override is holding the gate. `None` when
+    /// `manual_until` is `None`.
     pub source: Option<OverrideSource>,
 }
 
-/// Current goal / planned action of the entity.
-///
-/// **Stub for v2.x.** Today this is empty; future shape:
-/// ```ignore
-/// pub struct Intent {
-///     pub kind: IntentKind,        // Idle, Greeting, Listening, Speaking, Reacting
-///     pub started_at: Option<Instant>,
-///     pub target: Option<AttentionFocus>,
-/// }
-/// ```
-/// The `MindBridge` async firmware task (LAN HTTP/MQTT to the LLM
-/// host) will publish results into this field; modifiers in
-/// [`Phase::Speech`] / [`Phase::Motion`] will read it to drive
-/// behaviour.
-///
-/// [`Phase::Speech`]: crate::director::Phase::Speech
-/// [`Phase::Motion`]: crate::director::Phase::Motion
+/// Current goal or planned action of the entity. Placeholder marker
+/// type; not yet populated.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Intent;
 
-/// What the entity is currently focused on.
-///
-/// **Stub for v2.x.** Today this is empty; future shape:
-/// ```ignore
-/// pub struct Attention {
-///     pub focus: AttentionFocus,   // None, Toward(Direction), Listening
-///     pub since: Option<Instant>,
-/// }
-/// ```
-/// Used by future eye-gaze and head-pointing modifiers.
+/// What the entity is currently focused on. Placeholder marker type;
+/// not yet populated.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Attention;
 
-/// Persistent facts the entity remembers across boots.
-///
-/// **Stub for v2.x.** Today this is empty; future shape backs onto
-/// ESP-IDF NVS (non-volatile storage) for a typed key-value store:
-/// preferences, recent conversation summaries, learned facts. The
-/// API will be `entity.mind.memory.get::<T>(key)` /
-/// `entity.mind.memory.put(key, value)`.
+/// Persistent facts the entity remembers across boots. Placeholder
+/// marker type; not yet populated.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Memory;
 
-/// The cognitive layer of the entity.
-///
-/// Composed of five sub-components — [`Affect`] and [`Autonomy`] are
-/// active today, [`Intent`] / [`Attention`] / [`Memory`] are
-/// reserved for v2.x. The container shape is stable; new fields can
-/// land on the sub-components without breaking modifiers.
+/// The cognitive layer of the entity. Sub-component shape is stable;
+/// new fields land on `Affect` / `Autonomy` / `Intent` / `Attention` /
+/// `Memory` without breaking modifiers that read `Mind`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Mind {
     /// Current felt state.
     pub affect: Affect,
     /// Manual-override gating.
     pub autonomy: Autonomy,
-    /// Current goal / planned action. v2.x.
+    /// Current goal or planned action.
     pub intent: Intent,
-    /// What the entity is focused on. v2.x.
+    /// What the entity is focused on.
     pub attention: Attention,
-    /// Persistent facts. v2.x (NVS-backed).
+    /// Persistent facts.
     pub memory: Memory,
 }

--- a/crates/stackchan-core/src/modifiers/breath.rs
+++ b/crates/stackchan-core/src/modifiers/breath.rs
@@ -1,13 +1,14 @@
-//! Breath modifier: gently shifts all features up and down on a sine-like cycle.
+//! Breath modifier: gently shifts all features up and down on a
+//! sine-like cycle.
 //!
-//! v0.1.0 uses a coarse triangle-wave approximation to keep the core crate
-//! `no_std` + dependency-free (no `libm`). The wave period defaults to ~6 s
-//! with a 2-pixel peak-to-peak amplitude, which reads as a subtle breathing
-//! animation at 30 FPS.
+//! A triangle-wave approximation keeps the core crate `no_std` and
+//! `libm`-free. The default period is ~6 s with a 2-pixel peak-to-peak
+//! amplitude, which reads as subtle breathing at 30 FPS.
 //!
-//! The amplitude is scaled per-tick by `entity.face.style.breath_depth_scale` so
-//! emotion-driven modifiers (Sleepy → deeper, Surprised → near-flat) can
-//! modulate breathing without owning Breath's state.
+//! The amplitude is scaled per-tick by
+//! `entity.face.style.breath_depth_scale` so emotion-driven modifiers
+//! (Sleepy → deeper, Surprised → near-flat) can modulate breathing
+//! without owning Breath's state.
 
 use crate::clock::Instant;
 use crate::director::{Field, ModifierMeta, Phase};

--- a/crates/stackchan-core/src/modifiers/idle_drift.rs
+++ b/crates/stackchan-core/src/modifiers/idle_drift.rs
@@ -1,9 +1,9 @@
-//! Idle eye drift: periodically shifts both eyes a small random-looking amount
-//! to avoid the uncanny "perfectly centered forever" stare.
+//! Idle eye drift: periodically shifts both eyes a small random-looking
+//! amount to avoid the uncanny "perfectly centered forever" stare.
 //!
-//! v0.1.0 uses a deterministic pseudo-random sequence (xorshift32) seeded at
-//! construction so sim tests are reproducible. A future release may swap in
-//! a hardware-RNG-backed source for the firmware build.
+//! Uses a deterministic xorshift32 PRNG seeded at construction so sim
+//! tests are reproducible; the firmware seeds it from the ESP32-S3
+//! hardware RNG at boot.
 
 use crate::clock::Instant;
 use crate::director::{Field, ModifierMeta, Phase};

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -1,11 +1,11 @@
-//! Animation modifiers — the v0.x reactive face/affect/motion behaviors.
+//! Reactive face / affect / motion modifiers.
 //!
-//! Each modifier in this module implements the [`crate::Modifier`]
-//! trait and registers with a [`crate::Director`] in a declared
-//! [`crate::director::Phase`]. The director sorts by `(phase, priority,
-//! registration order)` and ticks each modifier per frame.
+//! Each modifier implements the [`crate::Modifier`] trait and registers
+//! with a [`crate::Director`] in a declared [`crate::director::Phase`].
+//! The director sorts by `(phase, priority, registration_order)` and
+//! ticks each modifier per frame.
 //!
-//! ## Phase population (today's 14 modifiers)
+//! ## Phase population
 //!
 //! - **[`crate::director::Phase::Affect`]** — emotion deciders. 7
 //!   modifiers, registered in this canonical order:

--- a/crates/stackchan-core/src/motor.rs
+++ b/crates/stackchan-core/src/motor.rs
@@ -5,9 +5,6 @@
 //! task forwards it to the `SCServo` bus and reads back the actual servo
 //! position into `head_pose_actual` at ~1 Hz.
 //!
-//! Future v2.x extensions (e.g. arm servos, base motion) live as
-//! additional fields on this struct.
-//!
 //! [`Phase::Motion`]: crate::director::Phase::Motion
 
 use crate::head::Pose;

--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -1,20 +1,15 @@
 //! Sensor inputs feeding the entity's world model.
 //!
-//! [`Perception`] owns every reading the firmware's per-peripheral
+//! [`Perception`] holds every reading the firmware's per-peripheral
 //! tasks publish via Signal channels. Modifiers in [`Phase::Affect`]
-//! and [`Phase::Audio`] read these to react; nothing here directly
-//! affects the rendered face — translation to visible state happens
-//! through the emotion model and expression modifiers.
+//! and [`Phase::Audio`] read these; nothing here directly affects the
+//! rendered face — translation to visible state happens through the
+//! emotion model and expression modifiers.
 //!
-//! Sensor freshness: each `Option<…>` field is `None` before the first
-//! successful read and `Some(value)` after; the firmware never clears
-//! these back to `None`. Modifiers that need stale-value detection
-//! must track their own last-read timestamp via the entity's
-//! [`crate::entity::Tick`].
-//!
-//! Future v2.x extensions: a processed `WorldModel` sub-struct
-//! (smoothed velocities, sound-source bearing, gaze targets) sits on
-//! top of these raw readings and is what cognition consumes.
+//! Each `Option<…>` field is `None` before the first successful read
+//! and `Some(value)` after; the firmware never clears these back to
+//! `None`. Modifiers that need stale-value detection must track their
+//! own last-read timestamp via [`crate::entity::Tick`].
 //!
 //! [`Phase::Affect`]: crate::director::Phase::Affect
 //! [`Phase::Audio`]: crate::director::Phase::Audio

--- a/crates/stackchan-core/src/skill.rs
+++ b/crates/stackchan-core/src/skill.rs
@@ -1,49 +1,33 @@
-//! The [`Skill`] trait — discoverable NPC capabilities.
+//! [`Skill`] — longer-running NPC capability with discoverable
+//! metadata.
 //!
-//! **Status:** trait surface only. No implementations today.
+//! Each skill self-describes when to fire (its
+//! [`SkillMeta::description`] is meant for human readers and a future
+//! dispatcher) and what to do once fired. The [`crate::Director`]
+//! polls each registered skill's [`Skill::should_fire`] predicate per
+//! frame and invokes those that return `true`.
 //!
-//! Skills are modeled on the **Claude Code Skill** pattern: each skill
-//! self-describes *when to fire* (the [`SkillMeta::description`] field
-//! doubles as trigger guidance for human readers and, in v2.x,
-//! LAN-host-LLM dispatch) and *what to do once fired* (the trait body).
-//! This makes skills a literal capability menu: today the [`crate::Director`]
-//! polls each skill's [`Skill::should_fire`] predicate; tomorrow a
-//! cognition bridge can read all skills' descriptions and pick which
-//! to invoke.
-//!
-//! ## The single most important rule
-//!
-//! **Skills MUST NOT write to `entity.face` or `entity.motor` directly.**
-//! Skills express intent through `entity.mind`, `entity.voice`, and
+//! Skills don't write `entity.face` or `entity.motor` directly. They
+//! express intent through `entity.mind`, `entity.voice`, and
 //! `entity.events`; modifiers in [`crate::director::Phase::Expression`]
 //! and [`crate::director::Phase::Motion`] translate that intent into
-//! rendered face and physical motion.
-//!
-//! This invariant is doc-enforced today (Rust doesn't prevent a
-//! misbehaving skill from reaching into `face`). v2.x will introduce a
-//! `SkillView<'a>` borrow type that mechanically excludes `face` /
-//! `motor` from the writable surface, turning the rule into a compile
-//! error. Until then, treating it as a hard rule is the architectural
-//! contract.
+//! rendered face and physical motion. The rule is documented; a
+//! `SkillView<'a>` borrow type that enforces it via the type system is
+//! sketched but not implemented.
 //!
 //! ## Lifecycle
 //!
-//! Three methods total:
-//!
-//! 1. [`Skill::meta`] — static identity + description + arbitration data.
-//! 2. [`Skill::should_fire`] — predicate the [`crate::Director`] polls
-//!    every frame. Returning `true` causes the skill to be invoked.
-//!    Multiple skills can fire on the same frame; ordering is by
-//!    [`SkillMeta::priority`] (higher first).
+//! 1. [`Skill::meta`] — static identity, description, priority.
+//! 2. [`Skill::should_fire`] — polled each frame. Multiple skills may
+//!    fire on the same frame; order is by [`SkillMeta::priority`]
+//!    (higher first).
 //! 3. [`Skill::invoke`] — the action. Returns [`SkillStatus::Done`]
-//!    (one-shot finished) or [`SkillStatus::Continuing`] (poll
-//!    `should_fire` again next frame).
+//!    (finished) or [`SkillStatus::Continuing`] (re-invoke next frame
+//!    while `should_fire` stays `true`).
 //!
-//! Skills that need persistent cross-frame state hold it internally
-//! (e.g. a `last_fired: Option<Instant>` field). Skills that need
-//! cleanup-on-deactivation can detect the should-fire→false transition
-//! by tracking that internally too. v2.x may grow an `on_exit` hook
-//! with a default no-op impl if the pattern needs it.
+//! Persistent cross-frame state lives inside the skill; cleanup on
+//! deactivation is detected by tracking the should-fire→false
+//! transition internally.
 
 use crate::director::SkillMeta;
 use crate::entity::Entity;
@@ -60,19 +44,18 @@ pub enum SkillStatus {
     Continuing,
 }
 
-/// A discoverable NPC capability.
-///
-/// See module-level docs for the **face/motor write prohibition**.
+/// A discoverable NPC capability. See the module docs for the
+/// face/motor write prohibition.
 pub trait Skill {
-    /// Static identity + description + arbitration metadata.
+    /// Identity, description, priority.
     fn meta(&self) -> &'static SkillMeta;
 
-    /// Trigger predicate. Polled by [`crate::Director`] each frame;
-    /// `true` causes [`Skill::invoke`] to be called.
+    /// Trigger predicate. Polled each frame; `true` causes
+    /// [`Skill::invoke`] to be called.
     fn should_fire(&self, entity: &Entity) -> bool;
 
-    /// Invoke the skill. Returns [`SkillStatus::Done`] if the skill
-    /// has finished or [`SkillStatus::Continuing`] if it wants to be
-    /// invoked again next frame (subject to `should_fire`).
+    /// Invoke the skill. Returns [`SkillStatus::Done`] if finished or
+    /// [`SkillStatus::Continuing`] if it wants to be invoked again
+    /// next frame (subject to `should_fire`).
     fn invoke(&mut self, entity: &mut Entity) -> SkillStatus;
 }

--- a/crates/stackchan-core/src/voice.rs
+++ b/crates/stackchan-core/src/voice.rs
@@ -1,50 +1,34 @@
 //! Speech I/O surface of the entity.
 //!
-//! [`Voice`] is the entity's outbound audio interface. Today it carries
-//! a single field, [`Voice::chirp_request`], that modifiers set when
-//! they want the firmware to enqueue a one-shot audio clip (pickup
-//! chirp, wake chirp, low-battery beep, camera-mode tones). The
-//! firmware reads + clears this field after the modifier pass on each
-//! frame.
+//! [`Voice`] carries [`Voice::chirp_request`], which modifiers set
+//! when they want the firmware to enqueue a one-shot audio clip
+//! (pickup, wake, low-battery beep, camera-mode tone). The firmware
+//! reads + clears the field after the modifier pass each frame.
 //!
-//! v2.x extensions sketch:
-//! - `speech_queue`: bounded queue of phonemes / SSML / TTS-result
-//!   audio buffers that the firmware's audio TX task drains. A
-//!   `Skill` in [`Phase::Speech`] populates this from `mind.intent`.
-//! - `is_speaking`: read-only flag the firmware sets while audio TX
-//!   is actively playing speech, so other modifiers (e.g. `MouthOpenAudio`)
-//!   can choose lip-sync vs envelope behaviour.
-//!
-//! The `chirp_request` design replaces the `pickup.just_fired() /
-//! wake_on_voice.just_fired()` accessor pattern v0.x used: instead of
-//! the firmware peeking modifier-internal state to gate audio enqueue,
-//! modifiers publish *what they want* and the firmware decides *what
-//! to do with it* — cleaner separation, mod-friendly.
-//!
-//! [`Phase::Speech`]: crate::director::Phase::Speech
+//! Modifiers publish what they want; the firmware decides how to play
+//! it, so adding a new chirp kind doesn't require a modifier change
+//! beyond the enum.
 
-/// One-shot audio clips the firmware can enqueue. Modifiers set
-/// [`Voice::chirp_request`] to one of these; the render task reads it
-/// after `Director::run` returns and forwards to `audio::try_enqueue_*`.
+/// One-shot audio clips the firmware can enqueue.
 ///
-/// Adding a new variant requires:
+/// Adding a variant requires:
 /// 1. A matching enqueue helper in `stackchan-firmware/src/audio.rs`
 ///    (e.g. `try_enqueue_my_chirp()`).
 /// 2. The render task's chirp dispatch arm in `main.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ChirpKind {
-    /// Pickup-detected chirp. Set by `PickupReaction` when an IMU
-    /// pickup edge fires.
+    /// Pickup-detected chirp. Set by `PickupReaction` on an IMU
+    /// pickup edge.
     Pickup,
     /// Voice-wake chirp. Set by `WakeOnVoice` when sustained audio
-    /// activity wakes the entity from a non-attentive emotion.
+    /// wakes the entity.
     Wake,
-    /// Low-battery alert beep. Set by `LowBatteryEmotion` on the
-    /// downward-edge crossing of the enter threshold while unplugged.
+    /// Low-battery alert beep. Set by `LowBatteryEmotion` when the
+    /// percent crosses the enter threshold while unplugged.
     LowBatteryAlert,
     /// Camera-mode-enter tone. Set by the firmware's camera-mode
-    /// toggle handler; not currently produced by a `Modifier`.
+    /// toggle handler.
     CameraModeEnter,
     /// Camera-mode-exit tone. Counterpart to [`Self::CameraModeEnter`].
     CameraModeExit,
@@ -53,8 +37,8 @@ pub enum ChirpKind {
 /// The entity's outbound audio surface.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Voice {
-    /// One-shot chirp the firmware should enqueue this frame.
-    /// `None` between frames; modifiers set this in their `update`.
-    /// The render task reads + clears it after `Director::run` returns.
+    /// One-shot chirp the firmware should enqueue this frame. `None`
+    /// between frames; modifiers set it in `update`; the render task
+    /// reads + clears it after `Director::run` returns.
     pub chirp_request: Option<ChirpKind>,
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,12 +4,11 @@ title: Architecture overview
 
 # Architecture overview
 
-`stackchan-kai` models the desk toy as an NPC engine. An [`Entity`] is
-a component-model bag of state (face, motor, perception, voice, mind,
-events, input, tick); a [`Director`] owns the per-frame schedule, sorts
-[`Modifier`]s by phase + priority, and ticks them against the entity.
-The engine is `no_std`, allocation-free, and shared verbatim between
-the firmware and the host simulator.
+`stackchan-kai` models the desk toy as data. An [`Entity`] holds the
+state (face, motor, perception, voice, mind, events, input, tick); a
+[`Director`] sorts [`Modifier`]s by phase + priority and ticks them
+against the entity each frame. The engine is `no_std`, allocation-free,
+and shared verbatim between firmware and the host simulator.
 
 ## Boot sequence
 
@@ -41,15 +40,15 @@ PY32 co-processor (servo power, WS2812 ring)
 Spawn embassy tasks → main heartbeat loop
 ```
 
-Total time to "boot complete — idle heartbeat" is ~1.4 s on the CoreS3.
+Time to "boot complete — idle heartbeat" is ~1.4 s on the CoreS3.
 
 ## Task graph
 
-The render task is the orchestrator: every other task is either a
-producer (sensor → Signal) or a sink (Signal → hardware). Each frame
-the render task drains sensor signals into `entity.perception` /
-`entity.input`, calls `director.run(&mut entity, now)`, then dispatches
-post-frame sinks (LCD blit, head pose, LED frame, chirp request).
+Every task is either a producer (sensor → Signal) or a sink
+(Signal → hardware). Each frame the render task drains sensor signals
+into `entity.perception` / `entity.input`, calls
+`director.run(&mut entity, now)`, then dispatches the post-frame sinks
+(LCD blit, head pose, LED frame, chirp request).
 
 ```
                   ┌─────────────┐
@@ -65,27 +64,12 @@ post-frame sinks (LCD blit, head pose, LED frame, chirp request).
                          └──▶ heartbeat → watchdog (5 s poll)
 ```
 
-Each producer publishes via `Signal::signal(value)`. The render task
-drains via `try_take()` once per frame. **Latest-wins semantics**:
-producers signal at any rate, the render task picks up the most recent
-value per frame. Misses are normal and expected — the next signal
-overwrites unread values.
+Producers publish via `Signal::signal(value)`; the render task drains
+via `try_take()` once per frame. Latest-wins: producers signal at any
+rate, the render task picks up the most recent value, the next signal
+overwrites anything unread.
 
 ## The engine
-
-Three traits + one orchestrator:
-
-- **[`Modifier`]** — per-frame state mutator. `update(&mut Entity)`. The
-  14 stock animation behaviors all live here.
-- **[`Skill`]** — discoverable capability with a `name` + `description`
-  pair (modeled on Claude Code Skills) that doubles as trigger guidance
-  for human readers and v2.x LLM-driven dispatch. Trait surface only
-  today; zero implementations shipped.
-- **[`Director`]** — owns a fixed-capacity heapless registry of
-  modifier and skill references, sorts them once, ticks them each
-  frame.
-
-Modifiers declare static [`ModifierMeta`]:
 
 ```rust
 pub struct ModifierMeta {
@@ -98,27 +82,36 @@ pub struct ModifierMeta {
 }
 ```
 
-`reads` / `writes` are documentation today; v2.x will enforce them via
-debug-mode assertions after each `update`.
+[`Modifier`] mutates the entity once per frame via `update(&mut Entity)`
+and exposes static `ModifierMeta`. [`Director`] owns a fixed-capacity
+heapless registry of modifier and skill references, sorts them once
+on first `run()`, and ticks them each frame.
+
+[`Skill`] is a longer-running NPC capability with a `name` and a
+`description` consumable by a dispatcher. Trait surface only — no
+shipped implementations yet.
+
+`reads` / `writes` are documentation; debug-mode enforcement after each
+`update` is planned.
 
 ## Phase ordering
 
 Modifiers run in phase order, then by priority within a phase, then by
-registration order. The phase enum encodes the canonical NPC tick:
+registration order:
 
-| Phase        | Numeric | Today                                                 |
+| Phase        | Numeric | Population                                            |
 | ------------ | ------- | ----------------------------------------------------- |
-| `Perception` | 10      | empty — render task drains Signals before `run()`     |
-| `Cognition`  | 20      | empty — v2.x: LAN-host LLM bridge adapter             |
+| `Perception` | 10      | empty (render task drains Signals before `run()`)     |
+| `Cognition`  | 20      | empty                                                 |
 | `Affect`     | 30      | 7 emotion deciders (Touch/Remote/Pickup/Voice/...)    |
-| `Speech`     | 40      | empty — v2.x: TTS feeder + speech-queue producer      |
+| `Speech`     | 40      | empty                                                 |
 | `Expression` | 50      | 4 visual modifiers (`EmotionStyle`, Blink, Breath, …) |
 | `Motion`     | 60      | 2 head modifiers (`IdleSway`, `EmotionHead`)          |
 | `Audio`      | 70      | 1 audio-driven (`MouthOpenAudio`)                     |
-| `Output`     | 80      | empty — render task draws + dispatches after `run()`  |
+| `Output`     | 80      | empty (render task draws after `run()`)               |
 
-Numeric gaps of 10 leave room for v2.x phases (e.g.
-`PostPerception = 15`, `IntentRefinement = 25`) without renumbering.
+Numeric gaps of 10 leave room to insert a phase between existing
+variants without renumbering.
 
 ## Entity components
 
@@ -126,43 +119,39 @@ Numeric gaps of 10 leave room for v2.x phases (e.g.
 pub struct Entity {
     pub face: Face,         // visual surface
     pub motor: Motor,       // head pose
-    pub perception: Perception, // raw sensors → world model
-    pub voice: Voice,       // chirp_request, future speech queue
-    pub mind: Mind,         // affect, autonomy, intent (v2.x), …
-    pub events: Events,     // one-frame fire flags (cleared by Director)
-    pub input: Input,       // pending firmware → modifier inputs
-    pub tick: Tick,         // { now, dt_ms, frame } — stamped each run()
+    pub perception: Perception,
+    pub voice: Voice,
+    pub mind: Mind,
+    pub events: Events,     // one-frame flags, cleared by Director
+    pub input: Input,       // firmware → modifier pending inputs
+    pub tick: Tick,         // { now, dt_ms, frame }, stamped each run()
 }
 ```
 
-Sub-components carry domain boundaries: `entity.perception` is
-firmware-write / modifier-read; `entity.input` is firmware-write /
-modifier-consume; `entity.face` and `entity.motor` are
-modifier-write / firmware-read; `entity.voice.chirp_request` is
-modifier-write / firmware-drain.
+Sub-component ownership: `perception` and `input` are firmware-write
+/ modifier-read; `face`, `motor`, and `voice.chirp_request` are
+modifier-write / firmware-read.
 
 ## Skill conventions
 
-By documented contract, skills MUST NOT write to `entity.face` or
-`entity.motor` directly. Skills express intent through `mind`,
-`voice`, and `events`; modifiers in `Phase::Expression` and
-`Phase::Motion` translate that intent into rendered face and physical
-motion. The rule is doc-enforced today; v2.x will introduce a
-`SkillView<'a>` borrow type that mechanically excludes face/motor from
-the writable surface.
+Skills don't write `entity.face` or `entity.motor` directly. They
+express intent through `mind`, `voice`, and `events`; modifiers in
+`Phase::Expression` and `Phase::Motion` translate that intent into
+rendered face and physical motion. The rule is documented; a
+`SkillView<'a>` borrow type that enforces it via the type system is
+sketched but not implemented.
 
 ## Host simulator
 
 `crates/stackchan-sim` constructs an `Entity` + `FakeClock` and runs
 the same `Director` against hand-crafted time sequences. Pixel-golden
 tests assert on `Eye::weight`, `Mouth::mouth_open`, etc. The `viz`
-binary opens an `egui` + `winit` window and runs the canonical
-modifier stack at wall-clock 30 FPS — drops behavior-iteration cycles
-from ~30 s (build → flash → boot) to <1 s
+binary opens an `egui` + `winit` window and runs the modifier stack at
+30 FPS so behavior changes iterate in sub-second cycles instead of the
+~30 s build → flash → boot loop
 (`cargo run -p stackchan-sim --bin viz --features viz`).
 
 [`Entity`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/entity.rs
 [`Director`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/director.rs
 [`Modifier`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/modifier.rs
 [`Skill`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/skill.rs
-[`ModifierMeta`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/director.rs

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,42 +4,29 @@ title: stackchan-kai engineering handbook
 
 # stackchan-kai engineering handbook
 
-Reference docs for the [stackchan-kai](https://github.com/andymai/stackchan-kai)
-codebase — `no_std` Rust firmware for the M5Stack CoreS3 Stack-chan,
-plus the host-side simulator + 14 driver crates that compose it.
-
-This handbook complements the in-repo guides:
-
-- **[CLAUDE.md](https://github.com/andymai/stackchan-kai/blob/main/CLAUDE.md)** — shared human + AI orientation: build commands, conventions, hardware notes.
-- **[AGENTS.md](https://github.com/andymai/stackchan-kai/blob/main/AGENTS.md)** — agent-specific playbook: session shapes, debugging recipes, memory pointer.
+Reference docs for [stackchan-kai](https://github.com/andymai/stackchan-kai)
+— `no_std` Rust firmware for the M5Stack CoreS3 Stack-chan, plus the
+host simulator and 14 driver crates.
 
 ## Pages
 
-- [Architecture overview](architecture) — the engine (Entity, Director, Phase), the firmware's task graph, and how the host sim mirrors it.
-- [Modifier authoring guide](modifiers) — how to add a new behavior to the engine without breaking phase ordering.
+- [Architecture overview](architecture) — the engine, the firmware's task graph, and how the host sim mirrors it.
+- [Modifier authoring guide](modifiers) — adding a new behavior to the engine.
 - [Signal channels](signals) — the typed `Signal<…, T>` pattern that wires sensors to the render task.
-- [Typed-error catalog](errors) — every driver crate's `Error<E>` enum, with what each variant means and what to do about it.
+- [Typed-error catalog](errors) — every driver crate's `Error<E>` enum.
 
 ## Source layout
 
 ```
 crates/
-├── stackchan-core   # Pure no_std engine (Entity, Director, Modifier, Skill, Phase, Clock)
-├── stackchan-sim    # Host-side simulator (FakeClock, Framebuffer, viz binary)
+├── stackchan-core   # no_std engine (Entity, Director, Modifier, Skill, Phase, Clock)
+├── stackchan-sim    # host simulator (FakeClock, Framebuffer, viz binary)
 ├── stackchan-firmware  # CoreS3 firmware binary (embassy + esp-rtos)
-├── tracker          # Block-grid motion tracker for the camera path
+├── tracker          # block-grid motion tracker for the camera path
 └── 14 driver crates # axp2101, aw9523, aw88298, bm8563, bmi270, bmm150,
                     # es7210, ft6336u, gc0308, ir-nec, ltr553, py32,
                     # scservo, si12t, st25r3916
 ```
 
-## Stability model
-
-`stackchan-kai` is `v0.x` until v1.0 ships its polish milestone.
-v1.0 will not graduate any items to **Stable** — that's deferred to
-v2.x so the API can survive the architectural work planned there. See
-[STABILITY.md](https://github.com/andymai/stackchan-kai/blob/main/STABILITY.md)
-for the full graduation rules.
-
-Standalone driver crates (axp2101, aw9523, scservo, bm8563, etc.)
-graduate on their own cadence, not gated on the workspace version.
+See [STABILITY.md](https://github.com/andymai/stackchan-kai/blob/main/STABILITY.md)
+for the graduation rules.

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -4,11 +4,10 @@ title: Modifier authoring guide
 
 # Modifier authoring guide
 
-A `Modifier` is a state machine that mutates an `Entity` once per
-frame. Modifiers compose by registration order with a [`Director`]
-that sorts them by `(phase, priority, registration_order)` before the
-first tick. Each later modifier observes the cumulative effect of all
-earlier ones.
+A `Modifier` mutates an `Entity` once per frame. The [`Director`] sorts
+registered modifiers by `(phase, priority, registration_order)` before
+the first tick; each later modifier observes the cumulative effect of
+all earlier ones.
 
 ## The trait
 
@@ -19,18 +18,16 @@ pub trait Modifier {
 }
 ```
 
-Two methods. `meta` returns a `&'static ModifierMeta` constant
-declaring `name`, `description`, `phase`, `priority`, and the `reads`
-/ `writes` field sets. `update` is the only mutation surface — read
-the entity, decide, write back. Time flows in via `entity.tick.now`
-(stamped by `Director::run`); modifiers don't take a `now` parameter.
+`meta` returns a `&'static ModifierMeta` constant declaring `name`,
+`description`, `phase`, `priority`, and the `reads` / `writes` field
+sets. `update` is the only mutation surface; time flows in via
+`entity.tick.now` (stamped by `Director::run`).
 
-## Steps to add a new modifier
+## Adding a new modifier
 
-1. **Choose the file.** New modifiers go under
-   `crates/stackchan-core/src/modifiers/<your_name>.rs`.
+1. Create `crates/stackchan-core/src/modifiers/<your_name>.rs`.
 
-2. **Implement the state machine.** Pattern:
+2. Implement the state machine:
 
    ```rust
    use crate::director::{Field, ModifierMeta, Phase};
@@ -38,7 +35,7 @@ the entity, decide, write back. Time flows in via `entity.tick.now`
    use crate::modifier::Modifier;
 
    pub struct YourModifier {
-       // state fields — timers, RNG, last-value
+       // state: timers, RNG, last-value
    }
 
    impl YourModifier {
@@ -52,7 +49,7 @@ the entity, decide, write back. Time flows in via `entity.tick.now`
                name: "YourModifier",
                description: "One sentence: what triggers this and what \
                              entity fields it writes.",
-               phase: Phase::Expression, // or Affect / Motion / Audio / ...
+               phase: Phase::Expression,
                priority: 0,
                reads: &[/* Field::... */],
                writes: &[/* Field::... */],
@@ -62,57 +59,43 @@ the entity, decide, write back. Time flows in via `entity.tick.now`
 
        fn update(&mut self, entity: &mut Entity) {
            let now = entity.tick.now;
-           // Read entity fields the modifier is aware of.
-           // Mutate entity fields the modifier owns.
+           // Read + mutate entity fields.
        }
    }
    ```
 
-3. **Pick a phase.** See the architecture doc's phase table. Most
-   custom behaviors are `Affect` (decide an emotion), `Expression`
-   (modulate face style), `Motion` (head pose), or `Audio`
-   (audio-driven visual).
+3. Pick a phase. `Affect` decides emotions, `Expression` modulates face
+   style, `Motion` writes head pose, `Audio` drives visual from audio.
 
-4. **Add unit tests.** Each modifier file has a `mod tests` at the
-   bottom that exercises edge cases against `Instant::from_millis(...)`
-   sequences. Pattern: assert specific entity fields after a known tick
-   sequence. Set the time on `entity.tick.now`, call `update`,
-   assert.
+4. Add unit tests in a `mod tests` at the bottom of the file. Set
+   `entity.tick.now`, call `update`, assert.
 
-5. **Wire into `render_task`.** Open
-   `crates/stackchan-firmware/src/main.rs`, construct your modifier
-   alongside the others, and call
-   `director.add_modifier(&mut your_modifier).expect("registry full")`
-   in the canonical order. Update the boot info-line listing.
+5. Register in `crates/stackchan-firmware/src/main.rs::render_task`:
+   `director.add_modifier(&mut your_modifier).expect("registry full")`.
+   Update the boot info-line listing.
 
-6. **Add a sim integration test if behavior is non-local.** In
-   `crates/stackchan-sim/src/lib.rs`'s `integration_tests` mod, add a
-   test that drives the new modifier through a realistic time sequence
-   alongside related modifiers. Use `FakeClock` for deterministic
-   time.
+6. If the behavior is non-local, add a `stackchan-sim` integration
+   test that drives the new modifier alongside related ones.
 
 ## Reads vs writes
 
 Entity fields fall into a few buckets:
 
-- **Pixel-affecting** (`face.*`): listed in `Face::frame_eq`. New
-  pixel-affecting fields **must** be added to `frame_eq` so the render
+- Pixel-affecting (`face.*`): listed in `Face::frame_eq`. New
+  pixel-affecting fields must be added to `frame_eq` so the render
   task's dirty-check works correctly.
-- **Sensor inputs** (`perception.*`): firmware writes from sensor
-  drains; modifiers read.
-- **Pending inputs** (`input.tap_pending`, `input.remote_pending`):
+- Sensor inputs (`perception.*`): firmware writes; modifiers read.
+- Pending inputs (`input.tap_pending`, `input.remote_pending`):
   firmware writes; the consuming modifier reads + clears in the same
   tick.
-- **Cognitive state** (`mind.*`): emotion modifiers write
+- Cognitive state (`mind.*`): emotion modifiers write
   `mind.affect.emotion` + `mind.autonomy.manual_until`; downstream
   modifiers read.
-- **Output requests** (`voice.chirp_request`): modifiers write a
-  request; firmware reads + clears after `Director::run`.
+- Output requests (`voice.chirp_request`): modifiers write; firmware
+  reads + clears after `Director::run`.
 
-The `reads` / `writes` slices on `ModifierMeta` are documentation
-today. v2.x will enforce them via debug-mode assertions after each
-`update` — a write to an undeclared field becomes a panic in debug
-builds.
+The `reads` / `writes` slices on `ModifierMeta` are documentation;
+debug-mode enforcement after each `update` is planned.
 
 ## Field granularity
 
@@ -121,37 +104,32 @@ builds.
 false-flag as conflicts. `Field::group()` buckets fine variants into
 coarse `FieldGroup`s for human-readable conflict reports.
 
-## When ordering matters
+## Ordering
 
-The canonical Affect phase ordering is non-trivial. Examples:
+The Affect phase ordering matters:
 
-- `EmotionTouch` runs first (priority `-100`) — a tap queued from
-  the touch task must take effect before any environmental override.
-- `EmotionCycle` runs last in Affect — the autonomous advancer only
+- `EmotionTouch` runs first (priority `-100`) so a tap takes effect
+  before any environmental override.
+- `EmotionCycle` runs last in Affect; the autonomous advancer only
   fires when no input modifier set `mind.autonomy.manual_until`.
 - `EmotionStyle` runs in `Expression` and reads
-  `mind.affect.emotion` set by Affect modifiers; Blink / Breath /
-  IdleDrift then add per-frame deltas on top.
-- `IdleSway` (Motion) writes the base `motor.head_pose`;
-  `EmotionHead` (also Motion, registered later) adds an emotion-keyed
-  bias on top.
+  `mind.affect.emotion`; Blink / Breath / IdleDrift then add per-frame
+  deltas on top.
+- `IdleSway` (Motion) writes the base `motor.head_pose`; `EmotionHead`
+  (registered later in Motion) adds an emotion-keyed bias on top.
 - `MouthOpenAudio` runs in `Audio` so audio-driven mouth-open isn't
   overwritten by a stale earlier write.
 
 When in doubt, mirror the registration order in `render_task` and add
-a `stackchan-sim` integration test that asserts the visible behavior
-(eyes don't walk off-screen, mouth doesn't oscillate at 60 Hz, etc.).
+a sim integration test that asserts the visible behavior.
 
-## Skills (not modifiers)
+## Skills
 
-A modifier is the right shape when the behavior runs every frame and
-its job is to translate state. A `Skill` is the right shape when the
-behavior is **discoverable** — the kind of thing a future LLM
-dispatcher might pick from a menu by reading its description. Skills
-have `should_fire(&Entity)` + `invoke(&mut Entity)` + a richer
-`SkillMeta` and are bound by a doc-enforced rule: **no direct writes
-to `face` or `motor`** (skills go through `mind` / `voice` /
-`events`; modifiers translate). Trait surface ships today; zero skill
-implementations have landed.
+A `Skill` has `should_fire(&Entity) -> bool` and
+`invoke(&mut Entity) -> SkillStatus`, plus richer metadata than a
+modifier. Use it when the behavior is discoverable — selected from a
+menu rather than always-on. Skills don't write `face` or `motor`
+directly; they go through `mind` / `voice` / `events` and modifiers
+translate. The trait ships; no implementations have landed.
 
 [`Director`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/director.rs


### PR DESCRIPTION
## Summary

- Drops the explicit Claude Code Skills reference from README + public docs.
- Strips meta voice from public-facing prose: status callouts, "today / tomorrow / v2.x will" framing, "single most important rule" headings, marketing taglines, and parallel "Two trait families" / "Three traits + one orchestrator" structures.
- README loses the Status quote and the Roadmap section; non-goals shed their bold-prefix framing. Engine section drops the Skill bullet (zero implementations shipped, doesn't belong in the README) and the "Reactive emotion engine" feature bullet.
- docs/architecture.md, docs/modifiers.md, docs/index.md tightened to match. Functional content (phase table, ordering examples, modifier-authoring steps) stays; meta narration goes.
- Source doc-comments updated in stackchan-core: lib.rs, entity.rs, director.rs, skill.rs, mind.rs, voice.rs, events.rs, input.rs, motor.rs, perception.rs, face.rs, modifiers/{mod,breath,idle_drift}.rs.
- Side effect: `Entity::default` is now derived (was hand-rolled).

Net: -297 lines across 18 files. Behavior unchanged.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests all green
- [x] `cargo +esp check --release` clean