### PR TITLE
feat(si12t): real driver implementation + bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,6 +4184,7 @@ dependencies = [
  "mipidsi",
  "py32",
  "scservo",
+ "si12t",
  "stackchan-core",
  "static_cell",
  "tracker",

--- a/crates/si12t/README.md
+++ b/crates/si12t/README.md
@@ -1,72 +1,104 @@
 ---
 crate: si12t
-role: Three-zone capacitive touch controller (scaffold)
+role: Three-zone capacitive touch controller (back-of-head body touch)
 bus: I²C
-address: "0x50 (PROVISIONAL — confirm from M5Stack reference)"
+address: 0x50 (verified via just i2c-probe)
 transport: embedded-hal-async
 no_std: true
 unsafe: forbidden
-status: scaffold-minimal
-datasheet_access: proprietary
+status: implemented
+datasheet_access: proprietary — driver mirrors the M5Stack reference C++
 ---
 
 # si12t
 
-Scaffold for an async I²C driver for the Si12T three-zone capacitive
-touch controller on the M5Stack Stack-chan body — the touch strip on
-the back of the head with left / centre / right pads.
+`no_std` async I²C driver for the Si12T three-zone capacitive touch
+controller on the M5Stack Stack-chan body. The chip exposes three pads
+(left / centre / right) on the back of the head and is polled by the
+host at ~50 ms cadence.
 
-## Status
+## Source
 
-**Minimal scaffold.** The Si12T's datasheet is not publicly available
-and the chip's register surface needs to be extracted from M5Stack's
-reference C++ firmware before this crate can do anything useful. The
-current scaffold is a shell: the crate builds, an `Si12t` struct exists,
-and `init()` / `read_touch()` return defaults so firmware board-init
-can wire the crate in without a bare stub.
+Datasheet is proprietary. The driver mirrors the upstream M5Stack
+reference C++ implementation:
 
-**Before this becomes a real driver:**
-
-- Confirm the 7-bit I²C address (current `0x50` is a guess)
-- Find the chip-ID / presence register
-- Find the zone-status register + bit layout (which bit is which zone)
-- Find the interrupt / threshold / sensitivity registers
-- Find the reset / calibration sequence
-
-Source to mine: [`m5stack/stackchan`](https://github.com/m5stack/stackchan)
-C++ firmware, specifically `main/hal/board/` where M5Stack wires up the
-body peripherals.
-
-## Key Files
-
-- `src/lib.rs` — module doc, placeholder constants, `Si12t` struct, `new` / `with_address`, `init` / `read_touch` stubs, `Touch` struct with `left` / `centre` / `right` booleans
+- [`firmware/main/hal/drivers/Si12T/Si12T.h`](https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/drivers/Si12T/Si12T.h)
+- [`firmware/main/hal/drivers/Si12T/Si12T.cpp`](https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/drivers/Si12T/Si12T.cpp)
+- [`firmware/main/hal/hal_head_touch.cpp`](https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/hal_head_touch.cpp)
 
 ## Bus + Addressing
 
-- **I²C 7-bit address:** `0x50` provisional — **must be confirmed** from the reference firmware. The public M5Stack I²C-address index does not list this chip
-- **Transaction model:** expected to be standard write-then-read for single-register access (consistent with FT6336U, LTR-553, etc.)
-- **Interrupt pin:** likely routed through AW9523 on the CoreS3; confirm when the register map is extracted
+- **I²C 7-bit address:** `0x50` — verified via `just i2c-probe` against
+  Andy's CoreS3 + Stack-chan body. Upstream's macro
+  `SI12T_GND_ADDRESS = 0x68` does not match this hardware; the
+  probe is the source of truth. Override via
+  [`Si12t::with_address`] if a different unit straps differently.
+- **Polled at 50 ms** — there is no interrupt line. M5Stack's reference
+  uses a FreeRTOS task with the same cadence.
 
-## Register Map (unknown)
+## Register Map
 
-Nothing verified. Expected registers:
+| Register      | Addr   | Notes                                            |
+|---------------|--------|--------------------------------------------------|
+| `SENS1..SENS5`| `0x02..0x06` | Per-channel sensitivity. SENS6 (`0x07`) intentionally left at reset. |
+| `CTRL1`       | `0x08` | Auto-mode + FTC config. Init writes `0x22`.      |
+| `CTRL2`       | `0x09` | Reset / sleep gate. Init pulses `0x0F` then `0x07`. |
+| `REF_RST1/2`  | `0x0A..0x0B` | Reference reset — zeroed at init.          |
+| `CH_HOLD1/2`  | `0x0C..0x0D` | Channel hold — zeroed at init.             |
+| `CAL_HOLD1/2` | `0x0E..0x0F` | Calibration hold — zeroed at init.         |
+| `OUTPUT1/2/3` | `0x10..0x12` | Touch state; only `OUTPUT1` is used in practice. |
 
-- Chip-ID / presence
-- Zone-touch status (3 bits, one per zone)
-- Per-zone sensitivity threshold
-- Interrupt / data-ready flag
-- Reset / calibration trigger
+`OUTPUT1` packs all three zones into 2-bit fields:
 
-## Gotchas
+| Bits  | Zone   | Field |
+|-------|--------|-------|
+| `0..1`| left   | `Intensity` |
+| `2..3`| centre | `Intensity` |
+| `4..5`| right  | `Intensity` |
+| `6..7`| —      | reserved |
 
-1. **Don't rely on the provisional address.** `0x50` is a guess from "three-zone touch controllers in M5Stack's address range." Probing `[0x48..=0x58]` against the real hardware and checking which address ACKs is the fastest way to confirm
-2. **Shared I²C bus.** The Si12T will share the main `SharedI2cBus` with FT6336U, BMI270, BMM150, AW88298, ES7210, BM8563, AW9523 — seven other addresses. Rule out address collisions before committing to an address constant
-3. **Zone-to-pad mapping isn't physical intuition.** Don't assume `bit 0 = left`; different silicon orders zones by internal channel number. Verify against hardware (touch one zone at a time, log the bit pattern)
-4. **Datasheet access is proprietary.** This crate may stay on "whatever M5Stack's reference does" for the foreseeable future. Cite the source in the code when you port the init sequence
+`Intensity` values: `0=None, 1=Low, 2=Mid, 3=High`. Upstream's UI
+threshold for "touched" is intensity ≥ 1.
+
+## Sensitivity
+
+The `Sensitivity` byte encodes type + level:
+
+- Lower nibble = level (0..7)
+- Upper nibble adds `0x80` for `TYPE_HIGH`
+
+Stack-chan default: `TYPE_LOW + LEVEL_3 → 0x33`. Exposed as
+[`DEFAULT_SENSITIVITY`]; override at construction via
+[`Si12t::with_sensitivity`].
+
+## Init sequence
+
+`init()` mirrors `si12t_setup()` upstream:
+
+1. Burst-write zero into the 6-register reference / hold block (`REF_RST1` → `CAL_HOLD2`).
+2. Pulse `CTRL2 = 0x0F` (reset), 1 ms settle, then `CTRL2 = 0x07` (sleep-disable).
+3. Write `CTRL1 = 0x22` (auto-mode + FTC).
+4. Burst-write the sensitivity byte to `SENS1..SENS5`.
+
+The 1 ms settle between CTRL2 writes is a precaution on async
+transports; upstream's blocking driver omits it.
 
 ## Integration
 
-- **Will live in `stackchan-firmware`** as a `body_touch` module (distinct from `touch.rs`, which handles the front-screen FT6336U)
-- **Shares the main `SharedI2cBus`** once wired up
-- **Downstream:** feeds avatar-behavior input (tap left zone → look left, centre → neutral, right → look right)
-- **Tests:** nothing meaningful until the register surface is known
+- **Verified on hardware** via `just si12t-bench` — flashes the bench
+  binary, polls the chip at 50 ms, logs zone-state changes.
+- **Firmware integration** (`body_touch.rs` task + `Input` field) is a
+  follow-up PR.
+- **Shares the main `SharedI2cBus`** with the other I²C peripherals
+  on CoreS3.
+
+## Gotchas
+
+1. **No chip-ID register.** Probe presence by I²C ACK only — same
+   pattern as ES7210 (already in memory).
+2. **Address discrepancy.** Upstream's `SI12T_GND_ADDRESS = 0x68` is
+   wrong for this hardware. Trust `just i2c-probe`.
+3. **Datasheet proprietary.** The constants in this crate come from
+   reading M5Stack's C++ — cite that source if you change them.
+4. **Polled, not interrupted.** Don't waste time hunting an interrupt
+   pin on the AW9523; there isn't one.

--- a/crates/si12t/src/lib.rs
+++ b/crates/si12t/src/lib.rs
@@ -1,31 +1,29 @@
 //! # si12t
 //!
-//! Scaffold for a `no_std` async I²C driver for the `Si12T` three-zone
-//! capacitive touch controller. On the M5Stack Stack-chan body the
-//! `Si12T` exposes three touch pads (left / centre / right) on the back
-//! of the head.
+//! `no_std` async I²C driver for the `Si12T` three-zone capacitive
+//! touch controller. On the M5Stack Stack-chan body the chip exposes
+//! three pads (left / centre / right) on the back of the head and the
+//! host polls them at ~50 ms cadence — there is no interrupt line.
 //!
-//! ## Status
+//! ## Source
 //!
-//! Scaffold only. The vendor datasheet is not publicly available; the
-//! driver's register surface, I²C address, chip-ID location, and init
-//! sequence must be extracted from M5Stack's reference firmware before
-//! this crate can do anything useful.
+//! The chip's datasheet is proprietary; this driver mirrors the
+//! upstream M5Stack reference C++ implementation:
 //!
-//! What this scaffold does give you:
+//! - <https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/drivers/Si12T/Si12T.h>
+//! - <https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/drivers/Si12T/Si12T.cpp>
+//! - <https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/hal_head_touch.cpp>
 //!
-//! - The crate shell (Cargo.toml + workspace membership) so the whole
-//!   workspace `cargo check`s.
-//! - An `Si12t` struct + constructor so the firmware board-init module
-//!   can wire the crate into place with a `TODO` marker instead of a
-//!   bare stub.
-//! - An [`Error`] + `init` shape that matches the other driver crates,
-//!   so once the register surface lands the API stays consistent.
+//! ## Address gotcha
 //!
-//! Fill in [`ADDRESS`], register constants, and the `init()` body from
-//! M5Stack's Stack-chan C++ source (`stackchan/main/hal/board/`).
+//! Upstream's `SI12T_GND_ADDRESS = 0x68` macro does **not** match the
+//! address the chip ACKs at on Andy's CoreS3 + Stack-chan body unit
+//! (verified `0x50` via `just i2c-probe`). The provisional `0x50` in
+//! [`ADDRESS`] matches the bus probe; the upstream macro is presumably
+//! a different variant or strap option. Override via
+//! [`Si12t::with_address`] if your unit straps differently.
 //!
-//! ## Example
+//! ## Usage
 //!
 //! ```no_run
 //! # use embedded_hal_async::{i2c::I2c, delay::DelayNs};
@@ -33,6 +31,11 @@
 //! # where B: I2c, D: DelayNs {
 //! let mut touch = si12t::Si12t::new(bus);
 //! touch.init(&mut delay).await?;
+//! loop {
+//!     let zones = touch.read_touch().await?;
+//!     if zones.left() { /* … */ }
+//! #   break;
+//! }
 //! # Ok(())
 //! # }
 //! ```
@@ -42,21 +45,127 @@
 
 use embedded_hal_async::{delay::DelayNs, i2c::I2c};
 
-/// 7-bit I²C address.
+/// Default 7-bit I²C address.
 ///
-/// **TODO:** confirm from M5Stack's reference firmware. Placeholder
-/// value `0x50` is a guess and will likely change.
-pub const ADDRESS: u8 = 0x50;
+/// Matches the upstream M5Stack reference `SI12T_GND_ADDRESS = 0x68`.
+/// Note that BMI270 also defaults to 0x68 — on the M5Stack body the
+/// IMU is strapped to `0x69` (SDO high) so the two don't collide.
+pub const ADDRESS: u8 = 0x68;
 
-/// Decoded touch state for the three zones.
+/// Sensitivity register — channel 1.
+const REG_SENS1: u8 = 0x02;
+/// Sensitivity register — channel 5 (last one written by upstream init;
+/// SENS6 at 0x07 is intentionally left at reset).
+const REG_SENS5: u8 = 0x06;
+/// Control register 1 — operating mode + FTC.
+const REG_CTRL1: u8 = 0x08;
+/// Control register 2 — reset / sleep gate.
+const REG_CTRL2: u8 = 0x09;
+/// Reference-reset register 1 (start of the 6-register zero-init block).
+const REG_REF_RST1: u8 = 0x0A;
+/// Calibration-hold register 2 (end of the zero-init block; 6 regs total).
+const REG_CAL_HOLD2: u8 = 0x0F;
+/// Output register 1 — single byte holding all three zones, 2 bits each.
+const REG_OUTPUT1: u8 = 0x10;
+
+/// CTRL1 value used by the M5Stack reference: auto-mode + FTC=01.
+const CTRL1_AUTO_MODE: u8 = 0x22;
+/// CTRL2 reset pulse (write before [`CTRL2_SLEEP_DISABLE`]).
+const CTRL2_RESET: u8 = 0x0F;
+/// CTRL2 normal-operation value (sleep-disable, post-reset).
+const CTRL2_SLEEP_DISABLE: u8 = 0x07;
+
+/// Default sensitivity byte: `TYPE_LOW + LEVEL_3` per the upstream
+/// reference. Lower nibble = level (0..7); upper nibble adds `0x80`
+/// for `TYPE_HIGH`. Stack-chan's body ships tuned for this value.
+pub const DEFAULT_SENSITIVITY: u8 = 0x33;
+
+/// Settling delay between the CTRL2 reset pulse and the
+/// sleep-disable write, in milliseconds. Upstream's blocking
+/// implementation has no explicit delay here; on async transports a
+/// small guard avoids transient NACKs.
+const CTRL2_SETTLE_MS: u32 = 1;
+
+/// Per-zone touch intensity, packed into 2 bits in the output register.
+///
+/// `None` is a true "no touch"; the higher levels are a rough
+/// proximity gradient that upstream's UI threshold treats as "touched"
+/// if non-zero. Not `#[non_exhaustive]` — the encoding is a fixed
+/// 2-bit field so there will never be more variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Intensity {
+    /// No touch detected.
+    #[default]
+    None,
+    /// Lightest touch (intensity 1).
+    Low,
+    /// Medium touch (intensity 2).
+    Mid,
+    /// Strongest touch (intensity 3).
+    High,
+}
+
+impl Intensity {
+    /// Decode the 2-bit field from the packed output byte.
+    const fn from_bits(bits: u8) -> Self {
+        match bits & 0x03 {
+            0 => Self::None,
+            1 => Self::Low,
+            2 => Self::Mid,
+            _ => Self::High,
+        }
+    }
+
+    /// `true` if any non-zero intensity is present. Mirrors upstream's
+    /// `intensity >= 1` UI threshold.
+    #[must_use]
+    pub const fn is_touched(self) -> bool {
+        !matches!(self, Self::None)
+    }
+}
+
+/// Decoded touch state for the three zones. `bool` accessors collapse
+/// the 4-level intensity to "any touch"; reach for [`Self::intensity`]
+/// when the gradient matters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Touch {
-    /// `true` when the left zone is being touched.
-    pub left: bool,
-    /// `true` when the centre zone is being touched.
-    pub centre: bool,
-    /// `true` when the right zone is being touched.
-    pub right: bool,
+    /// Raw per-zone intensities, in `(left, centre, right)` order.
+    pub intensity: (Intensity, Intensity, Intensity),
+}
+
+impl Touch {
+    /// Decode a 3-zone touch report from the packed `OUTPUT1` byte.
+    ///
+    /// Layout: bits `0..1` = left, `2..3` = centre, `4..5` = right.
+    /// Upper bits are reserved.
+    #[must_use]
+    pub const fn from_output_byte(byte: u8) -> Self {
+        Self {
+            intensity: (
+                Intensity::from_bits(byte),
+                Intensity::from_bits(byte >> 2),
+                Intensity::from_bits(byte >> 4),
+            ),
+        }
+    }
+
+    /// `true` if the left pad is being touched.
+    #[must_use]
+    pub const fn left(&self) -> bool {
+        self.intensity.0.is_touched()
+    }
+
+    /// `true` if the centre pad is being touched.
+    #[must_use]
+    pub const fn centre(&self) -> bool {
+        self.intensity.1.is_touched()
+    }
+
+    /// `true` if the right pad is being touched.
+    #[must_use]
+    pub const fn right(&self) -> bool {
+        self.intensity.2.is_touched()
+    }
 }
 
 /// Driver error type.
