### PR TITLE
feat(core): LookAtSound skill + ListenHead motion modifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,20 @@ keeps the work scoped.
 4. `just check` — gates pass before flashing.
 5. Optional: `just fmr` to confirm on hardware.
 
+### Shape 1b: skill authoring
+Skills are predicate-fired capabilities that write `mind.intent` /
+`mind.attention` / `voice` / `events`; modifiers in later phases
+translate that into face / motor.
+1. Read `crates/stackchan-core/src/skill.rs` for the trait and pick
+   any existing impl in `crates/stackchan-core/src/skills/` as a
+   starting point.
+2. Add the new file under `crates/stackchan-core/src/skills/`,
+   re-export from `mod.rs`.
+3. Register in `render_task` via `director.add_skill(&mut x)`.
+4. If the skill's intent needs a visible response, add or extend a
+   modifier (`Phase::Motion` for pose, `Phase::Expression` for
+   face) that reads `mind.intent` / `mind.attention`.
+
 ### Shape 2: driver work (one of the 14 driver crates)
 1. Read the crate's README to understand current scope.
 2. Add registers, driver methods, or init steps; keep `embedded-hal-async` boundary clean.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ for ms in (0..10_000).step_by(33) {
 
 Each `Modifier` declares a phase (`Affect`, `Expression`, `Motion`,
 `Audio`) and a priority; the Director sorts once and ticks per frame.
-The 14 stock modifiers cover blinking, breathing, idle drift, head
-sway, emotion transitions, touch / IR / voice / ambient / battery
-reactions, and audio-driven mouth motion. See the
+Stock modifiers cover blinking, breathing, idle drift, head sway,
+emotion transitions, touch / IR / voice / ambient / battery reactions,
+attention-driven head tilt, and audio-driven mouth motion. A parallel
+`Skill` surface carries predicate-fired capabilities. See the
 [architecture overview](https://andymai.github.io/stackchan-kai/architecture)
 and [modifier authoring guide](https://andymai.github.io/stackchan-kai/modifiers)
 for the details.

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -52,9 +52,12 @@ pub const SKILL_CAP: usize = 16;
 /// - `Affect` (7): `EmotionTouch`, `RemoteCommand`, `PickupReaction`,
 ///   `WakeOnVoice`, `AmbientSleepy`, `LowBatteryEmotion`, `EmotionCycle`
 /// - `Expression` (4): `EmotionStyle`, Blink, Breath, `IdleDrift`
-/// - `Motion` (2): `IdleSway`, `EmotionHead`
+/// - `Motion` (3): `IdleSway`, `EmotionHead`, `ListenHead`
 /// - `Audio` (1): `MouthOpenAudio`
 /// - `Perception` / `Cognition` / `Speech` / `Output`: empty
+///
+/// Skills (1): `LookAtSound` (sets `mind.attention = Listening` on
+/// sustained `perception.audio_rms`).
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Phase {

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -43,6 +43,7 @@ pub mod modifiers;
 pub mod motor;
 pub mod perception;
 pub mod skill;
+pub mod skills;
 pub mod voice;
 
 pub use clock::{Clock, Instant};
@@ -56,7 +57,7 @@ pub use face::{Eye, EyePhase, Face, Mouth, Point, SCALE_DEFAULT, Style};
 pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
 pub use input::Input;
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
-pub use mind::{Affect, Autonomy, Mind, OverrideSource};
+pub use mind::{Affect, Attention, Autonomy, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
 pub use motor::Motor;
 pub use perception::Perception;

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -1,12 +1,14 @@
 //! Cognitive layer of the entity.
 //!
-//! [`Mind`] holds [`Affect`] (current emotion) and [`Autonomy`]
-//! (manual-override gating). [`Intent`], [`Attention`], and [`Memory`]
-//! are placeholder marker types reserved for future use. Modifiers in
+//! [`Mind`] holds [`Affect`] (current emotion), [`Autonomy`]
+//! (manual-override gating), [`Intent`] (current goal), and
+//! [`Attention`] (current focus). [`Memory`] is a marker type
+//! reserved for future cross-boot persistence. Modifiers in
 //! [`Phase::Affect`] write `mind.affect.emotion` and
-//! `mind.autonomy.manual_until`; modifiers in [`Phase::Expression`]
-//! and [`Phase::Motion`] read `mind.affect.emotion` to choose a face
-//! style and head bias.
+//! `mind.autonomy.manual_until`; skills write `mind.intent` and
+//! `mind.attention`; modifiers in [`Phase::Expression`] and
+//! [`Phase::Motion`] read `mind.affect.emotion` (for style + pose
+//! bias) and `mind.attention` (for attention-driven pose).
 //!
 //! Splitting `Affect` (what the entity feels) from `Autonomy` (whether
 //! autonomous drivers are allowed to override) lets emotion drivers
@@ -67,15 +69,37 @@ pub struct Autonomy {
     pub source: Option<OverrideSource>,
 }
 
-/// Current goal or planned action of the entity. Placeholder marker
-/// type; not yet populated.
+/// Current goal or planned action of the entity. Set by skills and
+/// read by modifiers in later phases. Default: [`Intent::Idle`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct Intent;
+#[non_exhaustive]
+pub enum Intent {
+    /// No active goal.
+    #[default]
+    Idle,
+    /// Listening to ambient sound. Set by
+    /// [`crate::skills::LookAtSound`]; cleared on release.
+    Listen,
+}
 
-/// What the entity is currently focused on. Placeholder marker type;
-/// not yet populated.
+/// What the entity is currently focused on.
+///
+/// Carries enough state for downstream modifiers to animate the focus
+/// (e.g. ease-in based on `since`). Default: [`Attention::None`].
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct Attention;
+#[non_exhaustive]
+pub enum Attention {
+    /// Not focused on anything specific.
+    #[default]
+    None,
+    /// Listening to a sound source. `since` is the instant the
+    /// listening attention began; consumers (e.g.
+    /// [`crate::modifiers::ListenHead`]) use it for ease-in animation.
+    Listening {
+        /// When the listening attention began.
+        since: Instant,
+    },
+}
 
 /// Persistent facts the entity remembers across boots. Placeholder
 /// marker type; not yet populated.

--- a/crates/stackchan-core/src/modifiers/listen_head.rs
+++ b/crates/stackchan-core/src/modifiers/listen_head.rs
@@ -1,0 +1,337 @@
+//! `ListenHead`: motion modifier that biases head pose upward when
+//! `mind.attention` is `Listening`, producing a cocked-head listening
+//! posture.
+//!
+//! Driven by [`crate::skills::LookAtSound`] (or any other source that
+//! sets `mind.attention = Listening`). Stays at zero bias when
+//! attention is `None`.
+//!
+//! ## Composition
+//!
+//! Runs after [`super::IdleSway`] (priority 0) and
+//! [`super::EmotionHead`] (priority 10) within [`Phase::Motion`], so
+//! its bias rides on top of the baseline sway and emotion-keyed bias.
+//! Same diff-and-undo pattern as `EmotionHead` / `IdleSway`: subtract
+//! the previous *applied* contribution before adding the new one,
+//! storing the post-clamp delta so asymmetric clamping doesn't
+//! accumulate into a permanent offset.
+//!
+//! ## Ease
+//!
+//! Linear ramp from 0 → [`LISTEN_HEAD_TILT_DEG`] over [`LISTEN_HEAD_EASE_MS`]
+//! when entering Listening; symmetric ramp back to 0 over the same
+//! window when leaving.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::head::Pose;
+use crate::mind::Attention;
+use crate::modifier::Modifier;
+
+/// Peak upward tilt added when fully attentive, in degrees.
+///
+/// Combined with `IdleSway`'s ±2.5° tilt and `EmotionHead`'s
+/// up-to-+3° (Happy) the worst-case tilt stays comfortably inside
+/// [`MAX_TILT_DEG`](crate::head::MAX_TILT_DEG).
+pub const LISTEN_HEAD_TILT_DEG: f32 = 8.0;
+
+/// Ease-in / ease-out window, in ms.
+///
+/// The bias ramps linearly from 0 → `LISTEN_HEAD_TILT_DEG` after
+/// attention enters `Listening` and back to 0 after it leaves. 200 ms
+/// reads as deliberate without feeling sluggish.
+pub const LISTEN_HEAD_EASE_MS: u64 = 200;
+
+/// Modifier that translates `mind.attention == Listening` into an
+/// additive upward tilt bias on `motor.head_pose`.
+#[derive(Debug, Clone, Copy)]
+pub struct ListenHead {
+    /// Tilt contribution as actually applied on the previous tick
+    /// (post-clamp). Subtracted before writing the new contribution
+    /// — see `IdleSway::last_pan_deg` for the same pattern.
+    last_tilt_deg: f32,
+    /// Instant attention transitioned `None` → `Listening`. `None`
+    /// when not currently in (or easing into) a listening run.
+    listen_since: Option<Instant>,
+    /// Instant attention transitioned `Listening` → `None`. `None`
+    /// unless currently easing out.
+    release_since: Option<Instant>,
+}
+
+impl ListenHead {
+    /// Construct an idle modifier with no in-flight ease state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            last_tilt_deg: 0.0,
+            listen_since: None,
+            release_since: None,
+        }
+    }
+}
+
+impl Default for ListenHead {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Linear `0..=1` ramp over `window_ms` from `start`. Saturates at
+/// 1.0 once the elapsed exceeds the window. Returns 0.0 if
+/// `window_ms == 0` (no ease — caller should snap).
+fn ease(start: Instant, now: Instant, window_ms: u64) -> f32 {
+    if window_ms == 0 {
+        return 1.0;
+    }
+    let elapsed = now.saturating_duration_since(start);
+    if elapsed >= window_ms {
+        return 1.0;
+    }
+    // Both elapsed and window_ms are bounded by LISTEN_HEAD_EASE_MS in
+    // practice; the cast is far inside f32 mantissa range. Match the
+    // pattern in `IdleSway::unit_triangle`.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "elapsed and window_ms are both well under 2^24"
+    )]
+    let t = elapsed as f32 / window_ms as f32;
+    t.clamp(0.0, 1.0)
+}
+
+impl Modifier for ListenHead {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "ListenHead",
+            description: "When mind.attention is Listening, adds an upward tilt bias to \
+                          motor.head_pose for a cocked-head listening posture. Eases in/out \
+                          over LISTEN_HEAD_EASE_MS. Composes additively after IdleSway and \
+                          EmotionHead via diff-and-undo.",
+            phase: Phase::Motion,
+            priority: 20,
+            reads: &[Field::Attention, Field::HeadPose],
+            writes: &[Field::HeadPose],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        let attending = matches!(entity.mind.attention, Attention::Listening { .. });
+
+        // Edge detection drives the ease anchors. Each transition
+        // resets the opposite anchor so the next ramp uses a fresh
+        // start time.
+        match (attending, self.listen_since.is_some()) {
+            (true, false) => {
+                self.listen_since = Some(now);
+                self.release_since = None;
+            }
+            (false, true) => {
+                self.listen_since = None;
+                self.release_since = Some(now);
+            }
+            _ => {}
+        }
+
+        // Desired tilt bias for this tick. Ease-in while attending,
+        // ease-out while a release anchor is live, else zero. The
+        // release anchor is cleared once fully decayed so we stop
+        // touching the pose.
+        let target_tilt = match (self.listen_since, self.release_since) {
+            (Some(since), _) => LISTEN_HEAD_TILT_DEG * ease(since, now, LISTEN_HEAD_EASE_MS),
+            (None, Some(rel_at)) => {
+                let t = ease(rel_at, now, LISTEN_HEAD_EASE_MS);
+                if t >= 1.0 {
+                    self.release_since = None;
+                    0.0
+                } else {
+                    LISTEN_HEAD_TILT_DEG * (1.0 - t)
+                }
+            }
+            (None, None) => 0.0,
+        };
+
+        // Diff-and-undo composition. Mirrors `EmotionHead`: subtract
+        // our previous applied contribution to recover upstream,
+        // add the new one, clamp, and store the post-clamp effective
+        // delta back into `last_tilt_deg`.
+        let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_tilt_deg;
+        let combined =
+            Pose::new(entity.motor.head_pose.pan_deg, upstream_tilt + target_tilt).clamped();
+        self.last_tilt_deg = combined.tilt_deg - upstream_tilt;
+        entity.motor.head_pose = combined;
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    reason = "tests compare bit-exact outputs of our own ease math, not accumulated FP arithmetic"
+)]
+mod tests {
+    use super::*;
+    use crate::Entity;
+    use crate::mind::Attention;
+
+    fn listening(since_ms: u64) -> Attention {
+        Attention::Listening {
+            since: Instant::from_millis(since_ms),
+        }
+    }
+
+    #[test]
+    fn no_attention_leaves_pose_alone() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+        // Use an in-range tilt: MIN_TILT_DEG is 0 (asymmetric clamp).
+        entity.motor.head_pose = Pose::new(2.0, 1.0);
+        entity.tick.now = Instant::from_millis(500);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose, Pose::new(2.0, 1.0));
+    }
+
+    #[test]
+    fn ease_in_starts_at_zero_and_reaches_full_after_window() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+
+        // Tick 0: attention transitions to Listening. Anchor is set
+        // this tick, elapsed = 0 → bias = 0.
+        entity.mind.attention = listening(0);
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.tilt_deg, 0.0);
+
+        // After full ease window: bias is at peak.
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.tilt_deg, LISTEN_HEAD_TILT_DEG);
+    }
+
+    #[test]
+    fn ease_in_is_monotonically_non_decreasing_across_window() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = listening(0);
+
+        let mut last_tilt = f32::NEG_INFINITY;
+        for ms in 0..=LISTEN_HEAD_EASE_MS {
+            entity.tick.now = Instant::from_millis(ms);
+            m.update(&mut entity);
+            let tilt = entity.motor.head_pose.tilt_deg;
+            assert!(
+                tilt >= last_tilt - 0.001,
+                "tilt regressed at {ms}ms: {tilt} < {last_tilt}",
+            );
+            last_tilt = tilt;
+        }
+    }
+
+    #[test]
+    fn ease_out_returns_to_zero_after_window() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+
+        // Tick 1 anchors `listen_since`; bias starts at 0 on the
+        // entry tick. Tick 2 (one full window later) reaches peak.
+        entity.mind.attention = listening(0);
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.tilt_deg, LISTEN_HEAD_TILT_DEG);
+
+        // Attention drops back to None — anchors `release_since`.
+        entity.mind.attention = Attention::None;
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 1);
+        m.update(&mut entity);
+        // First release tick: still at near-full bias.
+        assert!(entity.motor.head_pose.tilt_deg >= LISTEN_HEAD_TILT_DEG * 0.95);
+
+        // Full ease-out window past release anchor → bias = 0.
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 1 + LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.tilt_deg, 0.0);
+    }
+
+    #[test]
+    fn ease_out_is_monotonically_non_increasing_across_window() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+
+        // Get to full attention.
+        entity.mind.attention = listening(0);
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+
+        entity.mind.attention = Attention::None;
+        let release_start = LISTEN_HEAD_EASE_MS + 10;
+        let mut last_tilt = f32::INFINITY;
+        for offset in 0..=LISTEN_HEAD_EASE_MS {
+            entity.tick.now = Instant::from_millis(release_start + offset);
+            m.update(&mut entity);
+            let tilt = entity.motor.head_pose.tilt_deg;
+            assert!(
+                tilt <= last_tilt + 0.001,
+                "tilt grew during ease-out at +{offset}ms: {tilt} > {last_tilt}",
+            );
+            last_tilt = tilt;
+        }
+    }
+
+    #[test]
+    fn additive_composition_with_upstream_tilt() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = listening(0);
+        let upstream_tilt = -2.0;
+
+        for i in 0..30 {
+            entity.motor.head_pose = Pose::new(0.0, upstream_tilt);
+            entity.tick.now = Instant::from_millis(i * 10);
+            m.update(&mut entity);
+            // Our contribution should be the difference from upstream.
+            let attend_contribution = entity.motor.head_pose.tilt_deg - upstream_tilt;
+            assert!(
+                (0.0..=LISTEN_HEAD_TILT_DEG + 0.01).contains(&attend_contribution),
+                "contribution {attend_contribution} out of range at tick {i}",
+            );
+        }
+    }
+
+    #[test]
+    fn re_enter_during_ease_out_resumes_ease_in() {
+        let mut m = ListenHead::new();
+        let mut entity = Entity::default();
+
+        // Anchor + reach full attention (entry tick + one window).
+        entity.mind.attention = listening(0);
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.tilt_deg, LISTEN_HEAD_TILT_DEG);
+
+        // Begin release. The anchor tick produces full bias still
+        // (elapsed = 0). Advance one more tick into the window to
+        // observe the decrement.
+        entity.mind.attention = Attention::None;
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 1);
+        m.update(&mut entity);
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 50);
+        m.update(&mut entity);
+        let mid_release_tilt = entity.motor.head_pose.tilt_deg;
+        assert!(mid_release_tilt < LISTEN_HEAD_TILT_DEG);
+
+        // Re-enter Listening mid-release. This anchors a fresh
+        // `listen_since`; bias starts at 0 on this tick.
+        entity.mind.attention = listening(LISTEN_HEAD_EASE_MS + 100);
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 100);
+        m.update(&mut entity);
+        // After a full ease window from re-entry, bias is at peak.
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 100 + LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.tilt_deg, LISTEN_HEAD_TILT_DEG);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -36,11 +36,14 @@
 //!   3. [`Breath`] — vertical drift on all features.
 //!   4. [`IdleDrift`] — occasional eye-center jitter.
 //!
