### PR TITLE
feat(firmware): i2c_probe also reads register 0x00 for chip-ID disambiguation

### DIFF
--- a/crates/stackchan-firmware/examples/i2c_probe.rs
+++ b/crates/stackchan-firmware/examples/i2c_probe.rs
@@ -95,6 +95,17 @@ async fn probe<B: I2c>(bus: &mut B, addr: u8) -> bool {
     bus.read(addr, &mut buf).await.is_ok()
 }
 
+/// Read register `0x00` from the chip at `addr` (write-then-read).
+/// Many chips expose `WHO_AM_I` / `CHIP_ID` here (BMI270 = 0x24,
+/// BMM150 = 0x32, LIS3DH = 0x33, MPU6050 = 0x68, etc.) — useful for
+/// disambiguating UNKNOWN ACKs without a separate datasheet hunt.
+/// Returns `Some(byte)` on success, `None` on bus error.
+async fn read_reg0<B: I2c>(bus: &mut B, addr: u8) -> Option<u8> {
+    let mut buf = [0u8; 1];
+    bus.write_read(addr, &[0x00], &mut buf).await.ok()?;
+    Some(buf[0])
+}
+
 #[esp_rtos::main]
 #[allow(
     clippy::used_underscore_binding,
@@ -140,11 +151,31 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
     for addr in ADDR_LO..=ADDR_HI {
         if probe(&mut i2c, addr).await {
             acked += 1;
-            match label_for(addr) {
-                Some(label) => {
-                    defmt::info!("i2c-probe: 0x{=u8:02X} ACK ({=str} expected)", addr, label);
+            // Read register 0x00 to capture WHO_AM_I / CHIP_ID where
+            // the chip exposes one. Logged as "id=??" if the read
+            // fails (some chips refuse register-read after a bare
+            // address-byte read; not fatal).
+            let id = read_reg0(&mut i2c, addr).await;
+            match (label_for(addr), id) {
+                (Some(label), Some(byte)) => defmt::info!(
+                    "i2c-probe: 0x{=u8:02X} ACK ({=str} expected) reg0=0x{=u8:02X}",
+                    addr,
+                    label,
+                    byte,
+                ),
+                (Some(label), None) => defmt::info!(
+                    "i2c-probe: 0x{=u8:02X} ACK ({=str} expected) reg0=??",
+                    addr,
+                    label,
+                ),
+                (None, Some(byte)) => defmt::info!(
+                    "i2c-probe: 0x{=u8:02X} ACK (UNKNOWN) reg0=0x{=u8:02X}",
+                    addr,
+                    byte,
+                ),
+                (None, None) => {
+                    defmt::info!("i2c-probe: 0x{=u8:02X} ACK (UNKNOWN) reg0=??", addr);
                 }
-                None => defmt::info!("i2c-probe: 0x{=u8:02X} ACK (UNKNOWN)", addr),
             }
         }
     }


### PR DESCRIPTION
## Summary

Many I²C chips expose `WHO_AM_I` / `CHIP_ID` at register `0x00` (BMI270 = `0x24`, BMM150 = `0x32`, MPU6050 = `0x68`, LIS3DH = `0x33`, etc.). Reading reg0 alongside the existing ACK probe catches misidentification without a separate datasheet hunt — useful when an address ACKs both for the chip we expect AND for an unknown.

## Findings on Andy's CoreS3

| Addr | Expected | reg0 | Verdict |
|------|----------|------|---------|
| 0x21 | UNKNOWN  | `0x9B` | Still unknown — new hint |
| 0x23 | LTR-553  | `0x00` | OK |
| 0x34 | AXP2101  | `0x38` | OK |
| 0x36 | AW88298  | `0x18` | OK |
| 0x38 | FT6336U  | `0x00` | OK |
| 0x40 | ES7210   | `0x41` | OK |
| 0x41 | UNKNOWN  | `0x41` | reg0 == addr; possibly ES7210 alt-mapping artifact |
| 0x50 | Si12T    | `0xFF` | OK (no chip-ID register) |
| 0x51 | BM8563   | `0x00` | OK |
| 0x58 | AW9523   | `0x1F` | OK |
| 0x68 | Si12T    | `0xC0` | OK (Si12T is at 0x68 per #98 — driver verified) |
| **0x69** | **BMI270** | **`0x24`** | **Canonical BMI270 CHIP_ID — confirms BMI270 lives here, not at 0x68** |
| 0x6F | UNKNOWN  | `0x87` | Still unknown — new hint |

Three definitive validations: BMI270 verified at 0x69 by chip-ID match; Si12T-vs-BMI270 disambiguation at 0x68/0x69 closed; the 0x41 case is interesting (reg0 = address itself) and worth a follow-up datasheet check.

Memory `project_stackchan_this_unit_hardware.md` updated with the full reg0 column.

## Test plan
- [x] `just check` — passes
- [x] `just check-firmware` (`cargo +esp check`) — passes
- [x] `just i2c-probe` — flashes + sweeps + reads reg0 + halts cleanly