### PR TITLE
feat(core): AttentionFromTracking — Cognition modifier + Attention::Tracking (3/5)

### DIFF
--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -170,6 +170,8 @@ pub enum Field {
     AudioRms,
     /// `entity.perception.body_touch`
     BodyTouch,
+    /// `entity.perception.tracking`
+    Tracking,
 
     // ---- Mind ----
     /// `entity.mind.affect.emotion`
@@ -223,6 +225,7 @@ impl Field {
         Self::UsbPowerPresent,
         Self::AudioRms,
         Self::BodyTouch,
+        Self::Tracking,
         Self::Emotion,
         Self::Autonomy,
         Self::Intent,
@@ -260,7 +263,8 @@ impl Field {
             | Self::BatteryPercent
             | Self::UsbPowerPresent
             | Self::AudioRms
-            | Self::BodyTouch => FieldGroup::Perception,
+            | Self::BodyTouch
+            | Self::Tracking => FieldGroup::Perception,
             Self::Emotion | Self::Autonomy | Self::Intent | Self::Attention => FieldGroup::Mind,
             Self::ChirpRequest => FieldGroup::Voice,
             Self::TapPending | Self::RemotePending => FieldGroup::Input,
@@ -346,6 +350,7 @@ impl Field {
                 _ => true,
             },
             Self::BodyTouch => before.perception.body_touch != after.perception.body_touch,
+            Self::Tracking => before.perception.tracking != after.perception.tracking,
             Self::Emotion => before.mind.affect.emotion != after.mind.affect.emotion,
             Self::Autonomy => before.mind.autonomy != after.mind.autonomy,
             Self::Intent => before.mind.intent != after.mind.intent,
@@ -760,7 +765,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            33,
+            34,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -23,6 +23,7 @@
 
 use crate::clock::Instant;
 use crate::emotion::Emotion;
+use crate::head::Pose;
 
 /// The entity's current felt state.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -130,7 +131,11 @@ pub enum Intent {
 ///
 /// Carries enough state for downstream modifiers to animate the focus
 /// (e.g. ease-in based on `since`). Default: [`Attention::None`].
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+///
+/// Only `PartialEq` (not `Eq`) because [`Attention::Tracking`] carries
+/// a [`Pose`] with f32 fields. Modifier tests still use `assert_eq!`
+/// freely — that needs only `PartialEq`.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum Attention {
     /// Not focused on anything specific.
@@ -143,6 +148,18 @@ pub enum Attention {
         /// When the listening attention began.
         since: Instant,
     },
+    /// Tracking a moving target detected by the camera. `target` is
+    /// the head-pose the engine wants to look at (already in safe
+    /// pan/tilt range — the firmware tracker handles clamping); `since`
+    /// is the instant tracking attention began. Set by
+    /// [`crate::modifiers::AttentionFromTracking`].
+    Tracking {
+        /// Where the head should look. In the same coordinate system
+        /// as `motor.head_pose`.
+        target: Pose,
+        /// When the tracking attention began.
+        since: Instant,
+    },
 }
 
 /// Persistent facts the entity remembers across boots. Placeholder
@@ -153,7 +170,10 @@ pub struct Memory;
 /// The cognitive layer of the entity. Sub-component shape is stable;
 /// new fields land on `Affect` / `Autonomy` / `Intent` / `Attention` /
 /// `Memory` without breaking modifiers that read `Mind`.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+///
+/// `PartialEq` only — [`Attention::Tracking`] holds a [`Pose`] with
+/// f32 fields, which leak through here.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Mind {
     /// Current felt state.
     pub affect: Affect,

--- a/crates/stackchan-core/src/modifiers/attention_from_tracking.rs
+++ b/crates/stackchan-core/src/modifiers/attention_from_tracking.rs
@@ -1,0 +1,394 @@
+//! `AttentionFromTracking`: cognition-phase modifier that latches
+//! [`Attention::Tracking`] when the camera tracker reports sustained
+//! motion, and releases back to [`Attention::None`] after a quiet
+//! window.
+//!
+//! Reads `entity.perception.tracking` (populated each tick by the
+//! firmware drain of `CAMERA_TRACKING_SIGNAL`) and writes
+//! `entity.mind.attention`. The firmware-side tracker has already
+//! computed the target pose; this modifier's job is the
+//! *cognitive* decision: "should the avatar latch onto this motion
+//! as a thing to look at?" — with hysteresis to avoid flicker.
+//!
+//! ## Lock / release
+//!
+//! - **Enter `Tracking`** when [`TrackingMotion::Tracking`] persists
+//!   for [`TRACKING_LOCK_TICKS`] consecutive ticks. Each frame after
+//!   entry refreshes `target` from the latest observation while
+//!   pinning `since` to the entry tick (downstream modifiers use
+//!   `since` for ease-in animation; jumping it mid-track would
+//!   reset the ramp).
+//! - **Stay** while [`TrackingMotion::Tracking`] or
+//!   [`TrackingMotion::Holding`] keeps appearing — both indicate the
+//!   tracker still believes the target is meaningful.
+//! - **Release** to [`Attention::None`] once
+//!   [`TRACKING_RELEASE_MS`] has elapsed since the last
+//!   [`TrackingMotion::Tracking`] tick. We rely on real time (not
+//!   tick count) so the release window is independent of frame rate.
+//!
+//! ## Coexistence with [`Attention::Listening`]
+//!
+//! Only writes `Attention::Tracking` (when locked) or
+//! `Attention::None` (on release). If another modifier or skill has
+//! set `Attention::Listening`, this modifier leaves it alone unless
+//! it has its own lock-on edge to fire — that is, sustained motion
+//! interrupts a listening attention. The relative priority isn't
+//! enforced here; it falls out of registration order. Today this
+//! modifier is registered after [`crate::skills::Listening`], so
+//! tracking wins when both fire.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::Attention;
+use crate::modifier::Modifier;
+use crate::perception::TrackingMotion;
+
+/// Consecutive [`TrackingMotion::Tracking`] ticks required to enter
+/// [`Attention::Tracking`].
+///
+/// `3` ticks at the firmware tracker's ~30 Hz cadence is ~100 ms —
+/// long enough to ignore single-frame spikes (e.g. a hand swept past
+/// the camera once), short enough that the avatar reacts within the
+/// first sustained motion of a real interaction.
+pub const TRACKING_LOCK_TICKS: u8 = 3;
+
+/// How long to hold [`Attention::Tracking`] after the last
+/// [`TrackingMotion::Tracking`] tick before releasing to
+/// [`Attention::None`], in ms.
+///
+/// `1500` ms reads as "the avatar stays interested for a moment
+/// after the motion stops" — matches the
+/// [`crate::skills::Listening`] release window for symmetry.
+pub const TRACKING_RELEASE_MS: u64 = 1_500;
+
+/// Modifier that watches `perception.tracking` and decides whether
+/// `mind.attention` should be `Tracking{target}`.
+#[derive(Debug, Clone, Copy)]
+pub struct AttentionFromTracking {
+    /// Consecutive `Tracking`-classified ticks required to enter the
+    /// tracking attention state.
+    pub lock_ticks: u8,
+    /// Hold window after the last tracking tick before releasing
+    /// attention back to `None`, in ms.
+    pub release_ms: u64,
+    /// Running counter of consecutive `Tracking` ticks. Saturates at
+    /// `u8::MAX` so a very long sustained run doesn't wrap.
+    consecutive_tracking: u8,
+    /// Instant of the most recent `Tracking` tick. Drives the release
+    /// window. `None` between motion bursts.
+    last_tracking_at: Option<Instant>,
+}
+
+impl AttentionFromTracking {
+    /// Construct with default tuning ([`TRACKING_LOCK_TICKS`] /
+    /// [`TRACKING_RELEASE_MS`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            lock_ticks: TRACKING_LOCK_TICKS,
+            release_ms: TRACKING_RELEASE_MS,
+            consecutive_tracking: 0,
+            last_tracking_at: None,
+        }
+    }
+
+    /// Construct with custom lock + release tuning.
+    #[must_use]
+    pub const fn with_config(lock_ticks: u8, release_ms: u64) -> Self {
+        Self {
+            lock_ticks,
+            release_ms,
+            consecutive_tracking: 0,
+            last_tracking_at: None,
+        }
+    }
+}
+
+impl Default for AttentionFromTracking {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for AttentionFromTracking {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "AttentionFromTracking",
+            description: "Watches perception.tracking; latches mind.attention=Tracking{target} \
+                          after TRACKING_LOCK_TICKS consecutive Tracking-classified ticks. \
+                          Releases to None after TRACKING_RELEASE_MS quiet ms. Updates target \
+                          continuously while locked; pins `since` to the entry tick for \
+                          stable ease-in animation.",
+            phase: Phase::Cognition,
+            priority: 0,
+            reads: &[Field::Tracking, Field::Attention],
+            writes: &[Field::Attention],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        let Some(obs) = entity.perception.tracking else {
+            // No observation yet — leave attention alone, reset
+            // counter so the next non-None obs starts fresh.
+            self.consecutive_tracking = 0;
+            return;
+        };
+
+        let active = matches!(obs.motion, TrackingMotion::Tracking);
+        if active {
+            self.consecutive_tracking = self.consecutive_tracking.saturating_add(1);
+            self.last_tracking_at = Some(now);
+        } else {
+            self.consecutive_tracking = 0;
+        }
+
+        let currently_tracking = matches!(entity.mind.attention, Attention::Tracking { .. });
+
+        if self.consecutive_tracking >= self.lock_ticks {
+            // Locked. Refresh target on every tick; preserve `since`
+            // if already locked so consumers' ease-in math stays
+            // anchored.
+            let since = match entity.mind.attention {
+                Attention::Tracking { since, .. } => since,
+                _ => now,
+            };
+            entity.mind.attention = Attention::Tracking {
+                target: obs.target_pose,
+                since,
+            };
+            return;
+        }
+
+        // Not enough sustained motion to lock. If we're already
+        // tracking, hold until the release window expires.
+        if currently_tracking {
+            let elapsed = self
+                .last_tracking_at
+                .map_or(u64::MAX, |t| now.saturating_duration_since(t));
+            if elapsed >= self.release_ms {
+                entity.mind.attention = Attention::None;
+                self.last_tracking_at = None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    reason = "let-else with panic is the cleanest pattern for value extraction \
+              on enum variants in tests"
+)]
+mod tests {
+    use super::*;
+    use crate::Pose;
+    use crate::perception::TrackingObservation;
+
+    fn at(now_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.tick.now = Instant::from_millis(now_ms);
+        e
+    }
+
+    fn observation(motion: TrackingMotion, target: Pose) -> TrackingObservation {
+        TrackingObservation {
+            target_pose: target,
+            fired_cells: if matches!(motion, TrackingMotion::Tracking) {
+                4
+            } else {
+                0
+            },
+            motion,
+        }
+    }
+
+    #[test]
+    fn no_observation_keeps_attention_none() {
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        for t in 0..30 {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn warmup_does_not_lock() {
+        // The tracker reports Warmup on its first frame — must not
+        // trigger a lock.
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Warmup, Pose::new(10.0, 5.0)));
+        for t in 0..10 {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn sustained_tracking_locks_after_threshold() {
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        let target = Pose::new(15.0, 8.0);
+        entity.perception.tracking = Some(observation(TrackingMotion::Tracking, target));
+
+        // Drive for the lock-tick count.
+        for t in 0..u64::from(TRACKING_LOCK_TICKS) {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        match entity.mind.attention {
+            Attention::Tracking {
+                target: t,
+                since: _,
+            } => {
+                assert_eq!(t, target);
+            }
+            other => panic!("expected Tracking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn target_updates_while_locked_since_pinned() {
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        let initial = Pose::new(10.0, 0.0);
+        entity.perception.tracking = Some(observation(TrackingMotion::Tracking, initial));
+        for t in 0..u64::from(TRACKING_LOCK_TICKS) {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        let Attention::Tracking {
+            since: original_since,
+            ..
+        } = entity.mind.attention
+        else {
+            panic!("expected Tracking after lock");
+        };
+
+        // Move the target.
+        let updated = Pose::new(-12.0, 6.0);
+        entity.perception.tracking = Some(observation(TrackingMotion::Tracking, updated));
+        entity.tick.now = Instant::from_millis(10 * 33);
+        m.update(&mut entity);
+
+        match entity.mind.attention {
+            Attention::Tracking { target, since } => {
+                assert_eq!(target, updated, "target should refresh");
+                assert_eq!(since, original_since, "since should pin to entry tick");
+            }
+            _ => panic!("expected Tracking still"),
+        }
+    }
+
+    #[test]
+    fn quiet_within_release_window_holds() {
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Tracking, Pose::new(10.0, 5.0)));
+        for t in 0..u64::from(TRACKING_LOCK_TICKS) {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        assert!(matches!(entity.mind.attention, Attention::Tracking { .. }));
+
+        // Tracker switches to Holding (idle but inside window).
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Holding, Pose::new(10.0, 5.0)));
+        entity.tick.now = Instant::from_millis(u64::from(TRACKING_LOCK_TICKS) * 33 + 100);
+        m.update(&mut entity);
+        assert!(
+            matches!(entity.mind.attention, Attention::Tracking { .. }),
+            "tracking attention should hold inside release window"
+        );
+    }
+
+    #[test]
+    fn quiet_past_release_window_clears() {
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Tracking, Pose::new(10.0, 5.0)));
+        for t in 0..u64::from(TRACKING_LOCK_TICKS) {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        let lock_at = entity.tick.now;
+
+        // Tracker switches to Returning. Step past the release window.
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Returning, Pose::new(0.0, 0.0)));
+        entity.tick.now = lock_at + TRACKING_RELEASE_MS + 200;
+        m.update(&mut entity);
+
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn single_frame_motion_below_threshold_does_not_lock() {
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        // One frame of Tracking, then immediately quiet.
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Tracking, Pose::new(10.0, 5.0)));
+        m.update(&mut entity);
+        entity.perception.tracking =
+            Some(observation(TrackingMotion::Holding, Pose::new(10.0, 5.0)));
+        for t in 1..10 {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn quiet_tick_resets_counter_mid_burst() {
+        // LOCK_TICKS - 1 Tracking, one Holding (resets), then more
+        // Tracking — should NOT lock because each run is below the
+        // threshold.
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        let target = Pose::new(10.0, 5.0);
+
+        for t in 0..(u64::from(TRACKING_LOCK_TICKS) - 1) {
+            entity.tick.now = Instant::from_millis(t * 33);
+            entity.perception.tracking = Some(observation(TrackingMotion::Tracking, target));
+            m.update(&mut entity);
+        }
+        // Quiet tick.
+        entity.tick.now = Instant::from_millis((u64::from(TRACKING_LOCK_TICKS)) * 33);
+        entity.perception.tracking = Some(observation(TrackingMotion::Holding, target));
+        m.update(&mut entity);
+        // Another partial run, still below threshold.
+        for t in 0..(u64::from(TRACKING_LOCK_TICKS) - 1) {
+            entity.tick.now = Instant::from_millis((u64::from(TRACKING_LOCK_TICKS) + 1 + t) * 33);
+            entity.perception.tracking = Some(observation(TrackingMotion::Tracking, target));
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn global_event_does_not_count_as_motion() {
+        // Lighting change → tracker reports GlobalEvent → must not
+        // trip the lock even if sustained.
+        let mut m = AttentionFromTracking::new();
+        let mut entity = at(0);
+        entity.perception.tracking = Some(observation(
+            TrackingMotion::GlobalEvent,
+            Pose::new(0.0, 0.0),
+        ));
+        for t in 0..20 {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -59,12 +59,18 @@
 //!   1. [`MouthFromAudio`] — reads `perception.audio_rms`, writes
 //!      `face.mouth.mouth_open`.
 //!
+//! - **[`crate::director::Phase::Cognition`]** — synthesis across
+//!   percepts:
+//!   1. [`AttentionFromTracking`] — reads `perception.tracking`,
+//!      writes `mind.attention=Tracking{target}` after sustained
+//!      camera motion; releases after the quiet window.
+//!
 //! Empty phases today (slots reserved for v2.x):
 //! [`crate::director::Phase::Perception`],
-//! [`crate::director::Phase::Cognition`],
 //! [`crate::director::Phase::Speech`],
 //! [`crate::director::Phase::Output`].
 
+mod attention_from_tracking;
 mod blink;
 mod breath;
 mod emotion_cycle;
@@ -85,6 +91,9 @@ mod mouth_from_audio;
 mod style_from_emotion;
 mod style_from_intent;
 
+pub use attention_from_tracking::{
+    AttentionFromTracking, TRACKING_LOCK_TICKS, TRACKING_RELEASE_MS,
+};
 pub use blink::Blink;
 pub use breath::Breath;
 pub use emotion_cycle::EmotionCycle;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -65,10 +65,10 @@ use mipidsi::{
 use stackchan_core::{
     Clock, Director, Entity, Face, HeadDriver, LedFrame,
     modifiers::{
-        Blink, Breath, EmotionCycle, EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent,
-        EmotionFromRemote, EmotionFromTouch, EmotionFromVoice, HeadFromAttention, HeadFromEmotion,
-        HeadFromIntent, IdleDrift, IdleSway, IntentFromBodyTouch, IntentFromLoud, MouthFromAudio,
-        StyleFromEmotion, StyleFromIntent,
+        AttentionFromTracking, Blink, Breath, EmotionCycle, EmotionFromAmbient, EmotionFromBattery,
+        EmotionFromIntent, EmotionFromRemote, EmotionFromTouch, EmotionFromVoice,
+        HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleSway,
+        IntentFromBodyTouch, IntentFromLoud, MouthFromAudio, StyleFromEmotion, StyleFromIntent,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -185,6 +185,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut emotion_from_battery = EmotionFromBattery::new();
     let mut emotion_from_voice = EmotionFromVoice::new();
     let mut intent_from_loud = IntentFromLoud::new();
+    let mut attention_from_tracking = AttentionFromTracking::new();
     let mut cycle = EmotionCycle::new();
     let mut style = StyleFromEmotion::new();
     let mut style_from_intent = StyleFromIntent::new();
@@ -239,6 +240,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     director
         .add_modifier(&mut emotion_from_battery)
         .expect("registry full");
+    director
+        .add_modifier(&mut attention_from_tracking)
+        .expect("registry full");
     director.add_modifier(&mut cycle).expect("registry full");
     director.add_modifier(&mut style).expect("registry full");
     director
@@ -287,7 +291,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + EmotionCycle + StyleFromEmotion + StyleFromIntent + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + EmotionCycle + StyleFromEmotion + StyleFromIntent + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 


### PR DESCRIPTION
## Summary

PR3 of the camera/tracking arc. **Still no visible reaction** (PR4 wires head + eye).

## What changes

- \`Attention::Tracking { target: Pose, since: Instant }\` — new variant. \`Attention\` and \`Mind\` drop \`Eq\` (Pose has f32 fields); \`PartialEq\` was already what every call site needed.
- \`Field::Tracking\` — new perception-group field tag.
- \`AttentionFromTracking\` — new modifier in **Phase::Cognition** (the previously-empty phase, now activated). Schmitt-style hysteresis with a lock window (3 consecutive \`TrackingMotion::Tracking\` ticks ≈ 100ms at 30Hz) and a release window (1500ms — matches the \`Listening\` skill for symmetry).
- While locked, \`target\` refreshes per tick from the latest observation; \`since\` pins to the entry tick so downstream consumers' ease-in math stays anchored.

## Sim coverage

9 unit tests in the modifier itself: warmup ignored, sustained-lock entry, target-refresh + since-pin, release window hold + clear, single-frame motion below threshold, mid-burst counter reset, GlobalEvent (lighting change) ignored.

## Test plan

- [x] \`just check\` (240+ host tests)
- [x] \`just clippy-firmware\`
- [x] \`just build-firmware\`
- [ ] On-device — no visible reaction yet, but \`mind.attention\` should flip to \`Tracking{...}\` when motion sustains (visible in defmt logs after PR4)