### PR TITLE
refactor: apply naming convention sweep across the inventory

### DIFF
--- a/crates/ft6336u/README.md
+++ b/crates/ft6336u/README.md
@@ -66,6 +66,6 @@ accessors for the common "is a finger down, and where?" question.
 
 ## Integration
 
-- **Firmware `touch` module** polls via `read_touch()` and feeds results to the avatar's `EmotionTouch` modifier (tap → emotion change)
+- **Firmware `touch` module** polls via `read_touch()` and feeds results to the avatar's `EmotionFromTouch` modifier (tap → emotion change)
 - **Shares the main `SharedI2cBus`** with AXP2101, AW9523, BMI270, BMM150, BM8563, and the upcoming audio codecs
 - **Host-testable** — `decode_touch` is a pure `[u8; 7] → TouchReport` function with coverage for zero-touch, one-touch, two-touch, and reserved-bit edge cases

--- a/crates/ltr553/README.md
+++ b/crates/ltr553/README.md
@@ -63,6 +63,6 @@ Default ALS config: gain 1×, integration 100 ms, measurement rate 500 ms.
 
 ## Integration
 
-- **Firmware `ambient` module** polls ambient lux + proximity. Lux drives the `AmbientSleepy` avatar modifier (darkroom → sleepy face); proximity will drive a "someone is close" reaction once the integration is done
+- **Firmware `ambient` module** polls ambient lux + proximity. Lux drives the `EmotionFromAmbient` avatar modifier (darkroom → sleepy face); proximity will drive a "someone is close" reaction once the integration is done
 - **Shares the main `SharedI2cBus`**
 - **Host-testable** — the lux formula and byte-order handling are both testable via mock I²C

--- a/crates/scservo/README.md
+++ b/crates/scservo/README.md
@@ -73,6 +73,6 @@ table.
 
 ## Integration
 
-- **Firmware `head` module** drives pan + tilt via `write_position`. Values come from `stackchan_core::Pose` after the `EmotionHead` / `IdleDrift` / `IdleSway` modifier stack resolves
+- **Firmware `head` module** drives pan + tilt via `write_position`. Values come from `stackchan_core::Pose` after the `HeadFromEmotion` / `IdleDrift` / `IdleSway` modifier stack resolves
 - **Calibration bench** (`crates/stackchan-firmware/examples/bench.rs`, invoked via `just bench`) sweeps each servo and reads back `ADDR_PRESENT_POSITION` to find mechanical limits
 - **Host-testable** — packet encoding / decoding and checksum math are pure functions with golden-packet tests; response parsing has "malformed / checksum bad / truncated" coverage

--- a/crates/stackchan-core/Cargo.toml
+++ b/crates/stackchan-core/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 # the same e-g 0.8 types this crate emits.
 embedded-graphics = { workspace = true }
 # `micromath` brings `f32::mul_add`, `ln`, etc. to `no_std` without
-# pulling in full libm. Used by `MouthOpenAudio` for the dB mapping +
+# pulling in full libm. Used by `MouthFromAudio` for the dB mapping +
 # envelope math. Already in the transitive tree (esp-hal pulls it), so
 # adding it as a direct dep costs nothing on the firmware side.
 micromath = "2"

--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -63,16 +63,16 @@ render tick. Listed roughly in application order:
 
 | Modifier          | Effect                                                         |
 |-------------------|----------------------------------------------------------------|
-| `RemoteCommand`   | IR remote → emotion / pose override                            |
-| `EmotionTouch`    | Touch-panel tap → emotion bump                                 |
-| `AmbientSleepy`   | Dark room (low lux) → sleepy emotion                           |
-| `IntentReflex`    | `mind.intent` transitions → emotion (PickedUp→Surprised, Shaken→Angry) |
-| `WakeOnVoice`     | Sustained `audio_rms` above threshold → `Happy` + `Wake` chirp |
+| `EmotionFromRemote`   | IR remote → emotion / pose override                            |
+| `EmotionFromTouch`    | Touch-panel tap → emotion bump                                 |
+| `EmotionFromAmbient`   | Dark room (low lux) → sleepy emotion                           |
+| `EmotionFromIntent`    | `mind.intent` transitions → emotion (PickedUp→Surprised, Shaken→Angry) |
+| `EmotionFromVoice`     | Sustained `audio_rms` above threshold → `Happy` + `Wake` chirp |
 | `IntentFromLoud`   | Rising-edge `audio_rms` across loud threshold → `Surprised` + `Startled` intent + `Startle` chirp |
 | `EmotionCycle`    | Default sequence: Neutral → Happy → Sleepy → Surprised → Sad   |
-| `EmotionStyle`    | 300 ms ease on style fields (curves, scale, blush) per emotion |
-| `EmotionHead`     | Per-emotion pose bias (neutral center, surprised up, etc.)     |
-| `ListenHead`      | Upward tilt bias while `mind.attention == Listening`           |
+| `StyleFromEmotion`    | 300 ms ease on style fields (curves, scale, blush) per emotion |
+| `HeadFromEmotion`     | Per-emotion pose bias (neutral center, surprised up, etc.)     |
+| `HeadFromAttention`      | Upward tilt bias while `mind.attention == Listening`           |
 | `HeadFromIntent`     | Brief asymmetric pan/tilt recoil on entry to `Startled`     |
 | `IdleDrift`       | Slow randomized gaze drift                                     |
 | `IdleSway`        | Subtle head-pan sway when idle                                 |
@@ -82,7 +82,7 @@ render tick. Listed roughly in application order:
 The full set lives in `src/modifiers/mod.rs` — the table above is
 representative, not exhaustive.
 
-`EmotionCycle → EmotionStyle → Blink → Breath → IdleDrift` is the
+`EmotionCycle → StyleFromEmotion → Blink → Breath → IdleDrift` is the
 minimum stack; the firmware adds the others. The `Clock` argument makes
 time a trait so the simulator can advance deterministically while
 firmware advances from `embassy-time`.
@@ -102,7 +102,7 @@ firmware advances from `embassy-time`.
 1. **No `alloc`.** Modifiers own their state in fixed-size fields. Callers that want N of a modifier build a wrapper; the crate won't `Box` anything
 2. **Time must be monotonic.** `Clock::now()` is trusted — a backward jump breaks modifiers that cache `last_update`. Wall-clock sources need a wrapper
 3. **Draw is pure.** `Avatar::draw` produces pixels into the provided `DrawTarget`; it doesn't mutate the avatar. Run modifiers first, then draw
