### PR TITLE
feat(core): BodyGesture modifier — Press/Swipe/Release on Si12T strip

### DIFF
--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -38,8 +38,10 @@ pub struct Affect {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OverrideSource {
-    /// Touch tap from the user.
+    /// Front-screen tap (FT6336U).
     Touch,
+    /// Back-of-head body-touch tap (`Si12T` 3-zone pads).
+    BodyTouch,
     /// IR-remote button press.
     Remote,
     /// IMU pickup detection.

--- a/crates/stackchan-core/src/modifiers/body_gesture.rs
+++ b/crates/stackchan-core/src/modifiers/body_gesture.rs
@@ -1,0 +1,407 @@
+//! `BodyGesture`: state-machine gesture recognition on the back-of-head
+//! `Si12T` petting strip.
+//!
+//! Reads `entity.perception.body_touch` (intensity-aware) and emits
+//! emotion + autonomy changes for the four gestures M5Stack's
+//! reference firmware also recognises:
+//!
+//! | Gesture        | Trigger                                         | Emotion             |
+//! |----------------|-------------------------------------------------|---------------------|
+//! | `Press`        | rising edge from no-touch to any-zone touched   | per-zone (mapping)  |
+//! | `SwipeForward` | centroid shifts right by ≥ `SWIPE_DELTA` mid-touch | `Happy`          |
+//! | `SwipeBackward`| centroid shifts left by ≥ `SWIPE_DELTA` mid-touch  | `Surprised`      |
+//! | `Release`      | falling edge to no-touch                        | (no-op)             |
+//!
+//! State machine mirrors `m5stack/StackChan/firmware/main/hal/hal_head_touch.cpp`:
+//! `Idle → Touched (Press) → Swiping (SwipeForward / SwipeBackward) → Idle (Release)`.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::emotion::Emotion;
+use crate::entity::Entity;
+use crate::mind::OverrideSource;
+use crate::modifier::Modifier;
+
+/// Default emotion set on `Press` of the left zone (no centre touch).
+pub const DEFAULT_LEFT_PRESS: Emotion = Emotion::Sleepy;
+/// Default emotion set on `Press` of the centre zone (or centre-tied multi-zone).
+pub const DEFAULT_CENTRE_PRESS: Emotion = Emotion::Happy;
+/// Default emotion set on `Press` of the right zone (no centre touch).
+pub const DEFAULT_RIGHT_PRESS: Emotion = Emotion::Surprised;
+/// Default emotion set on `SwipeForward` (left → right).
+pub const DEFAULT_SWIPE_FORWARD: Emotion = Emotion::Happy;
+/// Default emotion set on `SwipeBackward` (right → left).
+pub const DEFAULT_SWIPE_BACKWARD: Emotion = Emotion::Surprised;
+
+/// How long any body-touch gesture pins the emotion before
+/// `EmotionCycle` is allowed to advance, in milliseconds.
+pub const BODY_GESTURE_HOLD_MS: u64 = 5_000;
+
+/// Centroid-shift threshold for swipe detection, in the same
+/// `-100..=+100` units `BodyTouch::position()` returns. Matches the
+/// upstream reference's `swipe_threshold = 40`.
+pub const SWIPE_DELTA: i16 = 40;
+
+/// Per-gesture emotion mapping for [`BodyGesture`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GestureMapping {
+    /// Press of the left zone (no centre).
+    pub press_left: Emotion,
+    /// Press of the centre zone (or centre-tied multi-zone).
+    pub press_centre: Emotion,
+    /// Press of the right zone (no centre).
+    pub press_right: Emotion,
+    /// `SwipeForward` (left → right).
+    pub swipe_forward: Emotion,
+    /// `SwipeBackward` (right → left).
+    pub swipe_backward: Emotion,
+}
+
+impl GestureMapping {
+    /// Default mapping documented in the module-level table.
+    pub const DEFAULT: Self = Self {
+        press_left: DEFAULT_LEFT_PRESS,
+        press_centre: DEFAULT_CENTRE_PRESS,
+        press_right: DEFAULT_RIGHT_PRESS,
+        swipe_forward: DEFAULT_SWIPE_FORWARD,
+        swipe_backward: DEFAULT_SWIPE_BACKWARD,
+    };
+}
+
+/// Internal gesture-detection state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// No touch active.
+    Idle,
+    /// Touched, no swipe yet. Carries the position recorded at the
+    /// initial Press for delta comparison.
+    Touched {
+        /// Centroid (`-100..=+100`) at the moment of Press; swipes
+        /// are detected as deltas from this value.
+        initial_position: i16,
+    },
+    /// Swipe in progress — only one swipe per touch run; subsequent
+    /// position changes don't re-fire until release.
+    Swiping,
+}
+
+/// Gesture-detection modifier for the back-of-head `Si12T` petting strip.
+#[derive(Debug, Clone, Copy)]
+pub struct BodyGesture {
+    /// Per-gesture emotion targets.
+    pub mapping: GestureMapping,
+    /// Hold duration written to `mind.autonomy.manual_until`.
+    pub hold_ms: u64,
+    /// Centroid-shift threshold for swipe detection.
+    pub swipe_delta: i16,
+    /// Internal state-machine state.
+    state: State,
+}
+
+impl BodyGesture {
+    /// Construct with the default mapping + [`BODY_GESTURE_HOLD_MS`] hold + [`SWIPE_DELTA`] threshold.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            mapping: GestureMapping::DEFAULT,
+            hold_ms: BODY_GESTURE_HOLD_MS,
+            swipe_delta: SWIPE_DELTA,
+            state: State::Idle,
+        }
+    }
+
+    /// Override the per-gesture emotion mapping.
+    #[must_use]
+    pub const fn with_mapping(mut self, mapping: GestureMapping) -> Self {
+        self.mapping = mapping;
+        self
+    }
+}
+
+impl Default for BodyGesture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for BodyGesture {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "BodyGesture",
+            description: "State-machine gesture recognition on perception.body_touch \
+                          (Si12T petting strip): Press emits per-zone emotion, \
+                          SwipeForward/Backward emit Happy/Surprised. Mirrors M5Stack's \
+                          reference hal_head_touch.cpp gesture model.",
+            phase: Phase::Affect,
+            priority: 0,
+            reads: &[Field::BodyTouch],
+            writes: &[Field::Emotion, Field::Autonomy],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let Some(touch) = entity.perception.body_touch else {
+            return;
+        };
+        let touched_now = touch.any();
+
+        match (self.state, touched_now) {
+            // Idle + no touch = stay idle. Swiping + still touched =
+            // already swiped this run, ignore further centroid drift.
+            (State::Idle, false) | (State::Swiping, true) => {}
+            (State::Idle, true) => {
+                // Press: pick zone-derived emotion + transition to Touched.
+                let emotion = if touch.centre >= 1 {
+                    self.mapping.press_centre
+                } else if touch.left >= 1 {
+                    self.mapping.press_left
+                } else if touch.right >= 1 {
+                    self.mapping.press_right
+                } else {
+                    return;
+                };
+                pin_emotion(entity, emotion, self.hold_ms);
+                self.state = State::Touched {
+                    initial_position: touch.position(),
+                };
+            }
+            (State::Touched { initial_position }, true) => {
+                // Watch the centroid for a swipe.
+                let delta = touch.position() - initial_position;
+                if delta >= self.swipe_delta {
+                    pin_emotion(entity, self.mapping.swipe_forward, self.hold_ms);
+                    self.state = State::Swiping;
+                } else if delta <= -self.swipe_delta {
+                    pin_emotion(entity, self.mapping.swipe_backward, self.hold_ms);
+                    self.state = State::Swiping;
+                }
+            }
+            (State::Touched { .. } | State::Swiping, false) => {
+                // Release: return to Idle, no emotion change.
+                self.state = State::Idle;
+            }
+        }
+    }
+}
+
+/// Write emotion + autonomy hold for any body-touch gesture.
+fn pin_emotion(entity: &mut Entity, emotion: Emotion, hold_ms: u64) {
+    let now: Instant = entity.tick.now;
+    entity.mind.affect.emotion = emotion;
+    entity.mind.autonomy.manual_until = Some(now + hold_ms);
+    entity.mind.autonomy.source = Some(OverrideSource::BodyTouch);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perception::BodyTouch;
+
+    fn entity_with_touch(touch: Option<BodyTouch>) -> Entity {
+        let mut e = Entity::default();
+        e.perception.body_touch = touch;
+        e
+    }
+
+    fn run(m: &mut BodyGesture, entity: &mut Entity, now_ms: u64) {
+        entity.tick.now = Instant::from_millis(now_ms);
+        m.update(entity);
+    }
+
+    #[test]
+    fn no_perception_does_nothing() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(None);
+        run(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Neutral);
+        assert!(entity.mind.autonomy.manual_until.is_none());
+    }
+
+    #[test]
+    fn press_left_sets_sleepy() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            left: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_LEFT_PRESS);
+        assert_eq!(entity.mind.autonomy.source, Some(OverrideSource::BodyTouch));
+    }
+
+    #[test]
+    fn press_centre_sets_happy_even_with_other_zones() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            left: 3,
+            centre: 3,
+            right: 3,
+        }));
+        run(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_CENTRE_PRESS);
+    }
+
+    #[test]
+    fn sustained_touch_does_not_re_extend_hold() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        let first_hold = entity.mind.autonomy.manual_until;
+
+        for t in (200..2_000).step_by(100) {
+            run(&mut m, &mut entity, t);
+        }
+        assert_eq!(entity.mind.autonomy.manual_until, first_hold);
+    }
+
+    #[test]
+    fn release_then_press_fires_again() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            left: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_LEFT_PRESS);
+
+        // Release.
+        entity.perception.body_touch = Some(BodyTouch::default());
+        run(&mut m, &mut entity, 200);
+
+        // Re-press on the right.
+        entity.perception.body_touch = Some(BodyTouch {
+            right: 3,
+            ..BodyTouch::default()
+        });
+        run(&mut m, &mut entity, 300);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_RIGHT_PRESS);
+    }
+
+    #[test]
+    fn left_to_right_slide_fires_swipe_forward() {
+        let mut m = BodyGesture::new();
+        // Press on left.
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            left: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_LEFT_PRESS);
+
+        // Slide to right — centroid shifts well past +SWIPE_DELTA.
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 0,
+            centre: 0,
+            right: 3,
+        });
+        run(&mut m, &mut entity, 200);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_SWIPE_FORWARD);
+    }
+
+    #[test]
+    fn right_to_left_slide_fires_swipe_backward() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            right: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_RIGHT_PRESS);
+
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 3,
+            centre: 0,
+            right: 0,
+        });
+        run(&mut m, &mut entity, 200);
+        assert_eq!(entity.mind.affect.emotion, DEFAULT_SWIPE_BACKWARD);
+    }
+
+    #[test]
+    fn swipe_does_not_re_fire_within_a_run() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            left: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        entity.perception.body_touch = Some(BodyTouch {
+            right: 3,
+            ..BodyTouch::default()
+        });
+        run(&mut m, &mut entity, 200);
+        let after_swipe = entity.mind.autonomy.manual_until;
+
+        // Continue touching at the new position. No re-fire.
+        for t in (300..2_000).step_by(100) {
+            run(&mut m, &mut entity, t);
+        }
+        assert_eq!(entity.mind.autonomy.manual_until, after_swipe);
+    }
+
+    #[test]
+    fn small_centroid_drift_does_not_trigger_swipe() {
+        let mut m = BodyGesture::new();
+        let mut entity = entity_with_touch(Some(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        }));
+        run(&mut m, &mut entity, 100);
+        let after_press = entity.mind.affect.emotion;
+
+        // Slightly stronger right finger pressure — small centroid
+        // shift, well under SWIPE_DELTA. No new gesture should fire.
+        entity.perception.body_touch = Some(BodyTouch {
+            centre: 3,
+            right: 1,
+            ..BodyTouch::default()
+        });
+        run(&mut m, &mut entity, 200);
+        assert_eq!(entity.mind.affect.emotion, after_press);
+    }
+
+    #[test]
+    fn body_touch_position_is_centroid() {
+        // Pin the math the swipe state machine depends on.
+        assert_eq!(
+            BodyTouch {
+                left: 3,
+                ..BodyTouch::default()
+            }
+            .position(),
+            -100,
+        );
+        assert_eq!(
+            BodyTouch {
+                right: 3,
+                ..BodyTouch::default()
+            }
+            .position(),
+            100,
+        );
+        assert_eq!(
+            BodyTouch {
+                centre: 3,
+                ..BodyTouch::default()
+            }
+            .position(),
+            0,
+        );
+        // Equal left + right cancels out.
+        assert_eq!(
+            BodyTouch {
+                left: 2,
+                right: 2,
+                ..BodyTouch::default()
+            }
+            .position(),
+            0,
+        );
+        // Position with no touch is zero.
+        assert_eq!(BodyTouch::default().position(), 0);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -58,6 +58,7 @@
 
 mod ambient_sleepy;
 mod blink;
+mod body_gesture;
 mod breath;
 mod emotion_cycle;
 mod emotion_head;
@@ -74,6 +75,11 @@ mod wake_on_voice;
 
 pub use ambient_sleepy::{AMBIENT_HOLD_MS, AmbientSleepy, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX};
 pub use blink::Blink;
+pub use body_gesture::{
+    BODY_GESTURE_HOLD_MS, BodyGesture, DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS,
+    DEFAULT_RIGHT_PRESS, DEFAULT_SWIPE_BACKWARD, DEFAULT_SWIPE_FORWARD, GestureMapping,
+    SWIPE_DELTA,
+};
 pub use breath::Breath;
 pub use emotion_cycle::EmotionCycle;
 pub use emotion_head::EmotionHead;

--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -14,25 +14,49 @@
 //! [`Phase::Affect`]: crate::director::Phase::Affect
 //! [`Phase::Audio`]: crate::director::Phase::Audio
 
-/// Per-zone body-touch state (back-of-head `Si12T` pads).
+/// Per-zone body-touch intensity (back-of-head `Si12T` pads).
 ///
-/// Continuous "currently touched" state — modifiers / skills do their
-/// own edge detection if they need tap vs hold vs swipe semantics.
+/// Each zone carries a 0..=3 intensity matching the chip's 2-bit
+/// per-channel encoding (`0` = no touch, `1..=3` = touch with rising
+/// firmness). Modifiers / skills do their own edge / gesture detection.
+///
+/// The intensity (vs a plain `bool`) is what `position()` and the
+/// swipe state machine in [`crate::modifiers::BodyGesture`] need —
+/// reducing to `bool` would lose the centroid math.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BodyTouch {
-    /// Left zone is currently touched (`Si12T` intensity ≥ 1).
-    pub left: bool,
-    /// Centre zone is currently touched.
-    pub centre: bool,
-    /// Right zone is currently touched.
-    pub right: bool,
+    /// Left zone intensity, `0..=3`.
+    pub left: u8,
+    /// Centre zone intensity, `0..=3`.
+    pub centre: u8,
+    /// Right zone intensity, `0..=3`.
+    pub right: u8,
 }
 
 impl BodyTouch {
-    /// `true` if any zone is touched.
+    /// `true` if any zone has non-zero intensity (matches upstream's
+    /// `is_touched` heuristic of `intensity >= 1`).
     #[must_use]
     pub const fn any(&self) -> bool {
-        self.left || self.centre || self.right
+        self.left >= 1 || self.centre >= 1 || self.right >= 1
+    }
+
+    /// Centroid in `-100..=+100` (left-most → -100, centre → 0,
+    /// right-most → +100), weighted by intensity. Returns `0` when
+    /// no zones are touched. Used by gesture detection to recognise
+    /// swipes as the touch centroid moves across the strip.
+    #[must_use]
+    pub const fn position(&self) -> i16 {
+        let total = self.left as i16 + self.centre as i16 + self.right as i16;
+        if total == 0 {
+            return 0;
+        }
+        // Centre contributes 0; left = -100, right = +100. Max
+        // numerator magnitude is 3 × 100 = 300; dividing by total
+        // (≥ 1, ≤ 9) keeps the result in `-100..=+100` — well inside
+        // i16 range.
+        let weighted = (self.right as i16 - self.left as i16) * 100;
+        weighted / total
     }
 }
 