-//! - **[`crate::director::Phase::Motion`]** — head motion. 2 modifiers:
+//! - **[`crate::director::Phase::Motion`]** — head motion. 3 modifiers:
 //!   1. [`IdleSway`] — slow pan/tilt head wander written to
 //!      `motor.head_pose`.
 //!   2. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top
 //!      of sway.
+//!   3. [`ListenHead`] — upward tilt bias when `mind.attention` is
+//!      `Listening` (cocked-head listening posture). Added on top of
+//!      sway + emotion bias.
 //!
 //! - **[`crate::director::Phase::Audio`]** — audio-driven visual. 1
 //!   modifier:
@@ -62,6 +65,7 @@ mod emotion_style;
 mod emotion_touch;
 mod idle_drift;
 mod idle_sway;
+mod listen_head;
 mod low_battery;
 mod mouth_open_audio;
 mod pickup_reaction;
@@ -77,6 +81,7 @@ pub use emotion_style::EmotionStyle;
 pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
+pub use listen_head::{LISTEN_HEAD_EASE_MS, LISTEN_HEAD_TILT_DEG, ListenHead};
 pub use low_battery::{
     LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT, LOW_BATTERY_HOLD_MS, LowBatteryEmotion,
 };

--- a/crates/stackchan-core/src/skills/look_at_sound.rs
+++ b/crates/stackchan-core/src/skills/look_at_sound.rs
@@ -1,0 +1,396 @@
+//! `LookAtSound`: attention-shifting skill driven by sustained voice
+//! activity.
+//!
+//! ## Trigger shape
+//!
+//! Watches `entity.perception.audio_rms` (linear, `0.0..=1.0`).
+//! Counts consecutive ticks above [`LISTEN_RMS_THRESHOLD`]; once the
+//! run length reaches [`LISTEN_SUSTAIN_TICKS`] the skill fires:
+//!
+//! - `entity.mind.intent` ← [`Intent::Listen`]
+//! - `entity.mind.attention` ← [`Attention::Listening { since: now }`]
+//!
+//! Once fired, attention persists while loudness continues. After the
+//! audio drops back below threshold, the skill clears intent +
+//! attention back to defaults [`LISTEN_RELEASE_MS`] later.
+//!
+//! Unknown audio (`audio_rms = None`, before the firmware publishes
+//! its first window) is treated as silence and never triggers.
+//!
+//! ## Relationship to `WakeOnVoice`
+//!
+//! [`WakeOnVoice`](crate::modifiers::WakeOnVoice) reacts to the same
+//! `audio_rms` trigger but writes `mind.affect.emotion = Happy` and
+//! queues `voice.chirp_request = Wake`. The two are complementary: a
+//! sustained voice burst makes the entity *feel* happy (`WakeOnVoice`)
+//! and *focus its attention* on the sound (this skill). They share
+//! [`LISTEN_RMS_THRESHOLD`] / [`LISTEN_SUSTAIN_TICKS`] values so both
+//! fire on the same tick.
+//!
+//! ## Why a Skill, not a Modifier
+//!
+//! The output is *attention*, not face / motor. Skills write
+//! `mind.intent` / `mind.attention` / `voice` / `events` by contract;
+//! modifiers translate that into face + pose. The companion
+//! [`ListenHead`](crate::modifiers::ListenHead) modifier consumes
+//! `mind.attention` and biases head tilt accordingly.
+
+use crate::clock::Instant;
+use crate::director::{Field, SkillMeta};
+use crate::entity::Entity;
+use crate::mind::{Attention, Intent};
+use crate::modifiers::{WAKE_RMS_THRESHOLD, WAKE_SUSTAIN_TICKS};
+use crate::skill::{Skill, SkillStatus};
+
+/// Linear RMS threshold for the "loud" classification.
+///
+/// Re-exports [`WAKE_RMS_THRESHOLD`] so attention and emotion shifts
+/// fire on the same audio event — a single source of truth prevents
+/// the two detectors from drifting apart.
+pub const LISTEN_RMS_THRESHOLD: f32 = WAKE_RMS_THRESHOLD;
+
+/// Consecutive loud ticks required to enter Listening attention.
+///
+/// Re-exports [`WAKE_SUSTAIN_TICKS`] for the same reason as
+/// [`LISTEN_RMS_THRESHOLD`]: pin both detectors to the same trigger
+/// shape so they fire on the same tick.
+pub const LISTEN_SUSTAIN_TICKS: u8 = WAKE_SUSTAIN_TICKS;
+
+/// How long Listening attention persists after audio drops back below
+/// threshold, in ms.
+///
+/// 1500 ms reads as "the entity stayed engaged for a moment after the
+/// sound stopped" without lingering so long it fights other behaviors.
+pub const LISTEN_RELEASE_MS: u64 = 1_500;
+
+/// Attention-shifting skill driven by sustained voice activity. See
+/// the module docs for trigger shape.
+#[derive(Debug, Clone, Copy)]
+pub struct LookAtSound {
+    /// Linear-RMS threshold above which a tick counts as loud.
+    pub threshold: f32,
+    /// Consecutive-loud-ticks required to enter Listening.
+    pub sustain_ticks: u8,
+    /// Hold window after audio quiets before clearing attention.
+    pub release_ms: u64,
+    /// Running count of consecutive loud ticks. Reset on any quiet
+    /// tick. Saturates at `u8::MAX` so a very long sustained run
+    /// doesn't wrap.
+    consecutive_loud: u8,
+    /// Instant of the most recent loud tick, used to time the
+    /// post-quiet release window. `None` between bursts.
+    last_loud: Option<Instant>,
+}
+
+impl LookAtSound {
+    /// Construct with default tuning ([`LISTEN_RMS_THRESHOLD`] /
+    /// [`LISTEN_SUSTAIN_TICKS`] / [`LISTEN_RELEASE_MS`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            threshold: LISTEN_RMS_THRESHOLD,
+            sustain_ticks: LISTEN_SUSTAIN_TICKS,
+            release_ms: LISTEN_RELEASE_MS,
+            consecutive_loud: 0,
+            last_loud: None,
+        }
+    }
+}
+
+impl Default for LookAtSound {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Skill for LookAtSound {
+    fn meta(&self) -> &'static SkillMeta {
+        static META: SkillMeta = SkillMeta {
+            name: "LookAtSound",
+            description: "Sustained perception.audio_rms above LISTEN_RMS_THRESHOLD sets \
+                          mind.intent=Listen and mind.attention=Listening{since}. Attention \
+                          clears LISTEN_RELEASE_MS after audio quiets. Pairs with the \
+                          ListenHead motion modifier for a cocked-head listening posture.",
+            priority: 50,
+            writes: &[Field::Intent, Field::Attention],
+        };
+        &META
+    }
+
+    fn should_fire(&self, _entity: &Entity) -> bool {
+        true
+    }
+
+    fn invoke(&mut self, entity: &mut Entity) -> SkillStatus {
+        let now = entity.tick.now;
+        let loud = entity
+            .perception
+            .audio_rms
+            .is_some_and(|rms| rms > self.threshold);
+
+        if loud {
+            self.consecutive_loud = self.consecutive_loud.saturating_add(1);
+            self.last_loud = Some(now);
+        } else {
+            self.consecutive_loud = 0;
+        }
+
+        if self.consecutive_loud >= self.sustain_ticks {
+            // Sustained loud: enter or maintain Listening. `since`
+            // pins to the first frame of this run — re-entering
+            // doesn't reset it mid-sustain.
+            if !matches!(entity.mind.attention, Attention::Listening { .. }) {
+                entity.mind.attention = Attention::Listening { since: now };
+            }
+            entity.mind.intent = Intent::Listen;
+            return SkillStatus::Continuing;
+        }
+
+        if matches!(entity.mind.attention, Attention::Listening { .. }) {
+            // Inside the release window of a recent burst → hold.
+            if self
+                .last_loud
+                .is_some_and(|t| now.saturating_duration_since(t) < self.release_ms)
+            {
+                return SkillStatus::Continuing;
+            }
+            entity.mind.attention = Attention::None;
+            entity.mind.intent = Intent::Idle;
+            self.last_loud = None;
+        } else if !loud {
+            // Not listening, not loud: drop any stale anchor left by
+            // a sub-sustain blip so it can't gate a spurious hold on
+            // the next entry into Listening.
+            self.last_loud = None;
+        }
+        SkillStatus::Done
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    reason = "let-else with panic is the cleanest pattern for value extraction \
+              on enum variants in tests"
+)]
+mod tests {
+    use super::*;
+
+    fn loud_avatar() -> Entity {
+        let mut e = Entity::default();
+        e.perception.audio_rms = Some(0.3);
+        e
+    }
+
+    fn quiet_avatar() -> Entity {
+        let mut e = Entity::default();
+        e.perception.audio_rms = Some(0.001);
+        e
+    }
+
+    /// Drive the skill's state machine for `ticks` frames at 33 ms /
+    /// tick, starting at `start_ms`. Mirrors the cadence of the
+    /// firmware render loop.
+    fn step(skill: &mut LookAtSound, entity: &mut Entity, start_ms: u64, ticks: u64) {
+        for t in 0..ticks {
+            entity.tick.now = Instant::from_millis(start_ms + t * 33);
+            let _ = skill.invoke(entity);
+        }
+    }
+
+    #[test]
+    fn never_fires_on_silence() {
+        let mut skill = LookAtSound::new();
+        let mut entity = quiet_avatar();
+        step(
+            &mut skill,
+            &mut entity,
+            0,
+            u64::from(LISTEN_SUSTAIN_TICKS) + 5,
+        );
+        assert_eq!(entity.mind.attention, Attention::None);
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn unknown_audio_is_silence() {
+        // `audio_rms = None` (default) before the audio task
+        // publishes. Treated as silent.
+        let mut skill = LookAtSound::new();
+        let mut entity = Entity::default();
+        step(
+            &mut skill,
+            &mut entity,
+            0,
+            u64::from(LISTEN_SUSTAIN_TICKS) + 5,
+        );
+        assert_eq!(entity.mind.attention, Attention::None);
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn sustained_loud_enters_listening() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
+        assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
+        assert_eq!(entity.mind.intent, Intent::Listen);
+    }
+
+    #[test]
+    fn loud_below_sustain_does_not_enter() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        step(
+            &mut skill,
+            &mut entity,
+            0,
+            u64::from(LISTEN_SUSTAIN_TICKS) - 1,
+        );
+        assert_eq!(entity.mind.attention, Attention::None);
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn quiet_tick_resets_counter_mid_burst() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        // SUSTAIN_TICKS - 1 loud, then one quiet (resets), then a
+        // few more loud — should not trigger because each run is
+        // below sustain.
+        step(
+            &mut skill,
+            &mut entity,
+            0,
+            u64::from(LISTEN_SUSTAIN_TICKS) - 1,
+        );
+        entity.perception.audio_rms = Some(0.001);
+        step(&mut skill, &mut entity, 1_000, 1);
+        entity.perception.audio_rms = Some(0.3);
+        step(
+            &mut skill,
+            &mut entity,
+            2_000,
+            u64::from(LISTEN_SUSTAIN_TICKS) - 1,
+        );
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn since_timestamp_pins_to_first_listening_frame() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        // Drive past the sustain threshold.
+        step(
+            &mut skill,
+            &mut entity,
+            0,
+            u64::from(LISTEN_SUSTAIN_TICKS) + 5,
+        );
+        let Attention::Listening { since: first } = entity.mind.attention else {
+            panic!("expected Listening, got {:?}", entity.mind.attention);
+        };
+        // Continue loud for several more ticks. `since` must stay
+        // pinned to the first listening frame — consumers depend on
+        // this to compute ease-in elapsed time.
+        step(
+            &mut skill,
+            &mut entity,
+            10_000,
+            u64::from(LISTEN_SUSTAIN_TICKS),
+        );
+        let Attention::Listening { since: later } = entity.mind.attention else {
+            panic!("expected Listening still, got {:?}", entity.mind.attention);
+        };
+        assert_eq!(first, later, "since must not advance during a sustain run");
+    }
+
+    #[test]
+    fn quiet_within_release_window_holds_attention() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
+        let last_loud_at = entity.tick.now;
+        // Go quiet but stay inside the release window (well below
+        // 1500 ms past the last loud tick).
+        entity.perception.audio_rms = Some(0.001);
+        entity.tick.now = last_loud_at + (LISTEN_RELEASE_MS / 2);
+        let _ = skill.invoke(&mut entity);
+        assert!(
+            matches!(entity.mind.attention, Attention::Listening { .. }),
+            "attention must hold within release window"
+        );
+        assert_eq!(entity.mind.intent, Intent::Listen);
+    }
+
+    #[test]
+    fn quiet_past_release_window_clears_attention() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
+        let last_loud_at = entity.tick.now;
+        entity.perception.audio_rms = Some(0.001);
+        // Step well past the release window.
+        entity.tick.now = last_loud_at + LISTEN_RELEASE_MS + 100;
+        let _ = skill.invoke(&mut entity);
+        assert_eq!(entity.mind.attention, Attention::None);
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn re_entry_after_release_pins_new_since() {
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
+        let Attention::Listening { since: first } = entity.mind.attention else {
+            panic!("expected Listening");
+        };
+
+        // Quiet past release.
+        entity.perception.audio_rms = Some(0.001);
+        entity.tick.now = first + LISTEN_RELEASE_MS + 200;
+        let _ = skill.invoke(&mut entity);
+        assert_eq!(entity.mind.attention, Attention::None);
+
+        // Second sustained burst much later.
+        entity.perception.audio_rms = Some(0.3);
+        let restart = first + 30_000;
+        step(
+            &mut skill,
+            &mut entity,
+            restart.as_millis(),
+            u64::from(LISTEN_SUSTAIN_TICKS),
+        );
+        let Attention::Listening { since: second } = entity.mind.attention else {
+            panic!("expected Listening on second burst");
+        };
+        assert!(
+            second > first,
+            "second listening attention must use a fresh `since`"
+        );
+    }
+
+    #[test]
+    fn at_threshold_does_not_count_as_loud() {
+        // Pin: the predicate is `> threshold`, not `>=`.
+        let mut skill = LookAtSound::new();
+        let mut entity = Entity::default();
+        entity.perception.audio_rms = Some(LISTEN_RMS_THRESHOLD);
+        step(
+            &mut skill,
+            &mut entity,
+            0,
+            u64::from(LISTEN_SUSTAIN_TICKS) + 5,
+        );
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn counter_saturates_does_not_wrap() {
+        // 300 loud ticks (well past u8::MAX) should not panic.
+        let mut skill = LookAtSound::new();
+        let mut entity = loud_avatar();
+        step(&mut skill, &mut entity, 0, 300);
+        assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
+    }
+}