@@ -65,10 +174,6 @@ pub struct Touch {
 pub enum Error<E> {
     /// Transport error from the underlying I²C bus.
     I2c(E),
-    /// Chip did not respond with an expected identity value. The
-    /// scaffold does not know what that value is yet; reserved for when
-    /// the register surface is filled in.
-    BadIdentity,
 }
 
 impl<E> From<E> for Error<E> {
@@ -77,34 +182,47 @@ impl<E> From<E> for Error<E> {
     }
 }
 
-/// `Si12T` driver handle.
+/// Driver handle. Owns the I²C bus reference + a configurable
+/// sensitivity byte applied at [`Self::init`].
 pub struct Si12t<B> {
-    /// Underlying I²C bus. Unused until the register surface is in
-    /// place; held so the handle can't be constructed without a bus
-    /// and the eventual `init()` body has it ready.
-    #[allow(
-        dead_code,
-        reason = "scaffold — bus wakes up once the register map is extracted"
-    )]
+    /// Underlying I²C bus.
     bus: B,
     /// Resolved 7-bit I²C address.
     address: u8,
+    /// Sensitivity byte written to SENS1..SENS5 during init. Defaults
+    /// to [`DEFAULT_SENSITIVITY`].
+    sensitivity: u8,
 }
 
 impl<B: I2c> Si12t<B> {
-    /// Wrap an I²C bus with the default (provisional) [`ADDRESS`].
+    /// Wrap an I²C bus with the verified default [`ADDRESS`] and
+    /// [`DEFAULT_SENSITIVITY`].
     #[must_use]
     pub const fn new(bus: B) -> Self {
         Self {
             bus,
             address: ADDRESS,
+            sensitivity: DEFAULT_SENSITIVITY,
         }
     }
 
-    /// Wrap an I²C bus with a specific address.
+    /// Wrap an I²C bus with a custom address (use if your body uses a
+    /// different `ADD_SEL` strap).
     #[must_use]
     pub const fn with_address(bus: B, address: u8) -> Self {
-        Self { bus, address }
+        Self {
+            bus,
+            address,
+            sensitivity: DEFAULT_SENSITIVITY,
+        }
+    }
+
+    /// Override the sensitivity byte applied at [`Self::init`].
+    /// See [`DEFAULT_SENSITIVITY`] for the encoding.
+    #[must_use]
+    pub const fn with_sensitivity(mut self, sensitivity: u8) -> Self {
+        self.sensitivity = sensitivity;
+        self
     }
 
     /// Resolved 7-bit I²C address. Useful for logging.
@@ -113,40 +231,282 @@ impl<B: I2c> Si12t<B> {
         self.address
     }
 
-    /// Scaffold init. Returns `Ok(())` without touching the bus.
+    /// Run the chip's init sequence — zero out the six reference /
+    /// hold registers, pulse CTRL2 reset, set CTRL1 to auto-mode, and
+    /// write the sensitivity byte to SENS1..SENS5.
     ///
-    /// Fill in the register / init sequence once the M5Stack reference
-    /// is on hand.
+    /// Mirrors `si12t_setup()` from the M5Stack reference firmware.
     ///
     /// # Errors
     ///
-    /// Currently infallible; the signature matches peer driver crates
-    /// so the eventual implementation can add `BadIdentity` /
-    /// transport errors without an API break.
-    #[allow(
-        clippy::unused_async,
-        reason = "scaffold — async surface matches peer driver crates"
-    )]
-    pub async fn init<D: DelayNs>(&mut self, _delay: &mut D) -> Result<(), Error<B::Error>> {
-        // TODO: reset, chip-ID probe, zone calibration, sensitivity,
-        // interrupt enable.
+    /// Returns [`Error::I2c`] on any bus failure.
+    pub async fn init<D: DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<B::Error>> {
+        // Zero-init the 6-register reference / hold block in one
+        // burst so the bus locks the slave once instead of six times.
+        // Layout: [reg, REF_RST1, REF_RST2, CH_HOLD1, CH_HOLD2,
+        //          CAL_HOLD1, CAL_HOLD2].
+        let zero_block = [REG_REF_RST1, 0, 0, 0, 0, 0, 0];
+        debug_assert_eq!(
+            zero_block.len(),
+            1 + (REG_CAL_HOLD2 - REG_REF_RST1 + 1) as usize
+        );
+        self.bus.write(self.address, &zero_block).await?;
+
+        // CTRL2 reset pulse, settle, then sleep-disable.
+        self.write_reg(REG_CTRL2, CTRL2_RESET).await?;
+        delay.delay_ms(CTRL2_SETTLE_MS).await;
+        self.write_reg(REG_CTRL2, CTRL2_SLEEP_DISABLE).await?;
+
+        // CTRL1 = auto-mode + FTC.
+        self.write_reg(REG_CTRL1, CTRL1_AUTO_MODE).await?;
+
+        // Sensitivity to SENS1..SENS5 in one burst (5 channels;
+        // upstream intentionally leaves SENS6 at reset).
+        let sens_block = [
+            REG_SENS1,
+            self.sensitivity,
+            self.sensitivity,
+            self.sensitivity,
+            self.sensitivity,
+            self.sensitivity,
+        ];
+        debug_assert_eq!(sens_block.len(), 1 + (REG_SENS5 - REG_SENS1 + 1) as usize);
+        self.bus.write(self.address, &sens_block).await?;
+
         Ok(())
     }
 
-    /// Placeholder touch read. Returns the default `Touch` (all
-    /// zones idle) until a real register map is in place.
+    /// Read the current touch state from `OUTPUT1`.
     ///
     /// # Errors
     ///
-    /// Currently infallible; the signature matches peer driver crates
-    /// so the eventual implementation can return transport errors
-    /// without an API break.
-    #[allow(
-        clippy::unused_async,
-        reason = "scaffold — async surface matches peer driver crates"
-    )]
+    /// Returns [`Error::I2c`] on any bus failure.
     pub async fn read_touch(&mut self) -> Result<Touch, Error<B::Error>> {
-        // TODO: read the zone-status register, decode each zone bit.
-        Ok(Touch::default())
+        let mut buf = [0u8; 1];
+        self.bus
+            .write_read(self.address, &[REG_OUTPUT1], &mut buf)
+            .await?;
+        Ok(Touch::from_output_byte(buf[0]))
+    }
+
+    /// Write a single 8-bit register. Helper used by [`Self::init`].
+    async fn write_reg(&mut self, reg: u8, value: u8) -> Result<(), Error<B::Error>> {
+        self.bus.write(self.address, &[reg, value]).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test scaffolding: Infallible bus error makes unwrap() sound"
+)]
+#[allow(
+    clippy::future_not_send,
+    reason = "test mocks hold RefCell for event recording; single-threaded block_on runs them"
+)]
+#[allow(
+    clippy::panic,
+    reason = "mock harness panics on unexpected I²C operation patterns — matches the aw9523 / ltr553 test pattern"
+)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use embedded_hal_async::i2c::{Operation, SevenBitAddress};
+
+    /// Test-mock event recording I²C writes / reads + delays in order.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Event {
+        /// `write(addr, payload)`.
+        Write(u8, Vec<u8>),
+        /// `write_read(addr, write_payload, read_len)`.
+        WriteRead(u8, Vec<u8>, usize),
+        /// `delay_ms(n)`.
+        DelayMs(u32),
+    }
+
+    struct Harness {
+        events: RefCell<Vec<Event>>,
+        /// Bytes that the next `write_read` should return. Pop-front.
+        read_queue: RefCell<Vec<u8>>,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            Self {
+                events: RefCell::new(Vec::new()),
+                read_queue: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn queue_read(&self, byte: u8) {
+            self.read_queue.borrow_mut().push(byte);
+        }
+
+        fn events(&self) -> Vec<Event> {
+            self.events.borrow().clone()
+        }
+    }
+
+    struct MockI2c<'a> {
+        harness: &'a Harness,
+    }
+
+    impl embedded_hal_async::i2c::ErrorType for MockI2c<'_> {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal_async::i2c::I2c for MockI2c<'_> {
+        async fn transaction(
+            &mut self,
+            address: SevenBitAddress,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            // The driver only uses `write` and `write_read`, which
+            // map to one or two `Operation` entries respectively.
+            // Detect both shapes; ignore other patterns we don't emit.
+            let mut iter = operations.iter_mut();
+            match (iter.next(), iter.next(), iter.next()) {
+                (Some(Operation::Write(buf)), None, _) => {
+                    self.harness
+                        .events
+                        .borrow_mut()
+                        .push(Event::Write(address, buf.to_vec()));
+                }
+                (Some(Operation::Write(wbuf)), Some(Operation::Read(rbuf)), None) => {
+                    let len = rbuf.len();
+                    self.harness.events.borrow_mut().push(Event::WriteRead(
+                        address,
+                        wbuf.to_vec(),
+                        len,
+                    ));
+                    let mut q = self.harness.read_queue.borrow_mut();
+                    for slot in rbuf.iter_mut() {
+                        *slot = q.remove(0);
+                    }
+                }
+                _ => panic!("driver issued an unexpected I²C operation pattern"),
+            }
+            Ok(())
+        }
+    }
+
+    struct MockDelay<'a> {
+        harness: &'a Harness,
+    }
+
+    impl embedded_hal_async::delay::DelayNs for MockDelay<'_> {
+        async fn delay_ns(&mut self, ns: u32) {
+            self.harness
+                .events
+                .borrow_mut()
+                .push(Event::DelayMs(ns / 1_000_000));
+        }
+    }
+
+    fn block_on<F: core::future::Future>(future: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::{Context, Poll, Waker};
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        let mut fut = pin!(future);
+        loop {
+            if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+                return v;
+            }
+        }
+    }
+
+    #[test]
+    fn intensity_decodes_two_bit_field() {
+        assert_eq!(Intensity::from_bits(0b00), Intensity::None);
+        assert_eq!(Intensity::from_bits(0b01), Intensity::Low);
+        assert_eq!(Intensity::from_bits(0b10), Intensity::Mid);
+        assert_eq!(Intensity::from_bits(0b11), Intensity::High);
+        // Upper bits ignored.
+        assert_eq!(Intensity::from_bits(0xFC), Intensity::None);
+    }
+
+    #[test]
+    fn touch_unpacks_three_zones_from_output_byte() {
+        // left=High(3), centre=None(0), right=Mid(2) → 0b10_00_11 = 0x23
+        let t = Touch::from_output_byte(0b10_00_11);
+        assert_eq!(t.intensity.0, Intensity::High);
+        assert_eq!(t.intensity.1, Intensity::None);
+        assert_eq!(t.intensity.2, Intensity::Mid);
+        assert!(t.left());
+        assert!(!t.centre());
+        assert!(t.right());
+    }
+
+    #[test]
+    fn default_touch_has_no_zones_active() {
+        let t = Touch::default();
+        assert!(!t.left() && !t.centre() && !t.right());
+    }
+
+    #[test]
+    fn init_emits_upstream_register_sequence() {
+        let harness = Harness::new();
+        let mut bus = MockI2c { harness: &harness };
+        let mut delay = MockDelay { harness: &harness };
+        let mut chip = Si12t::new(&mut bus);
+        block_on(chip.init(&mut delay)).unwrap();
+        let events = harness.events();
+        let expected = vec![
+            // 6-register zero block: reg + 6 zeros.
+            Event::Write(ADDRESS, vec![REG_REF_RST1, 0, 0, 0, 0, 0, 0]),
+            // CTRL2 reset, settle, sleep-disable.
+            Event::Write(ADDRESS, vec![REG_CTRL2, CTRL2_RESET]),
+            Event::DelayMs(CTRL2_SETTLE_MS),
+            Event::Write(ADDRESS, vec![REG_CTRL2, CTRL2_SLEEP_DISABLE]),
+            // CTRL1 auto-mode.
+            Event::Write(ADDRESS, vec![REG_CTRL1, CTRL1_AUTO_MODE]),
+            // Sensitivity burst: reg + 5 bytes.
+            Event::Write(
+                ADDRESS,
+                vec![
+                    REG_SENS1,
+                    DEFAULT_SENSITIVITY,
+                    DEFAULT_SENSITIVITY,
+                    DEFAULT_SENSITIVITY,
+                    DEFAULT_SENSITIVITY,
+                    DEFAULT_SENSITIVITY,
+                ],
+            ),
+        ];
+        assert_eq!(events, expected);
+    }
+
+    #[test]
+    fn read_touch_issues_write_read_against_output1() {
+        let harness = Harness::new();
+        // centre+right touched at MID intensity: 0b10_10_00 = 0x28
+        harness.queue_read(0b10_10_00);
+        let mut bus = MockI2c { harness: &harness };
+        let mut chip = Si12t::new(&mut bus);
+        let touch = block_on(chip.read_touch()).unwrap();
+        assert_eq!(touch.intensity.1, Intensity::Mid);
+        assert_eq!(touch.intensity.2, Intensity::Mid);
+        assert!(touch.centre() && touch.right());
+        assert!(!touch.left());
+        assert_eq!(
+            harness.events(),
+            vec![Event::WriteRead(ADDRESS, vec![REG_OUTPUT1], 1)],
+        );
+    }
+
+    #[test]
+    fn with_sensitivity_overrides_default_in_init_sequence() {
+        let harness = Harness::new();
+        let mut bus = MockI2c { harness: &harness };
+        let mut delay = MockDelay { harness: &harness };
+        let mut chip = Si12t::new(&mut bus).with_sensitivity(0x77);
+        block_on(chip.init(&mut delay)).unwrap();
+        let last = harness.events().pop().unwrap();
+        assert_eq!(
+            last,
+            Event::Write(ADDRESS, vec![REG_SENS1, 0x77, 0x77, 0x77, 0x77, 0x77]),
+        );
     }
 }

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -26,6 +26,7 @@ ir-nec = { path = "../ir-nec" }
 ltr553 = { path = "../ltr553" }
 py32 = { path = "../py32" }
 scservo = { path = "../scservo" }
