### PR TITLE
feat(firmware): always-on camera capture + tracker wired into engine signal (1/5)

### DIFF
--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -60,6 +60,6 @@ pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use mind::{Affect, Attention, Autonomy, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
 pub use motor::Motor;
-pub use perception::{BodyTouch, Perception};
+pub use perception::{BodyTouch, Perception, TrackingMotion, TrackingObservation};
 pub use skill::{Skill, SkillStatus};
 pub use voice::{ChirpKind, Voice};

--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -14,6 +14,8 @@
 //! [`Phase::Affect`]: crate::director::Phase::Affect
 //! [`Phase::Audio`]: crate::director::Phase::Audio
 
+use crate::head::Pose;
+
 /// Per-zone body-touch intensity (back-of-head `Si12T` pads).
 ///
 /// Each zone carries a 0..=3 intensity matching the chip's 2-bit
@@ -58,6 +60,50 @@ impl BodyTouch {
         let weighted = (self.right as i16 - self.left as i16) * 100;
         weighted / total
     }
+}
+
+/// One-frame summary of the firmware-side camera tracker's analysis.
+///
+/// The firmware's `tracker` crate runs the block-grid motion analysis
+/// inside the camera task and publishes one of these per processed
+/// frame. The engine consumes it via `entity.perception.tracking`
+/// (added in the next PR) and decides what to do — see the
+/// `TrackingFromCamera` `Phase::Perception` modifier and the
+/// `AttentionFromTracking` `Phase::Cognition` modifier.
+///
+/// The shape mirrors `tracker::Outcome` minus the centroid, which is
+/// already baked into `target_pose` by the tracker.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TrackingObservation {
+    /// Where the tracker thinks the head should look — already through
+    /// the tracker's dead zone, P-gain, slew limit, and clamp.
+    pub target_pose: Pose,
+    /// Number of grid cells whose per-block luma delta exceeded the
+    /// tracker's threshold this frame. `0` during warmup or genuine
+    /// stillness; saturates at the grid's cell count.
+    pub fired_cells: u16,
+    /// Classification of this analysis step.
+    pub motion: TrackingMotion,
+}
+
+/// Why the tracker chose its current target. Mirrors `tracker::Motion`
+/// without depending on the tracker crate from `stackchan-core`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TrackingMotion {
+    /// First frame after construction or `reset` — no previous frame
+    /// to diff against. Target pose is unchanged from `Pose::NEUTRAL`.
+    Warmup,
+    /// Real motion detected; target pose was nudged toward it.
+    Tracking,
+    /// No motion this step but still inside the idle timeout window;
+    /// target pose held at the last commanded value.
+    Holding,
+    /// Idle long enough to be slewing back toward `Pose::NEUTRAL`.
+    Returning,
+    /// Too many cells fired this frame — the tracker treated it as a
+    /// global lighting change and held the target.
+    GlobalEvent,
 }
 
 /// Raw sensor readings that drive reactive modifiers.

--- a/crates/stackchan-firmware/src/camera.rs
+++ b/crates/stackchan-firmware/src/camera.rs
@@ -7,17 +7,18 @@
 //! [`SharedI2c`] bus; the [`gc0308`] driver handles register-level
 //! init, format selection, and stream gating.
 //!
-//! ## Mode-gated lifecycle
+//! ## Always-on capture for tracking
 //!