--- a/crates/stackchan-core/src/skills/mod.rs
+++ b/crates/stackchan-core/src/skills/mod.rs
@@ -1,0 +1,23 @@
+//! Skill implementations.
+//!
+//! Each skill implements the [`crate::Skill`] trait and registers with
+//! a [`crate::Director`] via [`crate::Director::add_skill`]. Skills
+//! poll their `should_fire` predicate every frame; matching skills'
+//! `invoke` runs in priority order.
+//!
+//! Skills write `mind.intent` / `mind.attention` / `voice` /
+//! `events` — modifiers translate that intent into face / motor.
+//! See [`crate::skill`] for the trait contract.
+//!
+//! ## Catalog
+//!
+//! - [`LookAtSound`] — sustained `perception.audio_rms` flips
+//!   `mind.attention` to `Listening` and `mind.intent` to `Listen`.
+//!   Pairs with the [`crate::modifiers::ListenHead`] motion modifier
+//!   for a cocked-head listening posture.
+
+mod look_at_sound;
+
+pub use look_at_sound::{
+    LISTEN_RELEASE_MS, LISTEN_RMS_THRESHOLD, LISTEN_SUSTAIN_TICKS, LookAtSound,
+};

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -66,10 +66,11 @@ use stackchan_core::{
     Clock, Director, Entity, Face, HeadDriver, LedFrame,
     modifiers::{
         AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
-        IdleDrift, IdleSway, LowBatteryEmotion, MouthOpenAudio, PickupReaction, RemoteCommand,
-        WakeOnVoice,
+        IdleDrift, IdleSway, ListenHead, LowBatteryEmotion, MouthOpenAudio, PickupReaction,
+        RemoteCommand, WakeOnVoice,
     },
     render_leds,
+    skills::LookAtSound,
     voice::ChirpKind,
 };
 use static_cell::StaticCell;
