### PR TITLE
feat(firmware): wire Si12T body-touch into engine perception

### DIFF
--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -174,6 +174,8 @@ pub enum Field {
     UsbPowerPresent,
     /// `entity.perception.audio_rms`
     AudioRms,
+    /// `entity.perception.body_touch`
+    BodyTouch,
 
     // ---- Mind ----
     /// `entity.mind.affect.emotion`
@@ -226,6 +228,7 @@ impl Field {
         Self::BatteryPercent,
         Self::UsbPowerPresent,
         Self::AudioRms,
+        Self::BodyTouch,
         Self::Emotion,
         Self::Autonomy,
         Self::Intent,
@@ -262,7 +265,8 @@ impl Field {
             | Self::AmbientLux
             | Self::BatteryPercent
             | Self::UsbPowerPresent
-            | Self::AudioRms => FieldGroup::Perception,
+            | Self::AudioRms
+            | Self::BodyTouch => FieldGroup::Perception,
             Self::Emotion | Self::Autonomy | Self::Intent | Self::Attention => FieldGroup::Mind,
             Self::ChirpRequest => FieldGroup::Voice,
             Self::TapPending | Self::RemotePending => FieldGroup::Input,
@@ -347,6 +351,7 @@ impl Field {
                 (None, None) => false,
                 _ => true,
             },
+            Self::BodyTouch => before.perception.body_touch != after.perception.body_touch,
             Self::Emotion => before.mind.affect.emotion != after.mind.affect.emotion,
             Self::Autonomy => before.mind.autonomy != after.mind.autonomy,
             Self::Intent => before.mind.intent != after.mind.intent,
@@ -761,7 +766,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            32,
+            33,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -60,6 +60,6 @@ pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use mind::{Affect, Attention, Autonomy, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
 pub use motor::Motor;
-pub use perception::Perception;
+pub use perception::{BodyTouch, Perception};
 pub use skill::{Skill, SkillStatus};
 pub use voice::{ChirpKind, Voice};

--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -14,6 +14,28 @@
 //! [`Phase::Affect`]: crate::director::Phase::Affect
 //! [`Phase::Audio`]: crate::director::Phase::Audio
 
+/// Per-zone body-touch state (back-of-head `Si12T` pads).
+///
+/// Continuous "currently touched" state — modifiers / skills do their
+/// own edge detection if they need tap vs hold vs swipe semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BodyTouch {
+    /// Left zone is currently touched (`Si12T` intensity ≥ 1).
+    pub left: bool,
+    /// Centre zone is currently touched.
+    pub centre: bool,
+    /// Right zone is currently touched.
+    pub right: bool,
+}
+
+impl BodyTouch {
+    /// `true` if any zone is touched.
+    #[must_use]
+    pub const fn any(&self) -> bool {
+        self.left || self.centre || self.right
+    }
+}
+
 /// Raw sensor readings that drive reactive modifiers.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Perception {
@@ -37,6 +59,10 @@ pub struct Perception {
     /// i16 (`0.0..=1.0`), or `None` before the audio task publishes
     /// its first window.
     pub audio_rms: Option<f32>,
+    /// Per-zone body-touch state from the back-of-head `Si12T` pads,
+    /// or `None` before the first successful read. Continuous state,
+    /// not an edge — modifiers add their own edge detection if needed.
+    pub body_touch: Option<BodyTouch>,
 }
 
 impl Default for Perception {
@@ -49,6 +75,7 @@ impl Default for Perception {
             battery_percent: None,
             usb_power_present: None,
             audio_rms: None,
+            body_touch: None,
         }
     }
 }

--- a/crates/stackchan-firmware/src/body_touch.rs
+++ b/crates/stackchan-firmware/src/body_touch.rs
@@ -1,0 +1,69 @@
+//! Si12T body-touch task.
+//!
+//! Polls the back-of-head 3-zone capacitive controller over the shared
+//! I²C0 bus at the same 50 ms cadence the M5Stack reference firmware
+//! uses, and publishes the per-zone state on [`BODY_TOUCH_SIGNAL`].
+//! The render task drains the signal each tick into
+//! `entity.perception.body_touch`.
+//!
+//! Continuous state, not edges — modifiers / skills do their own
+//! tap / hold / swipe detection on top.
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{Delay, Duration, Ticker, Timer};
+use embedded_hal_async::i2c::I2c as AsyncI2c;
+use si12t::Si12t;
+use stackchan_core::BodyTouch;
+
+/// Latest body-touch reading: body-touch task → render task.
+///
+/// The task replaces the value once per poll. Render-side `try_take`
+/// drops misses (latest wins) — same Signal pattern as the other
+/// sensor tasks.
+pub static BODY_TOUCH_SIGNAL: Signal<CriticalSectionRawMutex, BodyTouch> = Signal::new();
+
+/// Poll cadence — matches the M5Stack reference body-touch task.
+const POLL_PERIOD_MS: u64 = 50;
+
+/// Si12T post-init settle. The reference task waits this long after
+/// `si12t_setup` before the first read; the chip is in an undefined
+/// state until then and reports `0xFF` / `0x3F`.
+const POST_INIT_SETTLE_MS: u64 = 200;
+
+/// Drive the Si12T body-touch polling loop.
+///
+/// Takes an owned I²C device so the task outlives any stack frame in
+/// `main`. Init failures log at `warn` and the loop continues — bus
+/// errors at poll time also log + skip, never panic. A stuck Si12T
+/// must not blank the face.
+pub async fn run_body_touch_loop<I: AsyncI2c>(bus: I) -> ! {
+    let mut chip = Si12t::new(bus);
+    let mut delay = Delay;
+    if let Err(e) = chip.init(&mut delay).await {
+        defmt::warn!(
+            "Si12T: init failed — body-touch will publish stale defaults: {}",
+            defmt::Debug2Format(&e),
+        );
+    } else {
+        defmt::info!(
+            "Si12T: body-touch task ready (poll {=u64} ms)",
+            POLL_PERIOD_MS
+        );
+    }
+    Timer::after_millis(POST_INIT_SETTLE_MS).await;
+
+    let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
+    loop {
+        match chip.read_touch().await {
+            Ok(touch) => {
+                BODY_TOUCH_SIGNAL.signal(BodyTouch {
+                    left: touch.left(),
+                    centre: touch.centre(),
+                    right: touch.right(),
+                });
+            }
+            Err(e) => defmt::warn!("Si12T: read_touch failed: {}", defmt::Debug2Format(&e),),
+        }
+        ticker.next().await;
+    }
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -20,6 +20,7 @@ extern crate alloc;
 pub mod ambient;
 pub mod audio;
 pub mod board;
+pub mod body_touch;
 pub mod button;
 pub mod camera;
 pub mod clock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -25,8 +25,8 @@
 extern crate alloc;
 
 use stackchan_firmware::{
-    ambient, audio, board, button, camera, clock, framebuffer, head, imu, ir, leds, power, touch,
-    wallclock, watchdog,
+    ambient, audio, board, body_touch, button, camera, clock, framebuffer, head, imu, ir, leds,
+    power, touch, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -341,6 +341,10 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         if let Some(rms) = audio::AUDIO_RMS_SIGNAL.try_take() {
             entity.perception.audio_rms = Some(rms.0);
         }
+        // Drain the latest body-touch (back-of-head Si12T) reading.
+        if let Some(touch) = body_touch::BODY_TOUCH_SIGNAL.try_take() {
+            entity.perception.body_touch = Some(touch);
+        }
 
         // Run the entire modifier graph in one call. The Director sorts
         // by (phase, priority, registration order) and ticks each
@@ -512,6 +516,16 @@ async fn head_task(mut driver: HeadDriverImpl) {
 async fn touch_task(shared_i2c: SharedI2c) -> ! {
     let touch = ft6336u::Ft6336u::new(shared_i2c);
     touch::run_touch_loop(touch).await
+}
+
+/// Si12T body-touch polling task. Drives the back-of-head 3-zone pads
+/// at 50 ms cadence and publishes per-zone state on
+/// [`body_touch::BODY_TOUCH_SIGNAL`]. The render task drains it into
+/// `entity.perception.body_touch`; modifiers / skills do their own
+/// edge detection from there.
+#[embassy_executor::task]
+async fn body_touch_task(shared_i2c: SharedI2c) -> ! {
+    body_touch::run_body_touch_loop(shared_i2c).await
 }
 
 /// BMI270 IMU polling task. Wraps a second shared-bus handle onto the
@@ -693,6 +707,9 @@ async fn main(spawner: Spawner) -> ! {
     }
     if let Err(e) = spawner.spawn(touch_task(board_io.i2c)) {
         defmt::panic!("spawn touch_task failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(body_touch_task(I2cDevice::new(board_io.i2c_bus))) {
+        defmt::panic!("spawn body_touch_task failed: {}", defmt::Debug2Format(&e));
     }
     // Three more shared-bus handles onto the same I²C0. The
     // `I2cDevice` wrapper serialises concurrent access so each task


### PR DESCRIPTION
## Summary

Adds end-to-end plumbing for the back-of-head 3-zone touch pads from hardware → engine: new `body_touch` firmware task polls the Si12T at 50 ms, publishes per-zone state via Signal, `render_task` drains into `entity.perception.body_touch` each frame.

Behavior on top is intentionally not in this PR — modifiers / skills that react to body touches (gestures, swipes, "petting" detection) are follow-ups now that the data path exists.

## What changed

- **`stackchan-core::perception`**: new `BodyTouch { left, centre, right }` type + `Perception::body_touch: Option<BodyTouch>`. Continuous state, not edges — matches the `accel_g` / `audio_rms` pattern. `None` until the first successful read; modifiers add their own edge detection.
- **`Field::BodyTouch`** registered + grouped under `FieldGroup::Perception`, added to `Field::ALL` + `Field::changed` so the debug-mode enforcement (#95) covers it.
- **`stackchan-firmware/src/body_touch.rs`** — new task. Mirrors M5Stack's reference: 200 ms post-init settle, 50 ms polling cadence. Init failures log + the loop continues; bus errors log + skip.
- **`BODY_TOUCH_SIGNAL`** with latest-wins Signal semantics.
- **main.rs**: spawns `body_touch_task`, drains the signal in `render_task` before `director.run()`.

## Hardware verification (`just fmr`)

```
1408 ms BMI270: detected at 0x69
1417 ms Si12T: body-touch task ready (poll 50 ms)
1814 ms BMI270: init attempt 1/3 failed (I2c(I2c(Timeout))); retrying in 200 ms
3343 ms BMI270: init complete — polling @ 10 ms tick
```

**Bonus**: the BMI270 init failure (`AcknowledgeCheckFailed(Data)` mid-blob) that's been blocking the IMU since v0.10 is gone. The chip is at `0x69` (SDO-high alt) on this board — confirms the address theory from #98 (Si12T at 0x68, BMI270 at 0x69, no collision).

## Test plan
- [x] `just check` — passes (172 core tests including the bumped `Field::ALL.len()` pin)
- [x] `just check-firmware` (`cargo +esp check`) — passes
- [x] `just fmr` — boots clean; body-touch task ready, BMI270 init complete