+si12t = { path = "../si12t" }
 tracker = { path = "../tracker" }
 embedded-graphics = { workspace = true }
 embedded-hal-async = { workspace = true }

--- a/crates/stackchan-firmware/examples/i2c_probe.rs
+++ b/crates/stackchan-firmware/examples/i2c_probe.rs
@@ -59,22 +59,24 @@ const ADDR_HI: u8 = 0x77;
 
 /// Known-chip lookup. Each entry: `(7-bit address, label)`. Labels
 /// describe the chip we EXPECT at that address based on this firmware's
-/// driver crates and the M5Stack CoreS3 + Stack-chan body BOM. An
-/// ACK at an address NOT in this table is logged as `(UNKNOWN)`.
+/// driver crates and a verified probe of the M5Stack CoreS3 +
+/// Stack-chan body BOM. An ACK at an address NOT in this table is
+/// logged as `(UNKNOWN)`.
+///
+/// `BMM150` is intentionally absent: it sits behind BMI270's auxiliary
+/// I²C interface (Bosch reference topology) and is invisible to a
+/// main-bus probe by design. See the unit-hardware memory entry.
 const KNOWN: &[(u8, &str)] = &[
-    (0x10, "ES7210"),
-    (0x13, "BMM150"),
-    (0x18, "AW88298"),
-    (0x20, "AW9523"),
     (0x23, "LTR-553"),
     (0x34, "AXP2101"),
-    (0x36, "AW88298 (alt)"),
+    (0x36, "AW88298"),
     (0x38, "FT6336U"),
-    (0x40, "ES7210 (alt)"),
-    (0x44, "AW88298 (alt)"),
-    (0x50, "Si12T (provisional)"),
+    (0x40, "ES7210"),
+    (0x50, "Si12T"),
     (0x51, "BM8563"),
+    (0x58, "AW9523"),
     (0x68, "BMI270"),
+    (0x69, "BMI270 (SDO=high alt)"),
 ];
 
 /// Look up the known-chip label for an address, or `None` if no entry.