@@ -146,11 +147,14 @@ type LcdDisplay = mipidsi::Display<
 ///
 /// Modifier order is the canonical stackchan-core stack:
 /// `EmotionTouch` → `EmotionCycle` → `EmotionStyle` → `Blink` →
-/// `Breath` → `IdleDrift` → `IdleSway` → `EmotionHead`. `EmotionTouch`
-/// runs first so a tap queued from the touch task becomes the active
-/// emotion before `EmotionCycle` checks the `manual_until` gate.
-/// `IdleSway` writes the base `avatar.head_pose` (slow wander);
-/// `EmotionHead` adds an emotion-keyed bias on top (layered compose).
+/// `Breath` → `IdleDrift` → `IdleSway` → `EmotionHead` →
+/// `ListenHead`. `EmotionTouch` runs first so a tap queued from the
+/// touch task becomes the active emotion before `EmotionCycle` checks
+/// the `manual_until` gate. `IdleSway` writes the base
+/// `avatar.head_pose` (slow wander); `EmotionHead` adds an
+/// emotion-keyed bias on top; `ListenHead` adds an upward listening
+/// tilt when the `LookAtSound` skill (registered separately) sets
+/// `mind.attention = Listening`.
 /// The final pose is published to the 50 Hz head task via
 /// [`head::POSE_SIGNAL`]. `frame_eq` short-circuits blits when no
 /// pixel-affecting modifier changed anything — pose updates alone never
