### PR TITLE
fix(core): repair Style::* intra-doc links in draw.rs (CI hotfix)

### DIFF
--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -9,11 +9,14 @@
 //!
 //! - Background: `Rgb565::WHITE`.
 //! - Eyes: `Rgb565::BLACK`, either filled ellipses (when
-//!   [`Style::eye_curve`] is 0) or a stroked polyline arc (otherwise).
+//!   [`Style::eye_curve`](crate::face::Style::eye_curve) is 0) or a
+//!   stroked polyline arc (otherwise).
 //! - Mouth: pink (`MOUTH_COLOR`), either the v0.1.0 line/ellipse (when
-//!   [`Style::mouth_curve`] is 0) or a stroked polyline curve.
+//!   [`Style::mouth_curve`](crate::face::Style::mouth_curve) is 0) or
+//!   a stroked polyline curve.
 //! - Cheeks: a weight-blended white→pink circle below each eye when
-//!   [`Style::cheek_blush`] is non-zero.
+//!   [`Style::cheek_blush`](crate::face::Style::cheek_blush) is
+//!   non-zero.
 //!
 //! ## Curves
 //!


### PR DESCRIPTION
## Summary

`Style` is in `crate::face` but not imported into `draw.rs`, so the three intra-doc links introduced by #90 (`Style::eye_curve`, `Style::mouth_curve`, `Style::cheek_blush`) were unresolved. `cargo doc -D warnings` has failed on main since #90 — three merges red in a row.

Fix uses the disambiguating link form `[\`text\`](crate::face::Style::field)` to resolve without adding an unused import.

## Test plan
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features` (matches the failing CI step) passes locally.