-4. **Emotion transitions are 300 ms eased by `EmotionStyle`.** Don't snap emotion changes directly on the `Avatar` — go through the modifier so the ease kicks in
+4. **Emotion transitions are 300 ms eased by `StyleFromEmotion`.** Don't snap emotion changes directly on the `Avatar` — go through the modifier so the ease kicks in
 5. **No panic in library code.** Workspace lints deny `unwrap` / `expect` / `panic`. All APIs return values in documented ranges; pathological inputs saturate rather than panic
 
 ## Integration

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -67,13 +67,13 @@ pub enum Phase {
     Affect = 30,
     /// Intent → speech queue. Empty.
     Speech = 40,
-    /// Emotion → face style. `EmotionStyle` picks curve / scale /
+    /// Emotion → face style. `StyleFromEmotion` picks curve / scale /
     /// blush; Blink / Breath / `IdleDrift` add per-frame deltas.
     Expression = 50,
     /// Intent + emotion → pose. `IdleSway` writes a baseline;
-    /// `EmotionHead` adds an emotion-keyed bias on top.
+    /// `HeadFromEmotion` adds an emotion-keyed bias on top.
     Motion = 60,
-    /// Audio-driven visual updates. `MouthOpenAudio` drives
+    /// Audio-driven visual updates. `MouthFromAudio` drives
     /// `mouth.mouth_open` from the mic RMS.
     Audio = 70,
     /// Face → frame, pose → servos. Empty for modifiers; the render

--- a/crates/stackchan-core/src/emotion.rs
+++ b/crates/stackchan-core/src/emotion.rs
@@ -17,7 +17,7 @@ pub enum Emotion {
     /// Surprised / wide-eyed.
     Surprised,
     /// Angry / narrowed eyes + frown. Reactive only — set by
-    /// `IntentReflex` on a transition into `Intent::Shaken`. Not part
+    /// `EmotionFromIntent` on a transition into `Intent::Shaken`. Not part
     /// of the autonomous `EmotionCycle` or touch-cycle order.
     Angry,
 }

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -55,7 +55,7 @@ pub struct Eye {
     /// The blink modifier drops this toward zero during a blink.
     pub weight: u8,
     /// Upper bound on `weight` when the eye is open, 0..=100. `Blink` reads
-    /// this on every open transition, so `EmotionStyle` can drop it (e.g.
+    /// this on every open transition, so `StyleFromEmotion` can drop it (e.g.
     /// `Sleepy = 55`) without fighting Blink's state machine. Default 100.
     pub open_weight: u8,
 }
@@ -96,7 +96,7 @@ pub struct Mouth {
     pub weight: u8,
     /// Audio-driven mouth-open amount, 0.0..=1.0.
     ///
-    /// Written by the `MouthOpenAudio` modifier in response to
+    /// Written by the `MouthFromAudio` modifier in response to
     /// microphone input; a value of `0.0` is a closed mouth, `1.0` is
     /// fully open. Additive to [`Self::weight`] / [`Style::mouth_curve`]
     /// at the renderer — emotion keeps its static mouth shape while
@@ -111,7 +111,7 @@ pub const SCALE_DEFAULT: u8 = 128;
 
 /// Emotion-driven appearance modulators.
 ///
-/// Written by the `EmotionStyle` modifier in [`Phase::Expression`];
+/// Written by the `StyleFromEmotion` modifier in [`Phase::Expression`];
 /// consumed by the renderer (`Face::draw`) and the `Blink` / `Breath`
 /// modifiers (which read the *_scale fields to modulate their cadence).
 /// Defaults are chosen so a `Style::default()` renders exactly like

--- a/crates/stackchan-core/src/head.rs
+++ b/crates/stackchan-core/src/head.rs
@@ -36,7 +36,7 @@ pub const MAX_PAN_DEG: f32 = 45.0;
 /// Asymmetric with [`MAX_TILT_DEG`] because Stack-chan's chassis
 /// cutout typically blocks downward head travel — the head's
 /// mechanical rest position already sits at the lower stop.
-/// Modifiers that request negative tilt (e.g. `EmotionHead::Sad`/
+/// Modifiers that request negative tilt (e.g. `HeadFromEmotion::Sad`/
 /// `Sleepy`'s downcast bias) are silently clamped to `MIN_TILT_DEG`
 /// by [`Pose::clamped`]; the emotion's other channels (eyes, mouth,
 /// LEDs) still differentiate.

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -20,9 +20,9 @@
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Input {
     /// Tap edge from the touch sensor or power button. Consumed by
-    /// [`crate::modifiers::EmotionTouch`].
+    /// [`crate::modifiers::EmotionFromTouch`].
     pub tap_pending: bool,
     /// Most recent decoded IR-remote `(address, command)` pair.
-    /// Consumed by [`crate::modifiers::RemoteCommand`].
+    /// Consumed by [`crate::modifiers::EmotionFromRemote`].
     pub remote_pending: Option<(u16, u8)>,
 }

--- a/crates/stackchan-core/src/leds.rs
+++ b/crates/stackchan-core/src/leds.rs
@@ -18,8 +18,8 @@
 //!   ([`Neutral`]=soft white, [`Happy`]=amber, [`Sad`]=deep blue,
 //!   [`Sleepy`]=dim violet, [`Surprised`]=cyan).
 //! - **Intent overrides emotion colour** for sound-reactive intents:
-//!   [`Intent::Listen`] swaps the palette to a teal "I'm listening"
-//!   hue regardless of the underlying emotion (which `WakeOnVoice`
+//!   [`Intent::Listening`] swaps the palette to a teal "I'm listening"
+//!   hue regardless of the underlying emotion (which `EmotionFromVoice`
 //!   typically pins to `Happy`). [`Intent::Startled`] keeps the
 //!   `Surprised` cyan but pins brightness to peak — the breath dim
 //!   is suppressed so the ring "flashes" for the hold duration.
@@ -35,7 +35,7 @@
 //! The mapping is uniform across all 12 pixels — no per-pixel animation
 //! yet. A gaze-direction arc is an obvious next iteration.
 //!
-//! [`Intent::Listen`]: crate::mind::Intent::Listen
+//! [`Intent::Listening`]: crate::mind::Intent::Listening
 //! [`Intent::Startled`]: crate::mind::Intent::Startled
 //!
 //! [`Neutral`]: crate::Emotion::Neutral
@@ -108,9 +108,9 @@ const fn palette(emotion: Emotion) -> u32 {
 }
 
 /// "Listening" teal — used as a palette override when
-/// [`Intent::Listen`] is held.
+/// [`Intent::Listening`] is held.
 ///
-/// Cool, calm, distinct from both `Happy`'s amber (which `WakeOnVoice`
+/// Cool, calm, distinct from both `Happy`'s amber (which `EmotionFromVoice`
 /// typically pins simultaneously) and `Surprised`'s cyan (used for
 /// [`Intent::Startled`]).
 const LISTEN_PALETTE: u32 = 0x0010_C0A0;
@@ -120,13 +120,13 @@ const LISTEN_PALETTE: u32 = 0x0010_C0A0;
 #[must_use]
 const fn palette_for(intent: Intent, emotion: Emotion) -> u32 {
     match intent {
-        Intent::Listen => LISTEN_PALETTE,
+        Intent::Listening => LISTEN_PALETTE,
         // Startled doesn't override the palette — it relies on the
         // `Surprised` emotion that `IntentFromLoud` writes simultaneously.
         // Idle / BeingPet / PickedUp / Shaken / Tilted / Startled all
         // fall through to the emotion palette.
         Intent::Idle
-        | Intent::BeingPet
+        | Intent::Petted
         | Intent::PickedUp
         | Intent::Shaken
         | Intent::Tilted
@@ -359,12 +359,12 @@ mod tests {
 
     #[test]
     fn listen_intent_overrides_emotion_palette() {
-        // `WakeOnVoice` pins emotion to Happy when sustained voice is
-        // detected. With Intent::Listen also set (by LookAtSound), the
+        // `EmotionFromVoice` pins emotion to Happy when sustained voice is
+        // detected. With Intent::Listening also set (by Listening), the
         // LED palette must shift to teal — not amber.
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Happy;
-        entity.mind.intent = Intent::Listen;
+        entity.mind.intent = Intent::Listening;
         let mut frame = LedFrame::default();
         render_leds(&entity, Instant::from_millis(3_000), &mut frame);
         let listen_px = frame.0[0];
@@ -418,7 +418,7 @@ mod tests {
         let baseline = frame.0[0];
 
         for intent in [
-            Intent::BeingPet,
+            Intent::Petted,
             Intent::PickedUp,
             Intent::Shaken,
             Intent::Tilted,

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -29,7 +29,7 @@ use crate::emotion::Emotion;
 pub struct Affect {
     /// Current emotional expression. Set by `Phase::Affect` modifiers
     /// (touch, IR, voice, ambient, battery, autonomous cycler);
-    /// consumed by `EmotionStyle` and `EmotionHead`.
+    /// consumed by `StyleFromEmotion` and `HeadFromEmotion`.
     pub emotion: Emotion,
 }
 
@@ -38,16 +38,16 @@ pub struct Affect {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OverrideSource {
-    /// Front-screen tap (FT6336U).
-    Touch,
+    /// Front-screen (avatar's face) tap (FT6336U).
+    FaceTouch,
     /// Back-of-head body-touch tap (`Si12T` 3-zone pads).
     BodyTouch,
     /// IR-remote button press.
     Remote,
-    /// IMU pickup detection — set by `IntentReflex` on a transition
+    /// IMU pickup detection — set by `EmotionFromIntent` on a transition
     /// into [`Intent::PickedUp`].
     Pickup,
-    /// IMU shake detection — set by `IntentReflex` on a transition
+    /// IMU shake detection — set by `EmotionFromIntent` on a transition
     /// into [`Intent::Shaken`].
     Shake,
     /// Sustained voice activity.
@@ -87,7 +87,7 @@ pub struct Autonomy {
 /// Multiple skills may try to write `intent` on the same tick. The
 /// [`crate::skills::Handling`] skill resolves IMU-derived states
 /// against [`crate::skills::Petting`] using the order
-/// `Startled > PickedUp > Shaken > BeingPet > Tilted > Listen > Idle`
+/// `Startled > PickedUp > Shaken > Petted > Tilted > Listening > Idle`
 /// — a startle-class transient outranks even physical handling
 /// (the avatar reacts to a loud noise even mid-pickup), passive
 /// pose (`Tilted`) is lowest because it's not active handling.
@@ -98,31 +98,31 @@ pub enum Intent {
     #[default]
     Idle,
     /// Listening to ambient sound. Set by
-    /// [`crate::skills::LookAtSound`]; cleared on release.
-    Listen,
+    /// [`crate::skills::Listening`]; cleared on release.
+    Listening,
     /// Reacting to an acoustic transient (clap, shout, slam). Set by
     /// [`crate::modifiers::IntentFromLoud`] on the rising edge across
     /// the loud-threshold; cleared by the modifier when the hold
-    /// expires. `IntentReflex` does not own the emotion for this
+    /// expires. `EmotionFromIntent` does not own the emotion for this
     /// intent — `IntentFromLoud` writes `Surprised` directly to keep
     /// reaction latency to a single tick.
     Startled,
     /// Being pet on the back-of-head strip. Set by
     /// [`crate::skills::Petting`] after sustained any-zone contact;
     /// cleared on release.
-    BeingPet,
+    Petted,
     /// Held in the air. Set by [`crate::skills::Handling`] after
     /// sustained `|accel| ≠ 1 g`. Cleared when the avatar settles.
-    /// `IntentReflex` translates the entry edge to `Surprised`.
+    /// `EmotionFromIntent` translates the entry edge to `Surprised`.
     PickedUp,
     /// Being shaken. Set by [`crate::skills::Handling`] when accel
     /// oscillates above the shake threshold within a short window.
-    /// `IntentReflex` translates the entry edge to `Angry`.
+    /// `EmotionFromIntent` translates the entry edge to `Angry`.
     Shaken,
     /// Lying on its side / face-down. Set by [`crate::skills::Handling`]
     /// when the gravity vector deviates from face-up for a sustained
     /// window. Passive — no reflex emotion attached; downstream
-    /// modifiers (e.g. an extended `IntentStyle`) own the visual.
+    /// modifiers (e.g. an extended `StyleFromIntent`) own the visual.
     Tilted,
 }
 
@@ -138,7 +138,7 @@ pub enum Attention {
     None,
     /// Listening to a sound source. `since` is the instant the
     /// listening attention began; consumers (e.g.
-    /// [`crate::modifiers::ListenHead`]) use it for ease-in animation.
+    /// [`crate::modifiers::HeadFromAttention`]) use it for ease-in animation.
     Listening {
         /// When the listening attention began.
         since: Instant,

--- a/crates/stackchan-core/src/modifiers/emotion_cycle.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_cycle.rs
@@ -3,7 +3,7 @@
 //!
 //! Used by the firmware to exercise the full emotion pipeline on hardware
 //! without needing input (touch, network, serial). It writes *only* to
-//! `entity.mind.affect.emotion`; the downstream `EmotionStyle` modifier does the
+//! `entity.mind.affect.emotion`; the downstream `StyleFromEmotion` modifier does the
 //! actual style-field mutation.
 //!
 //! Cycle order is the default StackChan demo rotation; see

--- a/crates/stackchan-core/src/modifiers/emotion_from_ambient.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_ambient.rs
@@ -1,4 +1,4 @@
-//! `AmbientSleepy`: ambient-light-reactive modifier that flips
+//! `EmotionFromAmbient`: ambient-light-reactive modifier that flips
 //! `entity.mind.affect.emotion` to `Sleepy` when the room gets dark and wakes
 //! when the light comes back on.
 //!
@@ -19,7 +19,7 @@
 //!
 //! ## Coordination with the other emotion modifiers
 //!
-//! Like [`super::IntentReflex`], this modifier respects an existing
+//! Like [`super::EmotionFromIntent`], this modifier respects an existing
 //! `entity.mind.autonomy.manual_until` hold — if touch, a pickup, or any other
 //! explicit input has already claimed the emotion, we stand down.
 //! Ambient sleep is *background state*: it shouldn't override a user's
@@ -61,7 +61,7 @@ pub const AMBIENT_HOLD_MS: u64 = 5_000;
 /// Modifier that watches `entity.perception.ambient_lux` and toggles Sleepy
 /// with hysteresis.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct AmbientSleepy {
+pub struct EmotionFromAmbient {
     /// `true` while this modifier believes the entity should currently
     /// be asleep. Driven by the two-threshold hysteresis; a fresh
     /// instance starts `false` regardless of the first ambient
@@ -70,7 +70,7 @@ pub struct AmbientSleepy {
     is_asleep: bool,
 }
 
-impl AmbientSleepy {
+impl EmotionFromAmbient {
     /// Construct a modifier in the awake state.
     #[must_use]
     pub const fn new() -> Self {
@@ -85,10 +85,10 @@ impl AmbientSleepy {
     }
 }
 
-impl Modifier for AmbientSleepy {
+impl Modifier for EmotionFromAmbient {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "AmbientSleepy",
+            name: "EmotionFromAmbient",
             description: "Hysteresis on perception.ambient_lux: forces emotion=Sleepy in dark \
                           rooms. Stands down when an earlier modifier already holds \
                           mind.autonomy.manual_until.",
@@ -133,7 +133,7 @@ impl Modifier for AmbientSleepy {
         // When `is_asleep == false` and no hold is active we do
         // nothing — `EmotionCycle` takes over on the next tick and
         // drives autonomy forward. No need to explicitly clear
-        // `manual_until` here; `EmotionTouch::update` handles
+        // `manual_until` here; `EmotionFromTouch::update` handles
         // expiry cleanup on every tick.
     }
 }
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn no_reading_does_nothing() {
         let mut entity = Entity::default(); // ambient_lux = None
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
         for t in (0..1_000).step_by(50) {
             entity.tick.now = Instant::from_millis(t);
             sleepy.update(&mut entity);
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn dark_room_triggers_sleepy() {
         let mut entity = dark();
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
         entity.tick.now = Instant::from_millis(100);
         sleepy.update(&mut entity);
         assert_eq!(entity.mind.affect.emotion, Emotion::Sleepy);
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn bright_room_does_not_trigger() {
         let mut entity = bright();
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
         entity.tick.now = Instant::from_millis(100);
         sleepy.update(&mut entity);
         assert_eq!(entity.mind.affect.emotion, Emotion::Neutral);
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn hysteresis_holds_sleep_between_thresholds() {
         let mut entity = dark();
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
 
         // Enter sleep at 5 lux.
         entity.tick.now = Instant::from_millis(0);
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn bright_room_wakes_from_sleep() {
         let mut entity = dark();
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
         entity.tick.now = Instant::from_millis(0);
         sleepy.update(&mut entity);
 
@@ -226,7 +226,7 @@ mod tests {
         sleepy.update(&mut entity);
         assert!(!sleepy.is_asleep());
         // Prior-frame hold remains (the modifier re-affirms but
-        // doesn't actively clear); EmotionTouch::update clears
+        // doesn't actively clear); EmotionFromTouch::update clears
         // expired holds in the normal pipeline.
     }
 
@@ -237,7 +237,7 @@ mod tests {
         // hysteresis (20 / 50), a hover in the 25–45 band never
         // toggles state.
         let mut entity = dark();
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
         entity.tick.now = Instant::from_millis(0);
         sleepy.update(&mut entity);
         assert!(sleepy.is_asleep());
@@ -259,7 +259,7 @@ mod tests {
         // Touch just set emotion=Happy + 30 s hold.
         entity.mind.affect.emotion = Emotion::Happy;
         entity.mind.autonomy.manual_until = Some(Instant::from_millis(30_000));
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
 
         entity.tick.now = Instant::from_millis(100);
         sleepy.update(&mut entity);
@@ -278,7 +278,7 @@ mod tests {
     #[test]
     fn ambient_hold_is_renewed_every_dark_tick() {
         let mut entity = dark();
-        let mut sleepy = AmbientSleepy::new();
+        let mut sleepy = EmotionFromAmbient::new();
 
         // First dark tick.
         entity.tick.now = Instant::from_millis(0);
@@ -288,9 +288,9 @@ mod tests {
             Some(Instant::from_millis(AMBIENT_HOLD_MS))
         );
 
-        // Simulate clearing by EmotionTouch::update when the hold
+        // Simulate clearing by EmotionFromTouch::update when the hold
         // expires (3 s later, still dark — modifier stack would see
-        // the clear before AmbientSleepy runs in the same frame).
+        // the clear before EmotionFromAmbient runs in the same frame).
         entity.mind.autonomy.manual_until = None;
 
         entity.tick.now = Instant::from_millis(3_000);

--- a/crates/stackchan-core/src/modifiers/emotion_from_battery.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_battery.rs
@@ -1,11 +1,11 @@
-//! `LowBatteryEmotion`: forces `Emotion::Sleepy` when the AXP2101's
+//! `EmotionFromBattery`: forces `Emotion::Sleepy` when the AXP2101's
 //! reported battery state-of-charge drops below a threshold, and
 //! requests a one-shot alert chirp on the arming edge.
 //!
 //! ## Detection shape
 //!
 //! Reads `entity.perception.battery_percent` each tick. Two-threshold
-//! hysteresis mirrors [`super::AmbientSleepy`]:
+//! hysteresis mirrors [`super::EmotionFromAmbient`]:
 //!
 //! - **Enter low:** percent below [`LOW_BATTERY_ENTER_PERCENT`] while
 //!   not already low.
@@ -41,7 +41,7 @@
 //!
 //! ## Coordination with the other emotion modifiers
 //!
-//! Like [`super::IntentReflex`] and [`super::AmbientSleepy`], this
+//! Like [`super::EmotionFromIntent`] and [`super::EmotionFromAmbient`], this
 //! modifier respects an existing `entity.mind.autonomy.manual_until`
 //! hold — if touch, a pickup, or any other explicit input has already
 //! claimed the emotion, we stand down. Low battery is *background
@@ -51,7 +51,7 @@
 //! Subsequent ticks short-circuit on the active hold; once it expires
 //! and the battery is still low (and not on USB), the next tick
 //! re-fires and sets a fresh hold. So Sleepy effectively rolls forward
-//! in [`LOW_BATTERY_HOLD_MS`]-sized chunks, mirroring `AmbientSleepy`.
+//! in [`LOW_BATTERY_HOLD_MS`]-sized chunks, mirroring `EmotionFromAmbient`.
 
 use crate::director::{Field, ModifierMeta, Phase};
 use crate::emotion::Emotion;
@@ -91,7 +91,7 @@ pub const LOW_BATTERY_HOLD_MS: u64 = 5_000;
 /// per-instance so apps can dial them up or down without recompiling
 /// the core crate.
 #[derive(Debug, Clone, Copy)]
-pub struct LowBatteryEmotion {
+pub struct EmotionFromBattery {
     /// Lower threshold (`<`): transitions out of healthy into low.
     pub enter_threshold_percent: u8,
     /// Upper threshold (`>`): transitions out of low back into healthy.
@@ -107,7 +107,7 @@ pub struct LowBatteryEmotion {
     alert_armed: bool,
 }
 
-impl LowBatteryEmotion {
+impl EmotionFromBattery {
     /// Construct with the default thresholds
     /// ([`LOW_BATTERY_ENTER_PERCENT`] / [`LOW_BATTERY_EXIT_PERCENT`]).
     #[must_use]
@@ -143,16 +143,16 @@ impl LowBatteryEmotion {
     }
 }
 
-impl Default for LowBatteryEmotion {
+impl Default for EmotionFromBattery {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for LowBatteryEmotion {
+impl Modifier for EmotionFromBattery {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "LowBatteryEmotion",
+            name: "EmotionFromBattery",
             description: "Hysteresis on perception.battery_percent + usb_power_present: forces \
                           emotion=Sleepy below threshold while unplugged, and sets \
                           voice.chirp_request = LowBatteryAlert on the arming edge.",
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn no_battery_reading_does_nothing() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         // battery_percent = None
         let mut entity = {
             let mut e = Entity::default();
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn healthy_battery_does_nothing() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = {
             let mut e = healthy_avatar();
             e.mind.affect.emotion = Emotion::Happy;
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn low_battery_forces_sleepy() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = {
             let mut e = low_battery_avatar();
             e.mind.affect.emotion = Emotion::Happy;
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn manual_hold_suppresses_low_battery_override() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let hold_deadline = Instant::from_millis(10_000);
         let mut entity = {
             let mut e = low_battery_avatar();
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn expired_manual_hold_lets_low_battery_through() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = low_battery_avatar();
         entity.mind.autonomy.manual_until = Some(Instant::from_millis(1_000));
         let now = Instant::from_millis(2_000);
@@ -324,7 +324,7 @@ mod tests {
     fn enter_threshold_boundary_at_exactly_threshold_does_not_fire() {
         // The check is `percent < enter_threshold`, so
         // exactly-at-threshold is considered healthy.
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = Entity::default();
         entity.perception.battery_percent = Some(LOW_BATTERY_ENTER_PERCENT);
         entity.mind.affect.emotion = Emotion::Happy;
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn enter_threshold_boundary_one_below_fires() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = {
             let mut e = Entity::default();
             e.perception.battery_percent = Some(LOW_BATTERY_ENTER_PERCENT - 1);
@@ -353,7 +353,7 @@ mod tests {
         // Once below the enter threshold, the modifier stays low until
         // the percent crosses *above* the exit threshold — even if it
         // climbs above the enter threshold along the way.
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = {
             let mut e = Entity::default();
             e.perception.battery_percent = Some(10);
@@ -386,7 +386,7 @@ mod tests {
     fn usb_power_suppresses_low_battery_override() {
         // Battery is below threshold but USB is plugged in — modifier
         // tracks "is_low" but does not write Sleepy.
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = Entity::default();
         entity.perception.battery_percent = Some(5);
         entity.perception.usb_power_present = Some(true);
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn unknown_usb_state_lets_override_fire() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = Entity::default();
         entity.perception.battery_percent = Some(5);
         entity.perception.usb_power_present = None;
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn unplugging_usb_releases_suppression() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = Entity::default();
         entity.perception.battery_percent = Some(5);
         entity.perception.usb_power_present = Some(true);
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn custom_thresholds_take_effect() {
-        let mut modifier = LowBatteryEmotion::with_thresholds(50, 60);
+        let mut modifier = EmotionFromBattery::with_thresholds(50, 60);
         let mut entity = {
             let mut e = Entity::default();
             e.perception.battery_percent = Some(40);
@@ -455,11 +455,11 @@ mod tests {
 
     #[test]
     fn second_tick_within_hold_window_does_not_refresh_deadline() {
-        // Mirrors AmbientSleepy: once the modifier sets a hold, it
+        // Mirrors EmotionFromAmbient: once the modifier sets a hold, it
         // short-circuits on subsequent ticks until the hold expires.
         // The hold rolls forward in [LOW_BATTERY_HOLD_MS]-sized
         // chunks, not on every tick.
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = low_battery_avatar();
         entity.tick.now = Instant::from_millis(1_000);
         modifier.update(&mut entity);
@@ -474,7 +474,7 @@ mod tests {
     fn rolls_hold_forward_after_expiry() {
         // After the first hold expires, a still-low battery should
         // re-fire the modifier and set a fresh hold.
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = low_battery_avatar();
         entity.tick.now = Instant::from_millis(1_000);
         modifier.update(&mut entity);
@@ -494,7 +494,7 @@ mod tests {
     fn arming_edge_fires_alert_chirp_once() {
         // Boot already low + unplugged. First tick fires the alert; a
         // continued low-percent tick does NOT re-fire (still armed).
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = low_battery_avatar();
         entity.perception.usb_power_present = Some(false);
         entity.tick.now = Instant::ZERO;
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn alert_rearms_after_healthy_crossing() {
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = low_battery_avatar();
         entity.perception.usb_power_present = Some(false);
         entity.tick.now = Instant::ZERO;
@@ -539,7 +539,7 @@ mod tests {
         // Boot below threshold but plugged in — alert must not fire,
         // emotion override must not engage. Subsequent unplug while
         // still low fires the alert.
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = low_battery_avatar();
         entity.perception.usb_power_present = Some(true);
         entity.mind.affect.emotion = Emotion::Happy;
@@ -561,7 +561,7 @@ mod tests {
         // emotion thrash. Specifically: enter low, climb into band,
         // dip back below enter, climb again — emotion stays Sleepy
         // throughout (after the initial trigger).
-        let mut modifier = LowBatteryEmotion::new();
+        let mut modifier = EmotionFromBattery::new();
         let mut entity = {
             let mut e = Entity::default();
             e.perception.battery_percent = Some(10);

--- a/crates/stackchan-core/src/modifiers/emotion_from_intent.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_intent.rs
@@ -1,4 +1,4 @@
-//! `IntentReflex`: translates IMU-derived intent transitions into
+//! `EmotionFromIntent`: translates IMU-derived intent transitions into
 //! `mind.affect.emotion` + `mind.autonomy.manual_until` + a one-shot
 //! `voice.chirp_request`.
 //!
@@ -17,7 +17,7 @@
 //! ## Coordination with explicit user input
 //!
 //! Like the modifier it replaces, this defers when an
-//! [`crate::modifiers::EmotionTouch`]-set hold is active — explicit
+//! [`crate::modifiers::EmotionFromTouch`]-set hold is active — explicit
 //! taps beat reflexive pickup/shake reactions.
 //!
 //! ## Frame-ordering caveat
@@ -39,14 +39,14 @@ use crate::voice::ChirpKind;
 /// Modifier that watches `mind.intent` and reacts to transitions into
 /// IMU-derived states.
 #[derive(Debug, Clone, Copy)]
-pub struct IntentReflex {
+pub struct EmotionFromIntent {
     /// Last-tick intent. Initialised to [`Intent::Idle`] so the first
     /// observed `Idle → X` transition fires correctly without a
     /// startup blip.
     last_intent: Intent,
 }
 
-impl IntentReflex {
+impl EmotionFromIntent {
     /// Construct an unarmed reflex.
     #[must_use]
     pub const fn new() -> Self {
@@ -56,21 +56,21 @@ impl IntentReflex {
     }
 }
 
-impl Default for IntentReflex {
+impl Default for EmotionFromIntent {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for IntentReflex {
+impl Modifier for EmotionFromIntent {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "IntentReflex",
+            name: "EmotionFromIntent",
             description: "Reacts to mind.intent transitions: PickedUp → Surprised + Pickup chirp; \
-                          Shaken → Angry; Tilted → no reflex. Defers to active EmotionTouch \
+                          Shaken → Angry; Tilted → no reflex. Defers to active EmotionFromTouch \
                           holds.",
             phase: Phase::Affect,
-            // After `EmotionTouch` clears expired holds, before
+            // After `EmotionFromTouch` clears expired holds, before
             // `EmotionCycle` advances autonomously.
             priority: -80,
             reads: &[Field::Intent, Field::Autonomy],
@@ -102,7 +102,7 @@ impl Modifier for IntentReflex {
             return;
         };
 
-        // Defer to an active explicit-input hold. `EmotionTouch` clears
+        // Defer to an active explicit-input hold. `EmotionFromTouch` clears
         // expired holds on its tick (which runs before this one), so a
         // `manual_until` still in the future means a real user
         // override is in effect.
@@ -134,9 +134,9 @@ const fn react(intent: Intent) -> Option<(Emotion, OverrideSource, Option<ChirpK
         Intent::Shaken => Some((Emotion::Angry, OverrideSource::Shake, None)),
         // `Startled` reaction is owned by `IntentFromLoud` (single-tick
         // latency: it writes emotion + chirp + hold itself in
-        // `Phase::Affect`). Returning `None` here keeps IntentReflex
+        // `Phase::Affect`). Returning `None` here keeps EmotionFromIntent
         // out of the way so we don't double-emit.
-        Intent::Tilted | Intent::Idle | Intent::Listen | Intent::BeingPet | Intent::Startled => {
+        Intent::Tilted | Intent::Idle | Intent::Listening | Intent::Petted | Intent::Startled => {
             None
         }
     }
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn idle_does_not_fire() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         for t in (0..500).step_by(33) {
             entity.tick.now = Instant::from_millis(t);
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn picked_up_transition_fires_surprised_with_chirp() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         m.update(&mut entity);
 
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn shaken_transition_fires_angry_no_chirp() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         m.update(&mut entity);
 
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn tilted_does_not_fire() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         m.update(&mut entity);
 
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn sustained_picked_up_only_fires_once() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         entity.mind.intent = Intent::PickedUp;
         m.update(&mut entity);
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn touch_hold_blocks_pickup_reflex() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         entity.mind.affect.emotion = Emotion::Happy;
         entity.mind.autonomy.manual_until = Some(Instant::from_millis(MANUAL_HOLD_MS));
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn reflex_fires_after_touch_hold_expires() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         entity.mind.affect.emotion = Emotion::Happy;
         entity.mind.autonomy.manual_until = Some(Instant::from_millis(1_000));
@@ -282,7 +282,7 @@ mod tests {
         m.update(&mut entity);
         assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
 
-        // Hold expires (in real code, EmotionTouch clears it). Re-arm
+        // Hold expires (in real code, EmotionFromTouch clears it). Re-arm
         // by transitioning back to Idle, then in to PickedUp again so
         // a fresh edge is observed.
         entity.tick.now = Instant::from_millis(1_500);
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn pickup_then_release_then_pickup_re_fires() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         entity.mind.intent = Intent::PickedUp;
         m.update(&mut entity);
@@ -320,12 +320,12 @@ mod tests {
 
     #[test]
     fn picked_up_to_shaken_re_fires_with_angry() {
-        let mut m = IntentReflex::new();
+        let mut m = EmotionFromIntent::new();
         let mut entity = at(0);
         entity.mind.intent = Intent::PickedUp;
         m.update(&mut entity);
         assert_eq!(entity.mind.affect.emotion, Emotion::Surprised);
-        // Clear the hold the way EmotionTouch would after expiry —
+        // Clear the hold the way EmotionFromTouch would after expiry —
         // otherwise the second transition would be blocked.
         entity.mind.autonomy.manual_until = None;
         entity.voice.chirp_request = None;

--- a/crates/stackchan-core/src/modifiers/emotion_from_remote.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_remote.rs
@@ -1,4 +1,4 @@
-//! `RemoteCommand`: consumes IR-remote events and maps them to
+//! `EmotionFromRemote`: consumes IR-remote events and maps them to
 //! emotions via a user-supplied lookup table.
 //!
 //! ## Why a mapping table instead of fixed behavior?
@@ -18,9 +18,9 @@
 //! ## Coordination
 //!
 //! Follows the same "explicit input wins" convention as
-//! [`super::EmotionTouch`] and [`super::IntentReflex`]: if
+//! [`super::EmotionFromTouch`] and [`super::EmotionFromIntent`]: if
 //! `entity.mind.autonomy.manual_until` is already set by another
-//! modifier, the `RemoteCommand` stands down. Otherwise it sets the
+//! modifier, the `EmotionFromRemote` stands down. Otherwise it sets the
 //! emotion from the table + writes `manual_until = now + MANUAL_HOLD_MS`.
 //!
 //! Pending input lives on `entity.input.remote_pending`. The firmware's
@@ -56,13 +56,13 @@ pub struct RemoteMapping {
 /// `entity.input.remote_pending`; the modifier reads + clears it on
 /// each tick.
 #[derive(Debug, Clone, Copy)]
-pub struct RemoteCommand {
+pub struct EmotionFromRemote {
     /// Per-remote mapping table. Empty by default, which means the
     /// modifier is a no-op until populated.
     mapping: &'static [RemoteMapping],
 }
 
-impl RemoteCommand {
+impl EmotionFromRemote {
     /// Construct with an empty mapping. The modifier is a no-op in
     /// this state — useful when the remote codes are still being
     /// discovered, or for sim tests that don't care about IR.
@@ -78,16 +78,16 @@ impl RemoteCommand {
     }
 }
 
-impl Default for RemoteCommand {
+impl Default for EmotionFromRemote {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for RemoteCommand {
+impl Modifier for EmotionFromRemote {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "RemoteCommand",
+            name: "EmotionFromRemote",
             description: "Maps entity.input.remote_pending (address, command) pairs to emotions \
                           via a user-supplied table. Stands down when an earlier modifier already \
                           set mind.autonomy.manual_until.",
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn mapped_code_sets_emotion_and_hold() {
         let mut entity = Entity::default();
-        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        let mut remote = EmotionFromRemote::with_mapping(MAPPING);
         entity.input.remote_pending = Some((0xFF00, 0x01));
         entity.tick.now = Instant::from_millis(1_000);
         remote.update(&mut entity);
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn unmapped_code_is_silent_noop() {
         let mut entity = Entity::default();
-        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        let mut remote = EmotionFromRemote::with_mapping(MAPPING);
         entity.input.remote_pending = Some((0x1234, 0x56));
         entity.tick.now = Instant::from_millis(1_000);
         remote.update(&mut entity);
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn empty_mapping_is_always_noop() {
         let mut entity = Entity::default();
-        let mut remote = RemoteCommand::new();
+        let mut remote = EmotionFromRemote::new();
         entity.input.remote_pending = Some((0xFF00, 0x01));
         entity.tick.now = Instant::from_millis(1_000);
         remote.update(&mut entity);
@@ -183,11 +183,11 @@ mod tests {
     #[test]
     fn update_consumes_queued_command() {
         let mut entity = Entity::default();
-        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        let mut remote = EmotionFromRemote::with_mapping(MAPPING);
         entity.input.remote_pending = Some((0xFF00, 0x01));
         entity.tick.now = Instant::from_millis(0);
         remote.update(&mut entity);
-        // Simulate the hold expiring + being cleared by EmotionTouch.
+        // Simulate the hold expiring + being cleared by EmotionFromTouch.
         entity.mind.autonomy.manual_until = None;
         entity.mind.affect.emotion = Emotion::Neutral;
         // Another update with no new queued command must be a no-op.
@@ -204,7 +204,7 @@ mod tests {
             e.mind.autonomy.manual_until = Some(Instant::from_millis(30_000));
             e
         };
-        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        let mut remote = EmotionFromRemote::with_mapping(MAPPING);
         entity.input.remote_pending = Some((0xFF00, 0x01));
         entity.tick.now = Instant::from_millis(1_000);
         remote.update(&mut entity);
@@ -223,7 +223,7 @@ mod tests {
     #[test]
     fn remote_fires_after_hold_expires() {
         let mut entity = Entity::default();
-        let mut remote = RemoteCommand::with_mapping(MAPPING);
+        let mut remote = EmotionFromRemote::with_mapping(MAPPING);
 
         // Hold set by (say) touch in the recent past.
         entity.mind.autonomy.manual_until = Some(Instant::from_millis(1_000));

--- a/crates/stackchan-core/src/modifiers/emotion_from_touch.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_touch.rs
@@ -1,4 +1,4 @@
-//! `EmotionTouch`: advances `entity.mind.affect.emotion` on explicit
+//! `EmotionFromTouch`: advances `entity.mind.affect.emotion` on explicit
 //! user input and pins the chosen emotion for a configurable hold
 //! window.
 //!
@@ -37,12 +37,12 @@ use crate::modifier::Modifier;
 /// How long a tap pins the chosen emotion, in milliseconds.
 ///
 /// 30 s feels intentional without being permanent: long enough for the
-/// eased `EmotionStyle` transition to read visually + for the user to
+/// eased `StyleFromEmotion` transition to read visually + for the user to
 /// notice their tap stuck, short enough that Stack-chan resumes its
 /// autonomous cycle before it seems "frozen."
 pub const MANUAL_HOLD_MS: u64 = 30_000;
 
-/// Order in which [`EmotionTouch`] cycles through emotions on each tap.
+/// Order in which [`EmotionFromTouch`] cycles through emotions on each tap.
 ///
 /// Defined independently of [`super::EmotionCycle::DEFAULT_SEQUENCE`] so
 /// touch cycling can use a different ordering from autonomous cycling
@@ -63,9 +63,9 @@ pub const EMOTION_ORDER: [Emotion; 5] = [
 /// Stateless: input lives in `entity.input.tap_pending`; the modifier
 /// reads + clears it on each tick.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct EmotionTouch;
+pub struct EmotionFromTouch;
 
-impl EmotionTouch {
+impl EmotionFromTouch {
     /// Construct.
     #[must_use]
     pub const fn new() -> Self {
@@ -87,16 +87,16 @@ const fn next_emotion(current: Emotion) -> Emotion {
         Emotion::Sleepy => Emotion::Surprised,
         Emotion::Surprised => Emotion::Sad,
         // `Sad` wraps the cycle back to `Neutral`. `Angry` is
-        // reactive-only (set by `IntentReflex` on shake) and exits to
+        // reactive-only (set by `EmotionFromIntent` on shake) and exits to
         // `Neutral` rather than threading into the cycle.
         Emotion::Sad | Emotion::Angry => Emotion::Neutral,
     }
 }
 
-impl Modifier for EmotionTouch {
+impl Modifier for EmotionFromTouch {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "EmotionTouch",
+            name: "EmotionFromTouch",
             description: "On a pending tap (entity.input.tap_pending), advances emotion to the \
                           next in EMOTION_ORDER and pins it via mind.autonomy.manual_until. \
                           Clears expired holds.",
@@ -116,7 +116,7 @@ impl Modifier for EmotionTouch {
             entity.input.tap_pending = false;
             entity.mind.affect.emotion = next_emotion(entity.mind.affect.emotion);
             entity.mind.autonomy.manual_until = Some(now + MANUAL_HOLD_MS);
-            entity.mind.autonomy.source = Some(crate::mind::OverrideSource::Touch);
+            entity.mind.autonomy.source = Some(crate::mind::OverrideSource::FaceTouch);
             return;
         }
 
@@ -142,7 +142,7 @@ mod tests {
         let mut entity = Entity::default();
         assert_eq!(entity.mind.affect.emotion, Emotion::Neutral);
 
-        let mut touch = EmotionTouch::new();
+        let mut touch = EmotionFromTouch::new();
         entity.input.tap_pending = true;
         entity.tick.now = Instant::from_millis(1_000);
         touch.update(&mut entity);
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn repeated_taps_cycle_through_order() {
         let mut entity = Entity::default();
-        let mut touch = EmotionTouch::new();
+        let mut touch = EmotionFromTouch::new();
 
         for (i, expected) in [
             Emotion::Happy,
@@ -188,7 +188,7 @@ mod tests {
             e.mind.affect.emotion = Emotion::Happy;
             e
         };
-        let mut touch = EmotionTouch::new();
+        let mut touch = EmotionFromTouch::new();
 
         for step in 0..10 {
             entity.tick.now = Instant::from_millis(step * 100);
@@ -201,9 +201,9 @@ mod tests {
     #[test]
     fn held_finger_does_not_re_fire() {
         // The firmware task only publishes rising-edge taps, so from
-        // EmotionTouch's perspective a held finger is just one tap.
+        // EmotionFromTouch's perspective a held finger is just one tap.
         let mut entity = Entity::default();
-        let mut touch = EmotionTouch::new();
+        let mut touch = EmotionFromTouch::new();
 
         entity.input.tap_pending = true;
         entity.tick.now = Instant::from_millis(0);
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn expired_hold_is_cleared() {
         let mut entity = Entity::default();
-        let mut touch = EmotionTouch::new();
+        let mut touch = EmotionFromTouch::new();
 
         entity.input.tap_pending = true;
         entity.tick.now = Instant::from_millis(1_000);
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn tap_during_active_hold_extends_it() {
         let mut entity = Entity::default();
-        let mut touch = EmotionTouch::new();
+        let mut touch = EmotionFromTouch::new();
 
         entity.input.tap_pending = true;
         entity.tick.now = Instant::from_millis(0);

--- a/crates/stackchan-core/src/modifiers/emotion_from_voice.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_voice.rs
@@ -1,4 +1,4 @@
-//! `WakeOnVoice`: flips `entity.mind.affect.emotion` to `Happy` when
+//! `EmotionFromVoice`: flips `entity.mind.affect.emotion` to `Happy` when
 //! the microphone observes sustained voice activity.
 //!
 //! ## Detection shape
@@ -21,7 +21,7 @@
 //!
 //! ## Coordination with the other emotion modifiers
 //!
-//! Unlike [`super::AmbientSleepy`] / [`super::LowBatteryEmotion`],
+//! Unlike [`super::EmotionFromAmbient`] / [`super::EmotionFromBattery`],
 //! this modifier is intended to *override* a sleepy state on voice
 //! activity — so it does **not** respect an existing
 //! `entity.mind.autonomy.manual_until` hold. It runs early in the
@@ -64,7 +64,7 @@ pub const WAKE_HOLD_MS: u64 = 5_000;
 /// allocation and is `Copy` so callers can stash it on the stack
 /// alongside the other modifier instances.
 #[derive(Debug, Clone, Copy)]
-pub struct WakeOnVoice {
+pub struct EmotionFromVoice {
     /// Linear-RMS threshold above which a tick counts as loud.
     pub threshold: f32,
     /// Consecutive-loud-ticks required to trigger the wake. Saturates
@@ -75,7 +75,7 @@ pub struct WakeOnVoice {
     consecutive_loud: u8,
 }
 
-impl WakeOnVoice {
+impl EmotionFromVoice {
     /// Construct with the default thresholds ([`WAKE_RMS_THRESHOLD`] /
     /// [`WAKE_SUSTAIN_TICKS`]).
     #[must_use]
@@ -104,16 +104,16 @@ impl WakeOnVoice {
     }
 }
 
-impl Default for WakeOnVoice {
+impl Default for EmotionFromVoice {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for WakeOnVoice {
+impl Modifier for EmotionFromVoice {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "WakeOnVoice",
+            name: "EmotionFromVoice",
             description: "Sustained perception.audio_rms above threshold flips emotion to Happy \
                           (wake from Sleepy). Sets voice.chirp_request = Wake on the rising edge.",
             phase: Phase::Affect,
@@ -147,7 +147,7 @@ impl Modifier for WakeOnVoice {
         }
 
         // Threshold-and-sustain met. If a hold is already active,
-        // don't extend it on every tick (mirrors AmbientSleepy's
+        // don't extend it on every tick (mirrors EmotionFromAmbient's
         // rolling-hold behaviour); once it expires, the next still-
         // loud tick rolls a new one.
         if let Some(until) = entity.mind.autonomy.manual_until
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn no_reading_keeps_counter_zero() {
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = Entity::default(); // audio_rms = None
         for t in 0..20 {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn quiet_keeps_counter_zero() {
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = quiet_avatar();
         for t in 0..20 {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn loud_below_sustain_does_not_fire() {
         // sustain_ticks - 1 loud ticks should NOT trigger.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn sustained_loud_triggers_happy() {
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         for t in 0..(u64::from(WAKE_SUSTAIN_TICKS)) {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -242,7 +242,7 @@ mod tests {
     fn quiet_tick_resets_counter_mid_burst() {
         // 9 loud ticks, one quiet (resets), then 9 more loud — should
         // not yet fire because each run is below sustain.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -266,7 +266,7 @@ mod tests {
         // loudness within the hold window short-circuits at the
         // manual_until check; only after the hold expires AND a
         // fresh sustain accumulates does it fire again.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         // First fire.
         for t in 0..(u64::from(WAKE_SUSTAIN_TICKS)) {
@@ -285,10 +285,10 @@ mod tests {
 
     #[test]
     fn manual_hold_from_other_modifier_blocks_wake() {
-        // IntentReflex has already claimed the avatar with Surprised
-        // and a long hold. WakeOnVoice still sees sustained loud
+        // EmotionFromIntent has already claimed the avatar with Surprised
+        // and a long hold. EmotionFromVoice still sees sustained loud
         // ticks but stands down — explicit input wins.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let pickup_deadline = Instant::from_millis(30_000);
         let mut entity = {
             let mut e = loud_avatar();
@@ -310,10 +310,10 @@ mod tests {
 
     #[test]
     fn voice_overrides_sleepy_when_hold_expired() {
-        // AmbientSleepy set Sleepy + a hold; the hold has expired.
-        // WakeOnVoice should fire on sustained loud audio and write
+        // EmotionFromAmbient set Sleepy + a hold; the hold has expired.
+        // EmotionFromVoice should fire on sustained loud audio and write
         // Happy with a fresh hold.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let expired = Instant::from_millis(0);
         let mut entity = {
             let mut e = loud_avatar();
@@ -334,7 +334,7 @@ mod tests {
     fn counter_saturates_does_not_wrap() {
         // 300 loud ticks (well past u8::MAX) should not panic and
         // should keep the modifier in a consistent state.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         for t in 0..300_u64 {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -349,7 +349,7 @@ mod tests {
     #[test]
     fn custom_config_takes_effect() {
         // Lower sustain count fires faster.
-        let mut wake = WakeOnVoice::with_config(0.05, 3);
+        let mut wake = EmotionFromVoice::with_config(0.05, 3);
         let mut entity = loud_avatar();
         for t in 0..3 {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -363,7 +363,7 @@ mod tests {
         // Sustained loudness fires on the Nth tick. chirp_request is
         // Some on that tick; firmware drains it. On the (N+1)th tick
         // (still-loud, still-held), no fresh request.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         for t in 0..(u64::from(WAKE_SUSTAIN_TICKS) - 1) {
             entity.tick.now = Instant::from_millis(t * 33);
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn quiet_tick_after_fire_resets_counter() {
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = loud_avatar();
         entity.tick.now = Instant::from_millis(0);
         wake.update(&mut entity);
@@ -406,7 +406,7 @@ mod tests {
     fn at_threshold_does_not_count_as_loud() {
         // The check is `rms > threshold`, so exactly-at-threshold is
         // treated as quiet. Pin this so it doesn't drift to `>=`.
-        let mut wake = WakeOnVoice::new();
+        let mut wake = EmotionFromVoice::new();
         let mut entity = {
             let mut e = Entity::default();
             e.perception.audio_rms = Some(WAKE_RMS_THRESHOLD);

--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -1,17 +1,17 @@
-//! `ListenHead`: motion modifier that biases head pose upward when
+//! `HeadFromAttention`: motion modifier that biases head pose upward when
 //! `mind.attention` is `Listening`, producing a cocked-head listening
 //! posture.
 //!
-//! Driven by [`crate::skills::LookAtSound`] (or any other source that
+//! Driven by [`crate::skills::Listening`] (or any other source that
 //! sets `mind.attention = Listening`). Stays at zero bias when
 //! attention is `None`.
 //!
 //! ## Composition
 //!
 //! Runs after [`super::IdleSway`] (priority 0) and
-//! [`super::EmotionHead`] (priority 10) within [`Phase::Motion`], so
+//! [`super::HeadFromEmotion`] (priority 10) within [`Phase::Motion`], so
 //! its bias rides on top of the baseline sway and emotion-keyed bias.
-//! Same diff-and-undo pattern as `EmotionHead` / `IdleSway`: subtract
+//! Same diff-and-undo pattern as `HeadFromEmotion` / `IdleSway`: subtract
 //! the previous *applied* contribution before adding the new one,
 //! storing the post-clamp delta so asymmetric clamping doesn't
 //! accumulate into a permanent offset.
@@ -31,7 +31,7 @@ use crate::modifier::Modifier;
 
 /// Peak upward tilt added when fully attentive, in degrees.
 ///
-/// Combined with `IdleSway`'s ±2.5° tilt and `EmotionHead`'s
+/// Combined with `IdleSway`'s ±2.5° tilt and `HeadFromEmotion`'s
 /// up-to-+3° (Happy) the worst-case tilt stays comfortably inside
 /// [`MAX_TILT_DEG`](crate::head::MAX_TILT_DEG).
 pub const LISTEN_HEAD_TILT_DEG: f32 = 8.0;
@@ -46,7 +46,7 @@ pub const LISTEN_HEAD_EASE_MS: u64 = 200;
 /// Modifier that translates `mind.attention == Listening` into an
 /// additive upward tilt bias on `motor.head_pose`.
 #[derive(Debug, Clone, Copy)]
-pub struct ListenHead {
+pub struct HeadFromAttention {
     /// Tilt contribution as actually applied on the previous tick
     /// (post-clamp). Subtracted before writing the new contribution
     /// — see `IdleSway::last_pan_deg` for the same pattern.
@@ -59,7 +59,7 @@ pub struct ListenHead {
     release_since: Option<Instant>,
 }
 
-impl ListenHead {
+impl HeadFromAttention {
     /// Construct an idle modifier with no in-flight ease state.
     #[must_use]
     pub const fn new() -> Self {
@@ -71,7 +71,7 @@ impl ListenHead {
     }
 }
 
-impl Default for ListenHead {
+impl Default for HeadFromAttention {
     fn default() -> Self {
         Self::new()
     }
@@ -99,14 +99,14 @@ fn ease(start: Instant, now: Instant, window_ms: u64) -> f32 {
     t.clamp(0.0, 1.0)
 }
 
-impl Modifier for ListenHead {
+impl Modifier for HeadFromAttention {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "ListenHead",
+            name: "HeadFromAttention",
             description: "When mind.attention is Listening, adds an upward tilt bias to \
                           motor.head_pose for a cocked-head listening posture. Eases in/out \
                           over LISTEN_HEAD_EASE_MS. Composes additively after IdleSway and \
-                          EmotionHead via diff-and-undo.",
+                          HeadFromEmotion via diff-and-undo.",
             phase: Phase::Motion,
             priority: 20,
             reads: &[Field::Attention, Field::HeadPose],
@@ -152,7 +152,7 @@ impl Modifier for ListenHead {
             (None, None) => 0.0,
         };
 
-        // Diff-and-undo composition. Mirrors `EmotionHead`: subtract
+        // Diff-and-undo composition. Mirrors `HeadFromEmotion`: subtract
         // our previous applied contribution to recover upstream,
         // add the new one, clamp, and store the post-clamp effective
         // delta back into `last_tilt_deg`.
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn no_attention_leaves_pose_alone() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
         // Use an in-range tilt: MIN_TILT_DEG is 0 (asymmetric clamp).
         entity.motor.head_pose = Pose::new(2.0, 1.0);
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn ease_in_starts_at_zero_and_reaches_full_after_window() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
 
         // Tick 0: attention transitions to Listening. Anchor is set
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn ease_in_is_monotonically_non_decreasing_across_window() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
         entity.mind.attention = listening(0);
 
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn ease_out_returns_to_zero_after_window() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
 
         // Tick 1 anchors `listen_since`; bias starts at 0 on the
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn ease_out_is_monotonically_non_increasing_across_window() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
 
         // Get to full attention.
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn additive_composition_with_upstream_tilt() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
         entity.mind.attention = listening(0);
         let upstream_tilt = -2.0;
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn re_enter_during_ease_out_resumes_ease_in() {
-        let mut m = ListenHead::new();
+        let mut m = HeadFromAttention::new();
         let mut entity = Entity::default();
 
         // Anchor + reach full attention (entry tick + one window).

--- a/crates/stackchan-core/src/modifiers/head_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_emotion.rs
@@ -1,4 +1,4 @@
-//! `EmotionHead`: translate [`Emotion`] into a head pan/tilt **bias**.
+//! `HeadFromEmotion`: translate [`Emotion`] into a head pan/tilt **bias**.
 //!
 //! Runs after [`IdleSway`](super::IdleSway) in the modifier pipeline and
 //! adds its bias on top of whatever sway has already written — the same
@@ -6,7 +6,7 @@
 //! wanders the head around a *biased* center rather than fighting with
 //! a second absolute-set source.
 //!
-//! Transition timing matches [`EmotionStyle`](super::EmotionStyle): 300 ms
+//! Transition timing matches [`StyleFromEmotion`](super::StyleFromEmotion): 300 ms
 //! linear ease so the face and head both finish their transition at the
 //! same moment, giving the emotion change a single coherent feel rather
 //! than two staggered animations.
@@ -85,12 +85,12 @@ const fn targets_for(emotion: Emotion) -> HeadBias {
 /// A modifier that translates `entity.mind.affect.emotion` into a head-pose bias and
 /// adds it onto `entity.motor.head_pose`.
 ///
-/// Mirrors [`EmotionStyle`](super::EmotionStyle): carries `from` / `to`
+/// Mirrors [`StyleFromEmotion`](super::StyleFromEmotion): carries `from` / `to`
 /// state slots and a transition start instant so transitions ease rather
 /// than snap. The initial tick (before any emotion has been seen) snaps
 /// straight to the current emotion's bias — there's nothing to ease from.
 #[derive(Debug, Clone, Copy)]
-pub struct EmotionHead {
+pub struct HeadFromEmotion {
     /// Duration of an emotion transition, in milliseconds.
     transition_ms: u64,
     /// Bias we're transitioning *from*. `None` on the first tick.
@@ -109,8 +109,8 @@ pub struct EmotionHead {
     last_applied: HeadBias,
 }
 
-impl EmotionHead {
-    /// Default transition duration, matching [`super::EmotionStyle::TRANSITION_MS`].
+impl HeadFromEmotion {
+    /// Default transition duration, matching [`super::StyleFromEmotion::TRANSITION_MS`].
     pub const TRANSITION_MS: u64 = 300;
 
     /// Construct with the default 300 ms linear transition.
@@ -148,16 +148,16 @@ impl EmotionHead {
     }
 }
 
-impl Default for EmotionHead {
+impl Default for HeadFromEmotion {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for EmotionHead {
+impl Modifier for HeadFromEmotion {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "EmotionHead",
+            name: "HeadFromEmotion",
             description: "Adds an emotion-keyed pan/tilt bias on top of motor.head_pose. Composes \
                           additively after IdleSway via diff-and-undo so upstream pose writes \
                           survive.",
@@ -259,7 +259,7 @@ mod tests {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Neutral;
         entity.motor.head_pose = Pose::new(1.0, 2.0); // simulate IdleSway output
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
         // First tick: snap, then hold.
         entity.tick.now = Instant::from_millis(0);
         eh.update(&mut entity);
@@ -273,10 +273,10 @@ mod tests {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Happy;
         entity.motor.head_pose = Pose::new(0.0, 0.0);
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
 
         // Past TRANSITION_MS: the full Happy bias is applied.
-        entity.tick.now = Instant::from_millis(EmotionHead::TRANSITION_MS + 1);
+        entity.tick.now = Instant::from_millis(HeadFromEmotion::TRANSITION_MS + 1);
         eh.update(&mut entity);
         assert_eq!(entity.motor.head_pose.tilt_deg, 3.0);
         assert_eq!(entity.motor.head_pose.pan_deg, 0.0);
@@ -286,7 +286,7 @@ mod tests {
     fn transition_eases_halfway() {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Neutral;
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
 
         // Start at Neutral (bias 0).
         entity.tick.now = Instant::from_millis(0);
@@ -317,11 +317,11 @@ mod tests {
         // (downward tilts get pinned to MIN_TILT_DEG = 0 — see below).
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Happy;
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
 
         // Advance past transition so the full bias applies.
         entity.motor.head_pose = Pose::new(2.0, 1.5); // sway output
-        entity.tick.now = Instant::from_millis(EmotionHead::TRANSITION_MS + 1);
+        entity.tick.now = Instant::from_millis(HeadFromEmotion::TRANSITION_MS + 1);
         eh.update(&mut entity);
         // Happy tilt bias is +3 → final tilt = 1.5 + 3 = 4.5.
         assert_eq!(entity.motor.head_pose.pan_deg, 2.0);
@@ -335,10 +335,10 @@ mod tests {
         use crate::head::MIN_TILT_DEG;
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Sleepy;
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
 
         entity.motor.head_pose = Pose::new(0.0, -1.5);
-        entity.tick.now = Instant::from_millis(EmotionHead::TRANSITION_MS + 1);
+        entity.tick.now = Instant::from_millis(HeadFromEmotion::TRANSITION_MS + 1);
         eh.update(&mut entity);
         assert_eq!(entity.motor.head_pose.tilt_deg, MIN_TILT_DEG);
     }
@@ -356,7 +356,7 @@ mod tests {
         // re-anchoring behaviour we're testing.
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Neutral;
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
         entity.tick.now = Instant::from_millis(0);
         eh.update(&mut entity);
         assert_eq!(
@@ -381,7 +381,7 @@ mod tests {
         entity.mind.affect.emotion = Emotion::Happy;
         entity.tick.now = Instant::from_millis(150);
         eh.update(&mut entity);
-        entity.tick.now = Instant::from_millis(150 + EmotionHead::TRANSITION_MS + 1);
+        entity.tick.now = Instant::from_millis(150 + HeadFromEmotion::TRANSITION_MS + 1);
         eh.update(&mut entity);
         assert_eq!(
             entity.motor.head_pose.tilt_deg, 3.0,
@@ -392,9 +392,9 @@ mod tests {
     #[test]
     fn bias_does_not_accumulate_across_ticks() {
         // Regression for the diff-and-undo refactor: previously
-        // EmotionHead added bias absolutely, which relied on IdleSway
+        // HeadFromEmotion added bias absolutely, which relied on IdleSway
         // clobbering head_pose first. Now that IdleSway also contributes
-        // additively, EmotionHead must subtract the previous tick's bias
+        // additively, HeadFromEmotion must subtract the previous tick's bias
         // before adding the new one — otherwise a steady-state emotion
         // would see its bias compound each tick.
         //
@@ -403,12 +403,12 @@ mod tests {
         // by saturating both the buggy and correct cases at MIN_TILT_DEG.
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Happy; // +3° tilt bias at steady state
-        let mut eh = EmotionHead::new();
+        let mut eh = HeadFromEmotion::new();
 
         // Drive past the transition, then many more ticks. The tilt must
         // stay at +3, not drift to +6, +9, ...
         for i in 0..=50 {
-            entity.tick.now = Instant::from_millis(EmotionHead::TRANSITION_MS + i * 33);
+            entity.tick.now = Instant::from_millis(HeadFromEmotion::TRANSITION_MS + i * 33);
             eh.update(&mut entity);
         }
         assert_eq!(entity.motor.head_pose.tilt_deg, 3.0);
@@ -422,8 +422,8 @@ mod tests {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Happy;
         entity.motor.head_pose = Pose::new(0.0, 29.0);
-        let mut eh = EmotionHead::new();
-        entity.tick.now = Instant::from_millis(EmotionHead::TRANSITION_MS + 1);
+        let mut eh = HeadFromEmotion::new();
+        entity.tick.now = Instant::from_millis(HeadFromEmotion::TRANSITION_MS + 1);
         eh.update(&mut entity);
         assert_eq!(entity.motor.head_pose.tilt_deg, MAX_TILT_DEG);
 
@@ -432,8 +432,8 @@ mod tests {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Sleepy;
         entity.motor.head_pose = Pose::new(0.0, -29.0);
-        let mut eh = EmotionHead::new();
-        entity.tick.now = Instant::from_millis(EmotionHead::TRANSITION_MS + 1);
+        let mut eh = HeadFromEmotion::new();
+        entity.tick.now = Instant::from_millis(HeadFromEmotion::TRANSITION_MS + 1);
         eh.update(&mut entity);
         assert_eq!(entity.motor.head_pose.tilt_deg, MIN_TILT_DEG);
     }

--- a/crates/stackchan-core/src/modifiers/head_from_intent.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_intent.rs
@@ -21,8 +21,8 @@
 //!
 //! ## Composition
 //!
-//! Runs after [`super::IdleSway`] (priority 0), [`super::EmotionHead`]
-//! (priority 10), and [`super::ListenHead`] (priority 20) within
+//! Runs after [`super::IdleSway`] (priority 0), [`super::HeadFromEmotion`]
+//! (priority 10), and [`super::HeadFromAttention`] (priority 20) within
 //! [`Phase::Motion`], so its bias rides on top of all three. Same
 //! diff-and-undo pattern as the other [`Phase::Motion`] modifiers:
 //! subtract the previous applied contribution before adding the new
@@ -40,14 +40,14 @@ use crate::modifier::Modifier;
 ///
 /// `+6°` reads as "alert, head up" without overpowering the other
 /// motion modifiers (combined with `IdleSway`'s ±2.5° tilt and
-/// `EmotionHead`'s up-to-+3° plus `ListenHead`'s +8° upper bound, the
+/// `HeadFromEmotion`'s up-to-+3° plus `HeadFromAttention`'s +8° upper bound, the
 /// worst-case stays inside [`MAX_TILT_DEG`](crate::head::MAX_TILT_DEG)).
 pub const STARTLE_HEAD_TILT_DEG: f32 = 6.0;
 
 /// Peak pan offset during the recoil, in degrees.
 ///
 /// `+5°` (right-ish jerk) is small enough that combined with
-/// `IdleSway` and `EmotionHead`'s pan contributions, the result stays
+/// `IdleSway` and `HeadFromEmotion`'s pan contributions, the result stays
 /// inside [`MAX_PAN_DEG`](crate::head::MAX_PAN_DEG).
 pub const STARTLE_HEAD_PAN_DEG: f32 = 5.0;
 
@@ -73,7 +73,7 @@ pub const STARTLE_HEAD_TOTAL_MS: u64 = STARTLE_HEAD_ATTACK_MS + STARTLE_HEAD_DEC
 #[derive(Debug, Clone, Copy)]
 pub struct HeadFromIntent {
     /// Pan contribution as actually applied last tick (post-clamp).
-    /// Diff-and-undo bookkeeping — see `ListenHead::last_tilt_deg`.
+    /// Diff-and-undo bookkeeping — see `HeadFromAttention::last_tilt_deg`.
     last_pan_deg: f32,
     /// Tilt contribution as actually applied last tick (post-clamp).
     last_tilt_deg: f32,
@@ -137,7 +137,7 @@ impl Modifier for HeadFromIntent {
             description: "On entry to Intent::Startled, applies a brief asymmetric recoil \
                           (fast attack, slower decay) to motor.head_pose pan + tilt. Total \
                           duration STARTLE_HEAD_TOTAL_MS regardless of how long the intent \
-                          holds. Composes additively after IdleSway / EmotionHead / ListenHead \
+                          holds. Composes additively after IdleSway / HeadFromEmotion / HeadFromAttention \
                           via diff-and-undo.",
             phase: Phase::Motion,
             priority: 30,

--- a/crates/stackchan-core/src/modifiers/idle_sway.rs
+++ b/crates/stackchan-core/src/modifiers/idle_sway.rs
@@ -20,7 +20,7 @@
 //! new one. That way modifiers running *before* `IdleSway` (e.g. a
 //! future head-pose source that sets an absolute target) are not
 //! silently clobbered, and modifiers running *after* (e.g.
-//! [`EmotionHead`](super::EmotionHead), which biases on top) see the
+//! [`HeadFromEmotion`](super::HeadFromEmotion), which biases on top) see the
 //! already-swayed pose without `IdleSway` overwriting their work on the
 //! next tick.
 

--- a/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
@@ -1,4 +1,4 @@
-//! `BodyGesture`: state-machine gesture recognition on the back-of-head
+//! `IntentFromBodyTouch`: state-machine gesture recognition on the back-of-head
 //! `Si12T` petting strip.
 //!
 //! Reads `entity.perception.body_touch` (intensity-aware) and emits
@@ -42,7 +42,7 @@ pub const BODY_GESTURE_HOLD_MS: u64 = 5_000;
 /// upstream reference's `swipe_threshold = 40`.
 pub const SWIPE_DELTA: i16 = 40;
 
-/// Per-gesture emotion mapping for [`BodyGesture`].
+/// Per-gesture emotion mapping for [`IntentFromBodyTouch`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GestureMapping {
     /// Press of the left zone (no centre).
@@ -87,7 +87,7 @@ enum State {
 
 /// Gesture-detection modifier for the back-of-head `Si12T` petting strip.
 #[derive(Debug, Clone, Copy)]
-pub struct BodyGesture {
+pub struct IntentFromBodyTouch {
     /// Per-gesture emotion targets.
     pub mapping: GestureMapping,
     /// Hold duration written to `mind.autonomy.manual_until`.
@@ -98,7 +98,7 @@ pub struct BodyGesture {
     state: State,
 }
 
-impl BodyGesture {
+impl IntentFromBodyTouch {
     /// Construct with the default mapping + [`BODY_GESTURE_HOLD_MS`] hold + [`SWIPE_DELTA`] threshold.
     #[must_use]
     pub const fn new() -> Self {
@@ -118,16 +118,16 @@ impl BodyGesture {
     }
 }
 
-impl Default for BodyGesture {
+impl Default for IntentFromBodyTouch {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for BodyGesture {
+impl Modifier for IntentFromBodyTouch {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "BodyGesture",
+            name: "IntentFromBodyTouch",
             description: "State-machine gesture recognition on perception.body_touch \
                           (Si12T petting strip): Press emits per-zone emotion, \
                           SwipeForward/Backward emit Happy/Surprised. Mirrors M5Stack's \
@@ -204,14 +204,14 @@ mod tests {
         e
     }
 
-    fn run(m: &mut BodyGesture, entity: &mut Entity, now_ms: u64) {
+    fn run(m: &mut IntentFromBodyTouch, entity: &mut Entity, now_ms: u64) {
         entity.tick.now = Instant::from_millis(now_ms);
         m.update(entity);
     }
 
     #[test]
     fn no_perception_does_nothing() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(None);
         run(&mut m, &mut entity, 100);
         assert_eq!(entity.mind.affect.emotion, Emotion::Neutral);
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn press_left_sets_sleepy() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             left: 3,
             ..BodyTouch::default()
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn press_centre_sets_happy_even_with_other_zones() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             left: 3,
             centre: 3,
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn sustained_touch_does_not_re_extend_hold() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             centre: 3,
             ..BodyTouch::default()
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn release_then_press_fires_again() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             left: 3,
             ..BodyTouch::default()
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn left_to_right_slide_fires_swipe_forward() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         // Press on left.
         let mut entity = entity_with_touch(Some(BodyTouch {
             left: 3,
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn right_to_left_slide_fires_swipe_backward() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             right: 3,
             ..BodyTouch::default()
@@ -323,7 +323,7 @@ mod tests {
 
     #[test]
     fn swipe_does_not_re_fire_within_a_run() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             left: 3,
             ..BodyTouch::default()
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn small_centroid_drift_does_not_trigger_swipe() {
-        let mut m = BodyGesture::new();
+        let mut m = IntentFromBodyTouch::new();
         let mut entity = entity_with_touch(Some(BodyTouch {
             centre: 3,
             ..BodyTouch::default()

--- a/crates/stackchan-core/src/modifiers/intent_from_loud.rs
+++ b/crates/stackchan-core/src/modifiers/intent_from_loud.rs
@@ -15,7 +15,7 @@
 //! - `voice.chirp_request` ← [`ChirpKind::Startle`]
 //!
 //! There's no sustain requirement (the contrast with
-//! [`super::WakeOnVoice`] / [`super::super::skills::LookAtSound`], both
+//! [`super::EmotionFromVoice`] / [`super::super::skills::Listening`], both
 //! of which want sustained voice). A startle is by definition a single
 //! transient; sustain would defeat the responsiveness.
 //!
@@ -31,9 +31,9 @@
 //!
 //! ## Coordination with explicit input
 //!
-//! Defers to `EmotionTouch` / `RemoteCommand` holds (`OverrideSource::Touch`,
+//! Defers to `EmotionFromTouch` / `EmotionFromRemote` holds (`OverrideSource::FaceTouch`,
 //! `BodyTouch`, `Remote`). Overrides everything else, including
-//! [`super::WakeOnVoice`]'s sustained-voice hold — a sudden loud noise
+//! [`super::EmotionFromVoice`]'s sustained-voice hold — a sudden loud noise
 //! during a conversation should still startle the avatar.
 //!
 //! Self-trigger from the speaker is gated at the firmware boundary:
@@ -117,7 +117,7 @@ impl Default for IntentFromLoud {
 const fn is_explicit_input(source: Option<OverrideSource>) -> bool {
     matches!(
         source,
-        Some(OverrideSource::Touch | OverrideSource::BodyTouch | OverrideSource::Remote)
+        Some(OverrideSource::FaceTouch | OverrideSource::BodyTouch | OverrideSource::Remote)
     )
 }
 
@@ -131,8 +131,8 @@ impl Modifier for IntentFromLoud {
                           overrides Voice / Pickup / Ambient. Holds intent for STARTLE_HOLD_MS \
                           then releases to Idle.",
             phase: Phase::Affect,
-            // After WakeOnVoice (-70) so a startle wins over a
-            // sustained-voice hold; before AmbientSleepy / EmotionCycle.
+            // After EmotionFromVoice (-70) so a startle wins over a
+            // sustained-voice hold; before EmotionFromAmbient / EmotionCycle.
             priority: -65,
             reads: &[Field::AudioRms, Field::Autonomy, Field::Intent],
             writes: &[
@@ -360,10 +360,10 @@ mod tests {
     fn touch_hold_blocks_startle() {
         let mut m = IntentFromLoud::new();
         let mut entity = with_rms(0, Some(0.01));
-        // Pretend EmotionTouch already claimed the avatar.
+        // Pretend EmotionFromTouch already claimed the avatar.
         entity.mind.affect.emotion = Emotion::Happy;
         entity.mind.autonomy.manual_until = Some(Instant::from_millis(10_000));
-        entity.mind.autonomy.source = Some(OverrideSource::Touch);
+        entity.mind.autonomy.source = Some(OverrideSource::FaceTouch);
         m.update(&mut entity);
 
         entity.tick.now = Instant::from_millis(33);
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn voice_hold_does_not_block_startle() {
-        // WakeOnVoice has set Happy + Voice hold. A loud transient
+        // EmotionFromVoice has set Happy + Voice hold. A loud transient
         // mid-conversation must still startle the avatar.
         let mut m = IntentFromLoud::new();
         let mut entity = with_rms(0, Some(0.01));

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -9,26 +9,26 @@
 //!
 //! - **[`crate::director::Phase::Affect`]** — emotion deciders.
 //!   Registered in this canonical order:
-//!   1. [`EmotionTouch`] — consumes `entity.input.tap_pending`,
+//!   1. [`EmotionFromTouch`] — consumes `entity.input.tap_pending`,
 //!      advances `mind.affect.emotion`, sets
 //!      `mind.autonomy.manual_until`.
-//!   2. [`RemoteCommand`] — consumes `entity.input.remote_pending`,
+//!   2. [`EmotionFromRemote`] — consumes `entity.input.remote_pending`,
 //!      looks the `(address, command)` pair up in a user-supplied
 //!      mapping table, sets emotion + autonomy.
-//!   3. [`IntentReflex`] — reads `mind.intent`, flips emotion to
+//!   3. [`EmotionFromIntent`] — reads `mind.intent`, flips emotion to
 //!      `Surprised` on `* → PickedUp` and to `Angry` on
 //!      `* → Shaken`. Stands down when autonomy is already held.
 //!      Driven by the [`crate::skills::Handling`] skill upstream.
-//!   4. [`WakeOnVoice`] — reads `perception.audio_rms`, flips to
+//!   4. [`EmotionFromVoice`] — reads `perception.audio_rms`, flips to
 //!      `Happy` on sustained voice. Wakes from `Sleepy`.
 //!   5. [`IntentFromLoud`] — reads `perception.audio_rms`, flips to
 //!      `Surprised` + writes `Intent::Startled` + queues
 //!      `ChirpKind::Startle` on the rising edge above the loud
-//!      threshold. Overrides `WakeOnVoice` (sustained voice) but
+//!      threshold. Overrides `EmotionFromVoice` (sustained voice) but
 //!      defers to explicit-input holds.
-//!   6. [`AmbientSleepy`] — reads `perception.ambient_lux`, flips to
+//!   6. [`EmotionFromAmbient`] — reads `perception.ambient_lux`, flips to
 //!      `Sleepy` in dark rooms.
-//!   7. [`LowBatteryEmotion`] — reads `perception.battery_percent` and
+//!   7. [`EmotionFromBattery`] — reads `perception.battery_percent` and
 //!      `perception.usb_power_present`, forces `Sleepy` below threshold
 //!      while unplugged. Sets `voice.chirp_request` to `LowBatteryAlert`
 //!      on the arming edge.
@@ -37,7 +37,7 @@
 //!
 //! - **[`crate::director::Phase::Expression`]** — visual style. 4
 //!   modifiers:
-//!   1. [`EmotionStyle`] — translates emotion into face style fields.
+//!   1. [`StyleFromEmotion`] — translates emotion into face style fields.
 //!   2. [`Blink`] — drives eye open/closed phase.
 //!   3. [`Breath`] — vertical drift on all features.
 //!   4. [`IdleDrift`] — occasional eye-center jitter.
@@ -45,9 +45,9 @@
 //! - **[`crate::director::Phase::Motion`]** — head motion:
 //!   1. [`IdleSway`] — slow pan/tilt head wander written to
 //!      `motor.head_pose`.
-//!   2. [`EmotionHead`] — emotion-keyed pan/tilt bias added on top
+//!   2. [`HeadFromEmotion`] — emotion-keyed pan/tilt bias added on top
 //!      of sway.
-//!   3. [`ListenHead`] — upward tilt bias when `mind.attention` is
+//!   3. [`HeadFromAttention`] — upward tilt bias when `mind.attention` is
 //!      `Listening` (cocked-head listening posture). Added on top of
 //!      sway + emotion bias.
 //!   4. [`HeadFromIntent`] — brief asymmetric pan/tilt recoil on the
@@ -56,7 +56,7 @@
 //!
 //! - **[`crate::director::Phase::Audio`]** — audio-driven visual. 1
 //!   modifier:
-//!   1. [`MouthOpenAudio`] — reads `perception.audio_rms`, writes
+//!   1. [`MouthFromAudio`] — reads `perception.audio_rms`, writes
 //!      `face.mouth.mouth_open`.
 //!
 //! Empty phases today (slots reserved for v2.x):
@@ -65,53 +65,57 @@
 //! [`crate::director::Phase::Speech`],
 //! [`crate::director::Phase::Output`].
 
-mod ambient_sleepy;
 mod blink;
-mod body_gesture;
 mod breath;
 mod emotion_cycle;
-mod emotion_head;
-mod emotion_style;
-mod emotion_touch;
+mod emotion_from_ambient;
+mod emotion_from_battery;
+mod emotion_from_intent;
+mod emotion_from_remote;
+mod emotion_from_touch;
+mod emotion_from_voice;
+mod head_from_attention;
+mod head_from_emotion;
 mod head_from_intent;
 mod idle_drift;
 mod idle_sway;
+mod intent_from_body_touch;
 mod intent_from_loud;
-mod intent_reflex;
-mod intent_style;
-mod listen_head;
-mod low_battery;
-mod mouth_open_audio;
-mod remote_command;
-mod wake_on_voice;
+mod mouth_from_audio;
+mod style_from_emotion;
+mod style_from_intent;
 
-pub use ambient_sleepy::{AMBIENT_HOLD_MS, AmbientSleepy, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX};
 pub use blink::Blink;
-pub use body_gesture::{
-    BODY_GESTURE_HOLD_MS, BodyGesture, DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS,
-    DEFAULT_RIGHT_PRESS, DEFAULT_SWIPE_BACKWARD, DEFAULT_SWIPE_FORWARD, GestureMapping,
-    SWIPE_DELTA,
-};
 pub use breath::Breath;
 pub use emotion_cycle::EmotionCycle;
-pub use emotion_head::EmotionHead;
-pub use emotion_style::EmotionStyle;
-pub use emotion_touch::{EMOTION_ORDER, EmotionTouch, MANUAL_HOLD_MS};
+pub use emotion_from_ambient::{
+    AMBIENT_HOLD_MS, EmotionFromAmbient, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX,
+};
+pub use emotion_from_battery::{
+    EmotionFromBattery, LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT, LOW_BATTERY_HOLD_MS,
+};
+pub use emotion_from_intent::EmotionFromIntent;
+pub use emotion_from_remote::{EmotionFromRemote, RemoteMapping};
+pub use emotion_from_touch::{EMOTION_ORDER, EmotionFromTouch, MANUAL_HOLD_MS};
+pub use emotion_from_voice::{
+    EmotionFromVoice, WAKE_HOLD_MS, WAKE_RMS_THRESHOLD, WAKE_SUSTAIN_TICKS,
+};
+pub use head_from_attention::{HeadFromAttention, LISTEN_HEAD_EASE_MS, LISTEN_HEAD_TILT_DEG};
+pub use head_from_emotion::HeadFromEmotion;
 pub use head_from_intent::{
     HeadFromIntent, STARTLE_HEAD_ATTACK_MS, STARTLE_HEAD_DECAY_MS, STARTLE_HEAD_PAN_DEG,
     STARTLE_HEAD_TILT_DEG, STARTLE_HEAD_TOTAL_MS,
 };
 pub use idle_drift::IdleDrift;
 pub use idle_sway::IdleSway;
+pub use intent_from_body_touch::{
+    BODY_GESTURE_HOLD_MS, DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS, DEFAULT_RIGHT_PRESS,
+    DEFAULT_SWIPE_BACKWARD, DEFAULT_SWIPE_FORWARD, GestureMapping, IntentFromBodyTouch,
+    SWIPE_DELTA,
+};
 pub use intent_from_loud::{IntentFromLoud, STARTLE_HOLD_MS, STARTLE_RMS_THRESHOLD};
-pub use intent_reflex::IntentReflex;
-pub use intent_style::{IntentStyle, PETTING_BLUSH_BUMP};
-pub use listen_head::{LISTEN_HEAD_EASE_MS, LISTEN_HEAD_TILT_DEG, ListenHead};
-pub use low_battery::{
-    LOW_BATTERY_ENTER_PERCENT, LOW_BATTERY_EXIT_PERCENT, LOW_BATTERY_HOLD_MS, LowBatteryEmotion,
+pub use mouth_from_audio::{
+    DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthFromAudio,
 };
-pub use mouth_open_audio::{
-    DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthOpenAudio,
-};
-pub use remote_command::{RemoteCommand, RemoteMapping};
-pub use wake_on_voice::{WAKE_HOLD_MS, WAKE_RMS_THRESHOLD, WAKE_SUSTAIN_TICKS, WakeOnVoice};
+pub use style_from_emotion::StyleFromEmotion;
+pub use style_from_intent::{PETTING_BLUSH_BUMP, StyleFromIntent};

--- a/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
+++ b/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
@@ -1,4 +1,4 @@
-//! `MouthOpenAudio`: drives `face.mouth.mouth_open` from a microphone
+//! `MouthFromAudio`: drives `face.mouth.mouth_open` from a microphone
 //! RMS signal with a dB-mapped attack/release envelope.
 //!
 //! The firmware audio task publishes per-render-tick RMS (linear
@@ -49,7 +49,7 @@ const INAUDIBLE_RMS: f32 = 1e-5;
 
 /// Modifier that turns microphone RMS into a mouth-open amplitude.
 #[derive(Debug, Clone, Copy)]
-pub struct MouthOpenAudio {
+pub struct MouthFromAudio {
     /// Envelope state — the smoothed `mouth_open` value that actually
     /// gets written to the avatar.
     current: f32,
@@ -65,7 +65,7 @@ pub struct MouthOpenAudio {
     last_tick: Option<Instant>,
 }
 
-impl MouthOpenAudio {
+impl MouthFromAudio {
     /// Construct with default dB window + envelope timings.
     #[must_use]
     pub const fn new() -> Self {
@@ -120,16 +120,16 @@ impl MouthOpenAudio {
     }
 }
 
-impl Default for MouthOpenAudio {
+impl Default for MouthFromAudio {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for MouthOpenAudio {
+impl Modifier for MouthFromAudio {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "MouthOpenAudio",
+            name: "MouthFromAudio",
             description: "Drives face.mouth.mouth_open from perception.audio_rms via a dB-mapped \
                           attack/release envelope so the mouth lip-syncs roughly to mic input.",
             phase: Phase::Audio,
@@ -292,7 +292,7 @@ mod tests {
     /// mouth-open range — well within the modifier's perceptual band.
     const TOL: f32 = 0.05;
 
-    fn run(mouth: &mut MouthOpenAudio, entity: &mut Entity, rms: f32, ms: u64) {
+    fn run(mouth: &mut MouthFromAudio, entity: &mut Entity, rms: f32, ms: u64) {
         entity.perception.audio_rms = Some(rms);
         entity.tick.now = Instant::from_millis(ms);
         mouth.update(entity);
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn inaudible_rms_maps_to_closed() {
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         run(&mut mouth, &mut entity, 0.0, 0);
         assert!(entity.face.mouth.mouth_open.abs() < f32::EPSILON);
         run(&mut mouth, &mut entity, 1e-6, 10);
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn full_scale_rms_opens_mouth_fully() {
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         // First tick snaps to target (no envelope on boot).
         run(&mut mouth, &mut entity, 1.0, 0);
         assert!(
@@ -326,7 +326,7 @@ mod tests {
         // Boot-time behaviour: we don't want the mouth to slew from 0
         // to a live target over the release window.
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         // -30 dBFS ≈ rms 0.0316; with default window that's
         // (−30 − (−50)) / 40 = 0.5.
         run(&mut mouth, &mut entity, 0.031_62, 0);
@@ -343,7 +343,7 @@ mod tests {
         // opening vs closing. Attack τ=20 ms should cover more ground
         // than release τ=100 ms over a 10 ms tick.
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         // Boot at closed.
         run(&mut mouth, &mut entity, 1e-6, 0);
         let before_attack = entity.face.mouth.mouth_open;
@@ -353,7 +353,7 @@ mod tests {
 
         // Reset: boot at full.
         let mut avatar2 = Entity::default();
-        let mut mouth2 = MouthOpenAudio::new();
+        let mut mouth2 = MouthFromAudio::new();
         run(&mut mouth2, &mut avatar2, 1.0, 0);
         let before_release = avatar2.face.mouth.mouth_open;
         // One 10 ms tick with silent target.
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn envelope_settles_to_target_eventually() {
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         // Boot at closed.
         run(&mut mouth, &mut entity, 1e-6, 0);
         // 2 seconds of full-scale audio at 33 ms tick — well past
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn clamp_handles_out_of_range_rms() {
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         run(&mut mouth, &mut entity, 10.0, 0); // 10× full-scale
         assert!(
             entity.face.mouth.mouth_open <= 1.0 + 1e-3,
@@ -401,14 +401,14 @@ mod tests {
     #[test]
     fn clamp_handles_nan_rms() {
         let mut entity = Entity::default();
-        let mut mouth = MouthOpenAudio::new();
+        let mut mouth = MouthFromAudio::new();
         run(&mut mouth, &mut entity, f32::NAN, 0);
         assert!(entity.face.mouth.mouth_open.abs() < f32::EPSILON);
     }
 
     #[test]
     fn target_from_rms_maps_dbfs_linearly() {
-        let mouth = MouthOpenAudio::new();
+        let mouth = MouthFromAudio::new();
         // Midpoint of default window: -30 dBFS = rms 10^(-30/20) ≈ 0.0316
         let t = mouth.target_from_rms(0.031_62);
         assert!((t - 0.5).abs() < TOL, "expected 0.5, got {t}");

--- a/crates/stackchan-core/src/modifiers/style_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_emotion.rs
@@ -1,4 +1,4 @@
-//! `EmotionStyle`: translate [`Emotion`] into the entity's style fields.
+//! `StyleFromEmotion`: translate [`Emotion`] into the entity's style fields.
 //!
 //! This modifier is the single source of truth for how a given emotion
 //! *looks*. It writes absolute target values to the entity's style fields
@@ -7,7 +7,7 @@
 //! `open_weight`. The renderer and `Blink`/`Breath` read those fields
 //! without knowing about `Emotion` itself.
 //!
-//! Transitions are linearly eased over [`EmotionStyle::TRANSITION_MS`]
+//! Transitions are linearly eased over [`StyleFromEmotion::TRANSITION_MS`]
 //! so an emotion flip doesn't snap the face. The previous target is
 //! captured on every emotion change; interpolation runs per-field.
 //!
@@ -176,7 +176,7 @@ const fn clamp_i8(v: i32) -> i8 {
 /// current transition — so it is idempotent across multiple `update` calls
 /// at the same time.
 #[derive(Debug, Clone, Copy)]
-pub struct EmotionStyle {
+pub struct StyleFromEmotion {
     /// Duration of an emotion transition, in milliseconds.
     transition_ms: u64,
     /// Target state we're transitioning *from*. `None` on the very first
@@ -192,7 +192,7 @@ pub struct EmotionStyle {
     transition_start: Option<Instant>,
 }
 
-impl EmotionStyle {
+impl StyleFromEmotion {
     /// Default transition duration, in milliseconds.
     pub const TRANSITION_MS: u64 = 300;
 
@@ -309,16 +309,16 @@ impl EmotionStyle {
     }
 }
 
-impl Default for EmotionStyle {
+impl Default for StyleFromEmotion {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Modifier for EmotionStyle {
+impl Modifier for StyleFromEmotion {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "EmotionStyle",
+            name: "StyleFromEmotion",
             description: "Translates mind.affect.emotion into face.style fields (curves, scales, \
                           cheek blush, open_weight) with linear easing over the transition window.",
             phase: Phase::Expression,
@@ -390,7 +390,7 @@ mod tests {
     fn first_tick_snaps_to_desired_emotion() {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Happy;
-        let mut style = EmotionStyle::new();
+        let mut style = StyleFromEmotion::new();
         entity.tick.now = Instant::from_millis(0);
         style.update(&mut entity);
 
@@ -404,7 +404,7 @@ mod tests {
     fn easing_interpolates_over_transition_window() {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Neutral;
-        let mut style = EmotionStyle::with_transition_ms(300);
+        let mut style = StyleFromEmotion::with_transition_ms(300);
 
         // Establish Neutral as both from and to.
         entity.tick.now = Instant::from_millis(0);
@@ -436,7 +436,7 @@ mod tests {
     fn mid_transition_emotion_change_restarts_cleanly() {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Neutral;
-        let mut style = EmotionStyle::with_transition_ms(300);
+        let mut style = StyleFromEmotion::with_transition_ms(300);
         entity.tick.now = Instant::from_millis(0);
         style.update(&mut entity);
 
@@ -466,13 +466,13 @@ mod tests {
     fn surprised_suppresses_blink_rate() {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Surprised;
-        let mut style = EmotionStyle::new();
+        let mut style = StyleFromEmotion::new();
 
         entity.tick.now = Instant::from_millis(0);
         style.update(&mut entity);
         // After the transition elapses, Surprised's `blink_rate_scale = 0`
         // fully propagates.
-        entity.tick.now = Instant::from_millis(EmotionStyle::TRANSITION_MS);
+        entity.tick.now = Instant::from_millis(StyleFromEmotion::TRANSITION_MS);
         style.update(&mut entity);
         assert_eq!(entity.face.style.blink_rate_scale, 0);
         assert_eq!(entity.face.mouth.weight, 100);
@@ -482,10 +482,10 @@ mod tests {
     fn sleepy_droops_eye_open_weight() {
         let mut entity = Entity::default();
         entity.mind.affect.emotion = Emotion::Sleepy;
-        let mut style = EmotionStyle::new();
+        let mut style = StyleFromEmotion::new();
         entity.tick.now = Instant::from_millis(0);
         style.update(&mut entity);
-        entity.tick.now = Instant::from_millis(EmotionStyle::TRANSITION_MS);
+        entity.tick.now = Instant::from_millis(StyleFromEmotion::TRANSITION_MS);
         style.update(&mut entity);
         let sleepy = targets_for(Emotion::Sleepy);
         assert_eq!(entity.face.left_eye.open_weight, sleepy.open_weight);

--- a/crates/stackchan-core/src/modifiers/style_from_intent.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_intent.rs
@@ -1,14 +1,14 @@
-//! `IntentStyle`: translate `mind.intent` into face-style additions.
+//! `StyleFromIntent`: translate `mind.intent` into face-style additions.
 //!
-//! Mirrors [`super::EmotionStyle`] in shape — `Phase::Expression`,
-//! runs after `EmotionStyle` and before `Blink` so the canonical
-//! `EmotionStyle → Blink` ordering still holds — but reads
+//! Mirrors [`super::StyleFromEmotion`] in shape — `Phase::Expression`,
+//! runs after `StyleFromEmotion` and before `Blink` so the canonical
+//! `StyleFromEmotion → Blink` ordering still holds — but reads
 //! `mind.intent` instead of `mind.affect.emotion`.
 //!
 //! Today it bumps `face.style.cheek_blush` when intent is
-//! [`Intent::BeingPet`](crate::mind::Intent::BeingPet) so a sustained
+//! [`Intent::Petted`](crate::mind::Intent::Petted) so a sustained
 //! pet visibly intensifies the blush regardless of which emotion is
-//! active. Pure addition — `EmotionStyle` writes a fresh
+//! active. Pure addition — `StyleFromEmotion` writes a fresh
 //! `cheek_blush` baseline every tick (no persistent state to undo),
 //! so this modifier just reads-then-writes with `saturating_add`.
 //!
@@ -17,9 +17,9 @@
 //! | Intent        | `cheek_blush` add | Why                                       |
 //! |---------------|-------------------|-------------------------------------------|
 //! | `Idle`        |              `0`  | no override                               |
-//! | `Listen`      |              `0`  | handled separately by `ListenHead`        |
+//! | `Listen`      |              `0`  | handled separately by `HeadFromAttention`        |
 //! | `Startled` |              `0`  | `IntentFromLoud` writes `Surprised`, which |
-//! |               |                   | `EmotionStyle` already renders            |
+//! |               |                   | `StyleFromEmotion` already renders            |
 //! | `BeingPet`    |             `+30` | extra blush on top of any emotion base    |
 
 use crate::director::{Field, ModifierMeta, Phase};
@@ -28,18 +28,18 @@ use crate::mind::Intent;
 use crate::modifier::Modifier;
 
 /// Cheek-blush bump added when `mind.intent` is
-/// [`Intent::BeingPet`](crate::mind::Intent::BeingPet). Bumped on top
-/// of whatever `EmotionStyle` set; saturates at `255`.
+/// [`Intent::Petted`](crate::mind::Intent::Petted). Bumped on top
+/// of whatever `StyleFromEmotion` set; saturates at `255`.
 pub const PETTING_BLUSH_BUMP: u8 = 30;
 
 /// Per-intent face-style additions.
 ///
 /// Stateless — every tick reads the upstream `cheek_blush`
-/// (`EmotionStyle` writes it fresh) and adds the per-intent bump.
+/// (`StyleFromEmotion` writes it fresh) and adds the per-intent bump.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct IntentStyle;
+pub struct StyleFromIntent;
 
-impl IntentStyle {
+impl StyleFromIntent {
     /// Construct.
     #[must_use]
     pub const fn new() -> Self {
@@ -50,13 +50,13 @@ impl IntentStyle {
 /// Look up the per-intent cheek-blush addition.
 ///
 /// `PickedUp` / `Shaken` / `Tilted` get their visible reaction from
-/// [`super::IntentReflex`] (emotion + autonomy hold), which then flows
-/// through `EmotionStyle`. They contribute zero blush themselves.
+/// [`super::EmotionFromIntent`] (emotion + autonomy hold), which then flows
+/// through `StyleFromEmotion`. They contribute zero blush themselves.
 const fn blush_for(intent: Intent) -> u8 {
     match intent {
-        Intent::BeingPet => PETTING_BLUSH_BUMP,
+        Intent::Petted => PETTING_BLUSH_BUMP,
         Intent::Idle
-        | Intent::Listen
+        | Intent::Listening
         | Intent::PickedUp
         | Intent::Shaken
         | Intent::Tilted
@@ -64,16 +64,16 @@ const fn blush_for(intent: Intent) -> u8 {
     }
 }
 
-impl Modifier for IntentStyle {
+impl Modifier for StyleFromIntent {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
-            name: "IntentStyle",
+            name: "StyleFromIntent",
             description: "Translates mind.intent into additive face.style overrides. \
                           BeingPet adds +PETTING_BLUSH_BUMP to cheek_blush; other intents \
-                          contribute 0. Stateless — relies on EmotionStyle re-writing the \
+                          contribute 0. Stateless — relies on StyleFromEmotion re-writing the \
                           cheek_blush baseline each tick.",
             phase: Phase::Expression,
-            // Runs after `EmotionStyle` (priority -10) but before
+            // Runs after `StyleFromEmotion` (priority -10) but before
             // `Blink` / `Breath` / `IdleDrift` (priority 0). Same
             // bracket the canonical-order test pins.
             priority: -5,
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn idle_intent_does_not_change_blush() {
-        let mut m = IntentStyle::new();
+        let mut m = StyleFromIntent::new();
         let mut entity = entity_with(Intent::Idle, 100);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 100);
@@ -110,8 +110,8 @@ mod tests {
 
     #[test]
     fn listen_intent_does_not_change_blush() {
-        let mut m = IntentStyle::new();
-        let mut entity = entity_with(Intent::Listen, 100);
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Listening, 100);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 100);
     }
@@ -120,7 +120,7 @@ mod tests {
     fn hearing_loud_intent_does_not_change_blush() {
         // IntentFromLoud writes Emotion::Surprised which gives the
         // visible reaction; this modifier stays out.
-        let mut m = IntentStyle::new();
+        let mut m = StyleFromIntent::new();
         let mut entity = entity_with(Intent::Startled, 100);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 100);
@@ -128,28 +128,28 @@ mod tests {
 
     #[test]
     fn being_pet_adds_bump_on_top_of_upstream() {
-        let mut m = IntentStyle::new();
-        let mut entity = entity_with(Intent::BeingPet, 100);
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 100);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 100 + PETTING_BLUSH_BUMP);
     }
 
     #[test]
     fn being_pet_saturates_at_max() {
-        let mut m = IntentStyle::new();
-        let mut entity = entity_with(Intent::BeingPet, 250);
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 250);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 255);
     }
 
     #[test]
     fn intent_change_to_idle_returns_to_upstream_after_emotionstyle_rewrites() {
-        let mut m = IntentStyle::new();
-        let mut entity = entity_with(Intent::BeingPet, 100);
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 100);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 130);
 
-        // EmotionStyle re-writes the baseline each tick. Intent
+        // StyleFromEmotion re-writes the baseline each tick. Intent
         // flips to Idle — the bump goes away and we observe upstream.
         entity.face.style.cheek_blush = 70;
         entity.mind.intent = Intent::Idle;
@@ -159,12 +159,12 @@ mod tests {
 
     #[test]
     fn sustained_being_pet_keeps_bump_stable_across_ticks() {
-        let mut m = IntentStyle::new();
-        let mut entity = entity_with(Intent::BeingPet, 100);
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 100);
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 130);
 
-        // EmotionStyle re-writes the baseline (the same value, since
+        // StyleFromEmotion re-writes the baseline (the same value, since
         // emotion is unchanged). Bump should add fresh again.
         entity.face.style.cheek_blush = 100;
         m.update(&mut entity);

--- a/crates/stackchan-core/src/motor.rs
+++ b/crates/stackchan-core/src/motor.rs
@@ -13,7 +13,7 @@ use crate::head::Pose;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Motor {
     /// Commanded head pose in degrees. Produced by motion modifiers
-    /// ([`crate::modifiers::IdleSway`], [`crate::modifiers::EmotionHead`]);
+    /// ([`crate::modifiers::IdleSway`], [`crate::modifiers::HeadFromEmotion`]);
     /// consumed by firmware's head-update task. Excluded from
     /// [`crate::entity::Entity::frame_eq`] — the LCD is rigidly mounted
     /// to the head, so pan/tilt updates never change pixels.

--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -21,7 +21,7 @@
 /// firmness). Modifiers / skills do their own edge / gesture detection.
 ///
 /// The intensity (vs a plain `bool`) is what `position()` and the
-/// swipe state machine in [`crate::modifiers::BodyGesture`] need —
+/// swipe state machine in [`crate::modifiers::IntentFromBodyTouch`] need —
 /// reducing to `bool` would lose the centroid math.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct BodyTouch {

--- a/crates/stackchan-core/src/skills/handling.rs
+++ b/crates/stackchan-core/src/skills/handling.rs
@@ -20,13 +20,13 @@
 //! When multiple detectors fire on the same tick, this skill applies
 //! the project-wide intent priority `PickedUp > Shaken > Tilted` and
 //! writes the highest. It also overrides
-//! [`Intent::BeingPet`](crate::skills::Petting) — physical handling of
+//! [`Intent::Petted`](crate::skills::Petting) — physical handling of
 //! the whole avatar dominates over local back-of-head touch — except
 //! `Tilted`, which is a passive pose and yields to `BeingPet`.
 //!
 //! ## Coexistence
 //!
-//! The reflex layer ([`crate::modifiers::IntentReflex`]) reads `intent`
+//! The reflex layer ([`crate::modifiers::EmotionFromIntent`]) reads `intent`
 //! transitions and supplies the matching emotion + manual-hold + chirp.
 //! This skill writes intent only.
 //!
@@ -62,7 +62,7 @@ const fn magnitude_squared((x, y, z): (f32, f32, f32)) -> f32 {
 /// How far `|accel|` must deviate from the resting 1 g value, in g
 /// units, to count as "in motion" for [`Intent::PickedUp`].
 ///
-/// Matches the existing reflex-layer threshold so `IntentReflex` and
+/// Matches the existing reflex-layer threshold so `EmotionFromIntent` and
 /// `Handling` agree on what "lifted" means; only the sustain durations
 /// differ.
 pub const PICKUP_DEVIATION_G: f32 = 0.5;
@@ -323,7 +323,7 @@ impl Skill for Handling {
                 // Tilted yields to BeingPet (lower priority than touch
                 // per project intent ordering). Don't clobber if the
                 // user is actively petting.
-                if !matches!(entity.mind.intent, Intent::BeingPet) {
+                if !matches!(entity.mind.intent, Intent::Petted) {
                     entity.mind.intent = Intent::Tilted;
                     self.last_set = Some(Intent::Tilted);
                     return SkillStatus::Continuing;
@@ -494,7 +494,7 @@ mod tests {
         let mut skill = Handling::new();
         let mut entity = at_rest();
         // Some other skill set BeingPet earlier this tick.
-        entity.mind.intent = Intent::BeingPet;
+        entity.mind.intent = Intent::Petted;
         set_accel(&mut entity, (0.0, 0.0, 1.8));
         step(&mut skill, &mut entity, PICKUP_SUSTAIN_MS / TICK_MS + 1);
         assert_eq!(entity.mind.intent, Intent::PickedUp);
@@ -504,7 +504,7 @@ mod tests {
     fn tilted_yields_to_being_pet() {
         let mut skill = Handling::new();
         let mut entity = at_rest();
-        entity.mind.intent = Intent::BeingPet;
+        entity.mind.intent = Intent::Petted;
         // Force perception to also indicate active body touch so the
         // semantics match a real concurrent-sustained-pet scenario.
         entity.perception.body_touch = Some(BodyTouch {
@@ -515,7 +515,7 @@ mod tests {
         let ticks = TILT_SUSTAIN_MS.div_ceil(TICK_MS) + 1;
         step(&mut skill, &mut entity, ticks);
         // BeingPet survived; Handling stood down.
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
     }
 
     #[test]
@@ -538,10 +538,10 @@ mod tests {
         let mut entity = at_rest();
         // Some other skill (Petting) set BeingPet; Handling never
         // touched intent.
-        entity.mind.intent = Intent::BeingPet;
+        entity.mind.intent = Intent::Petted;
         // Idle accel for several ticks — Handling should not write.
         step(&mut skill, &mut entity, 10);
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
     }
 
     #[test]
@@ -559,9 +559,9 @@ mod tests {
 
         // Now Petting writes BeingPet — Handling must not clear it
         // back to Idle.
-        entity.mind.intent = Intent::BeingPet;
+        entity.mind.intent = Intent::Petted;
         step(&mut skill, &mut entity, 5);
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
     }
 
     #[test]

--- a/crates/stackchan-core/src/skills/listening.rs
+++ b/crates/stackchan-core/src/skills/listening.rs
@@ -1,4 +1,4 @@
-//! `LookAtSound`: attention-shifting skill driven by sustained voice
+//! `Listening`: attention-shifting skill driven by sustained voice
 //! activity.
 //!
 //! ## Trigger shape
@@ -7,7 +7,7 @@
 //! Counts consecutive ticks above [`LISTEN_RMS_THRESHOLD`]; once the
 //! run length reaches [`LISTEN_SUSTAIN_TICKS`] the skill fires:
 //!
-//! - `entity.mind.intent` ← [`Intent::Listen`]
+//! - `entity.mind.intent` ← [`Intent::Listening`]
 //! - `entity.mind.attention` ← [`Attention::Listening { since: now }`]
 //!
 //! Once fired, attention persists while loudness continues. After the
@@ -17,12 +17,12 @@
 //! Unknown audio (`audio_rms = None`, before the firmware publishes
 //! its first window) is treated as silence and never triggers.
 //!
-//! ## Relationship to `WakeOnVoice`
+//! ## Relationship to `EmotionFromVoice`
 //!
-//! [`WakeOnVoice`](crate::modifiers::WakeOnVoice) reacts to the same
+//! [`EmotionFromVoice`](crate::modifiers::EmotionFromVoice) reacts to the same
 //! `audio_rms` trigger but writes `mind.affect.emotion = Happy` and
 //! queues `voice.chirp_request = Wake`. The two are complementary: a
-//! sustained voice burst makes the entity *feel* happy (`WakeOnVoice`)
+//! sustained voice burst makes the entity *feel* happy (`EmotionFromVoice`)
 //! and *focus its attention* on the sound (this skill). They share
 //! [`LISTEN_RMS_THRESHOLD`] / [`LISTEN_SUSTAIN_TICKS`] values so both
 //! fire on the same tick.
@@ -32,7 +32,7 @@
 //! The output is *attention*, not face / motor. Skills write
 //! `mind.intent` / `mind.attention` / `voice` / `events` by contract;
 //! modifiers translate that into face + pose. The companion
-//! [`ListenHead`](crate::modifiers::ListenHead) modifier consumes
+//! [`HeadFromAttention`](crate::modifiers::HeadFromAttention) modifier consumes
 //! `mind.attention` and biases head tilt accordingly.
 
 use crate::clock::Instant;
@@ -66,7 +66,7 @@ pub const LISTEN_RELEASE_MS: u64 = 1_500;
 /// Attention-shifting skill driven by sustained voice activity. See
 /// the module docs for trigger shape.
 #[derive(Debug, Clone, Copy)]
-pub struct LookAtSound {
+pub struct Listening {
     /// Linear-RMS threshold above which a tick counts as loud.
     pub threshold: f32,
     /// Consecutive-loud-ticks required to enter Listening.
@@ -82,7 +82,7 @@ pub struct LookAtSound {
     last_loud: Option<Instant>,
 }
 
-impl LookAtSound {
+impl Listening {
     /// Construct with default tuning ([`LISTEN_RMS_THRESHOLD`] /
     /// [`LISTEN_SUSTAIN_TICKS`] / [`LISTEN_RELEASE_MS`]).
     #[must_use]
@@ -97,20 +97,20 @@ impl LookAtSound {
     }
 }
 
-impl Default for LookAtSound {
+impl Default for Listening {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Skill for LookAtSound {
+impl Skill for Listening {
     fn meta(&self) -> &'static SkillMeta {
         static META: SkillMeta = SkillMeta {
-            name: "LookAtSound",
+            name: "Listening",
             description: "Sustained perception.audio_rms above LISTEN_RMS_THRESHOLD sets \
                           mind.intent=Listen and mind.attention=Listening{since}. Attention \
                           clears LISTEN_RELEASE_MS after audio quiets. Pairs with the \
-                          ListenHead motion modifier for a cocked-head listening posture.",
+                          HeadFromAttention motion modifier for a cocked-head listening posture.",
             priority: 50,
             writes: &[Field::Intent, Field::Attention],
         };
@@ -150,7 +150,7 @@ impl Skill for LookAtSound {
             // edge clobbered in the same frame, because skills run
             // after modifiers.
             if !matches!(entity.mind.intent, Intent::Startled) {
-                entity.mind.intent = Intent::Listen;
+                entity.mind.intent = Intent::Listening;
             }
             return SkillStatus::Continuing;
         }
@@ -166,7 +166,7 @@ impl Skill for LookAtSound {
             entity.mind.attention = Attention::None;
             // Same priority guard as the entry path: only clear back
             // to Idle if we're the one who set the current intent.
-            if matches!(entity.mind.intent, Intent::Listen) {
+            if matches!(entity.mind.intent, Intent::Listening) {
                 entity.mind.intent = Intent::Idle;
             }
             self.last_loud = None;
@@ -204,7 +204,7 @@ mod tests {
     /// Drive the skill's state machine for `ticks` frames at 33 ms /
     /// tick, starting at `start_ms`. Mirrors the cadence of the
     /// firmware render loop.
-    fn step(skill: &mut LookAtSound, entity: &mut Entity, start_ms: u64, ticks: u64) {
+    fn step(skill: &mut Listening, entity: &mut Entity, start_ms: u64, ticks: u64) {
         for t in 0..ticks {
             entity.tick.now = Instant::from_millis(start_ms + t * 33);
             let _ = skill.invoke(entity);
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn never_fires_on_silence() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = quiet_avatar();
         step(
             &mut skill,
@@ -229,7 +229,7 @@ mod tests {
     fn unknown_audio_is_silence() {
         // `audio_rms = None` (default) before the audio task
         // publishes. Treated as silent.
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = Entity::default();
         step(
             &mut skill,
@@ -243,16 +243,16 @@ mod tests {
 
     #[test]
     fn sustained_loud_enters_listening() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
         assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
-        assert_eq!(entity.mind.intent, Intent::Listen);
+        assert_eq!(entity.mind.intent, Intent::Listening);
     }
 
     #[test]
     fn loud_below_sustain_does_not_enter() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         step(
             &mut skill,
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn quiet_tick_resets_counter_mid_burst() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         // SUSTAIN_TICKS - 1 loud, then one quiet (resets), then a
         // few more loud — should not trigger because each run is
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn since_timestamp_pins_to_first_listening_frame() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         // Drive past the sustain threshold.
         step(
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn quiet_within_release_window_holds_attention() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
         let last_loud_at = entity.tick.now;
@@ -333,12 +333,12 @@ mod tests {
             matches!(entity.mind.attention, Attention::Listening { .. }),
             "attention must hold within release window"
         );
-        assert_eq!(entity.mind.intent, Intent::Listen);
+        assert_eq!(entity.mind.intent, Intent::Listening);
     }
 
     #[test]
     fn quiet_past_release_window_clears_attention() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
         let last_loud_at = entity.tick.now;
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn re_entry_after_release_pins_new_since() {
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         step(&mut skill, &mut entity, 0, u64::from(LISTEN_SUSTAIN_TICKS));
         let Attention::Listening { since: first } = entity.mind.attention else {
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn at_threshold_does_not_count_as_loud() {
         // Pin: the predicate is `> threshold`, not `>=`.
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = Entity::default();
         entity.perception.audio_rms = Some(LISTEN_RMS_THRESHOLD);
         step(
@@ -401,7 +401,7 @@ mod tests {
     #[test]
     fn counter_saturates_does_not_wrap() {
         // 300 loud ticks (well past u8::MAX) should not panic.
-        let mut skill = LookAtSound::new();
+        let mut skill = Listening::new();
         let mut entity = loud_avatar();
         step(&mut skill, &mut entity, 0, 300);
         assert!(matches!(entity.mind.attention, Attention::Listening { .. }));

--- a/crates/stackchan-core/src/skills/mod.rs
+++ b/crates/stackchan-core/src/skills/mod.rs
@@ -16,14 +16,12 @@
 //! dropping a module here and registering it on the [`crate::Director`].
 
 mod handling;
-mod look_at_sound;
+mod listening;
 mod petting;
 
 pub use handling::{
     Handling, PICKUP_DEVIATION_G, PICKUP_SUSTAIN_MS, SHAKE_DEVIATION_G, SHAKE_REQUIRED_TRANSITIONS,
     SHAKE_WINDOW_MS, TILT_SUSTAIN_MS, TILT_Z_THRESHOLD_G,
 };
-pub use look_at_sound::{
-    LISTEN_RELEASE_MS, LISTEN_RMS_THRESHOLD, LISTEN_SUSTAIN_TICKS, LookAtSound,
-};
+pub use listening::{LISTEN_RELEASE_MS, LISTEN_RMS_THRESHOLD, LISTEN_SUSTAIN_TICKS, Listening};
 pub use petting::{PETTING_SUSTAIN_TICKS, Petting};

--- a/crates/stackchan-core/src/skills/petting.rs
+++ b/crates/stackchan-core/src/skills/petting.rs
@@ -5,13 +5,13 @@
 //! the firmware `body_touch` task). Counts consecutive ticks where any
 //! zone has non-zero intensity; once the run reaches
 //! [`PETTING_SUSTAIN_TICKS`] the skill writes
-//! [`Intent::BeingPet`](crate::mind::Intent::BeingPet). On release
+//! [`Intent::Petted`](crate::mind::Intent::Petted). On release
 //! (any-zone-touched goes false) the intent clears back to
 //! [`Intent::Idle`](crate::mind::Intent::Idle).
 //!
-//! ## Coexistence with `BodyGesture`
+//! ## Coexistence with `IntentFromBodyTouch`
 //!
-//! [`crate::modifiers::BodyGesture`] reacts to the SAME perception
+//! [`crate::modifiers::IntentFromBodyTouch`] reacts to the SAME perception
 //! field but writes emotion + autonomy on the no-touch → touch rising
 //! edge (Press), or on swipes. `Petting` writes intent only, after a
 //! sustain. The two are complementary: a deliberate centre pet
@@ -84,7 +84,7 @@ impl Skill for Petting {
             name: "Petting",
             description: "Sustained back-of-head touch (any zone, ≥ PETTING_SUSTAIN_TICKS) sets \
                           mind.intent = BeingPet. Clears to Idle on release. Coexists with \
-                          BodyGesture (which writes emotion on the rising edge / on swipes).",
+                          IntentFromBodyTouch (which writes emotion on the rising edge / on swipes).",
             priority: 50,
             writes: &[Field::Intent],
         };
@@ -103,7 +103,7 @@ impl Skill for Petting {
         if touched {
             self.consecutive = self.consecutive.saturating_add(1);
             if self.consecutive >= self.sustain_ticks {
-                entity.mind.intent = Intent::BeingPet;
+                entity.mind.intent = Intent::Petted;
                 return SkillStatus::Continuing;
             }
             return SkillStatus::Done;
@@ -111,7 +111,7 @@ impl Skill for Petting {
 
         // Released. Clear counter + intent (only if we set it).
         self.consecutive = 0;
-        if matches!(entity.mind.intent, Intent::BeingPet) {
+        if matches!(entity.mind.intent, Intent::Petted) {
             entity.mind.intent = Intent::Idle;
         }
         SkillStatus::Done
@@ -170,7 +170,7 @@ mod tests {
             ..BodyTouch::default()
         });
         step(&mut skill, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
     }
 
     #[test]
@@ -181,7 +181,7 @@ mod tests {
             ..BodyTouch::default()
         });
         step(&mut skill, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
 
         // Release.
         entity.perception.body_touch = Some(BodyTouch::default());
@@ -194,10 +194,10 @@ mod tests {
         let mut skill = Petting::new();
         let mut entity = Entity::default();
         // Some other system set Listen — petting hasn't fired.
-        entity.mind.intent = Intent::Listen;
+        entity.mind.intent = Intent::Listening;
         // Release tick (no body touch).
         let _ = skill.invoke(&mut entity);
-        assert_eq!(entity.mind.intent, Intent::Listen);
+        assert_eq!(entity.mind.intent, Intent::Listening);
     }
 
     #[test]
@@ -237,7 +237,7 @@ mod tests {
             ..BodyTouch::default()
         });
         step(&mut skill, &mut entity, 500); // well past u8::MAX
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
     }
 
     #[test]
@@ -249,6 +249,6 @@ mod tests {
         });
         entity.tick.now = Instant::from_millis(0);
         step(&mut skill, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
-        assert_eq!(entity.mind.intent, Intent::BeingPet);
+        assert_eq!(entity.mind.intent, Intent::Petted);
     }
 }

--- a/crates/stackchan-core/src/voice.rs
+++ b/crates/stackchan-core/src/voice.rs
@@ -18,24 +18,24 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ChirpKind {
-    /// Pickup-detected chirp. Set by `IntentReflex` on a transition
+    /// Pickup-detected chirp. Set by `EmotionFromIntent` on a transition
     /// into `Intent::PickedUp` (driven by the `Handling` skill).
     Pickup,
-    /// Voice-wake chirp. Set by `WakeOnVoice` when sustained audio
+    /// Voice-wake chirp. Set by `EmotionFromVoice` when sustained audio
     /// wakes the entity.
     Wake,
     /// Startle chirp. Set by `IntentFromLoud` on a transient acoustic
     /// spike (clap, shout, slam) — distinct from `Wake`, which is
     /// sustained-voice driven.
     Startle,
-    /// Low-battery alert beep. Set by `LowBatteryEmotion` when the
+    /// Low-battery alert beep. Set by `EmotionFromBattery` when the
     /// percent crosses the enter threshold while unplugged.
     LowBatteryAlert,
-    /// Camera-mode-enter tone. Set by the firmware's camera-mode
+    /// Camera-mode-entered tone. Set by the firmware's camera-mode
     /// toggle handler.
-    CameraModeEnter,
-    /// Camera-mode-exit tone. Counterpart to [`Self::CameraModeEnter`].
-    CameraModeExit,
+    CameraModeEntered,
+    /// Camera-mode-exited tone. Counterpart to [`Self::CameraModeEntered`].
+    CameraModeExited,
 }
 
 /// The entity's outbound audio surface.

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -87,7 +87,7 @@ esp-println = { version = "0.17.0", default-features = false, features = [
 
 static_cell = "2.1.1"
 # `f32::sqrt` for the audio-task RMS computation. `stackchan-core`
-# already depends on the same major version for `MouthOpenAudio`'s
+# already depends on the same major version for `MouthFromAudio`'s
 # dB mapping; sharing the dep keeps the workspace libm-free.
 micromath = "2"
 

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -62,11 +62,11 @@ flowchart TB
 Main spawns a render task that runs this stack per tick:
 
 ```
-EmotionTouch → BodyGesture → RemoteCommand → IntentReflex →
-WakeOnVoice → IntentFromLoud → AmbientSleepy → LowBatteryEmotion →
-EmotionCycle → EmotionStyle → IntentStyle → Blink → Breath →
-IdleDrift → IdleSway → EmotionHead → ListenHead → HeadFromIntent →
-MouthOpenAudio
+EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIntent →
+EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
+EmotionCycle → StyleFromEmotion → StyleFromIntent → Blink → Breath →
+IdleDrift → IdleSway → HeadFromEmotion → HeadFromAttention → HeadFromIntent →
+MouthFromAudio
 ```
 
 Inputs arrive through embassy `Signal` channels from the per-peripheral

--- a/crates/stackchan-firmware/examples/ambient_bench.rs
+++ b/crates/stackchan-firmware/examples/ambient_bench.rs
@@ -2,7 +2,7 @@
 //! streams raw channel values + estimated lux at 5 Hz via defmt.
 //!
 //! Used to calibrate the 20 / 50 lux thresholds in
-//! `stackchan_core::modifiers::AmbientSleepy`. Move the device under
+//! `stackchan_core::modifiers::EmotionFromAmbient`. Move the device under
 //! various lighting conditions and grep the log for matching lux
 //! values.
 //!

--- a/crates/stackchan-firmware/examples/ir_bench.rs
+++ b/crates/stackchan-firmware/examples/ir_bench.rs
@@ -1,5 +1,5 @@
 //! IR bench: log every decoded NEC frame so the operator can populate
-//! `RemoteCommand`'s mapping table for their specific remote.
+//! `EmotionFromRemote`'s mapping table for their specific remote.
 //!
 //! Skips every other peripheral (LCD, servos, IMU, ambient) — just
 //! initialises the RMT RX path and prints each `(address, command)`
@@ -59,7 +59,7 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
         env!("CARGO_PKG_VERSION")
     );
     defmt::info!(
-        "ir-bench: point a remote at the device and press buttons. Lines with `addr=... cmd=...` go in RemoteCommand's mapping table.",
+        "ir-bench: point a remote at the device and press buttons. Lines with `addr=... cmd=...` go in EmotionFromRemote's mapping table.",
     );
 
     // ir::run_ir_loop configures the RMT channel + decodes into

--- a/crates/stackchan-firmware/src/ambient.rs
+++ b/crates/stackchan-firmware/src/ambient.rs
@@ -4,7 +4,7 @@
 //! adapt fast enough to care about higher rates) and publishes the
 //! latest lux estimate on [`AMBIENT_LUX_SIGNAL`]. The render task
 //! drains the signal, writes `avatar.ambient_lux`, and runs
-//! [`stackchan_core::modifiers::AmbientSleepy`].
+//! [`stackchan_core::modifiers::EmotionFromAmbient`].
 //!
 //! ## Boot probe
 //!

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -165,7 +165,7 @@ pub const BOOT_GREETING: AudioClip = AudioClip {
 
 /// Single-clip "wake" chirp: 100 ms of 1 kHz sine. Audibly soft but
 /// distinct from the boot greeting (which is 5× longer); enqueued
-/// when [`stackchan_core::modifiers::WakeOnVoice`] just fired.
+/// when [`stackchan_core::modifiers::EmotionFromVoice`] just fired.
 ///
 /// `100 cycles × 16 samples = 1 600 samples = 100 ms`.
 pub const WAKE_CHIRP: AudioClip = AudioClip {
@@ -181,7 +181,7 @@ const PICKUP_CHIRP_LO: AudioClip = AudioClip {
 /// Second leg of the pickup chirp: 50 ms of 4 kHz. Played
 /// back-to-back with [`PICKUP_CHIRP_LO`] for an upward sweep that
 /// matches the "Surprised!" emotion fire from
-/// [`stackchan_core::modifiers::IntentReflex`].
+/// [`stackchan_core::modifiers::EmotionFromIntent`].
 const PICKUP_CHIRP_HI: AudioClip = AudioClip {
     samples: &SINE_4KHZ_CYCLE,
     cycles: 200,
@@ -314,7 +314,7 @@ pub fn try_enqueue_low_battery_alert() -> Result<(), TrySendError<AudioClip>> {
 
 /// Enqueue the wake chirp: 100 ms of 1 kHz. One queued clip.
 ///
-/// `stackchan_core::modifiers::WakeOnVoice` sets
+/// `stackchan_core::modifiers::EmotionFromVoice` sets
 /// `entity.voice.chirp_request = Some(ChirpKind::Wake)` on the tick it
 /// flips emotion to `Happy`; the render task drains that and calls this
 /// to play a confirmation tone.
@@ -328,7 +328,7 @@ pub fn try_enqueue_wake_chirp() -> Result<(), TrySendError<AudioClip>> {
 
 /// Enqueue the pickup chirp: 50 ms of 2 kHz then 50 ms of 4 kHz —
 /// an upward sweep that matches the "Surprised!" emotion fire from
-/// [`stackchan_core::modifiers::IntentReflex`]. Two queued clips.
+/// [`stackchan_core::modifiers::EmotionFromIntent`]. Two queued clips.
 ///
 /// Best-effort, same partial-queue caveat as
 /// [`try_enqueue_low_battery_alert`].
@@ -399,7 +399,7 @@ pub fn try_enqueue_camera_mode_exit() -> Result<(), TrySendError<AudioClip>> {
 /// window, normalised to `[0.0, 1.0]` against full-scale i16
 /// (`32768.0`). A value of `0.01` ≈ -40 dBFS, `0.3` ≈ -10 dBFS.
 ///
-/// The downstream `MouthOpenAudio` modifier (PR 3) converts this to
+/// The downstream `MouthFromAudio` modifier (PR 3) converts this to
 /// dB + applies an attack/release envelope before writing to the
 /// avatar's `mouth_open` field.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -419,7 +419,7 @@ pub static AUDIO_RMS_SIGNAL: Signal<CriticalSectionRawMutex, AudioRms> = Signal:
 /// [`run_tx_loop`]. The render task reads this each frame and gates
 /// `entity.perception.audio_rms` to `None` while playing — without
 /// the gate, the speaker output would re-trigger sound-reactive
-/// modifiers (`WakeOnVoice` / `IntentFromLoud`) on its own chirps.
+/// modifiers (`EmotionFromVoice` / `IntentFromLoud`) on its own chirps.
 ///
 /// Pair the read with a [`TX_GATE_TAIL_MS`] tail window so the mic
 /// doesn't pick up the speaker's residual response immediately after

--- a/crates/stackchan-firmware/src/imu.rs
+++ b/crates/stackchan-firmware/src/imu.rs
@@ -7,7 +7,7 @@
 //! `avatar.gyro_dps` before running the modifier stack, where
 //! [`stackchan_core::skills::Handling`] consumes the values to derive
 //! `mind.intent` (`PickedUp` / `Shaken` / `Tilted`), and
-//! [`stackchan_core::modifiers::IntentReflex`] picks up those intent
+//! [`stackchan_core::modifiers::EmotionFromIntent`] picks up those intent
 //! transitions to drive the visible reaction.
 //!
 //! ## Error handling

--- a/crates/stackchan-firmware/src/ir.rs
+++ b/crates/stackchan-firmware/src/ir.rs
@@ -3,7 +3,7 @@
 //! Wraps an esp-hal RMT async RX channel, decodes the pulse train
 //! via the [`ir_nec`] crate, and publishes [`NecCommand`] values on
 //! [`REMOTE_SIGNAL`]. The render task drains the signal and feeds
-//! each command into the [`stackchan_core::modifiers::RemoteCommand`]
+//! each command into the [`stackchan_core::modifiers::EmotionFromRemote`]
 //! modifier.
 //!
 //! ## CoreS3 pin caveat
@@ -34,7 +34,7 @@ use ir_nec::{NecCommand, Pulse};
 /// Raw NEC commands decoded from the IR receiver: IR task → render task.
 ///
 /// The render task drains via [`Signal::try_take`] each frame and calls
-/// [`stackchan_core::modifiers::RemoteCommand::queue`] with the
+/// [`stackchan_core::modifiers::EmotionFromRemote::queue`] with the
 /// `(address, command)` pair. Signal semantics (latest wins, no backlog)
 /// mean if the user mashes buttons between render ticks, only the most
 /// recent command actually acts — acceptable for an emotion-control UX.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -5,7 +5,7 @@
 //! board-level enables and pulses LCD reset → SPI2 + ILI9342C via mipidsi.
 //! Main then spawns a ~30 FPS
 //! embassy task that runs the full modifier stack
-//! (`EmotionCycle` → `EmotionStyle` → `Blink` → `Breath` → `IdleDrift`)
+//! (`EmotionCycle` → `StyleFromEmotion` → `Blink` → `Breath` → `IdleDrift`)
 //! against an `Avatar`, draws into a PSRAM-backed framebuffer, and
 //! blits the whole frame to the LCD in one `fill_contiguous` call.
 //! Main drops into a heartbeat loop so "render task alive" and "main
@@ -65,12 +65,13 @@ use mipidsi::{
 use stackchan_core::{
     Clock, Director, Entity, Face, HeadDriver, LedFrame,
     modifiers::{
-        AmbientSleepy, Blink, BodyGesture, Breath, EmotionCycle, EmotionHead, EmotionStyle,
-        EmotionTouch, HeadFromIntent, IdleDrift, IdleSway, IntentFromLoud, IntentReflex,
-        IntentStyle, ListenHead, LowBatteryEmotion, MouthOpenAudio, RemoteCommand, WakeOnVoice,
+        Blink, Breath, EmotionCycle, EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent,
+        EmotionFromRemote, EmotionFromTouch, EmotionFromVoice, HeadFromAttention, HeadFromEmotion,
+        HeadFromIntent, IdleDrift, IdleSway, IntentFromBodyTouch, IntentFromLoud, MouthFromAudio,
+        StyleFromEmotion, StyleFromIntent,
     },
     render_leds,
-    skills::{Handling, LookAtSound, Petting},
+    skills::{Handling, Listening, Petting},
     voice::ChirpKind,
 };
 use static_cell::StaticCell;
@@ -146,14 +147,14 @@ type LcdDisplay = mipidsi::Display<
 /// complete frame, so the white-clear flicker from direct-draw is gone.
 ///
 /// Modifier order is the canonical stackchan-core stack:
-/// `EmotionTouch` → `EmotionCycle` → `EmotionStyle` → `Blink` →
-/// `Breath` → `IdleDrift` → `IdleSway` → `EmotionHead` →
-/// `ListenHead`. `EmotionTouch` runs first so a tap queued from the
+/// `EmotionFromTouch` → `EmotionCycle` → `StyleFromEmotion` → `Blink` →
+/// `Breath` → `IdleDrift` → `IdleSway` → `HeadFromEmotion` →
+/// `HeadFromAttention`. `EmotionFromTouch` runs first so a tap queued from the
 /// touch task becomes the active emotion before `EmotionCycle` checks
 /// the `manual_until` gate. `IdleSway` writes the base
-/// `entity.motor.head_pose` (slow wander); `EmotionHead` adds an
-/// emotion-keyed bias on top; `ListenHead` adds an upward listening
-/// tilt when the `LookAtSound` skill (registered separately) sets
+/// `entity.motor.head_pose` (slow wander); `HeadFromEmotion` adds an
+/// emotion-keyed bias on top; `HeadFromAttention` adds an upward listening
+/// tilt when the `Listening` skill (registered separately) sets
 /// `mind.attention = Listening`.
 /// The final pose is published to the 50 Hz head task via
 /// [`head::POSE_SIGNAL`]. `frame_eq` short-circuits blits when no
@@ -174,19 +175,19 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         FB_HEIGHT
     );
     let mut entity = Entity::default();
-    let mut emotion_touch = EmotionTouch::new();
+    let mut emotion_from_touch = EmotionFromTouch::new();
     // Empty remote mapping by default. Populate with your specific
     // NEC `(address, command, emotion)` tuples after running
     // `examples/ir_bench.rs` to discover your remote's codes.
-    let mut remote = RemoteCommand::new();
-    let mut intent_reflex = IntentReflex::new();
-    let mut ambient_sleepy = AmbientSleepy::new();
-    let mut low_battery = LowBatteryEmotion::new();
-    let mut wake_on_voice = WakeOnVoice::new();
+    let mut remote = EmotionFromRemote::new();
+    let mut emotion_from_intent = EmotionFromIntent::new();
+    let mut emotion_from_ambient = EmotionFromAmbient::new();
+    let mut emotion_from_battery = EmotionFromBattery::new();
+    let mut emotion_from_voice = EmotionFromVoice::new();
     let mut intent_from_loud = IntentFromLoud::new();
     let mut cycle = EmotionCycle::new();
-    let mut style = EmotionStyle::new();
-    let mut intent_style = IntentStyle::new();
+    let mut style = StyleFromEmotion::new();
+    let mut style_from_intent = StyleFromIntent::new();
     let mut blink = Blink::new();
     let mut breath = Breath::new();
     // Seed comes from the ESP32-S3 hardware RNG (`esp_hal::rng::Rng`),
@@ -195,14 +196,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     // the same micro-pattern after a power cycle.
     let mut drift = IdleDrift::with_seed(drift_seed);
     let mut sway = IdleSway::new();
-    let mut emotion_head = EmotionHead::new();
-    let mut listen_head = ListenHead::new();
+    let mut head_from_emotion = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
     let mut head_from_intent = HeadFromIntent::new();
-    let mut mouth_open_audio = MouthOpenAudio::new();
-    let mut look_at_sound = LookAtSound::new();
+    let mut mouth_from_audio = MouthFromAudio::new();
+    let mut listening = Listening::new();
     let mut petting = Petting::new();
     let mut handling = Handling::new();
-    let mut body_gesture = BodyGesture::new();
+    let mut intent_from_body_touch = IntentFromBodyTouch::new();
     let mut last_rendered: Option<Face> = None;
     // Last instant TX was observed playing. Drives the post-playback
     // tail of the audio_rms gate so the mic doesn't pick up the
@@ -217,50 +218,50 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     // `crates/stackchan-core/src/director.rs` for the rationale.
     let mut director = Director::new();
     director
-        .add_modifier(&mut emotion_touch)
+        .add_modifier(&mut emotion_from_touch)
         .expect("registry full");
     director
-        .add_modifier(&mut body_gesture)
+        .add_modifier(&mut intent_from_body_touch)
         .expect("registry full");
     director.add_modifier(&mut remote).expect("registry full");
     director
-        .add_modifier(&mut intent_reflex)
+        .add_modifier(&mut emotion_from_intent)
         .expect("registry full");
     director
-        .add_modifier(&mut wake_on_voice)
+        .add_modifier(&mut emotion_from_voice)
         .expect("registry full");
     director
         .add_modifier(&mut intent_from_loud)
         .expect("registry full");
     director
-        .add_modifier(&mut ambient_sleepy)
+        .add_modifier(&mut emotion_from_ambient)
         .expect("registry full");
     director
-        .add_modifier(&mut low_battery)
+        .add_modifier(&mut emotion_from_battery)
         .expect("registry full");
     director.add_modifier(&mut cycle).expect("registry full");
     director.add_modifier(&mut style).expect("registry full");
     director
-        .add_modifier(&mut intent_style)
+        .add_modifier(&mut style_from_intent)
         .expect("registry full");
     director.add_modifier(&mut blink).expect("registry full");
     director.add_modifier(&mut breath).expect("registry full");
     director.add_modifier(&mut drift).expect("registry full");
     director.add_modifier(&mut sway).expect("registry full");
     director
-        .add_modifier(&mut emotion_head)
+        .add_modifier(&mut head_from_emotion)
         .expect("registry full");
     director
-        .add_modifier(&mut listen_head)
+        .add_modifier(&mut head_from_attention)
         .expect("registry full");
     director
         .add_modifier(&mut head_from_intent)
         .expect("registry full");
     director
-        .add_modifier(&mut mouth_open_audio)
+        .add_modifier(&mut mouth_from_audio)
         .expect("registry full");
     director
-        .add_skill(&mut look_at_sound)
+        .add_skill(&mut listening)
         .expect("skill registry full");
     director
         .add_skill(&mut petting)
@@ -286,7 +287,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionTouch + BodyGesture + RemoteCommand + IntentReflex + WakeOnVoice + IntentFromLoud + AmbientSleepy + LowBatteryEmotion + EmotionCycle + EmotionStyle + IntentStyle + Blink + Breath + IdleDrift + IdleSway + EmotionHead + ListenHead + HeadFromIntent + MouthOpenAudio + LookAtSound[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + EmotionCycle + StyleFromEmotion + StyleFromIntent + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 
@@ -330,7 +331,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         // published since last frame. Both sources publish to the
         // same signal so a button press is UX-indistinguishable from
         // a screen tap. `try_take` is non-blocking; a missing signal
-        // is the common case and means `EmotionTouch::update` only
+        // is the common case and means `EmotionFromTouch::update` only
         // does the expired-hold cleanup work this tick.
         if touch::TAP_SIGNAL.try_take().is_some() {
             if camera_mode {
@@ -358,7 +359,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
             entity.perception.ambient_lux = Some(lux);
         }
         // Drain the latest power status from the AXP2101 task.
-        // The `LowBatteryEmotion` modifier owns the arming-edge logic
+        // The `EmotionFromBattery` modifier owns the arming-edge logic
         // for the alert chirp now — it sets
         // `entity.voice.chirp_request = Some(ChirpKind::LowBatteryAlert)`
         // and the post-`run()` dispatch below enqueues it.
@@ -396,7 +397,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         director.run(&mut entity, now);
 
         // Drain the chirp request modifiers raised this tick. Modifiers
-        // (`IntentReflex`, `WakeOnVoice`, `LowBatteryEmotion`) set
+        // (`EmotionFromIntent`, `EmotionFromVoice`, `EmotionFromBattery`) set
         // `entity.voice.chirp_request`; we read it once after `run()`,
         // dispatch on `ChirpKind`, then clear so the next frame starts
         // fresh.
@@ -406,8 +407,8 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
                 ChirpKind::Wake => audio::try_enqueue_wake_chirp(),
                 ChirpKind::Startle => audio::try_enqueue_startle_chirp(),
                 ChirpKind::LowBatteryAlert => audio::try_enqueue_low_battery_alert(),
-                ChirpKind::CameraModeEnter => audio::try_enqueue_camera_mode_enter(),
-                ChirpKind::CameraModeExit => audio::try_enqueue_camera_mode_exit(),
+                ChirpKind::CameraModeEntered => audio::try_enqueue_camera_mode_enter(),
+                ChirpKind::CameraModeExited => audio::try_enqueue_camera_mode_exit(),
                 // ChirpKind is `non_exhaustive`, so even though the
                 // arms above cover every variant defined today, future
                 // variants land as a no-op until firmware adds an arm.
@@ -556,7 +557,7 @@ async fn head_task(mut driver: HeadDriverImpl) {
 /// driver and delegates to [`touch::run_touch_loop`], which reads the
 /// vendor ID once at startup and then publishes rising-edge taps on
 /// [`touch::TAP_SIGNAL`]. The render task drains the signal and feeds
-/// it into the [`EmotionTouch`] modifier.
+/// it into the [`EmotionFromTouch`] modifier.
 #[embassy_executor::task]
 async fn touch_task(shared_i2c: SharedI2c) -> ! {
     let touch = ft6336u::Ft6336u::new(shared_i2c);

--- a/crates/stackchan-firmware/src/power.rs
+++ b/crates/stackchan-firmware/src/power.rs
@@ -4,7 +4,7 @@
 //! presence, publishing both as one [`PowerStatus`] struct on
 //! [`POWER_STATUS_SIGNAL`]. The render task drains it into
 //! `avatar.battery_percent` and `avatar.usb_power_present`, where
-//! [`stackchan_core::modifiers::LowBatteryEmotion`] picks up both:
+//! [`stackchan_core::modifiers::EmotionFromBattery`] picks up both:
 //! the percent drives the hysteresis state machine, and the USB-good
 //! bit suppresses the Sleepy override while the unit is charging.
 //!
@@ -15,7 +15,7 @@
 //! Failure mode: I²C read errors log at `warn` and we keep polling.
 //! A persistently-failing AXP2101 means `POWER_STATUS_SIGNAL` never
 //! publishes, so the avatar fields stay `None` and the
-//! `LowBatteryEmotion` modifier silently no-ops. Other power-related
+//! `EmotionFromBattery` modifier silently no-ops. Other power-related
 //! features (LDO rails) are unaffected — the chip itself is fine,
 //! just the gauge / VBUS readback isn't reaching the avatar.
 

--- a/crates/stackchan-firmware/src/touch.rs
+++ b/crates/stackchan-firmware/src/touch.rs
@@ -4,11 +4,11 @@
 //! ~60 Hz (matching the FT6336U's native sample rate), detects the
 //! 0→1 finger-count rising edge, and publishes a pulse on
 //! [`TAP_SIGNAL`]. The render task consumes the signal on each tick
-//! and feeds it into [`stackchan_core::modifiers::EmotionTouch`].
+//! and feeds it into [`stackchan_core::modifiers::EmotionFromTouch`].
 //!
 //! ## Why signal and not a richer event?
 //!
-//! The MVP treats every tap as equivalent: the `EmotionTouch` modifier
+//! The MVP treats every tap as equivalent: the `EmotionFromTouch` modifier
 //! only cares that *a* tap happened, not where on the screen. Sending
 //! `Signal<_, ()>` keeps this decoupling explicit — if we ever want
 //! zone-aware behaviour, growing the signal to `TouchEvent { x, y }`

--- a/crates/stackchan-sim/src/lib.rs
+++ b/crates/stackchan-sim/src/lib.rs
@@ -208,7 +208,7 @@ impl HeadDriver for RecordingHead {
 )]
 mod integration_tests {
     use super::*;
-    use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, EmotionStyle, IdleDrift};
+    use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, IdleDrift, StyleFromEmotion};
     use stackchan_core::{Director, Emotion, Entity, EyePhase, Modifier, SCALE_DEFAULT};
 
     /// End-to-end: drive a Blink + Breath + `IdleDrift` stack via the
@@ -343,7 +343,7 @@ mod integration_tests {
         let clock = FakeClock::new();
         let mut avatar = Entity::default();
         let mut cycle = EmotionCycle::new();
-        let mut style = EmotionStyle::new();
+        let mut style = StyleFromEmotion::new();
         let mut blink = Blink::new();
         let mut breath = Breath::new();
         let mut drift = IdleDrift::with_seed(core::num::NonZeroU32::new(0xDEAD_BEEF).unwrap());
@@ -403,11 +403,11 @@ mod integration_tests {
         );
     }
 
-    /// Regression test for the `EmotionStyle → Blink` ordering contract.
+    /// Regression test for the `StyleFromEmotion → Blink` ordering contract.
     /// The Director sorts modifiers by `(phase, priority,
-    /// registration_order)`; `EmotionStyle` has priority `-10` while
+    /// registration_order)`; `StyleFromEmotion` has priority `-10` while
     /// `Blink` has priority `0`, both in `Phase::Expression`, so
-    /// `EmotionStyle` runs first regardless of registration order.
+    /// `StyleFromEmotion` runs first regardless of registration order.
     /// Blink's effect on `Eye::weight` therefore reflects the *current*
     /// tick's `blink_rate_scale`, not a stale value from a previous tick.
     /// This pin would catch a future priority swap that broke the
@@ -416,7 +416,7 @@ mod integration_tests {
     fn canonical_order_propagates_blink_rate_within_one_tick() {
         let mut avatar = Entity::default();
         avatar.mind.affect.emotion = Emotion::Surprised;
-        let mut style = EmotionStyle::new();
+        let mut style = StyleFromEmotion::new();
         let mut blink = Blink::new();
         let mut director = Director::new();
         // Register in REVERSE of canonical order to prove the Director's
@@ -424,17 +424,17 @@ mod integration_tests {
         director.add_modifier(&mut blink).unwrap();
         director.add_modifier(&mut style).unwrap();
 
-        // First frame: Surprised establishes from + to in EmotionStyle,
+        // First frame: Surprised establishes from + to in StyleFromEmotion,
         // rate = 0 takes effect, Blink suppresses on the same frame.
         director.run(&mut avatar, Instant::from_millis(0));
         assert_eq!(
             avatar.face.style.blink_rate_scale, 0,
-            "EmotionStyle must snap to target on first observation of a new emotion"
+            "StyleFromEmotion must snap to target on first observation of a new emotion"
         );
         assert_eq!(
             avatar.face.left_eye.phase,
             EyePhase::Open,
-            "rate == 0 must force eyes open on the same frame EmotionStyle wrote it"
+            "rate == 0 must force eyes open on the same frame StyleFromEmotion wrote it"
         );
 
         // Baseline sanity: switch to Neutral, advance past the

--- a/crates/stackchan-sim/tests/body_gesture.rs
+++ b/crates/stackchan-sim/tests/body_gesture.rs
@@ -1,6 +1,6 @@
-//! End-to-end sim test for the `BodyGesture` modifier.
+//! End-to-end sim test for the `IntentFromBodyTouch` modifier.
 //!
-//! Drives a Director with `BodyGesture` + `EmotionStyle` (so emotion
+//! Drives a Director with `IntentFromBodyTouch` + `StyleFromEmotion` (so emotion
 //! changes propagate into the face style fields), varies
 //! `perception.body_touch` across simulated time, and asserts the
 //! Press / Swipe / Release state machine matches the documented
@@ -17,8 +17,8 @@
 )]
 
 use stackchan_core::modifiers::{
-    BodyGesture, DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS, DEFAULT_RIGHT_PRESS,
-    DEFAULT_SWIPE_BACKWARD, DEFAULT_SWIPE_FORWARD,
+    DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS, DEFAULT_RIGHT_PRESS, DEFAULT_SWIPE_BACKWARD,
+    DEFAULT_SWIPE_FORWARD, IntentFromBodyTouch,
 };
 use stackchan_core::{BodyTouch, Director, Emotion, Entity, Instant, OverrideSource};
 
@@ -36,7 +36,7 @@ fn run_for(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, tick
 #[test]
 fn press_centre_through_director_yields_happy() {
     let mut entity = Entity::default();
-    let mut gesture = BodyGesture::new();
+    let mut gesture = IntentFromBodyTouch::new();
     let mut director = Director::new();
     director.add_modifier(&mut gesture).unwrap();
 
@@ -54,7 +54,7 @@ fn press_centre_through_director_yields_happy() {
 #[test]
 fn left_press_then_release_then_right_press_fires_twice() {
     let mut entity = Entity::default();
-    let mut gesture = BodyGesture::new();
+    let mut gesture = IntentFromBodyTouch::new();
     let mut director = Director::new();
     director.add_modifier(&mut gesture).unwrap();
 
@@ -79,7 +79,7 @@ fn left_press_then_release_then_right_press_fires_twice() {
 #[test]
 fn left_to_right_slide_through_director_fires_swipe_forward() {
     let mut entity = Entity::default();
-    let mut gesture = BodyGesture::new();
+    let mut gesture = IntentFromBodyTouch::new();
     let mut director = Director::new();
     director.add_modifier(&mut gesture).unwrap();
 
@@ -104,7 +104,7 @@ fn left_to_right_slide_through_director_fires_swipe_forward() {
 #[test]
 fn right_to_left_slide_through_director_fires_swipe_backward() {
     let mut entity = Entity::default();
-    let mut gesture = BodyGesture::new();
+    let mut gesture = IntentFromBodyTouch::new();
     let mut director = Director::new();
     director.add_modifier(&mut gesture).unwrap();
 
@@ -126,7 +126,7 @@ fn right_to_left_slide_through_director_fires_swipe_backward() {
 #[test]
 fn no_perception_keeps_neutral() {
     let mut entity = Entity::default();
-    let mut gesture = BodyGesture::new();
+    let mut gesture = IntentFromBodyTouch::new();
     let mut director = Director::new();
     director.add_modifier(&mut gesture).unwrap();
 

--- a/crates/stackchan-sim/tests/intent_from_loud.rs
+++ b/crates/stackchan-sim/tests/intent_from_loud.rs
@@ -19,10 +19,10 @@
 )]
 
 use stackchan_core::modifiers::{
-    EmotionHead, HeadFromIntent, IdleSway, IntentFromLoud, ListenHead, STARTLE_HEAD_TOTAL_MS,
-    STARTLE_HOLD_MS, WakeOnVoice,
+    EmotionFromVoice, HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleSway, IntentFromLoud,
+    STARTLE_HEAD_TOTAL_MS, STARTLE_HOLD_MS,
 };
-use stackchan_core::skills::LookAtSound;
+use stackchan_core::skills::Listening;
 use stackchan_core::voice::ChirpKind;
 use stackchan_core::{Director, Emotion, Entity, Instant, LedFrame, mind::Intent, render_leds};
 
@@ -58,14 +58,14 @@ fn quiet_audio_does_not_startle() {
 fn loud_transient_fires_full_reaction_chain() {
     let mut entity = Entity::default();
     let mut sway = IdleSway::new();
-    let mut emo = EmotionHead::new();
-    let mut listen_head = ListenHead::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
     let mut head_from_intent = HeadFromIntent::new();
     let mut startle = IntentFromLoud::new();
     let mut director = Director::new();
     director.add_modifier(&mut sway).unwrap();
     director.add_modifier(&mut emo).unwrap();
-    director.add_modifier(&mut listen_head).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
     director.add_modifier(&mut head_from_intent).unwrap();
     director.add_modifier(&mut startle).unwrap();
 
@@ -128,14 +128,14 @@ fn loud_transient_fires_full_reaction_chain() {
 fn intent_clears_after_hold_head_returns_to_baseline() {
     let mut entity = Entity::default();
     let mut sway = IdleSway::new();
-    let mut emo = EmotionHead::new();
-    let mut listen_head = ListenHead::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
     let mut head_from_intent = HeadFromIntent::new();
     let mut startle = IntentFromLoud::new();
     let mut director = Director::new();
     director.add_modifier(&mut sway).unwrap();
     director.add_modifier(&mut emo).unwrap();
-    director.add_modifier(&mut listen_head).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
     director.add_modifier(&mut head_from_intent).unwrap();
     director.add_modifier(&mut startle).unwrap();
 
@@ -174,25 +174,25 @@ fn intent_clears_after_hold_head_returns_to_baseline() {
 #[test]
 fn startle_overrides_in_progress_listen() {
     // Sustained voice puts the avatar into Listen + Happy via
-    // LookAtSound + WakeOnVoice. A loud spike mid-conversation must
+    // Listening + EmotionFromVoice. A loud spike mid-conversation must
     // still flip the intent to Startled (IntentFromLoud overrides
-    // the WakeOnVoice hold).
+    // the EmotionFromVoice hold).
     let mut entity = Entity::default();
-    let mut wake_on_voice = WakeOnVoice::new();
+    let mut emotion_from_voice = EmotionFromVoice::new();
     let mut startle = IntentFromLoud::new();
-    let mut look_at_sound = LookAtSound::new();
+    let mut listening = Listening::new();
     let mut director = Director::new();
-    director.add_modifier(&mut wake_on_voice).unwrap();
+    director.add_modifier(&mut emotion_from_voice).unwrap();
     director.add_modifier(&mut startle).unwrap();
-    director.add_skill(&mut look_at_sound).unwrap();
+    director.add_skill(&mut listening).unwrap();
 
     // Sustained "voice" (above wake threshold, below startle).
     entity.perception.audio_rms = Some(0.1);
     run_for(&mut director, &mut entity, 0, 30);
     assert_eq!(
         entity.mind.intent,
-        Intent::Listen,
-        "sustained voice should enter Listen via LookAtSound",
+        Intent::Listening,
+        "sustained voice should enter Listen via Listening",
     );
     assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
 

--- a/crates/stackchan-sim/tests/leds.rs
+++ b/crates/stackchan-sim/tests/leds.rs
@@ -17,7 +17,7 @@
     reason = "test-only: Director registry capacity is a compile-time constant in this fixture, the unwraps can't fire"
 )]
 
-use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, EmotionStyle, IdleDrift};
+use stackchan_core::modifiers::{Blink, Breath, EmotionCycle, IdleDrift, StyleFromEmotion};
 use stackchan_core::{BRIGHTNESS_PEAK, Director, Emotion, Entity, LED_COUNT, LedFrame};
 use stackchan_core::{Instant, render_leds};
 
@@ -26,13 +26,13 @@ use stackchan_core::{Instant, render_leds};
 /// intermediate times), then render LEDs and return the frame.
 fn render_at(avatar: &mut Entity, modifiers_at: u64) -> LedFrame {
     let mut emotion_cycle = EmotionCycle::new();
-    let mut emotion_style = EmotionStyle::new();
+    let mut style_from_emotion = StyleFromEmotion::new();
     let mut blink = Blink::new();
     let mut breath = Breath::new();
     let mut drift = IdleDrift::new();
     let mut director = Director::new();
     director.add_modifier(&mut emotion_cycle).unwrap();
-    director.add_modifier(&mut emotion_style).unwrap();
+    director.add_modifier(&mut style_from_emotion).unwrap();
     director.add_modifier(&mut blink).unwrap();
     director.add_modifier(&mut breath).unwrap();
     director.add_modifier(&mut drift).unwrap();

--- a/crates/stackchan-sim/tests/listening.rs
+++ b/crates/stackchan-sim/tests/listening.rs
@@ -1,8 +1,8 @@
-//! End-to-end sim test for the `LookAtSound` skill + `ListenHead`
+//! End-to-end sim test for the `Listening` skill + `HeadFromAttention`
 //! motion modifier handoff.
 //!
 //! Drives a Director with the full Motion-phase modifier stack
-//! (`IdleSway` + `EmotionHead` + `ListenHead`) plus the `LookAtSound`
+//! (`IdleSway` + `HeadFromEmotion` + `HeadFromAttention`) plus the `Listening`
 //! skill, varies `perception.audio_rms` across simulated time, and
 //! asserts:
 //!
@@ -23,15 +23,15 @@
               fixture, the unwraps can't fire"
 )]
 
-use stackchan_core::modifiers::{EmotionHead, IdleSway, ListenHead};
-use stackchan_core::skills::{LISTEN_RELEASE_MS, LISTEN_SUSTAIN_TICKS, LookAtSound};
+use stackchan_core::modifiers::{HeadFromAttention, HeadFromEmotion, IdleSway};
+use stackchan_core::skills::{LISTEN_RELEASE_MS, LISTEN_SUSTAIN_TICKS, Listening};
 use stackchan_core::{Attention, Director, Entity, Instant};
 
 const TICK_MS: u64 = 33;
 
 /// Baseline tilt ceiling used by silence + post-release assertions:
-/// sway amplitude (±2.5°) + `EmotionHead` Neutral bias (0°) + a small
-/// margin. Tight enough that an 8° `ListenHead` leak would blow past
+/// sway amplitude (±2.5°) + `HeadFromEmotion` Neutral bias (0°) + a small
+/// margin. Tight enough that an 8° `HeadFromAttention` leak would blow past
 /// it. Pose clamps the lower bound at 0 so we only upper-bound here.
 const BASELINE_TILT_CEILING_DEG: f32 = 3.0;
 
@@ -50,14 +50,14 @@ fn run_for(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, tick
 fn silence_holds_attention_none_and_baseline_tilt() {
     let mut entity = Entity::default();
     let mut sway = IdleSway::new();
-    let mut emo = EmotionHead::new();
-    let mut listen_head = ListenHead::new();
-    let mut look_at_sound = LookAtSound::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
+    let mut listening = Listening::new();
     let mut director = Director::new();
     director.add_modifier(&mut sway).unwrap();
     director.add_modifier(&mut emo).unwrap();
-    director.add_modifier(&mut listen_head).unwrap();
-    director.add_skill(&mut look_at_sound).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
+    director.add_skill(&mut listening).unwrap();
 
     // Default perception.audio_rms = None ⇒ silence.
     run_for(&mut director, &mut entity, 0, 60);
@@ -74,14 +74,14 @@ fn silence_holds_attention_none_and_baseline_tilt() {
 fn sustained_loud_enters_listening_and_lifts_tilt() {
     let mut entity = Entity::default();
     let mut sway = IdleSway::new();
-    let mut emo = EmotionHead::new();
-    let mut listen_head = ListenHead::new();
-    let mut look_at_sound = LookAtSound::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
+    let mut listening = Listening::new();
     let mut director = Director::new();
     director.add_modifier(&mut sway).unwrap();
     director.add_modifier(&mut emo).unwrap();
-    director.add_modifier(&mut listen_head).unwrap();
-    director.add_skill(&mut look_at_sound).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
+    director.add_skill(&mut listening).unwrap();
 
     // Sample baseline tilt across a couple of seconds of silence so
     // we know the max sway+emotion contribution at rest.
@@ -93,7 +93,7 @@ fn sustained_loud_enters_listening_and_lifts_tilt() {
     assert_eq!(entity.mind.attention, Attention::None);
 
     // Drive long enough for both the skill's sustain count to fire
-    // AND ListenHead's ease window to fully ramp up.
+    // AND HeadFromAttention's ease window to fully ramp up.
     entity.perception.audio_rms = Some(0.3);
     run_for(
         &mut director,
@@ -107,7 +107,7 @@ fn sustained_loud_enters_listening_and_lifts_tilt() {
         "expected Listening after sustained audio, got {:?}",
         entity.mind.attention
     );
-    // ListenHead adds 8° on top of baseline. Even with sway at its
+    // HeadFromAttention adds 8° on top of baseline. Even with sway at its
     // valley, listening tilt must clear baseline + a few degrees.
     let listen_tilt = entity.motor.head_pose.tilt_deg;
     assert!(
@@ -120,14 +120,14 @@ fn sustained_loud_enters_listening_and_lifts_tilt() {
 fn quieting_past_release_window_returns_to_baseline() {
     let mut entity = Entity::default();
     let mut sway = IdleSway::new();
-    let mut emo = EmotionHead::new();
-    let mut listen_head = ListenHead::new();
-    let mut look_at_sound = LookAtSound::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
+    let mut listening = Listening::new();
     let mut director = Director::new();
     director.add_modifier(&mut sway).unwrap();
     director.add_modifier(&mut emo).unwrap();
-    director.add_modifier(&mut listen_head).unwrap();
-    director.add_skill(&mut look_at_sound).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
+    director.add_skill(&mut listening).unwrap();
 
     entity.perception.audio_rms = Some(0.3);
     let now = run_for(
@@ -138,7 +138,7 @@ fn quieting_past_release_window_returns_to_baseline() {
     );
     assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
 
-    // Step well past both the skill's release window AND ListenHead's
+    // Step well past both the skill's release window AND HeadFromAttention's
     // ease-out window so the bias has fully decayed back to 0.
     entity.perception.audio_rms = Some(0.001);
     run_for(

--- a/crates/stackchan-sim/tests/petting.rs
+++ b/crates/stackchan-sim/tests/petting.rs
@@ -1,6 +1,6 @@
 //! End-to-end sim test for the `Petting` skill.
 //!
-//! Verifies the parallel-driver design: `BodyGesture` (modifier) and
+//! Verifies the parallel-driver design: `IntentFromBodyTouch` (modifier) and
 //! `Petting` (skill) react to the same `perception.body_touch` input
 //! without conflict — modifier writes emotion + autonomy on the
 //! Press edge, skill writes intent after sustained contact.
@@ -10,7 +10,7 @@
     reason = "test-only: registry capacity is a compile-time constant in this fixture"
 )]
 
-use stackchan_core::modifiers::{BodyGesture, DEFAULT_CENTRE_PRESS};
+use stackchan_core::modifiers::{DEFAULT_CENTRE_PRESS, IntentFromBodyTouch};
 use stackchan_core::skills::{PETTING_SUSTAIN_TICKS, Petting};
 use stackchan_core::{BodyTouch, Director, Entity, Instant, Intent};
 
@@ -55,19 +55,19 @@ fn sustained_touch_through_director_fires_being_pet() {
         ..BodyTouch::default()
     });
     run_for(&mut director, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
-    assert_eq!(entity.mind.intent, Intent::BeingPet);
+    assert_eq!(entity.mind.intent, Intent::Petted);
 }
 
 #[test]
 fn body_gesture_and_petting_coexist_on_same_input() {
     let mut entity = Entity::default();
-    let mut gesture = BodyGesture::new();
+    let mut gesture = IntentFromBodyTouch::new();
     let mut petting = Petting::new();
     let mut director = Director::new();
     director.add_modifier(&mut gesture).unwrap();
     director.add_skill(&mut petting).unwrap();
 
-    // First frame: Press → BodyGesture sets emotion.
+    // First frame: Press → IntentFromBodyTouch sets emotion.
     entity.perception.body_touch = Some(BodyTouch {
         centre: 3,
         ..BodyTouch::default()
@@ -80,7 +80,7 @@ fn body_gesture_and_petting_coexist_on_same_input() {
     // change while emotion stays pinned.
     run_for(&mut director, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
     assert_eq!(entity.mind.affect.emotion, DEFAULT_CENTRE_PRESS);
-    assert_eq!(entity.mind.intent, Intent::BeingPet);
+    assert_eq!(entity.mind.intent, Intent::Petted);
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn release_clears_being_pet_through_director() {
         ..BodyTouch::default()
     });
     run_for(&mut director, &mut entity, u64::from(PETTING_SUSTAIN_TICKS));
-    assert_eq!(entity.mind.intent, Intent::BeingPet);
+    assert_eq!(entity.mind.intent, Intent::Petted);
 
     entity.perception.body_touch = Some(BodyTouch::default());
     let next = entity.tick.now.as_millis() + TICK_MS;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,9 +105,9 @@ registration order:
 | `Cognition`  | 20      | empty                                                 |
 | `Affect`     | 30      | emotion deciders (Touch/Remote/Pickup/Voice/...)      |
 | `Speech`     | 40      | empty                                                 |
-| `Expression` | 50      | visual modifiers (`EmotionStyle`, Blink, Breath, …)   |
-| `Motion`     | 60      | head modifiers (`IdleSway`, `EmotionHead`, …)         |
-| `Audio`      | 70      | audio-driven visual (`MouthOpenAudio`)                |
+| `Expression` | 50      | visual modifiers (`StyleFromEmotion`, Blink, Breath, …)   |
+| `Motion`     | 60      | head modifiers (`IdleSway`, `HeadFromEmotion`, …)         |
+| `Audio`      | 70      | audio-driven visual (`MouthFromAudio`)                |
 | `Output`     | 80      | empty (render task draws after `run()`)               |
 
 Numeric gaps of 10 leave room to insert a phase between existing

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -108,16 +108,16 @@ coarse `FieldGroup`s for human-readable conflict reports.
 
 The Affect phase ordering matters:
 
-- `EmotionTouch` runs first (priority `-100`) so a tap takes effect
+- `EmotionFromTouch` runs first (priority `-100`) so a tap takes effect
   before any environmental override.
 - `EmotionCycle` runs last in Affect; the autonomous advancer only
   fires when no input modifier set `mind.autonomy.manual_until`.
-- `EmotionStyle` runs in `Expression` and reads
+- `StyleFromEmotion` runs in `Expression` and reads
   `mind.affect.emotion`; Blink / Breath / IdleDrift then add per-frame
   deltas on top.
-- `IdleSway` (Motion) writes the base `motor.head_pose`; `EmotionHead`
+- `IdleSway` (Motion) writes the base `motor.head_pose`; `HeadFromEmotion`
   (registered later in Motion) adds an emotion-keyed bias on top.
-- `MouthOpenAudio` runs in `Audio` so audio-driven mouth-open isn't
+- `MouthFromAudio` runs in `Audio` so audio-driven mouth-open isn't
   overwritten by a stale earlier write.
 
 When in doubt, mirror the registration order in `render_task` and add

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -91,7 +91,7 @@ The `*Alert` suffix is acceptable when the chirp announces a
 Matches [`serde_json::Value`][serde-value] (bare nouns) and the
 animation-state-machine `OnEntered` / `OnExited` convention.
 
-Avoid `*Event` suffix — the enum name (`ChirpKind`, `IntentReflex`,
+Avoid `*Event` suffix — the enum name (`ChirpKind`, `EmotionFromIntent`,
 etc.) carries the kind information.
 
 [serde-value]: https://docs.rs/serde_json/latest/serde_json/enum.Value.html
@@ -119,78 +119,35 @@ grammatical forms of the same concept, so the pair reads naturally
 in context (`source = Pickup, intent = PickedUp`) without colliding
 on identifier.
 
-## Current violations
+## Current inventory
 
-Names on `main` today that break a rule, with the proposed rename.
-The rename PR sweeps these in one commit so reviewers can verify the
-mechanical correctness in a single diff.
+All names on `main` conform to the rules above. The inventory below
+is a quick cross-reference; the canonical lists live in the source
+(`crates/stackchan-core/src/{mind,voice,emotion}.rs` and
+`crates/stackchan-core/src/{modifiers,skills}/mod.rs`).
 
-### Intent
-
-| Current     | Renamed     | Rule |
-|-------------|-------------|------|
-| `Listen`    | `Listening` | A — own activity → gerund |
-| `BeingPet`  | `Petted`    | A — externally caused → past participle |
-
-### Skills
-
-| Current       | Renamed     | Rule |
-|---------------|-------------|------|
-| `LookAtSound` | `Listening` | C — recognizer → gerund (collision with `Attention::Listening` resolved by namespace: `skills::Listening` vs `Attention::Listening`) |
-
-### ChirpKind
-
-| Current             | Renamed              | Rule |
-|---------------------|----------------------|------|
-| `CameraModeEnter`   | `CameraModeEntered`  | D — transition → past participle |
-| `CameraModeExit`    | `CameraModeExited`   | D — transition → past participle |
-
-### Modifiers (translators)
-
-| Current             | Renamed              | Rule |
-|---------------------|----------------------|------|
-| `EmotionTouch`      | `EmotionFromTouch`   | B — `<Output>From<Source>` |
-| `RemoteCommand`     | `EmotionFromRemote`  | B (rename revisits if it grows beyond emotion) |
-| `BodyGesture`       | `IntentFromBodyTouch`| B — primary write is `mind.intent` (Petted) |
-| `IntentReflex`      | `EmotionFromIntent`  | B — reads intent transitions, writes emotion |
-| `WakeOnVoice`       | `EmotionFromVoice`   | B |
-| `AmbientSleepy`     | `EmotionFromAmbient` | B |
-| `LowBatteryEmotion` | `EmotionFromBattery` | B |
-| `EmotionStyle`      | `StyleFromEmotion`   | B |
-| `IntentStyle`       | `StyleFromIntent`    | B |
-| `EmotionHead`       | `HeadFromEmotion`    | B |
-| `ListenHead`        | `HeadFromAttention`  | B (specifically `Attention::Listening` — see doc comment) |
-| `MouthOpenAudio`    | `MouthFromAudio`     | B |
-
-### OverrideSource
-
-| Current | Renamed     | Rule |
-|---------|-------------|------|
-| `Touch` | `FaceTouch` | E — symmetric with `BodyTouch`; the screen IS the avatar's face |
-
-### Modifiers (autonomous, no rename)
-
-`Blink`, `Breath`, `IdleSway`, `IdleDrift`, `EmotionCycle` already
-conform to the bare-noun rule.
-
-### Already convention-compliant
-
-- All `Emotion` variants (`Neutral`, `Happy`, `Sad`, `Sleepy`,
-  `Surprised`, `Angry`) — single-word adjectives, matches the
-  [m5stack-avatar `Expression`][m5stack-expression] enum that this
-  project descends from.
-- Skills `Petting` and `Handling`.
-- Intents `PickedUp`, `Shaken`, `Tilted`, `Idle`, plus `Startled`
-  and the `IntentFromLoud` / `HeadFromIntent` modifiers introduced
-  by the [feat/listening-skill][pr-106] PR (which adopted the rules
-  ahead of the rename sweep).
-- `OverrideSource` variants `Pickup`, `Shake`, `Voice`, `Startle`,
-  `Ambient`, `LowBattery`, `BodyTouch`, `Remote`.
-- `ChirpKind` variants `Pickup`, `Wake`, `Startle`,
-  `LowBatteryAlert`.
+- **Intent** (rule A): `Idle`, `Listening`, `Startled`, `Petted`,
+  `PickedUp`, `Shaken`, `Tilted`.
+- **Emotion** (single-word adjectives, matches the
+  [m5stack-avatar `Expression`][m5stack-expression] enum this project
+  descends from): `Neutral`, `Happy`, `Sad`, `Sleepy`, `Surprised`,
+  `Angry`.
+- **Skills** (rule C, all gerund recognizers today): `Listening`,
+  `Petting`, `Handling`.
+- **ChirpKind** (rule D): `Pickup`, `Wake`, `Startle`,
+  `LowBatteryAlert`, `CameraModeEntered`, `CameraModeExited`.
+- **OverrideSource** (rule E): `FaceTouch`, `BodyTouch`, `Remote`,
+  `Pickup`, `Shake`, `Voice`, `Startle`, `Ambient`, `LowBattery`.
+- **Modifiers — autonomous** (rule B, bare noun): `Blink`, `Breath`,
+  `IdleSway`, `IdleDrift`, `EmotionCycle`.
+- **Modifiers — translators** (rule B, `<Output>From<Source>`):
+  `EmotionFromTouch`, `EmotionFromRemote`, `EmotionFromIntent`,
+  `EmotionFromVoice`, `EmotionFromAmbient`, `EmotionFromBattery`,
+  `IntentFromBodyTouch`, `IntentFromLoud`, `StyleFromEmotion`,
+  `StyleFromIntent`, `HeadFromEmotion`, `HeadFromAttention`,
+  `HeadFromIntent`, `MouthFromAudio`.
 
 [m5stack-expression]: https://github.com/stack-chan/m5stack-avatar/blob/master/src/Expression.h
-[pr-106]: https://github.com/andymai/stackchan-kai/pull/106
 
 ## Forward guidance
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -48,9 +48,9 @@ task's 33 ms tick virtually never coincides with the signal write.
 
 | Signal | Producer | Consumer | Cadence |
 |---|---|---|---|
-| `audio::AUDIO_RMS_SIGNAL` | audio task RX RMS loop | render → `MouthOpenAudio` + `WakeOnVoice` | ~33 ms |
-| `touch::TAP_SIGNAL` | touch task / button task | render → `EmotionTouch` | event |
-| `ir::REMOTE_SIGNAL` | IR RMT task | render → `RemoteCommand` | event |
+| `audio::AUDIO_RMS_SIGNAL` | audio task RX RMS loop | render → `MouthFromAudio` + `EmotionFromVoice` | ~33 ms |
+| `touch::TAP_SIGNAL` | touch task / button task | render → `EmotionFromTouch` | event |
+| `ir::REMOTE_SIGNAL` | IR RMT task | render → `EmotionFromRemote` | event |
 | `imu::IMU_SIGNAL` | IMU polling | render → `avatar.accel_g`, `gyro_dps` | 10 ms |
 | `ambient::AMBIENT_LUX_SIGNAL` | LTR-553 polling | render → `avatar.ambient_lux` | 500 ms |
 | `power::POWER_STATUS_SIGNAL` | AXP2101 polling | render → `avatar.battery_percent` | 1000 ms |

--- a/justfile
+++ b/justfile
@@ -222,7 +222,7 @@ ambient-bench:
 
 # IR-NEC bench: decodes incoming NEC frames from the IR receiver on
 # GPIO21 (RMT channel 7) and prints `(address, command)` tuples. Use to
-# discover your remote's codes for the `RemoteCommand` modifier mapping.
+# discover your remote's codes for the `EmotionFromRemote` modifier mapping.
 ir-bench:
     cd crates/stackchan-firmware && cargo +esp build --release --example ir_bench
     {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{example_elf_dir}}/ir_bench{{_serial_suffix}}


### PR DESCRIPTION
## Summary

Mechanical rename PR per the convention landed in #107. No behavior changes — every type, struct, variant, file, and module path renames in lockstep so the inventory matches the rules in `docs/naming.md`.

## Renames applied

### Intent variants (rule A)

  - \`Listen\` → \`Listening\` (own activity → gerund)
  - \`BeingPet\` → \`Petted\` (caused → past participle)

### ChirpKind variants (rule D)

  - \`CameraModeEnter\` → \`CameraModeEntered\`
  - \`CameraModeExit\` → \`CameraModeExited\`

### OverrideSource (rule E)

  - \`Touch\` → \`FaceTouch\` (symmetric with \`BodyTouch\`)

### Skill (rule C)

  - \`LookAtSound\` → \`Listening\` (file: \`look_at_sound.rs\` → \`listening.rs\`)

The collision with \`Attention::Listening\` and \`Intent::Listening\` is resolved by namespace (\`skills::Listening\`, \`Attention::Listening\`, \`Intent::Listening\`).

### Modifier translators (rule B — \`<Output>From<Source>\`)

| Old | New |
|---|---|
| \`EmotionTouch\` | \`EmotionFromTouch\` |
| \`RemoteCommand\` | \`EmotionFromRemote\` |
| \`IntentReflex\` | \`EmotionFromIntent\` |
| \`WakeOnVoice\` | \`EmotionFromVoice\` |
| \`AmbientSleepy\` | \`EmotionFromAmbient\` |
| \`LowBatteryEmotion\` | \`EmotionFromBattery\` |
| \`BodyGesture\` | \`IntentFromBodyTouch\` |
| \`EmotionStyle\` | \`StyleFromEmotion\` |
| \`IntentStyle\` | \`StyleFromIntent\` |
| \`EmotionHead\` | \`HeadFromEmotion\` |
| \`ListenHead\` | \`HeadFromAttention\` |
| \`MouthOpenAudio\` | \`MouthFromAudio\` |

All twelve module files renamed to match.

### What's NOT renamed

- **Bare-noun autonomous modifiers**: \`Blink\`, \`Breath\`, \`IdleSway\`, \`IdleDrift\`, \`EmotionCycle\` — already conform to the bare-noun rule.
- **Constants**: \`LISTEN_*\`, \`WAKE_*\`, \`STARTLE_*\`, \`MANUAL_HOLD_MS\`, \`PETTING_BLUSH_BUMP\`, etc. — they describe the *behavior* (which is invariant under the modifier rename), not the type name.
- **PR #106's introductions**: \`IntentFromLoud\`, \`HeadFromIntent\`, \`Intent::Startled\`, \`ChirpKind::Startle\`, \`OverrideSource::Startle\` adopted the convention from the start.

### Doc cleanup

\`docs/naming.md\` updated: the violation table is gone (no violations remain) and replaced with a single "Current inventory" list cross-referencing the source.

## Test plan

- [x] \`just check\` — fmt + workspace clippy + host tests
- [x] \`just clippy-firmware\` — strict firmware clippy
- [x] \`just build-firmware\` — release build

58 files changed, +601/-641 lines.