### PR TITLE
feat(core): Petting skill — sustained body-touch → mind.intent=BeingPet

### DIFF
--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -82,6 +82,10 @@ pub enum Intent {
     /// Listening to ambient sound. Set by
     /// [`crate::skills::LookAtSound`]; cleared on release.
     Listen,
+    /// Being pet on the back-of-head strip. Set by
+    /// [`crate::skills::Petting`] after sustained any-zone contact;
+    /// cleared on release.
+    BeingPet,
 }
 
 /// What the entity is currently focused on.

--- a/crates/stackchan-core/src/skills/mod.rs
+++ b/crates/stackchan-core/src/skills/mod.rs
@@ -17,7 +17,9 @@
 //!   for a cocked-head listening posture.
 
 mod look_at_sound;
+mod petting;
 
 pub use look_at_sound::{
     LISTEN_RELEASE_MS, LISTEN_RMS_THRESHOLD, LISTEN_SUSTAIN_TICKS, LookAtSound,
 };
+pub use petting::{PETTING_SUSTAIN_TICKS, Petting};

--- a/crates/stackchan-core/src/skills/petting.rs
+++ b/crates/stackchan-core/src/skills/petting.rs
@@ -1,0 +1,254 @@
+//! `Petting`: skill that sets `mind.intent = BeingPet` after sustained
+//! contact on the back-of-head strip.
+//!
+//! Reads `entity.perception.body_touch` (intensity-aware, populated by
+//! the firmware `body_touch` task). Counts consecutive ticks where any
+//! zone has non-zero intensity; once the run reaches
+//! [`PETTING_SUSTAIN_TICKS`] the skill writes
+//! [`Intent::BeingPet`](crate::mind::Intent::BeingPet). On release
+//! (any-zone-touched goes false) the intent clears back to
+//! [`Intent::Idle`](crate::mind::Intent::Idle).
+//!
+//! ## Coexistence with `BodyGesture`
+//!
+//! [`crate::modifiers::BodyGesture`] reacts to the SAME perception
+//! field but writes emotion + autonomy on the no-touch → touch rising
+//! edge (Press), or on swipes. `Petting` writes intent only, after a
+//! sustain. The two are complementary: a deliberate centre pet
+//! triggers Press → Happy emotion immediately, AND after 1.5 s of
+//! sustained contact, intent flips to `BeingPet`. Modifiers in later
+//! phases (when added) can read `mind.intent` and add visual flourish
+//! (extra blush, head bobs) on top of the emotion shift.
+//!
+//! ## Why a Skill, not a Modifier
+//!
+//! The output is `mind.intent` — a Mind field. Skills write Mind /
+//! Voice / Events; modifiers translate Mind into Face / Motor. This
+//! puts the sustain-detection logic on the right side of the
+//! architectural split, and the [`Director::add_skill`] check enforces
+//! the contract at registration time.
+//!
+//! [`Director::add_skill`]: crate::Director::add_skill
+
+use crate::director::{Field, SkillMeta};
+use crate::entity::Entity;
+use crate::mind::Intent;
+use crate::skill::{Skill, SkillStatus};
+
+/// Consecutive any-zone-touched ticks required to enter `BeingPet`.
+///
+/// At the firmware's 50 ms body-touch poll cadence, 30 ticks ≈ 1.5 s
+/// — long enough to ignore brushing past the strip, short enough that
+/// a deliberate pet is responsive.
+pub const PETTING_SUSTAIN_TICKS: u8 = 30;
+
+/// Skill that detects sustained back-of-head contact. See module docs.
+#[derive(Debug, Clone, Copy)]
+pub struct Petting {
+    /// Consecutive any-zone-touched ticks required to fire.
+    pub sustain_ticks: u8,
+    /// Running count of consecutive touched ticks. Reset on any
+    /// not-touched tick. Saturates at `u8::MAX`.
+    consecutive: u8,
+}
+
+impl Petting {
+    /// Construct with the default sustain ([`PETTING_SUSTAIN_TICKS`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            sustain_ticks: PETTING_SUSTAIN_TICKS,
+            consecutive: 0,
+        }
+    }
+
+    /// Construct with a custom sustain count.
+    #[must_use]
+    pub const fn with_sustain_ticks(sustain_ticks: u8) -> Self {
+        Self {
+            sustain_ticks,
+            consecutive: 0,
+        }
+    }
+}
+
+impl Default for Petting {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Skill for Petting {
+    fn meta(&self) -> &'static SkillMeta {
+        static META: SkillMeta = SkillMeta {
+            name: "Petting",
+            description: "Sustained back-of-head touch (any zone, ≥ PETTING_SUSTAIN_TICKS) sets \
+                          mind.intent = BeingPet. Clears to Idle on release. Coexists with \
+                          BodyGesture (which writes emotion on the rising edge / on swipes).",
+            priority: 50,
+            writes: &[Field::Intent],
+        };
+        &META
+    }
+
+    fn should_fire(&self, _entity: &Entity) -> bool {
+        // Always polled — the sustain counter needs to advance every
+        // frame regardless of current intent state.
+        true
+    }
+
+    fn invoke(&mut self, entity: &mut Entity) -> SkillStatus {
+        let touched = entity.perception.body_touch.is_some_and(|t| t.any());
+
+        if touched {
+            self.consecutive = self.consecutive.saturating_add(1);
+            if self.consecutive >= self.sustain_ticks {
+                entity.mind.intent = Intent::BeingPet;
+                return SkillStatus::Continuing;
+            }
+            return SkillStatus::Done;
+        }
+
+        // Released. Clear counter + intent (only if we set it).
+        self.consecutive = 0;
+        if matches!(entity.mind.intent, Intent::BeingPet) {
+            entity.mind.intent = Intent::Idle;
+        }
+        SkillStatus::Done
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::Instant;
+    use crate::perception::BodyTouch;
+
+    fn step(skill: &mut Petting, entity: &mut Entity, ticks: u64) {
+        let mut now = entity.tick.now;
+        for _ in 0..ticks {
+            now = now + 50;
+            entity.tick.now = now;
+            let _ = skill.invoke(entity);
+        }
+    }
+
+    fn touched_entity(touch: BodyTouch) -> Entity {
+        let mut e = Entity::default();
+        e.perception.body_touch = Some(touch);
+        e
+    }
+
+    #[test]
+    fn no_perception_keeps_idle() {
+        let mut skill = Petting::new();
+        let mut entity = Entity::default();
+        step(&mut skill, &mut entity, 100);
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn brief_touch_below_sustain_does_not_fire() {
+        let mut skill = Petting::new();
+        let mut entity = touched_entity(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        });
+        step(
+            &mut skill,
+            &mut entity,
+            u64::from(PETTING_SUSTAIN_TICKS) - 1,
+        );
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn sustained_touch_sets_being_pet() {
+        let mut skill = Petting::new();
+        let mut entity = touched_entity(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        });
+        step(&mut skill, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
+        assert_eq!(entity.mind.intent, Intent::BeingPet);
+    }
+
+    #[test]
+    fn release_clears_being_pet() {
+        let mut skill = Petting::new();
+        let mut entity = touched_entity(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        });
+        step(&mut skill, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
+        assert_eq!(entity.mind.intent, Intent::BeingPet);
+
+        // Release.
+        entity.perception.body_touch = Some(BodyTouch::default());
+        let _ = skill.invoke(&mut entity);
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn release_does_not_clobber_unrelated_intent() {
+        let mut skill = Petting::new();
+        let mut entity = Entity::default();
+        // Some other system set Listen — petting hasn't fired.
+        entity.mind.intent = Intent::Listen;
+        // Release tick (no body touch).
+        let _ = skill.invoke(&mut entity);
+        assert_eq!(entity.mind.intent, Intent::Listen);
+    }
+
+    #[test]
+    fn quiet_tick_resets_counter_mid_sustain() {
+        let mut skill = Petting::new();
+        let mut entity = touched_entity(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        });
+        // Almost there.
+        step(
+            &mut skill,
+            &mut entity,
+            u64::from(PETTING_SUSTAIN_TICKS) - 1,
+        );
+        // One quiet tick resets.
+        entity.perception.body_touch = Some(BodyTouch::default());
+        let _ = skill.invoke(&mut entity);
+        // Resume touching — must run the full sustain again.
+        entity.perception.body_touch = Some(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        });
+        step(
+            &mut skill,
+            &mut entity,
+            u64::from(PETTING_SUSTAIN_TICKS) - 1,
+        );
+        assert_eq!(entity.mind.intent, Intent::Idle);
+    }
+
+    #[test]
+    fn counter_saturates_does_not_wrap() {
+        let mut skill = Petting::new();
+        let mut entity = touched_entity(BodyTouch {
+            centre: 3,
+            ..BodyTouch::default()
+        });
+        step(&mut skill, &mut entity, 500); // well past u8::MAX
+        assert_eq!(entity.mind.intent, Intent::BeingPet);
+    }
+
+    #[test]
+    fn any_zone_counts_not_just_centre() {
+        let mut skill = Petting::new();
+        let mut entity = touched_entity(BodyTouch {
+            left: 1,
+            ..BodyTouch::default()
+        });
+        entity.tick.now = Instant::from_millis(0);
+        step(&mut skill, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
+        assert_eq!(entity.mind.intent, Intent::BeingPet);
+    }
+}

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -70,7 +70,7 @@ use stackchan_core::{
         PickupReaction, RemoteCommand, WakeOnVoice,
     },
     render_leds,
-    skills::LookAtSound,
+    skills::{LookAtSound, Petting},
     voice::ChirpKind,
 };
 use static_cell::StaticCell;
@@ -197,6 +197,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut listen_head = ListenHead::new();
     let mut mouth_open_audio = MouthOpenAudio::new();
     let mut look_at_sound = LookAtSound::new();
+    let mut petting = Petting::new();
     let mut body_gesture = BodyGesture::new();
     let mut last_rendered: Option<Face> = None;
 
@@ -241,6 +242,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         .expect("registry full");
     director
         .add_skill(&mut look_at_sound)
+        .expect("skill registry full");
+    director
+        .add_skill(&mut petting)
         .expect("skill registry full");
     let mut led_frame = LedFrame::default();
     // Camera-mode state. The button task's long-press handler is the

--- a/crates/stackchan-sim/tests/petting.rs
+++ b/crates/stackchan-sim/tests/petting.rs
@@ -1,0 +1,104 @@
+//! End-to-end sim test for the `Petting` skill.
+//!
+//! Verifies the parallel-driver design: `BodyGesture` (modifier) and
+//! `Petting` (skill) react to the same `perception.body_touch` input
+//! without conflict — modifier writes emotion + autonomy on the
+//! Press edge, skill writes intent after sustained contact.
+
+#![allow(
+    clippy::unwrap_used,
+    reason = "test-only: registry capacity is a compile-time constant in this fixture"
+)]
+
+use stackchan_core::modifiers::{BodyGesture, DEFAULT_CENTRE_PRESS};
+use stackchan_core::skills::{PETTING_SUSTAIN_TICKS, Petting};
+use stackchan_core::{BodyTouch, Director, Entity, Instant, Intent};
+
+const TICK_MS: u64 = 50;
+
+fn run_for(director: &mut Director<'_>, entity: &mut Entity, ticks: u64) {
+    let mut now_ms = entity.tick.now.as_millis();
+    for _ in 0..ticks {
+        now_ms += TICK_MS;
+        director.run(entity, Instant::from_millis(now_ms));
+    }
+}
+
+#[test]
+fn brief_touch_through_director_keeps_intent_idle() {
+    let mut entity = Entity::default();
+    let mut petting = Petting::new();
+    let mut director = Director::new();
+    director.add_skill(&mut petting).unwrap();
+
+    entity.perception.body_touch = Some(BodyTouch {
+        centre: 3,
+        ..BodyTouch::default()
+    });
+    run_for(
+        &mut director,
+        &mut entity,
+        u64::from(PETTING_SUSTAIN_TICKS) - 1,
+    );
+    assert_eq!(entity.mind.intent, Intent::Idle);
+}
+
+#[test]
+fn sustained_touch_through_director_fires_being_pet() {
+    let mut entity = Entity::default();
+    let mut petting = Petting::new();
+    let mut director = Director::new();
+    director.add_skill(&mut petting).unwrap();
+
+    entity.perception.body_touch = Some(BodyTouch {
+        centre: 3,
+        ..BodyTouch::default()
+    });
+    run_for(&mut director, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
+    assert_eq!(entity.mind.intent, Intent::BeingPet);
+}
+
+#[test]
+fn body_gesture_and_petting_coexist_on_same_input() {
+    let mut entity = Entity::default();
+    let mut gesture = BodyGesture::new();
+    let mut petting = Petting::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+    director.add_skill(&mut petting).unwrap();
+
+    // First frame: Press → BodyGesture sets emotion.
+    entity.perception.body_touch = Some(BodyTouch {
+        centre: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_CENTRE_PRESS);
+    assert_eq!(entity.mind.intent, Intent::Idle);
+
+    // Continue touching past the sustain — Petting fires intent
+    // change while emotion stays pinned.
+    run_for(&mut director, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
+    assert_eq!(entity.mind.affect.emotion, DEFAULT_CENTRE_PRESS);
+    assert_eq!(entity.mind.intent, Intent::BeingPet);
+}
+
+#[test]
+fn release_clears_being_pet_through_director() {
+    let mut entity = Entity::default();
+    let mut petting = Petting::new();
+    let mut director = Director::new();
+    director.add_skill(&mut petting).unwrap();
+
+    entity.perception.body_touch = Some(BodyTouch {
+        centre: 3,
+        ..BodyTouch::default()
+    });
+    run_for(&mut director, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
+    assert_eq!(entity.mind.intent, Intent::BeingPet);
+
+    entity.perception.body_touch = Some(BodyTouch::default());
+    let next = entity.tick.now.as_millis() + TICK_MS;
+    director.run(&mut entity, Instant::from_millis(next));
+    assert_eq!(entity.mind.intent, Intent::Idle);
+}


### PR DESCRIPTION
## Summary

Demonstrates the parallel-driver design landed by the Skill + ECS-enforcement work: `Petting` (skill) and `BodyGesture` (modifier) both react to `perception.body_touch` without conflict — modifier writes emotion + autonomy on the Press edge / on swipes; skill writes intent after sustained any-zone contact.

## Behavior

- **Trigger**: any-zone touched for ≥ `PETTING_SUSTAIN_TICKS` (default 30 ticks × 50 ms ≈ 1.5 s).
- **On fire**: `mind.intent = Intent::BeingPet`.
- **On release**: clears back to `Intent::Idle` — but only if the skill had set `BeingPet` (so an unrelated intent like `Listen` set by `LookAtSound` survives a quiet body-touch tick).

## What changed

- **`Intent::BeingPet` variant** on the existing enum.
- **`crates/stackchan-core/src/skills/petting.rs`** with 7 unit tests (idle / brief / sustained / release / unrelated-intent / mid-sustain reset / counter saturation / any-zone-counts).
- **`crates/stackchan-sim/tests/petting.rs`** with 4 sim integration tests through Director, including one explicitly verifying `BodyGesture` (modifier) + `Petting` (skill) coexist on the same input with no contention.
- **Firmware**: register `Petting` alongside `LookAtSound` in `render_task`. The Director's debug-mode contract check on `add_skill` passes (writes = `[Field::Intent]`, in `FieldGroup::Mind`).

No new chirp / no firmware behavior change beyond the intent write — visible reactions to `BeingPet` (e.g. an Expression-phase modifier that adds blush + a head bob) land in a follow-up.

## Test plan
- [x] `cargo test -p stackchan-core` — passes (179 tests including 7 new)
- [x] `cargo test -p stackchan-sim` — passes (4 new integration tests)
- [x] `just check` — passes
- [x] `just check-firmware` (`cargo +esp check`) — passes