@@ -190,10 +194,13 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut drift = IdleDrift::with_seed(drift_seed);
     let mut sway = IdleSway::new();
     let mut emotion_head = EmotionHead::new();
+    let mut listen_head = ListenHead::new();
     let mut mouth_open_audio = MouthOpenAudio::new();
+    let mut look_at_sound = LookAtSound::new();
     let mut last_rendered: Option<Face> = None;
 
-    // Build the Director and register the canonical 14-modifier stack.
+    // Build the Director and register the canonical modifier stack
+    // plus skills (via add_skill).
     // Phase ordering (Affect → Expression → Motion → Audio) is enforced
     // by `ModifierMeta::phase`; intra-phase ordering is registration
     // order modulated by per-modifier `priority`. See AGENTS.md and
@@ -223,8 +230,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         .add_modifier(&mut emotion_head)
         .expect("registry full");
     director
+        .add_modifier(&mut listen_head)
+        .expect("registry full");
+    director
         .add_modifier(&mut mouth_open_audio)
         .expect("registry full");
+    director
+        .add_skill(&mut look_at_sound)
+        .expect("skill registry full");
     let mut led_frame = LedFrame::default();
     // Camera-mode state. The button task's long-press handler is the
     // sole producer of `CAMERA_MODE_SIGNAL`; we mirror it locally so
