### PR TITLE
feat(core): IntentStyle modifier — visible reaction to mind.intent

### DIFF
--- a/crates/stackchan-core/src/modifiers/intent_style.rs
+++ b/crates/stackchan-core/src/modifiers/intent_style.rs
@@ -1,0 +1,152 @@
+//! `IntentStyle`: translate `mind.intent` into face-style additions.
+//!
+//! Mirrors [`super::EmotionStyle`] in shape — `Phase::Expression`,
+//! runs after `EmotionStyle` and before `Blink` so the canonical
+//! `EmotionStyle → Blink` ordering still holds — but reads
+//! `mind.intent` instead of `mind.affect.emotion`.
+//!
+//! Today it bumps `face.style.cheek_blush` when intent is
+//! [`Intent::BeingPet`](crate::mind::Intent::BeingPet) so a sustained
+//! pet visibly intensifies the blush regardless of which emotion is
+//! active. Pure addition — `EmotionStyle` writes a fresh
+//! `cheek_blush` baseline every tick (no persistent state to undo),
+//! so this modifier just reads-then-writes with `saturating_add`.
+//!
+//! ## Per-intent additions
+//!
+//! | Intent     | `cheek_blush` add | Why                                    |
+//! |------------|-------------------|----------------------------------------|
+//! | `Idle`     |              `0`  | no override                            |
+//! | `Listen`   |              `0`  | handled separately by `ListenHead`     |
+//! | `BeingPet` |             `+30` | extra blush on top of any emotion base |
+
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::Intent;
+use crate::modifier::Modifier;
+
+/// Cheek-blush bump added when `mind.intent` is
+/// [`Intent::BeingPet`](crate::mind::Intent::BeingPet). Bumped on top
+/// of whatever `EmotionStyle` set; saturates at `255`.
+pub const PETTING_BLUSH_BUMP: u8 = 30;
+
+/// Per-intent face-style additions.
+///
+/// Stateless — every tick reads the upstream `cheek_blush`
+/// (`EmotionStyle` writes it fresh) and adds the per-intent bump.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IntentStyle;
+
+impl IntentStyle {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+/// Look up the per-intent cheek-blush addition.
+const fn blush_for(intent: Intent) -> u8 {
+    match intent {
+        Intent::BeingPet => PETTING_BLUSH_BUMP,
+        Intent::Idle | Intent::Listen => 0,
+    }
+}
+
+impl Modifier for IntentStyle {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "IntentStyle",
+            description: "Translates mind.intent into additive face.style overrides. \
+                          BeingPet adds +PETTING_BLUSH_BUMP to cheek_blush; other intents \
+                          contribute 0. Stateless — relies on EmotionStyle re-writing the \
+                          cheek_blush baseline each tick.",
+            phase: Phase::Expression,
+            // Runs after `EmotionStyle` (priority -10) but before
+            // `Blink` / `Breath` / `IdleDrift` (priority 0). Same
+            // bracket the canonical-order test pins.
+            priority: -5,
+            reads: &[Field::Intent, Field::CheekBlush],
+            writes: &[Field::CheekBlush],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let bump = blush_for(entity.mind.intent);
+        entity.face.style.cheek_blush = entity.face.style.cheek_blush.saturating_add(bump);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity_with(intent: Intent, base_blush: u8) -> Entity {
+        let mut e = Entity::default();
+        e.mind.intent = intent;
+        e.face.style.cheek_blush = base_blush;
+        e
+    }
+
+    #[test]
+    fn idle_intent_does_not_change_blush() {
+        let mut m = IntentStyle::new();
+        let mut entity = entity_with(Intent::Idle, 100);
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 100);
+    }
+
+    #[test]
+    fn listen_intent_does_not_change_blush() {
+        let mut m = IntentStyle::new();
+        let mut entity = entity_with(Intent::Listen, 100);
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 100);
+    }
+
+    #[test]
+    fn being_pet_adds_bump_on_top_of_upstream() {
+        let mut m = IntentStyle::new();
+        let mut entity = entity_with(Intent::BeingPet, 100);
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 100 + PETTING_BLUSH_BUMP);
+    }
+
+    #[test]
+    fn being_pet_saturates_at_max() {
+        let mut m = IntentStyle::new();
+        let mut entity = entity_with(Intent::BeingPet, 250);
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 255);
+    }
+
+    #[test]
+    fn intent_change_to_idle_returns_to_upstream_after_emotionstyle_rewrites() {
+        let mut m = IntentStyle::new();
+        let mut entity = entity_with(Intent::BeingPet, 100);
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 130);
+
+        // EmotionStyle re-writes the baseline each tick. Intent
+        // flips to Idle — the bump goes away and we observe upstream.
+        entity.face.style.cheek_blush = 70;
+        entity.mind.intent = Intent::Idle;
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 70);
+    }
+
+    #[test]
+    fn sustained_being_pet_keeps_bump_stable_across_ticks() {
+        let mut m = IntentStyle::new();
+        let mut entity = entity_with(Intent::BeingPet, 100);
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 130);
+
+        // EmotionStyle re-writes the baseline (the same value, since
+        // emotion is unchanged). Bump should add fresh again.
+        entity.face.style.cheek_blush = 100;
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.cheek_blush, 130);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -66,6 +66,7 @@ mod emotion_style;
 mod emotion_touch;
 mod idle_drift;
 mod idle_sway;