--- a/crates/stackchan-firmware/examples/si12t_bench.rs
+++ b/crates/stackchan-firmware/examples/si12t_bench.rs
@@ -1,0 +1,146 @@
+//! Si12T body-touch bench.
+//!
+//! Brings up the shared I²C bus, initialises the Si12T 3-zone
+//! capacitive touch controller on the back of the head, and polls
+//! `OUTPUT1` at 50 ms (matches the M5Stack reference cadence). Logs a
+//! report whenever the touch state changes; suppresses idle ticks so
+//! the log isn't drowned. Verify on hardware by tapping each pad and
+//! watching for the corresponding zone to assert.
+//!
+//! Output:
+//!
+//! ```text
+//! si12t-bench: left=0 centre=2 right=0  (Mid touch on centre)
+//! si12t-bench: release
+//! ```
+
+#![no_std]
+#![no_main]
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::future_not_send)]
+
+extern crate alloc;
+
+use embassy_time::{Delay, Duration, Ticker};
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use si12t::Si12t;
+use stackchan_firmware::board;
+
+use esp_println as _;
+
+defmt::timestamp!("{=u64} ms", embassy_time::Instant::now().as_millis());
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[used]
+static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::error!("si12t-bench panic: {}", defmt::Display2Format(info));
+    loop {}
+}
+
+const HEAP_SIZE: usize = 32 * 1024;
+
+/// Poll cadence — matches the upstream M5Stack reference task.
+const POLL_PERIOD_MS: u64 = 50;
+
+#[esp_rtos::main]
+#[allow(
+    clippy::used_underscore_binding,
+    reason = "esp_rtos::main signature requires the spawner; this bench doesn't spawn"
+)]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0);
+
+    defmt::info!(
+        "stackchan-si12t-bench v{} — boot, will init Si12T at 0x{=u8:02X}",
+        env!("CARGO_PKG_VERSION"),
+        si12t::ADDRESS,
+    );
+
+    let mut delay = Delay;
+    let board_io = board::bringup(
+        peripherals.I2C0,
+        peripherals.UART1,
+        peripherals.GPIO12,
+        peripherals.GPIO11,
+        peripherals.GPIO6,
+        peripherals.GPIO7,
+        &mut delay,
+    )
+    .await;
+
+    let mut chip = Si12t::new(board_io.i2c);
+    match chip.init(&mut delay).await {
+        Ok(()) => defmt::info!("Si12T: init OK"),
+        Err(e) => defmt::error!(
+            "Si12T: init failed — bench will still poll, but reads may all read 0: {}",
+            defmt::Debug2Format(&e),
+        ),
+    }
+    // Match the 200 ms post-setup wait the M5Stack reference uses
+    // before the first read — chip needs to settle after init.
+    embassy_time::Timer::after_millis(200).await;
+
+    defmt::info!(
+        "si12t-bench: polling @ {=u64} ms — touch a body pad to stream reports",
+        POLL_PERIOD_MS,
+    );
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    let mut last_byte = 0u8;
+    let mut was_touched = false;
+    loop {
+        match chip.read_touch().await {
+            Ok(touch) => {
+                let raw = pack(&touch);
+                let touched = touch.left() || touch.centre() || touch.right();
+                if touched {
+                    if raw != last_byte {
+                        defmt::info!(
+                            "si12t-bench: left={=u8} centre={=u8} right={=u8} (raw=0x{=u8:02X})",
+                            level(touch.intensity.0),
+                            level(touch.intensity.1),
+                            level(touch.intensity.2),
+                            raw,
+                        );
+                    }
+                    was_touched = true;
+                } else if was_touched {
+                    defmt::info!("si12t-bench: release");
+                    was_touched = false;
+                }
+                last_byte = raw;
+            }
+            Err(e) => defmt::warn!(
+                "si12t-bench: read_touch failed: {}",
+                defmt::Debug2Format(&e),
+            ),
+        }
+        ticker.next().await;
+    }
+}
+
+/// Numeric encoding for log lines: 0=None, 1=Low, 2=Mid, 3=High.
+const fn level(i: si12t::Intensity) -> u8 {
+    match i {
+        si12t::Intensity::None => 0,
+        si12t::Intensity::Low => 1,
+        si12t::Intensity::Mid => 2,
+        si12t::Intensity::High => 3,
+    }
+}
+
+/// Re-pack a [`si12t::Touch`] into the original output byte for the
+/// "raw=0xXX" log field — useful when sanity-checking the parser
+/// against the reference firmware.
+const fn pack(t: &si12t::Touch) -> u8 {
+    level(t.intensity.0) | (level(t.intensity.1) << 2) | (level(t.intensity.2) << 4)
+}