--- a/crates/stackchan-firmware/src/body_touch.rs
+++ b/crates/stackchan-firmware/src/body_touch.rs
@@ -12,7 +12,7 @@
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Delay, Duration, Ticker, Timer};
 use embedded_hal_async::i2c::I2c as AsyncI2c;
-use si12t::Si12t;
+use si12t::{Intensity, Si12t};
 use stackchan_core::BodyTouch;
 
 /// Latest body-touch reading: body-touch task → render task.
@@ -57,13 +57,24 @@ pub async fn run_body_touch_loop<I: AsyncI2c>(bus: I) -> ! {
         match chip.read_touch().await {
             Ok(touch) => {
                 BODY_TOUCH_SIGNAL.signal(BodyTouch {
-                    left: touch.left(),
-                    centre: touch.centre(),
-                    right: touch.right(),
+                    left: intensity_u8(touch.intensity.0),
+                    centre: intensity_u8(touch.intensity.1),
+                    right: intensity_u8(touch.intensity.2),
                 });
             }
             Err(e) => defmt::warn!("Si12T: read_touch failed: {}", defmt::Debug2Format(&e),),
         }
         ticker.next().await;
+    }
+}
+
+/// Convert the driver's `Intensity` enum to the engine's `0..=3`
+/// numeric encoding.
+const fn intensity_u8(i: Intensity) -> u8 {
+    match i {
+        Intensity::None => 0,
+        Intensity::Low => 1,
+        Intensity::Mid => 2,
+        Intensity::High => 3,
     }
 }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -65,9 +65,9 @@ use mipidsi::{
 use stackchan_core::{
     Clock, Director, Entity, Face, HeadDriver, LedFrame,
     modifiers::{
-        AmbientSleepy, Blink, Breath, EmotionCycle, EmotionHead, EmotionStyle, EmotionTouch,
-        IdleDrift, IdleSway, ListenHead, LowBatteryEmotion, MouthOpenAudio, PickupReaction,
-        RemoteCommand, WakeOnVoice,
+        AmbientSleepy, Blink, BodyGesture, Breath, EmotionCycle, EmotionHead, EmotionStyle,
+        EmotionTouch, IdleDrift, IdleSway, ListenHead, LowBatteryEmotion, MouthOpenAudio,
+        PickupReaction, RemoteCommand, WakeOnVoice,
     },
     render_leds,
     skills::LookAtSound,
@@ -197,6 +197,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut listen_head = ListenHead::new();
     let mut mouth_open_audio = MouthOpenAudio::new();
     let mut look_at_sound = LookAtSound::new();
+    let mut body_gesture = BodyGesture::new();
     let mut last_rendered: Option<Face> = None;
 
     // Build the Director and register the canonical modifier stack
@@ -208,6 +209,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut director = Director::new();
     director
         .add_modifier(&mut emotion_touch)
+        .expect("registry full");
+    director
+        .add_modifier(&mut body_gesture)
         .expect("registry full");
     director.add_modifier(&mut remote).expect("registry full");
     director.add_modifier(&mut pickup).expect("registry full");
@@ -256,7 +260,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + RemoteCommand + PickupReaction + WakeOnVoice + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + ListenHead + MouthOpenAudio + LookAtSound[skill]",
+        "render task: {=u64} ms tick, EmotionTouch + BodyGesture + RemoteCommand + PickupReaction + WakeOnVoice + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + ListenHead + MouthOpenAudio + LookAtSound[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-sim/tests/body_gesture.rs
+++ b/crates/stackchan-sim/tests/body_gesture.rs
@@ -1,0 +1,137 @@
+//! End-to-end sim test for the `BodyGesture` modifier.
+//!
+//! Drives a Director with `BodyGesture` + `EmotionStyle` (so emotion
+//! changes propagate into the face style fields), varies
+//! `perception.body_touch` across simulated time, and asserts the
+//! Press / Swipe / Release state machine matches the documented
+//! contract.
+//!
+//! Routing through `Director` exercises the debug-mode `writes:`
+//! enforcement on every frame, so a future modifier change that
+//! silently writes a field outside its declared `writes:` slice would
+//! panic here.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-only: registry capacity is a compile-time constant in this fixture"
+)]
+
+use stackchan_core::modifiers::{
+    BodyGesture, DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS, DEFAULT_RIGHT_PRESS,
+    DEFAULT_SWIPE_BACKWARD, DEFAULT_SWIPE_FORWARD,
+};
+use stackchan_core::{BodyTouch, Director, Emotion, Entity, Instant, OverrideSource};
+
+const TICK_MS: u64 = 33;
+
+fn run_for(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, ticks: u64) -> Instant {
+    let mut last = Instant::from_millis(start_ms);
+    for t in 0..ticks {
+        last = Instant::from_millis(start_ms + t * TICK_MS);
+        director.run(entity, last);
+    }
+    last
+}
+
+#[test]
+fn press_centre_through_director_yields_happy() {
+    let mut entity = Entity::default();
+    let mut gesture = BodyGesture::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+
+    entity.perception.body_touch = Some(BodyTouch {
+        centre: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_CENTRE_PRESS);
+    assert_eq!(entity.mind.autonomy.source, Some(OverrideSource::BodyTouch));
+    assert!(entity.mind.autonomy.manual_until.is_some());
+}
+
+#[test]
+fn left_press_then_release_then_right_press_fires_twice() {
+    let mut entity = Entity::default();
+    let mut gesture = BodyGesture::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+
+    entity.perception.body_touch = Some(BodyTouch {
+        left: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_LEFT_PRESS);
+
+    entity.perception.body_touch = Some(BodyTouch::default());
+    run_for(&mut director, &mut entity, TICK_MS, 5);
+
+    entity.perception.body_touch = Some(BodyTouch {
+        right: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(10_000));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_RIGHT_PRESS);
+}
+
+#[test]
+fn left_to_right_slide_through_director_fires_swipe_forward() {
+    let mut entity = Entity::default();
+    let mut gesture = BodyGesture::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+
+    // Press on the left.
+    entity.perception.body_touch = Some(BodyTouch {
+        left: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_LEFT_PRESS);
+
+    // Slide finger right; centroid moves well past +SWIPE_DELTA.
+    entity.perception.body_touch = Some(BodyTouch {
+        left: 0,
+        centre: 0,
+        right: 3,
+    });
+    director.run(&mut entity, Instant::from_millis(100));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_SWIPE_FORWARD);
+}
+
+#[test]
+fn right_to_left_slide_through_director_fires_swipe_backward() {
+    let mut entity = Entity::default();
+    let mut gesture = BodyGesture::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+
+    entity.perception.body_touch = Some(BodyTouch {
+        right: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_RIGHT_PRESS);
+
+    entity.perception.body_touch = Some(BodyTouch {
+        left: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(100));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_SWIPE_BACKWARD);
+}
+
+#[test]
+fn no_perception_keeps_neutral() {
+    let mut entity = Entity::default();
+    let mut gesture = BodyGesture::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+
+    // perception.body_touch defaults to None.
+    run_for(&mut director, &mut entity, 0, 30);
+    assert_eq!(entity.mind.affect.emotion, Emotion::Neutral);
+    assert!(entity.mind.autonomy.manual_until.is_none());
+}


### PR DESCRIPTION
## Summary

First behavior consuming the body-touch perception field added in #99. Implements the same gesture state machine as M5Stack's reference [`hal_head_touch.cpp`](https://github.com/m5stack/StackChan/blob/main/firmware/main/hal/hal_head_touch.cpp):

```
Idle → Touched (Press) → Swiping (SwipeForward / SwipeBackward) → Idle (Release)
```

The back-of-head strip is a petting affordance, not three discrete buttons. The gesture model matches that physical interaction.

## Behavior

| Gesture | Trigger | Emotion |
|---------|---------|---------|
| `Press` | Rising edge no-touch → any-zone touched | per-zone (left=Sleepy, centre=Happy, right=Surprised; centre wins on multi-zone) |
| `SwipeForward` | Centroid shifts right ≥ `SWIPE_DELTA` mid-touch | `Happy` |
| `SwipeBackward` | Centroid shifts left ≥ `SWIPE_DELTA` mid-touch | `Surprised` |
| `Release` | Falling edge to no-touch | (no-op) |

Sustained touch + continued sliding within a single touch run does not re-fire.

## What changed

- **`perception::BodyTouch` carries `u8` intensity per zone** (0..=3 matching Si12T's 2-bit encoding) + `position()` returning intensity-weighted centroid in -100..=+100. The earlier bool-per-zone could not represent centroid shifts.
- **`OverrideSource::BodyTouch` variant** — autonomy source distinguishes back-of-head from front-screen taps.
- **`crates/stackchan-core/src/modifiers/body_gesture.rs`** — state machine + `GestureMapping` config + 10 unit tests.
- **`crates/stackchan-sim/tests/body_gesture.rs`** — 5 sim integration tests through Director (exercises the v0.10 debug-mode `writes:` enforcement on every frame).
- **Firmware**: body_touch.rs publishes the intensity-aware shape; render_task registers BodyGesture in Phase::Affect (priority 0, immediately after EmotionTouch); catalog log line updated.

## Hardware verification (`just fmr`)

```
1328 ms render task: ... + BodyGesture + ...
1412 ms Si12T: body-touch task ready (poll 50 ms)
```

Body-touch task and BodyGesture modifier both up. To verify the gesture detection itself, tap or slide on the back-of-head strip and watch the LCD emotion shift.

## Test plan
- [x] `just check` — passes (172 + 5 = 177 host tests)
- [x] `just check-firmware` (`cargo +esp check`) — passes
- [x] `just fmr` — boots clean, body-touch task ready, modifier registered