@@ -243,7 +256,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + WakeOnVoice + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + MouthOpenAudio",
+        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + WakeOnVoice + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + ListenHead + MouthOpenAudio + LookAtSound[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-sim/tests/look_at_sound.rs
+++ b/crates/stackchan-sim/tests/look_at_sound.rs
@@ -1,0 +1,161 @@
+//! End-to-end sim test for the `LookAtSound` skill + `ListenHead`
+//! motion modifier handoff.
+//!
+//! Drives a Director with the full Motion-phase modifier stack
+//! (`IdleSway` + `EmotionHead` + `ListenHead`) plus the `LookAtSound`
+//! skill, varies `perception.audio_rms` across simulated time, and
+//! asserts:
+//!
+//! - Silence keeps `mind.attention == None` and head tilt at the
+//!   sway+emotion baseline.
+//! - Sustained loud audio causes `mind.attention` to enter
+//!   `Listening` and adds an upward tilt bias.
+//! - Quieting past `LISTEN_RELEASE_MS` returns attention to None and
+//!   tilt to baseline.
+//!
+//! This is the host-side mirror of the firmware loop: it pins the
+//! Skill→Modifier handoff (the architectural point of the v0.10 split)
+//! against accidental regressions in either layer.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-only: registry capacity is a compile-time constant in this \
+              fixture, the unwraps can't fire"
+)]
+
+use stackchan_core::modifiers::{EmotionHead, IdleSway, ListenHead};
+use stackchan_core::skills::{LISTEN_RELEASE_MS, LISTEN_SUSTAIN_TICKS, LookAtSound};
+use stackchan_core::{Attention, Director, Entity, Instant};
+
+const TICK_MS: u64 = 33;
+
+/// Baseline tilt ceiling used by silence + post-release assertions:
+/// sway amplitude (±2.5°) + `EmotionHead` Neutral bias (0°) + a small
+/// margin. Tight enough that an 8° `ListenHead` leak would blow past
+/// it. Pose clamps the lower bound at 0 so we only upper-bound here.
+const BASELINE_TILT_CEILING_DEG: f32 = 3.0;
+
+/// Drive the director for `ticks` frames at `TICK_MS` cadence,
+/// starting at `start_ms`. Returns the final tick's `now`.
+fn run_for(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, ticks: u64) -> Instant {
+    let mut last = Instant::from_millis(start_ms);
+    for t in 0..ticks {
+        last = Instant::from_millis(start_ms + t * TICK_MS);
+        director.run(entity, last);
+    }
+    last
+}
+
+#[test]
+fn silence_holds_attention_none_and_baseline_tilt() {
+    let mut entity = Entity::default();
+    let mut sway = IdleSway::new();
+    let mut emo = EmotionHead::new();
+    let mut listen_head = ListenHead::new();
+    let mut look_at_sound = LookAtSound::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut sway).unwrap();
+    director.add_modifier(&mut emo).unwrap();
+    director.add_modifier(&mut listen_head).unwrap();
+    director.add_skill(&mut look_at_sound).unwrap();
+
+    // Default perception.audio_rms = None ⇒ silence.
+    run_for(&mut director, &mut entity, 0, 60);
+
+    assert_eq!(entity.mind.attention, Attention::None);
+    assert!(
+        entity.motor.head_pose.tilt_deg < BASELINE_TILT_CEILING_DEG,
+        "silence should leave tilt at baseline (<{BASELINE_TILT_CEILING_DEG}°), got {}",
+        entity.motor.head_pose.tilt_deg
+    );
+}
+
+#[test]
+fn sustained_loud_enters_listening_and_lifts_tilt() {
+    let mut entity = Entity::default();
+    let mut sway = IdleSway::new();
+    let mut emo = EmotionHead::new();
+    let mut listen_head = ListenHead::new();
+    let mut look_at_sound = LookAtSound::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut sway).unwrap();
+    director.add_modifier(&mut emo).unwrap();
+    director.add_modifier(&mut listen_head).unwrap();
+    director.add_skill(&mut look_at_sound).unwrap();
+
+    // Sample baseline tilt across a couple of seconds of silence so
+    // we know the max sway+emotion contribution at rest.
+    let mut baseline_max = 0.0_f32;
+    for t in 0..60 {
+        director.run(&mut entity, Instant::from_millis(t * TICK_MS));
+        baseline_max = baseline_max.max(entity.motor.head_pose.tilt_deg);
+    }
+    assert_eq!(entity.mind.attention, Attention::None);
+
+    // Drive long enough for both the skill's sustain count to fire
+    // AND ListenHead's ease window to fully ramp up.
+    entity.perception.audio_rms = Some(0.3);
+    run_for(
+        &mut director,
+        &mut entity,
+        60 * TICK_MS,
+        u64::from(LISTEN_SUSTAIN_TICKS) + 30,
+    );
+
+    assert!(
+        matches!(entity.mind.attention, Attention::Listening { .. }),
+        "expected Listening after sustained audio, got {:?}",
+        entity.mind.attention
+    );
+    // ListenHead adds 8° on top of baseline. Even with sway at its
+    // valley, listening tilt must clear baseline + a few degrees.
+    let listen_tilt = entity.motor.head_pose.tilt_deg;
+    assert!(
+        listen_tilt > baseline_max + 3.0,
+        "listening tilt {listen_tilt} did not lift meaningfully above baseline max {baseline_max}",
+    );
+}
+
+#[test]
+fn quieting_past_release_window_returns_to_baseline() {
+    let mut entity = Entity::default();
+    let mut sway = IdleSway::new();
+    let mut emo = EmotionHead::new();
+    let mut listen_head = ListenHead::new();
+    let mut look_at_sound = LookAtSound::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut sway).unwrap();
+    director.add_modifier(&mut emo).unwrap();
+    director.add_modifier(&mut listen_head).unwrap();
+    director.add_skill(&mut look_at_sound).unwrap();
+
+    entity.perception.audio_rms = Some(0.3);
+    let now = run_for(
+        &mut director,
+        &mut entity,
+        0,
+        u64::from(LISTEN_SUSTAIN_TICKS) + 30,
+    );
+    assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
+
+    // Step well past both the skill's release window AND ListenHead's
+    // ease-out window so the bias has fully decayed back to 0.
+    entity.perception.audio_rms = Some(0.001);
+    run_for(
+        &mut director,
+        &mut entity,
+        now.as_millis() + TICK_MS,
+        (LISTEN_RELEASE_MS / TICK_MS) + 30,
+    );
+
+    assert_eq!(
+        entity.mind.attention,
+        Attention::None,
+        "expected attention cleared after release window"
+    );
+    assert!(
+        entity.motor.head_pose.tilt_deg < BASELINE_TILT_CEILING_DEG,
+        "tilt did not return to baseline (<{BASELINE_TILT_CEILING_DEG}°) after release, got {}",
+        entity.motor.head_pose.tilt_deg
+    );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,19 +99,27 @@ shipped implementations yet.
 Modifiers run in phase order, then by priority within a phase, then by
 registration order:
 