+mod intent_style;
 mod listen_head;
 mod low_battery;
 mod mouth_open_audio;
@@ -87,6 +88,7 @@ pub use emotion_style::EmotionStyle;
 pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
+pub use intent_style::{IntentStyle, PETTING_BLUSH_BUMP};
 pub use listen_head::{LISTEN_HEAD_EASE_MS, LISTEN_HEAD_TILT_DEG, ListenHead};
 pub use low_battery::{
     LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT, LOW_BATTERY_HOLD_MS, LowBatteryEmotion,

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -66,8 +66,8 @@ use stackchan_core::{
     Clock, Director, Entity, Face, HeadDriver, LedFrame,
     modifiers::{
         AmbientSleepy, Blink, BodyGesture, Breath, EmotionCycle, EmotionHead, EmotionStyle,
-        EmotionTouch, IdleDrift, IdleSway, ListenHead, LowBatteryEmotion, MouthOpenAudio,
-        PickupReaction, RemoteCommand, WakeOnVoice,
+        EmotionTouch, IdleDrift, IdleSway, IntentStyle, ListenHead, LowBatteryEmotion,
+        MouthOpenAudio, PickupReaction, RemoteCommand, WakeOnVoice,
     },
     render_leds,
     skills::{LookAtSound, Petting},
@@ -185,6 +185,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut wake_on_voice = WakeOnVoice::new();
     let mut cycle = EmotionCycle::new();
     let mut style = EmotionStyle::new();
+    let mut intent_style = IntentStyle::new();
     let mut blink = Blink::new();
     let mut breath = Breath::new();
     // Seed comes from the ESP32-S3 hardware RNG (`esp_hal::rng::Rng`),
@@ -227,6 +228,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         .expect("registry full");
     director.add_modifier(&mut cycle).expect("registry full");
     director.add_modifier(&mut style).expect("registry full");
+    director
+        .add_modifier(&mut intent_style)
+        .expect("registry full");
     director.add_modifier(&mut blink).expect("registry full");
     director.add_modifier(&mut breath).expect("registry full");
     director.add_modifier(&mut drift).expect("registry full");


### PR DESCRIPTION
## Summary

Closes the BeingPet loop: `Petting` (skill, #102) writes intent; `IntentStyle` (modifier, this PR) translates intent into a face-style bump visible on the avatar. Without this, the `BeingPet` intent was metadata only — the engine knew it but the user couldn't see it.

## What changed

- **New `crates/stackchan-core/src/modifiers/intent_style.rs`**. Phase `Expression`, priority `-5` — runs after `EmotionStyle` (`-10`) but before `Blink` / `Breath` / `IdleDrift` (`0`), preserving the `canonical_order_propagates_blink_rate_within_one_tick` ordering the existing sim test pins.
- **Stateless**: `EmotionStyle` re-writes `face.style.cheek_blush` every tick (no persistent state to undo), so `IntentStyle` just reads the upstream value and `saturating_adds` the per-intent bump.
  - `BeingPet`: `+30` cheek_blush (saturates at 255)
  - `Idle` / `Listen`: 0
- 6 inline unit tests: idle/listen no-op, BeingPet bump, saturation at max, intent change releases bump, sustained intent keeps bump stable.
- Firmware: register `IntentStyle` in `render_task` right after `EmotionStyle`. The Director's debug-mode writes-enforcement catches any drift in declared writes (`[Field::CheekBlush]`).

## End-to-end demo flow

```
Touch back of head 1.5s
  → Petting fires (mind.intent = BeingPet)
  → IntentStyle bumps cheek_blush by +30
  → visible extra blush on the LCD on top of the emotion's normal blush
```

## Test plan
- [x] `cargo test -p stackchan-core` — passes (197 tests including 6 new)
- [x] `just check` — passes
- [x] `just check-firmware` (`cargo +esp check`) — passes