-//! The task does **not** stream continuously. It blocks on
-//! [`CAMERA_MODE_SIGNAL`] and only powers up when the user toggles into
-//! camera mode (long-press of the AXP2101 power button — see
-//! [`crate::button`]). On entry it opens the SCCB stream gate; on exit
-//! it closes the gate before parking. CoreS3 does not expose the
-//! GC0308's PWDN pin, so this SCCB-level gating is the only "stop the
-//! sensor" knob — the chip continues to draw a small idle current
-//! either way, but PCLK / HSYNC / VSYNC / data are tri-stated, so the
-//! DMA peripheral observes no edges.
+//! The task streams continuously from boot. The block-grid `tracker`
+//! runs on every captured frame; the resulting [`TrackingObservation`]
+//! is published on [`CAMERA_TRACKING_SIGNAL`] so the engine's
+//! Perception/Cognition modifiers can drive head + eye motion toward
+//! whatever moved.
+//!
+//! [`CAMERA_MODE_SIGNAL`] is **display-only** — it controls whether
+//! the LCD shows the camera preview vs. the avatar; it does not gate
+//! capture or tracking. Tracking observations flow regardless of
+//! preview state.
 //!
 //! ## DMA strategy
 //!
@@ -37,8 +38,7 @@
 //! [`CAMERA_MODE_SIGNAL`] is `true` it skips the avatar blit and instead
 //! reads the latest camera buffer pointer; when `false` it resumes
 //! avatar rendering. Modifiers keep ticking either way so the avatar's
-//! emotion state evolves in the background and resumes seamlessly on
-//! exit.
+//! emotion state evolves in the background.
 //!
 //! ## Unsafe usage
 //!
@@ -59,7 +59,7 @@
 )]
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-use embassy_time::{Duration, Timer};
+use embassy_time::{Duration, Instant, Timer};
 use esp_hal::{
     dma::DmaRxBuf,
     lcd_cam::{
@@ -72,6 +72,8 @@ use esp_hal::{
     },
     time::Rate,
 };
+use stackchan_core::{TrackingMotion, TrackingObservation};
+use tracker::{Motion, Tracker, TrackerConfig};
 
 use crate::board::SharedI2c;
 
@@ -101,10 +103,11 @@ const DESCRIPTORS_PER_BUFFER: usize = 40;
 /// peripheral expecting that `PCLK` rate.
 pub const PIXEL_CLOCK_HZ: u32 = 20_000_000;
 
-/// Mode-toggle signal published by [`crate::button`].
+/// LCD preview-mode toggle published by [`crate::button`].
 ///
-/// `true` = camera mode active (camera streaming + LCD shows preview).
-/// `false` = avatar mode (camera SCCB-gated off + LCD shows avatar).
+/// `true` = LCD shows the camera preview. `false` = LCD shows the
+/// avatar. The camera task itself ignores this signal — capture +
+/// tracking are always-on. The render task is the sole consumer.
 /// `Signal` semantics (latest-wins, no backlog) are correct here: a
 /// rapid double-toggle just lands on whichever value the producer
 /// signalled last, matching the user's intent.
@@ -134,6 +137,29 @@ pub static CAMERA_CAPTURE_REQUEST: Signal<CriticalSectionRawMutex, ()> = Signal:
 /// reads (the DMA peripheral never writes into a slot the render
 /// task is reading).
 pub static CAMERA_FRAME_SIGNAL: Signal<CriticalSectionRawMutex, &'static [u8]> = Signal::new();
+
+/// Latest tracker observation, camera task → engine.
+///
+/// The camera task runs `tracker::Tracker::step` on every captured
+/// frame and publishes the [`TrackingObservation`] result here.
+/// Latest-wins: the engine drains this once per render tick into
+/// `entity.perception.tracking`. Always-on regardless of
+/// [`CAMERA_MODE_SIGNAL`] — preview gating (display) is independent
+/// from tracker analysis (always running).
+pub static CAMERA_TRACKING_SIGNAL: Signal<CriticalSectionRawMutex, TrackingObservation> =
+    Signal::new();
+
+/// Translate the firmware-side `tracker::Motion` into the
+/// engine-side `TrackingMotion` mirror enum. Pure mapping; no logic.
+const fn motion_to_engine(m: Motion) -> TrackingMotion {
+    match m {
+        Motion::Warmup => TrackingMotion::Warmup,
+        Motion::Tracking => TrackingMotion::Tracking,
+        Motion::Holding => TrackingMotion::Holding,
+        Motion::Returning => TrackingMotion::Returning,
+        Motion::GlobalEvent => TrackingMotion::GlobalEvent,
+    }
+}
 
 /// Camera task peripherals, grouped so `main.rs` spawns the task with
 /// a single `Spawner::spawn` call rather than a 14-argument function.
@@ -174,12 +200,17 @@ pub struct CameraPeripherals {
 
 /// Camera task entry point.
 ///
-/// Runs the GC0308 SCCB init + `LCD_CAM` peripheral construction once at
-/// boot, then enters the mode-gated capture loop. On
-/// [`CAMERA_MODE_SIGNAL`] = true: open SCCB stream, alternate
-/// `receive(buf_a) / receive(buf_b)`, publish completed-buffer indices
-/// on [`CAMERA_FRAME_SIGNAL`]. On `CAMERA_MODE_SIGNAL` = false: close
-/// SCCB stream gate and block until the next mode change.
+/// Runs the GC0308 SCCB init + `LCD_CAM` peripheral construction once
+/// at boot, lifts the SCCB stream gate, then enters the always-on
+/// capture loop. Each completed frame is copied to a scratch slot,
+/// published on [`CAMERA_FRAME_SIGNAL`] for the render task's preview
+/// blit, and fed through `tracker::Tracker::step` — the resulting
+/// [`TrackingObservation`] lands on [`CAMERA_TRACKING_SIGNAL`] for the
+/// engine's Perception/Cognition modifiers.
+///
+/// [`CAMERA_MODE_SIGNAL`] is read by the render task only and decides
+/// whether the LCD shows the camera preview vs. the avatar; it does
+/// not gate capture or tracking.
 ///
 /// Init failures (chip-id mismatch, peripheral construction error)
 /// log at `error` and park the task — the avatar continues running
@@ -189,7 +220,7 @@ pub struct CameraPeripherals {
 #[allow(
     clippy::too_many_lines,
     reason = "single bring-up sequence — splitting into helpers fragments \
-              the SCCB init → peripheral construction → mode loop ordering"
+              the SCCB init → peripheral construction → capture loop ordering"
 )]
 pub async fn run_camera_task(p: CameraPeripherals) -> ! {
     use embassy_time::Delay;
@@ -224,16 +255,18 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
         );
         park_forever().await;
     }
