### PR TITLE
feat(core): head + eye reactions to Attention::Tracking (4/5)

### DIFF
--- a/crates/stackchan-core/src/modifiers/gaze_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/gaze_from_attention.rs
@@ -1,0 +1,242 @@
+//! `GazeFromAttention`: expression-phase modifier that shifts both
+//! eye centers toward the tracked target while
+//! [`Attention::Tracking`] is held.
+//!
+//! Eye gaze is the fastest cue for "the avatar is looking at *you*" —
+//! eyes can dart in a single frame, while the head pose has to slew
+//! through the `SCServo` control loop. This modifier produces the
+//! "eyes lock on first, head catches up" effect that reads as
+//! lifelike attention.
+//!
+//! ## Mapping
+//!
+//! Linear scale: each degree of head-target pan/tilt maps to
+//! [`GAZE_PIXELS_PER_DEG`] pixels of eye-center offset, both eyes
+//! shifted equally. Clamped to ±[`GAZE_MAX_OFFSET_PX`] so the iris
+//! never escapes the eye outline at extreme tracking targets.
+//!
+//! ## Composition
+//!
+//! Diff-and-undo like [`super::IdleDrift`]: subtract our previous
+//! offset before adding the new one, so other Expression modifiers
+//! that adjust eye centers compose cleanly.
+
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::Attention;
+use crate::modifier::Modifier;
+
+/// Pixels of eye-center offset per degree of head target pan / tilt.
+///
+/// `0.5 px/°` plus the [`GAZE_MAX_OFFSET_PX`] clamp puts the eyes at
+/// max offset for a ~12° target — comfortable visible response
+/// inside the head's working range.
+pub const GAZE_PIXELS_PER_DEG: f32 = 0.5;
+
+/// Maximum eye-center offset, in pixels, on either axis.
+///
+/// Small enough that the iris stays well inside the eye oval at the
+/// default radii (`radius_x` ≈ 30 px on QVGA).
+pub const GAZE_MAX_OFFSET_PX: i32 = 6;
+
+/// Modifier that translates `mind.attention == Tracking{target}`
+/// into an eye-center offset on both eyes.
+#[derive(Debug, Clone, Copy)]
+pub struct GazeFromAttention {
+    /// Pixel offset applied to both eye centers on the previous tick.
+    /// Subtracted before applying the new offset (diff-and-undo).
+    last_offset: (i32, i32),
+}
+
+impl GazeFromAttention {
+    /// Construct an idle modifier with no in-flight offset.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            last_offset: (0, 0),
+        }
+    }
+}
+
+impl Default for GazeFromAttention {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert a `(pan_deg, tilt_deg)` head target into a `(dx, dy)`
+/// pixel offset, clamped per axis.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "input is bounded by tracker pose clamps; result is then \
+              explicitly clamped to GAZE_MAX_OFFSET_PX before use"
+)]
+fn target_to_offset(pan_deg: f32, tilt_deg: f32) -> (i32, i32) {
+    let dx = (pan_deg * GAZE_PIXELS_PER_DEG) as i32;
+    let dy = (tilt_deg * GAZE_PIXELS_PER_DEG) as i32;
+    (
+        dx.clamp(-GAZE_MAX_OFFSET_PX, GAZE_MAX_OFFSET_PX),
+        dy.clamp(-GAZE_MAX_OFFSET_PX, GAZE_MAX_OFFSET_PX),
+    )
+}
+
+impl Modifier for GazeFromAttention {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "GazeFromAttention",
+            description: "When mind.attention is Tracking{target}, shifts both eye centers \
+                          toward the target via GAZE_PIXELS_PER_DEG, clamped to ±GAZE_MAX_OFFSET_PX. \
+                          Eye gaze leads head pose for a 'looking at you' effect. Composes \
+                          additively after EmotionStyle / Blink / Breath / IdleDrift via diff-and-undo.",
+            phase: Phase::Expression,
+            // After IdleDrift (priority 0) so the gaze override sits
+            // on top of any random gaze jitter.
+            priority: 5,
+            reads: &[
+                Field::Attention,
+                Field::LeftEyeCenter,
+                Field::RightEyeCenter,
+            ],
+            writes: &[Field::LeftEyeCenter, Field::RightEyeCenter],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let target_offset = match entity.mind.attention {
+            Attention::Tracking { target, .. } => target_to_offset(target.pan_deg, target.tilt_deg),
+            Attention::None | Attention::Listening { .. } => (0, 0),
+        };
+
+        let (prev_x, prev_y) = self.last_offset;
+        let (next_x, next_y) = target_offset;
+
+        // Diff-and-undo: subtract our previous offset, add the new
+        // one. Both eyes get the same shift (no convergence math).
+        let delta_x = next_x - prev_x;
+        let delta_y = next_y - prev_y;
+        entity.face.left_eye.center.x += delta_x;
+        entity.face.left_eye.center.y += delta_y;
+        entity.face.right_eye.center.x += delta_x;
+        entity.face.right_eye.center.y += delta_y;
+
+        self.last_offset = target_offset;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Pose;
+    use crate::clock::Instant;
+
+    fn tracking(pan_deg: f32, tilt_deg: f32) -> Attention {
+        Attention::Tracking {
+            target: Pose::new(pan_deg, tilt_deg),
+            since: Instant::from_millis(0),
+        }
+    }
+
+    #[test]
+    fn no_attention_leaves_eyes_alone() {
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        let baseline_left = entity.face.left_eye.center;
+        let baseline_right = entity.face.right_eye.center;
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center, baseline_left);
+        assert_eq!(entity.face.right_eye.center, baseline_right);
+    }
+
+    #[test]
+    fn listening_attention_leaves_eyes_alone() {
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = Attention::Listening {
+            since: Instant::from_millis(0),
+        };
+        let baseline_left = entity.face.left_eye.center;
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center, baseline_left);
+    }
+
+    #[test]
+    fn tracking_shifts_eyes_toward_target() {
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        let baseline_x = entity.face.left_eye.center.x;
+        let baseline_y = entity.face.left_eye.center.y;
+
+        // Pan +10° (right), tilt +6° (up). At 0.5 px/° that's
+        // (5, 3) — both inside the ±6 clamp.
+        entity.mind.attention = tracking(10.0, 6.0);
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center.x, baseline_x + 5);
+        assert_eq!(entity.face.left_eye.center.y, baseline_y + 3);
+        assert_eq!(
+            entity.face.right_eye.center.x,
+            entity.face.right_eye.center.x
+        );
+    }
+
+    #[test]
+    fn tracking_offset_clamps_at_max() {
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        let baseline_x = entity.face.left_eye.center.x;
+        // Pan +30° → 15 px raw → clamps to GAZE_MAX_OFFSET_PX.
+        entity.mind.attention = tracking(30.0, 0.0);
+        m.update(&mut entity);
+        assert_eq!(
+            entity.face.left_eye.center.x,
+            baseline_x + GAZE_MAX_OFFSET_PX
+        );
+    }
+
+    #[test]
+    fn tracking_to_none_returns_eyes_to_baseline() {
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        let baseline_x = entity.face.left_eye.center.x;
+
+        // Lock onto a target.
+        entity.mind.attention = tracking(10.0, 0.0);
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center.x, baseline_x + 5);
+
+        // Drop attention. Diff-and-undo subtracts last offset.
+        entity.mind.attention = Attention::None;
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center.x, baseline_x);
+    }
+
+    #[test]
+    fn target_change_updates_offset_in_place() {
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        let baseline_x = entity.face.left_eye.center.x;
+
+        entity.mind.attention = tracking(10.0, 0.0);
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center.x, baseline_x + 5);
+
+        entity.mind.attention = tracking(-10.0, 0.0);
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center.x, baseline_x - 5);
+    }
+
+    #[test]
+    fn both_eyes_track_same_offset() {
+        // No convergence math — both eyes see the same delta.
+        let mut m = GazeFromAttention::new();
+        let mut entity = Entity::default();
+        let left_baseline_x = entity.face.left_eye.center.x;
+        let right_baseline_x = entity.face.right_eye.center.x;
+
+        entity.mind.attention = tracking(8.0, 0.0);
+        m.update(&mut entity);
+        let left_delta = entity.face.left_eye.center.x - left_baseline_x;
+        let right_delta = entity.face.right_eye.center.x - right_baseline_x;
+        assert_eq!(left_delta, right_delta);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -43,10 +43,22 @@ pub const LISTEN_HEAD_TILT_DEG: f32 = 8.0;
 /// reads as deliberate without feeling sluggish.
 pub const LISTEN_HEAD_EASE_MS: u64 = 200;
 
-/// Modifier that translates `mind.attention == Listening` into an
-/// additive upward tilt bias on `motor.head_pose`.
+/// Modifier that translates `mind.attention` variants into a
+/// `motor.head_pose` contribution.
+///
+/// - `Attention::Listening` → eased upward tilt bias (cocked-head
+///   listening posture).
+/// - `Attention::Tracking { target }` → snap pose toward `target`
+///   (the firmware tracker's already-slewed target). No ease — the
+///   tracker handles smoothing via its own slew limit.
+/// - `Attention::None` → no contribution (release ease for
+///   Listening; instant for Tracking).
 #[derive(Debug, Clone, Copy)]
 pub struct HeadFromAttention {
+    /// Pan contribution as actually applied on the previous tick
+    /// (post-clamp). Subtracted before writing the new contribution.
+    /// `0.0` for the Listening case (which only modifies tilt).
+    last_pan_deg: f32,
     /// Tilt contribution as actually applied on the previous tick
     /// (post-clamp). Subtracted before writing the new contribution
     /// — see `IdleSway::last_pan_deg` for the same pattern.
@@ -64,6 +76,7 @@ impl HeadFromAttention {
     #[must_use]
     pub const fn new() -> Self {
         Self {
+            last_pan_deg: 0.0,
             last_tilt_deg: 0.0,
             listen_since: None,
             release_since: None,
@@ -103,10 +116,11 @@ impl Modifier for HeadFromAttention {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
             name: "HeadFromAttention",
-            description: "When mind.attention is Listening, adds an upward tilt bias to \
-                          motor.head_pose for a cocked-head listening posture. Eases in/out \
-                          over LISTEN_HEAD_EASE_MS. Composes additively after IdleSway and \
-                          HeadFromEmotion via diff-and-undo.",
+            description: "When mind.attention is Listening, eases an upward tilt bias on \
+                          motor.head_pose for a cocked-head listening posture. When attention \
+                          is Tracking{target}, snaps pose toward the tracker's slewed target \
+                          (no ease — the tracker handles smoothing). Composes additively after \
+                          IdleSway and HeadFromEmotion via diff-and-undo.",
             phase: Phase::Motion,
             priority: 20,
             reads: &[Field::Attention, Field::HeadPose],
@@ -117,12 +131,11 @@ impl Modifier for HeadFromAttention {
 
     fn update(&mut self, entity: &mut Entity) {
         let now = entity.tick.now;
-        let attending = matches!(entity.mind.attention, Attention::Listening { .. });
 
-        // Edge detection drives the ease anchors. Each transition
-        // resets the opposite anchor so the next ramp uses a fresh
-        // start time.
-        match (attending, self.listen_since.is_some()) {
+        // Edge detection for the Listening ease state machine. Only
+        // observes Listening transitions — Tracking has no ease.
+        let listening = matches!(entity.mind.attention, Attention::Listening { .. });
+        match (listening, self.listen_since.is_some()) {
             (true, false) => {
                 self.listen_since = Some(now);
                 self.release_since = None;
@@ -134,31 +147,51 @@ impl Modifier for HeadFromAttention {
             _ => {}
         }
 
-        // Desired tilt bias for this tick. Ease-in while attending,
-        // ease-out while a release anchor is live, else zero. The
-        // release anchor is cleared once fully decayed so we stop
-        // touching the pose.
-        let target_tilt = match (self.listen_since, self.release_since) {
-            (Some(since), _) => LISTEN_HEAD_TILT_DEG * ease(since, now, LISTEN_HEAD_EASE_MS),
-            (None, Some(rel_at)) => {
-                let t = ease(rel_at, now, LISTEN_HEAD_EASE_MS);
-                if t >= 1.0 {
-                    self.release_since = None;
-                    0.0
-                } else {
-                    LISTEN_HEAD_TILT_DEG * (1.0 - t)
-                }
+        // Recover upstream by subtracting our previous applied
+        // contribution. Same diff-and-undo pattern as `HeadFromEmotion`.
+        let upstream_pan = entity.motor.head_pose.pan_deg - self.last_pan_deg;
+        let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_tilt_deg;
+
+        // Pick the contribution shape per attention variant.
+        let (target_pan_contrib, target_tilt_contrib) = match entity.mind.attention {
+            Attention::Tracking { target, .. } => {
+                // Snap pose to the tracker's target by contributing
+                // (target - upstream). The result is `combined.pose
+                // == target` (post-clamp), so the tracker's already-
+                // slewed motion shows through directly.
+                (
+                    target.pan_deg - upstream_pan,
+                    target.tilt_deg - upstream_tilt,
+                )
             }
-            (None, None) => 0.0,
+            Attention::Listening { .. } | Attention::None => {
+                // Tilt-only contribution, eased by the listen / release
+                // anchors. Pan stays at zero (no contribution).
+                let target_tilt = match (self.listen_since, self.release_since) {
+                    (Some(since), _) => {
+                        LISTEN_HEAD_TILT_DEG * ease(since, now, LISTEN_HEAD_EASE_MS)
+                    }
+                    (None, Some(rel_at)) => {
+                        let t = ease(rel_at, now, LISTEN_HEAD_EASE_MS);
+                        if t >= 1.0 {
+                            self.release_since = None;
+                            0.0
+                        } else {
+                            LISTEN_HEAD_TILT_DEG * (1.0 - t)
+                        }
+                    }
+                    (None, None) => 0.0,
+                };
+                (0.0, target_tilt)
+            }
         };
 
-        // Diff-and-undo composition. Mirrors `HeadFromEmotion`: subtract
-        // our previous applied contribution to recover upstream,
-        // add the new one, clamp, and store the post-clamp effective
-        // delta back into `last_tilt_deg`.
-        let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_tilt_deg;
-        let combined =
-            Pose::new(entity.motor.head_pose.pan_deg, upstream_tilt + target_tilt).clamped();
+        let combined = Pose::new(
+            upstream_pan + target_pan_contrib,
+            upstream_tilt + target_tilt_contrib,
+        )
+        .clamped();
+        self.last_pan_deg = combined.pan_deg - upstream_pan;
         self.last_tilt_deg = combined.tilt_deg - upstream_tilt;
         entity.motor.head_pose = combined;
     }
@@ -333,5 +366,82 @@ mod tests {
         entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS + 100 + LISTEN_HEAD_EASE_MS);
         m.update(&mut entity);
         assert_eq!(entity.motor.head_pose.tilt_deg, LISTEN_HEAD_TILT_DEG);
+    }
+
+    fn tracking(target: Pose) -> Attention {
+        Attention::Tracking {
+            target,
+            since: Instant::from_millis(0),
+        }
+    }
+
+    #[test]
+    fn tracking_snaps_pose_to_target() {
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+        let target = Pose::new(15.0, 8.0);
+        entity.mind.attention = tracking(target);
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+
+        // No ease — pose snaps to target on the entry tick.
+        assert_eq!(entity.motor.head_pose, target);
+    }
+
+    #[test]
+    fn tracking_overrides_upstream_pan_and_tilt() {
+        // With a non-zero upstream pose (sway + emotion bias), the
+        // tracking branch contributes (target - upstream) so the
+        // combined pose lands exactly on target.
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+        let target = Pose::new(20.0, 12.0);
+        entity.mind.attention = tracking(target);
+        entity.motor.head_pose = Pose::new(-3.0, 4.0); // upstream
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+
+        assert_eq!(entity.motor.head_pose, target);
+    }
+
+    #[test]
+    fn tracking_target_updates_per_tick() {
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+        let t1 = Pose::new(10.0, 5.0);
+        entity.mind.attention = tracking(t1);
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose, t1);
+
+        let t2 = Pose::new(-5.0, 10.0);
+        entity.mind.attention = tracking(t2);
+        // Simulate upstream wandering on the next tick.
+        entity.motor.head_pose = Pose::new(t1.pan_deg + 1.0, t1.tilt_deg + 1.0);
+        entity.tick.now = Instant::from_millis(33);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose, t2);
+    }
+
+    #[test]
+    fn tracking_to_none_clears_pan_contribution() {
+        // After dropping attention, the modifier's `last_pan_deg`
+        // should converge back to 0 within a tick (no contribution
+        // when attention is None). Verifies the diff-and-undo state
+        // doesn't get stuck.
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+
+        entity.mind.attention = tracking(Pose::new(15.0, 8.0));
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+
+        entity.mind.attention = Attention::None;
+        entity.tick.now = Instant::from_millis(33);
+        m.update(&mut entity);
+
+        // Pan contribution should be zero (no attention, no
+        // listening ease for pan).
+        assert_eq!(m.last_pan_deg, 0.0);
     }
 }

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -35,12 +35,16 @@
 //!   8. [`EmotionCycle`] — autonomous emotion advancer. Stands
 //!      down when `mind.autonomy.manual_until` is held.
 //!
-//! - **[`crate::director::Phase::Expression`]** — visual style. 4
-//!   modifiers:
+//! - **[`crate::director::Phase::Expression`]** — visual style:
 //!   1. [`StyleFromEmotion`] — translates emotion into face style fields.
-//!   2. [`Blink`] — drives eye open/closed phase.
-//!   3. [`Breath`] — vertical drift on all features.
-//!   4. [`IdleDrift`] — occasional eye-center jitter.
+//!   2. [`StyleFromIntent`] — adds per-intent style overrides on top
+//!      (cheek blush bump for `Petted`).
+//!   3. [`GazeFromAttention`] — when `mind.attention` is `Tracking`,
+//!      shifts both eye centers toward the target so eyes lead head
+//!      motion.
+//!   4. [`Blink`] — drives eye open/closed phase.
+//!   5. [`Breath`] — vertical drift on all features.
+//!   6. [`IdleDrift`] — occasional eye-center jitter.
 //!
 //! - **[`crate::director::Phase::Motion`]** — head motion:
 //!   1. [`IdleSway`] — slow pan/tilt head wander written to
@@ -80,6 +84,7 @@ mod emotion_from_intent;
 mod emotion_from_remote;
 mod emotion_from_touch;
 mod emotion_from_voice;
+mod gaze_from_attention;
 mod head_from_attention;
 mod head_from_emotion;
 mod head_from_intent;
@@ -109,6 +114,7 @@ pub use emotion_from_touch::{EMOTION_ORDER, EmotionFromTouch, MANUAL_HOLD_MS};
 pub use emotion_from_voice::{
     EmotionFromVoice, WAKE_HOLD_MS, WAKE_RMS_THRESHOLD, WAKE_SUSTAIN_TICKS,
 };
+pub use gaze_from_attention::{GAZE_MAX_OFFSET_PX, GAZE_PIXELS_PER_DEG, GazeFromAttention};
 pub use head_from_attention::{HeadFromAttention, LISTEN_HEAD_EASE_MS, LISTEN_HEAD_TILT_DEG};
 pub use head_from_emotion::HeadFromEmotion;
 pub use head_from_intent::{

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -67,7 +67,7 @@ use stackchan_core::{
     modifiers::{
         AttentionFromTracking, Blink, Breath, EmotionCycle, EmotionFromAmbient, EmotionFromBattery,
         EmotionFromIntent, EmotionFromRemote, EmotionFromTouch, EmotionFromVoice,
-        HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleSway,
+        GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleSway,
         IntentFromBodyTouch, IntentFromLoud, MouthFromAudio, StyleFromEmotion, StyleFromIntent,
     },
     render_leds,
@@ -189,6 +189,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut cycle = EmotionCycle::new();
     let mut style = StyleFromEmotion::new();
     let mut style_from_intent = StyleFromIntent::new();
+    let mut gaze_from_attention = GazeFromAttention::new();
     let mut blink = Blink::new();
     let mut breath = Breath::new();
     // Seed comes from the ESP32-S3 hardware RNG (`esp_hal::rng::Rng`),
@@ -248,6 +249,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     director
         .add_modifier(&mut style_from_intent)
         .expect("registry full");
+    director
+        .add_modifier(&mut gaze_from_attention)
+        .expect("registry full");
     director.add_modifier(&mut blink).expect("registry full");
     director.add_modifier(&mut breath).expect("registry full");
     director.add_modifier(&mut drift).expect("registry full");
@@ -291,7 +295,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + EmotionCycle + StyleFromEmotion + StyleFromIntent + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 


### PR DESCRIPTION
## Summary

PR4 of the camera/tracking arc. **Visible on-device**: when the camera locks onto motion, head turns toward the target AND eyes shift toward it.

## What changes

- **HeadFromAttention** extended to handle the new \`Attention::Tracking{target}\` variant. Snaps pose toward the tracker's already-slewed target via diff-and-undo. Listening branch unchanged. Adds a \`last_pan_deg\` field for the new pan dimension.
- **GazeFromAttention** — new \`Phase::Expression\` modifier (priority 5, after IdleDrift). Maps target pan/tilt to eye-center pixel offsets via a linear scale (\`GAZE_PIXELS_PER_DEG = 0.5\`), clamped to \`±GAZE_MAX_OFFSET_PX = 6\`. Both eyes shift together. Eye gaze leads head pose for the "looks at you first, head catches up" effect.

## Coverage

- 4 new HeadFromAttention tests
- 7 new GazeFromAttention tests
- All host gates green; firmware builds clean

## What's left

- PR5: on-device tuning + README catalog refresh.

## Test plan

- [x] \`just check\`
- [x] \`just clippy-firmware\` + \`just build-firmware\`
- [ ] \`just fmr\` — wave hand in front of camera; head should turn + eyes should dart toward motion. Lock-on after ~100ms (3 ticks @ 30Hz). Release after ~1.5s of stillness.