### PR TITLE
feat(core): perception.tracking field + firmware drain (2/5)

### DIFF
--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -133,6 +133,14 @@ pub struct Perception {
     /// or `None` before the first successful read. Continuous state,
     /// not an edge — modifiers add their own edge detection if needed.
     pub body_touch: Option<BodyTouch>,
+    /// Latest camera tracker observation (target pose + motion class +
+    /// fired-cell count), or `None` before the camera task publishes
+    /// its first frame. The firmware tracker runs at camera frame
+    /// rate (~30 Hz); the engine drains into this field once per
+    /// render tick (~30 Hz). Cognition modifiers read this to decide
+    /// whether the avatar should latch attention to the moving
+    /// target.
+    pub tracking: Option<TrackingObservation>,
 }
 
 impl Default for Perception {
@@ -146,6 +154,7 @@ impl Default for Perception {
             usb_power_present: None,
             audio_rms: None,
             body_touch: None,
+            tracking: None,
         }
     }
 }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -386,6 +386,12 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         if let Some(touch) = body_touch::BODY_TOUCH_SIGNAL.try_take() {
             entity.perception.body_touch = Some(touch);
         }
+        // Drain the latest camera tracker observation. Cognition
+        // modifiers read entity.perception.tracking to decide whether
+        // to flip mind.attention to Tracking{target}.
+        if let Some(observation) = camera::CAMERA_TRACKING_SIGNAL.try_take() {
+            entity.perception.tracking = Some(observation);
+        }
 
         // Run the entire modifier graph in one call. The Director sorts
         // by (phase, priority, registration order) and ticks each


### PR DESCRIPTION
## Summary

PR2 of the camera/tracking arc. Engine-side wiring; **still no visible reaction**.

The firmware-side \`CAMERA_TRACKING_SIGNAL\` (added in #109) now flows into \`entity.perception.tracking: Option<TrackingObservation>\` via a single-line drain in the render task — same pattern as the existing \`audio_rms\` / \`body_touch\` / \`ambient_lux\` drains.

## Why no Phase::Perception modifier

The firmware drain IS the perception step for this percept — the firmware tracker has already done all the analysis. If a future Cognition modifier needs derived state across multiple frames (e.g. smoothed motion, lock-on hysteresis state visible to other modifiers), that's where a Perception modifier would fit; today nothing needs it.

PR3 adds the Cognition modifier that reads \`perception.tracking\` and decides whether to flip \`mind.attention\` to a new \`Tracking\` variant.

## Test plan

- [x] \`just check\` (host)
- [x] \`just clippy-firmware\`
- [ ] On-device — no behavior change yet, but \`entity.perception.tracking\` should be \`Some(...)\` after first camera frame