### PR TITLE
refactor(core): align ModifierMeta reads/writes with actual access

### DIFF
--- a/crates/stackchan-core/src/modifiers/ambient_sleepy.rs
+++ b/crates/stackchan-core/src/modifiers/ambient_sleepy.rs
@@ -94,7 +94,7 @@ impl Modifier for AmbientSleepy {
                           mind.autonomy.manual_until.",
             phase: Phase::Affect,
             priority: -50,
-            reads: &[Field::AmbientLux, Field::Autonomy, Field::Emotion],
+            reads: &[Field::AmbientLux, Field::Autonomy],
             writes: &[Field::Emotion, Field::Autonomy],
         };
         &META

--- a/crates/stackchan-core/src/modifiers/breath.rs
+++ b/crates/stackchan-core/src/modifiers/breath.rs
@@ -108,7 +108,12 @@ impl Modifier for Breath {
                           breathing. Scaled by face.style.breath_depth_scale.",
             phase: Phase::Expression,
             priority: 0,
-            reads: &[Field::BreathDepthScale],
+            reads: &[
+                Field::BreathDepthScale,
+                Field::LeftEyeCenter,
+                Field::RightEyeCenter,
+                Field::MouthCenter,
+            ],
             writes: &[
                 Field::LeftEyeCenter,
                 Field::RightEyeCenter,

--- a/crates/stackchan-core/src/modifiers/emotion_cycle.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_cycle.rs
@@ -91,7 +91,7 @@ impl Modifier for EmotionCycle {
             // Runs last in Affect so it observes the final manual_until
             // state set by Touch/Remote/Pickup/Voice/Ambient/LowBattery.
             priority: 100,
-            reads: &[Field::Autonomy, Field::Emotion],
+            reads: &[Field::Autonomy],
             writes: &[Field::Emotion],
         };
         &META

--- a/crates/stackchan-core/src/modifiers/idle_drift.rs
+++ b/crates/stackchan-core/src/modifiers/idle_drift.rs
@@ -113,7 +113,7 @@ impl Modifier for IdleDrift {
                           so a long-idle stare doesn't read as uncanny.",
             phase: Phase::Expression,
             priority: 0,
-            reads: &[],
+            reads: &[Field::LeftEyeCenter, Field::RightEyeCenter],
             writes: &[Field::LeftEyeCenter, Field::RightEyeCenter],
         };
         &META

--- a/crates/stackchan-core/src/modifiers/low_battery.rs
+++ b/crates/stackchan-core/src/modifiers/low_battery.rs
@@ -162,7 +162,6 @@ impl Modifier for LowBatteryEmotion {
                 Field::BatteryPercent,
                 Field::UsbPowerPresent,
                 Field::Autonomy,
-                Field::Emotion,
             ],
             writes: &[Field::Emotion, Field::Autonomy, Field::ChirpRequest],
         };

--- a/crates/stackchan-core/src/modifiers/mouth_open_audio.rs
+++ b/crates/stackchan-core/src/modifiers/mouth_open_audio.rs
@@ -134,7 +134,7 @@ impl Modifier for MouthOpenAudio {
                           attack/release envelope so the mouth lip-syncs roughly to mic input.",
             phase: Phase::Audio,
             priority: 0,
-            reads: &[Field::AudioRms, Field::MouthOpen],
+            reads: &[Field::AudioRms],
             writes: &[Field::MouthOpen],
         };
         &META

--- a/crates/stackchan-core/src/modifiers/pickup_reaction.rs
+++ b/crates/stackchan-core/src/modifiers/pickup_reaction.rs
@@ -125,7 +125,7 @@ impl Modifier for PickupReaction {
                           voice.chirp_request = Pickup for firmware audio.",
             phase: Phase::Affect,
             priority: -80,
-            reads: &[Field::AccelG, Field::Autonomy, Field::Emotion],
+            reads: &[Field::AccelG, Field::Autonomy],
             writes: &[Field::Emotion, Field::Autonomy, Field::ChirpRequest],
         };
         &META

--- a/crates/stackchan-core/src/modifiers/wake_on_voice.rs
+++ b/crates/stackchan-core/src/modifiers/wake_on_voice.rs
@@ -118,7 +118,7 @@ impl Modifier for WakeOnVoice {
                           (wake from Sleepy). Sets voice.chirp_request = Wake on the rising edge.",
             phase: Phase::Affect,
             priority: -70,
-            reads: &[Field::AudioRms, Field::Autonomy, Field::Emotion],
+            reads: &[Field::AudioRms, Field::Autonomy],
             writes: &[Field::Emotion, Field::Autonomy, Field::ChirpRequest],
         };
         &META

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -151,7 +151,7 @@ type LcdDisplay = mipidsi::Display<
 /// `ListenHead`. `EmotionTouch` runs first so a tap queued from the
 /// touch task becomes the active emotion before `EmotionCycle` checks
 /// the `manual_until` gate. `IdleSway` writes the base
-/// `avatar.head_pose` (slow wander); `EmotionHead` adds an
+/// `entity.motor.head_pose` (slow wander); `EmotionHead` adds an
 /// emotion-keyed bias on top; `ListenHead` adds an upward listening
 /// tilt when the `LookAtSound` skill (registered separately) sets
 /// `mind.attention = Listening`.
@@ -558,7 +558,7 @@ async fn led_task(shared_i2c: SharedI2c) -> ! {
 
 /// AXP2101 battery-monitor task. Polls the gauge register at 1 Hz
 /// and publishes the `SoC` percent on [`power::BATTERY_PERCENT_SIGNAL`]
-/// for the render task to drain into `avatar.battery_percent`.
+/// for the render task to drain into `entity.perception.battery_percent`.
 #[embassy_executor::task]
 async fn power_task(shared_i2c: SharedI2c) -> ! {
     power::run_power_loop(shared_i2c).await


### PR DESCRIPTION
## Summary

ECS-compliance audit found that several modifiers' declared `reads:` / `writes:` slices don't match what `update()` actually touches. These slices are documentation today, but the v2.x debug-mode enforcement noted in `director.rs` will assert against them — make them honest now so the enforcement (next PR) doesn't immediately fail.

- **Drop spurious `Field::Emotion` from `reads:`** on five Affect modifiers (`ambient_sleepy`, `low_battery`, `pickup_reaction`, `wake_on_voice`, `emotion_cycle`) — they write Emotion but never read it. Only `EmotionTouch` genuinely reads the current emotion to advance.
- **Drop spurious `Field::MouthOpen` from `reads:`** on `mouth_open_audio` — the envelope state lives in `self.current`, not on the entity.
- **Add eye/mouth centers to `reads:`** on `Breath` and `IdleDrift` — their diff-and-undo composition reads the center fields (via `+=` / `-=`) before writing them.
- **Sweep two `avatar.*` doc-rot references** in firmware `main.rs` to the v0.10 `entity.motor.*` / `entity.perception.*` paths.

## Test plan
- [x] `just check` (fmt + clippy + host tests + doctests)
- [x] `just check-firmware` (`cargo +esp check`)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features`