-    // Streaming starts gated off. The first CAMERA_MODE_SIGNAL=true
-    // edge will lift the gate.
-    if let Err(e) = sensor.set_streaming(false).await {
-        defmt::warn!(
-            "camera: set_streaming(false) failed ({:?})",
+    // Streaming is always-on for tracking. CAMERA_MODE_SIGNAL no
+    // longer gates capture (it now controls only whether the LCD
+    // shows the camera preview vs the avatar — see render_task).
+    if let Err(e) = sensor.set_streaming(true).await {
+        defmt::error!(
+            "camera: set_streaming(true) failed ({:?}); camera disabled",
             defmt::Debug2Format(&e),
         );
+        park_forever().await;
     }
     defmt::info!(
-        "camera: GC0308 SCCB init complete (chip ID 0x{=u8:02x})",
+        "camera: GC0308 SCCB init complete (chip ID 0x{=u8:02x}) — streaming ON for tracking",
         gc0308::CHIP_ID
     );
 
@@ -301,43 +334,14 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
     let mut buf_slot_a: Option<DmaRxBuf> = Some(buf_a);
     let mut buf_slot_b: Option<DmaRxBuf> = Some(buf_b);
     let mut active_idx: usize = 0;
-    let mut streaming_now = false;
+
+    // Tracker: block-grid motion analysis on each captured frame.
+    // Defaults are tuned in the `tracker` crate; tweak via
+    // `TrackerConfig` here if on-device tuning calls for it.
+    let mut tracker = Tracker::new(TrackerConfig::DEFAULT);
+    let mut last_step_at = Instant::now();
+
     loop {
-        // Wait for camera mode to be on; if we're already streaming
-        // this returns immediately because the signal is sticky.
-        let want_streaming = if streaming_now {
-            CAMERA_MODE_SIGNAL.try_take().unwrap_or(true)
-        } else {
-            CAMERA_MODE_SIGNAL.wait().await
-        };
-
-        if !want_streaming {
-            if streaming_now {
-                if let Err(e) = sensor.set_streaming(false).await {
-                    defmt::warn!(
-                        "camera: stream-off SCCB write failed ({:?})",
-                        defmt::Debug2Format(&e),
-                    );
-                }
-                defmt::info!("camera: streaming gated off (avatar mode)");
-                streaming_now = false;
-            }
-            continue;
-        }
-
-        if !streaming_now {
-            if let Err(e) = sensor.set_streaming(true).await {
-                defmt::warn!(
-                    "camera: stream-on SCCB write failed ({:?}); retrying",
-                    defmt::Debug2Format(&e),
-                );
-                Timer::after(Duration::from_millis(50)).await;
-                continue;
-            }
-            defmt::info!("camera: streaming enabled (camera mode)");
-            streaming_now = true;
-        }
-
         // Pick the buffer to fill on this iteration; the OTHER one
         // holds the most-recently-completed frame the render task is
         // (probably) reading. We use `Option::take()` so the slot
@@ -387,13 +391,6 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
             // period and well above the embassy timer tick — accurate
             // enough to catch the EOF without burning CPU.
             Timer::after(Duration::from_millis(1)).await;
-
-            // Bail mid-frame if the user toggles back to avatar mode;
-            // we'd rather drop a half-frame than wait for it.
-            if CAMERA_MODE_SIGNAL.try_take() == Some(false) {
-                CAMERA_MODE_SIGNAL.signal(false);
-                break;
-            }
         }
 
         let (result, returned_camera, completed_buf) = transfer.wait();
@@ -422,6 +419,21 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
             }
             let view: &'static [u8] = unsafe { core::slice::from_raw_parts(dst_ptr, copy_len) };
             CAMERA_FRAME_SIGNAL.signal(view);
+
+            // Run the block-grid tracker on this frame and publish
+            // the observation. `dt_ms` is the wall-clock interval
+            // since the previous step — feeds the tracker's idle /
+            // return-to-centre logic.
+            let now = Instant::now();
+            let dt_ms =
+                u32::try_from(now.duration_since(last_step_at).as_millis()).unwrap_or(u32::MAX);
+            last_step_at = now;
+            let outcome = tracker.step(view, dt_ms);
+            CAMERA_TRACKING_SIGNAL.signal(TrackingObservation {
+                target_pose: outcome.target,
+                fired_cells: outcome.fired_cells,
+                motion: motion_to_engine(outcome.motion),
+            });
 
             // Honour any pending capture request — log frame stats +
             // a 32×24 RGB565 thumbnail strip over RTT.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -297,8 +297,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         // Drain camera-mode toggle edges from the button task. Each
         // signal is a fresh "user wants this mode" assertion; we mirror
         // it locally + fire the appropriate audio chirp on transitions.
-        // The camera task gets the same signal directly and starts /
-        // stops streaming accordingly.
+        // CAMERA_MODE_SIGNAL is now a display-only toggle: the camera
+        // task always streams (for tracking); this flag only decides
+        // whether the LCD shows the camera preview or the avatar.
         if let Some(active) = camera::CAMERA_MODE_SIGNAL.try_take()
             && active != camera_mode
         {
@@ -314,11 +315,6 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
                     defmt::Debug2Format(&e),
                 );
             }