-| Phase        | Numeric | Population                                            |
+| Phase        | Numeric | Role                                                  |
 | ------------ | ------- | ----------------------------------------------------- |
 | `Perception` | 10      | empty (render task drains Signals before `run()`)     |
 | `Cognition`  | 20      | empty                                                 |
-| `Affect`     | 30      | 7 emotion deciders (Touch/Remote/Pickup/Voice/...)    |
+| `Affect`     | 30      | emotion deciders (Touch/Remote/Pickup/Voice/...)      |
 | `Speech`     | 40      | empty                                                 |
-| `Expression` | 50      | 4 visual modifiers (`EmotionStyle`, Blink, Breath, …) |
-| `Motion`     | 60      | 2 head modifiers (`IdleSway`, `EmotionHead`)          |
-| `Audio`      | 70      | 1 audio-driven (`MouthOpenAudio`)                     |
+| `Expression` | 50      | visual modifiers (`EmotionStyle`, Blink, Breath, …)   |
+| `Motion`     | 60      | head modifiers (`IdleSway`, `EmotionHead`, …)         |
+| `Audio`      | 70      | audio-driven visual (`MouthOpenAudio`)                |
 | `Output`     | 80      | empty (render task draws after `run()`)               |
 
 Numeric gaps of 10 leave room to insert a phase between existing