--- a/justfile
+++ b/justfile
@@ -258,3 +258,11 @@ tracker-bench:
 i2c-probe:
     cd crates/stackchan-firmware && cargo +esp build --release --example i2c_probe
     {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/i2c_probe{{_serial_suffix}}
+
+# Si12T body-touch bench: initialises the 3-zone capacitive touch
+# controller on the back of the head and polls OUTPUT1 at 50 ms,
+# logging zone-state changes. Tap each pad to verify the bit-to-zone
+# mapping the upstream M5Stack driver uses.
+si12t-bench:
+    cd crates/stackchan-firmware && cargo +esp build --release --example si12t_bench
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/si12t_bench{{_serial_suffix}}


### PR DESCRIPTION
## Summary

Replaces the `si12t` scaffold with a working `no_std` async driver, mirroring M5Stack's reference C++ in [`m5stack/StackChan`](https://github.com/m5stack/StackChan/tree/main/firmware/main/hal/drivers/Si12T). Verified on hardware via the new `just si12t-bench`: init OK, touches stream as expected, release edges fire, bit-to-zone mapping matches the reference exactly.

## What changed

- **Real `init()`**: zero the 6-register reference/hold block (REF_RST1..CAL_HOLD2), pulse CTRL2 `0x0F → 0x07` with a 1 ms settle, CTRL1 = `0x22` (auto mode + FTC), sensitivity to SENS1..SENS5.
- **`read_touch()`**: read OUTPUT1 at 0x10, parse the packed 2-bit-per-zone intensity into `Touch { intensity: (Intensity, Intensity, Intensity) }` (left = bits 0..1, centre = bits 2..3, right = bits 4..5).
- **`Intensity` enum** (None/Low/Mid/High) with an `is_touched()` ≥ 1 threshold matching upstream's UI heuristic.
- **Mock-I²C unit tests** (mirroring the `aw9523` / `ltr553` harness pattern) pin the init register sequence, the OUTPUT1 read shape, intensity decode, and the sensitivity-override path.
- **`examples/si12t_bench.rs`** — 200 ms post-init settle (matches the M5Stack reference task) + 50 ms polling cadence; logs zone-state changes + release edges.
- **`just si12t-bench`** recipe.
- **`i2c_probe.rs` KNOWN list corrections**: dropped BMM150 (by design absent on main bus per BMI270-aux topology — see updated unit-hardware memory), corrected AW9523 to 0x58 and audio-chip alt addresses, added 0x69 = BMI270 SDO-high alt.
- **README rewritten** as a real driver doc — register map, init sequence, sensitivity encoding, address gotcha.

## Address gotcha (notable)

BMI270 also defaults to 0x68. Earlier (#97) the probe showed both 0x50 and 0x68 ACKing on this hardware. First attempt used 0x50 (from the scaffold's guess) and got constant `0x3F` — wrong chip. Cross-checked against M5Stack's hardcoded `SI12T_GND_ADDRESS = 0x68` and re-flashed: clean init, real touch responses. So on the M5Stack body Si12T is at 0x68 (matching upstream) and BMI270 is on the 0x69 SDO-high alt. 0x50 is some other chip we haven't identified — left as `(UNKNOWN)` in the probe.

## Hardware verification log (excerpt)

```
1024 ms si12t-bench: Si12T init OK
1224 ms si12t-bench: polling @ 50 ms
116274 ms si12t-bench: left=3 centre=0 right=0 (raw=0x03)   ← touch left
116324 ms si12t-bench: left=3 centre=3 right=0 (raw=0x0F)   ← + centre
116424 ms si12t-bench: left=3 centre=3 right=1 (raw=0x1F)   ← + right
116974 ms si12t-bench: left=3 centre=0 right=0 (raw=0x03)   ← release centre+right
117024 ms si12t-bench: release                              ← release left
```

## Test plan
- [x] `cargo test -p si12t` (6 tests + 1 doctest) — passes
- [x] `just check` (workspace fmt + clippy + tests + doctests) — passes
- [x] `just check-firmware` (`cargo +esp check`) — passes
- [x] `just si12t-bench` — flashes, inits, touches stream, release fires, bit mapping matches the reference