-            // Re-publish so the camera task (which may have been
-            // drained between this take and its own try_take) still
-            // sees the latest intent. `Signal::signal` is latest-
-            // wins so a duplicate publish is safe.
-            camera::CAMERA_MODE_SIGNAL.signal(active);
         }
         // Drain any newly completed camera frame slice. Latest-wins:
         // we hold the most recent slice ref until the camera task
@@ -636,11 +632,11 @@ async fn audio_task(peripherals: audio::AudioPeripherals) -> ! {
 
 /// Camera task. Owns the `LCD_CAM` peripheral + `DMA_CH1` + 11 DVP pins,
 /// shares the I²C0 bus for SCCB control. Runs the GC0308 register
-/// init at boot, then mode-gates streaming on
-/// [`camera::CAMERA_MODE_SIGNAL`]: when active, alternates ping-pong
-/// DMA captures and copies each completed frame into a PSRAM scratch
-/// slot, publishing the slice via [`camera::CAMERA_FRAME_SIGNAL`] for
-/// the render task to blit.
+/// init at boot, then streams continuously: alternates ping-pong DMA
+/// captures and copies each completed frame into a PSRAM scratch slot,
+/// publishing the slice via [`camera::CAMERA_FRAME_SIGNAL`] for the
+/// render task to blit AND running the block-grid tracker on every
+/// frame, with results published on [`camera::CAMERA_TRACKING_SIGNAL`].
 #[embassy_executor::task]
 async fn camera_task(peripherals: camera::CameraPeripherals) -> ! {
     camera::run_camera_task(peripherals).await
@@ -805,9 +801,12 @@ async fn main(spawner: Spawner) -> ! {
     // Camera subsystem. The task owns LCD_CAM + DMA_CH1 + the 11 DVP
     // pins and shares the existing I²C0 bus for SCCB control. It
     // runs SCCB init + LCD_CAM construction once at boot, then
-    // mode-gates streaming on `CAMERA_MODE_SIGNAL`. Failures inside
-    // the task log-and-park — camera mode silently degrades to "no
-    // preview available" while the rest of the avatar keeps running.
+    // streams continuously: each frame is published on
+    // `CAMERA_FRAME_SIGNAL` for preview AND fed through the block-
+    // grid tracker, with the result landing on
+    // `CAMERA_TRACKING_SIGNAL` for the engine. Failures inside the
+    // task log-and-park — camera silently degrades to "no preview /
+    // no tracking" while the rest of the avatar keeps running.
     let camera_periph = camera::CameraPeripherals {
         lcd_cam: peripherals.LCD_CAM,
         dma: peripherals.DMA_CH1,


### PR DESCRIPTION
## Summary

PR1 of a 5-PR camera/tracking arc. **Foundation only — engine doesn't consume the new signal yet** (PR2 adds the perception field + modifier).

## What changes

- **Camera streams continuously from boot**. The \`CAMERA_MODE_SIGNAL\` gate that paused capture between previews is gone; the SCCB stream is enabled once at init and never disabled.
- **CAMERA_MODE_SIGNAL is now display-only** — the render task reads it to decide preview vs. avatar; the camera task ignores it.
- New \`stackchan_core::TrackingObservation { target_pose, fired_cells, motion }\` + \`TrackingMotion\` mirror enum, alongside \`BodyTouch\` in \`perception.rs\`.
- New \`stackchan_firmware::camera::CAMERA_TRACKING_SIGNAL\` — one observation per processed frame (~30 Hz), latest-wins.
- The camera task now constructs a \`Tracker::new(TrackerConfig::DEFAULT)\` once at task start, runs \`tracker.step(view, dt_ms)\` per frame, and publishes the result on the new signal. \`dt_ms\` is measured wall-clock between calls.

## Why no engine consumer yet

The 5-PR sequence is: foundation → perception field → cognition + Tracking attention → head/eye reactions → on-device tune. Per the design discussion (clean architecture first), each layer lands in its own PR with sim coverage. PR1 just gets the firmware-side wiring and the cross-task type definition right.

## Test plan

- [x] \`just check\` (host)
- [x] \`just clippy-firmware\`
- [x] \`just build-firmware\`
- [ ] On-device flash via \`just fmr\` — camera should now stream continuously; preview toggle (button long-press) still works for LCD display