-variants without renumbering.
+variants without renumbering. The current population list lives in
+`crates/stackchan-core/src/modifiers/mod.rs` and the `Phase` enum
+docstring — those track the source of truth.
+
+`Skill`s run after the modifier pass each frame; the `Director`
+polls each registered skill's `should_fire` predicate and invokes
+matching ones in priority order. Skills write `mind.intent` /
+`mind.attention` / `voice` / `events`; modifiers in later phases
+translate that into face / motor.
 
 ## Entity components
 


### PR DESCRIPTION
## Summary

- First Skill implementation, populating the trait surface that landed empty in v0.10's engine refactor. Sustained voice activity sets `mind.attention = Listening`; the new `ListenHead` motion modifier reads that attention and biases head pose upward for a cocked-head listening posture.
- Pairs with the existing `WakeOnVoice` modifier on the same `audio_rms` trigger — emotion and attention shifts fire together. Constants in `skills/look_at_sound.rs` re-export `WAKE_RMS_THRESHOLD` / `WAKE_SUSTAIN_TICKS` so the two detectors can't drift apart.
- Promotes `Intent` and `Attention` from marker structs to real enums.

## Test plan
- [x] `just check` (fmt + workspace clippy + host tests + doctests)
- [x] `just check-firmware` (cargo +esp check)
- [x] `just clippy-firmware` (strict, matches CI)
- [x] 169 unit tests in `stackchan-core` pass
- [x] 3 sim integration tests in `stackchan-sim/tests/look_at_sound.rs` exercise the Skill→Modifier handoff end-to-end through `Director`
- [ ] Hardware verification (`just fmr`) — not run this round; build-only