### PR TITLE
docs: refresh READMEs for camera/tracking arc (5/5)

### DIFF
--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -26,8 +26,9 @@ platform-independent heart of the firmware and the simulator.
 - `src/head.rs` — `Pose`, `HeadDriver` trait, pan / tilt range constants
 - `src/leds.rs` — `LedFrame`, `render_leds` — maps avatar state to the 12-pixel ring
 - `src/modifiers/mod.rs` — `Modifier` trait + re-exports
-- `src/modifiers/*.rs` — one file per modifier (blink, breath, emotion-*, idle-*, ambient-sleepy, intent-reflex, intent-style, body-gesture, wake-on-voice, low-battery, listen-head, mouth-open-audio, remote-command)
-- `src/skills/*.rs` — one file per skill (look-at-sound, petting, handling) — long-running NPC capabilities that write `mind.intent` / `mind.attention`
+- `src/modifiers/*.rs` — one file per modifier; names follow the convention in [`docs/naming.md`](../../docs/naming.md) (`<Output>From<Source>` for translators, bare noun for autonomous ones)
+- `src/skills/*.rs` — one file per skill (`listening`, `petting`, `handling`) — long-running NPC capabilities that write `mind.intent` / `mind.attention`
+- `src/perception.rs` — `Perception` struct (sensor inputs feeding modifiers) + `BodyTouch` / `TrackingObservation` / `TrackingMotion` sub-types
 
 ## Architecture
 
@@ -72,8 +73,10 @@ render tick. Listed roughly in application order:
 | `EmotionCycle`    | Default sequence: Neutral → Happy → Sleepy → Surprised → Sad   |
 | `StyleFromEmotion`    | 300 ms ease on style fields (curves, scale, blush) per emotion |
 | `HeadFromEmotion`     | Per-emotion pose bias (neutral center, surprised up, etc.)     |
-| `HeadFromAttention`      | Upward tilt bias while `mind.attention == Listening`           |
+| `HeadFromAttention`      | Upward tilt while `Listening`; snap-to-target while `Tracking`  |
 | `HeadFromIntent`     | Brief asymmetric pan/tilt recoil on entry to `Startled`     |
+| `GazeFromAttention`  | Eye centers shift toward target while `Tracking` (eyes lead head) |
+| `AttentionFromTracking` | Cognition: latches `mind.attention=Tracking{target}` on sustained camera motion |
 | `IdleDrift`       | Slow randomized gaze drift                                     |
 | `IdleSway`        | Subtle head-pan sway when idle                                 |
 | `Blink`           | Lid close / open pulses                                        |

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -28,6 +28,7 @@ modifier pipeline at ~30 FPS.
 - `src/imu.rs` — BMI270 task publishing accel/gyro samples on `IMU_SIGNAL`
 - `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` / `src/power.rs` — per-peripheral tasks
 - `src/audio.rs` — I²S0 + codec bring-up, then RX RMS loop (publishing on `AUDIO_RMS_SIGNAL`) + TX feeder (silence between trigger-driven clips) running concurrently via `embassy_futures::join`. Exposes `AUDIO_TX_PLAYING` so the render loop can gate `audio_rms` against speaker self-trigger
+- `src/camera.rs` — `LCD_CAM` + DMA bring-up + always-on capture loop. Each frame is published on `CAMERA_FRAME_SIGNAL` for the LCD preview AND fed through `tracker::Tracker::step`, with the result on `CAMERA_TRACKING_SIGNAL`. `CAMERA_MODE_SIGNAL` is now display-only (preview vs avatar)
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
 - `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; the streaming I²S path runs only inside `src/audio.rs` in the main firmware)
 
@@ -64,9 +65,9 @@ Main spawns a render task that runs this stack per tick:
 ```
 EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIntent →
 EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
-EmotionCycle → StyleFromEmotion → StyleFromIntent → Blink → Breath →
-IdleDrift → IdleSway → HeadFromEmotion → HeadFromAttention → HeadFromIntent →
-MouthFromAudio
+AttentionFromTracking → EmotionCycle → StyleFromEmotion → StyleFromIntent →
+GazeFromAttention → Blink → Breath → IdleDrift → IdleSway → HeadFromEmotion →
+HeadFromAttention → HeadFromIntent → MouthFromAudio
 ```
 
 Inputs arrive through embassy `Signal` channels from the per-peripheral
@@ -120,5 +121,5 @@ port is `/dev/ttyACM1`; override with `just PORT=/dev/ttyACM0 flash`.
 ## Integration
 
 - **Consumes `stackchan-core`** for every domain type (`Avatar`, `Modifier`, `Pose`, `Clock`, `HeadDriver`, `LedFrame`)
-- **Consumes every driver crate in the workspace** — axp2101, aw9523, aw88298, bm8563, bmi270, es7210, ft6336u, ir-nec, ltr553, py32, scservo, si12t. ES7210 streams RX over I²S into the RMS loop in `src/audio.rs`; AW88298 streams TX (digital silence between trigger-driven clips). Si12T 3-zone body-touch publishes via `src/body_touch.rs`. bmm150 is bench-only (`examples/mag_bench.rs`) until a real consumer modifier is built. Scaffolded-only: gc0308.
+- **Consumes every driver crate in the workspace** — axp2101, aw9523, aw88298, bm8563, bmi270, es7210, ft6336u, gc0308, ir-nec, ltr553, py32, scservo, si12t. ES7210 streams RX over I²S into the RMS loop in `src/audio.rs`; AW88298 streams TX (digital silence between trigger-driven clips). Si12T 3-zone body-touch publishes via `src/body_touch.rs`. gc0308 streams continuously into `src/camera.rs` and the `tracker` crate runs block-grid motion analysis on every frame, publishing `TrackingObservation` for the engine. bmm150 is bench-only (`examples/mag_bench.rs`) until a real consumer modifier is built.
 - **HIL via probe-rs + defmt-test** (planned) — CI runs host tests today; on-device integration tests run on a flash-and-capture rig


### PR DESCRIPTION
## Summary

Final PR of the camera/tracking 5-PR arc. README-only — no code changes. Updates the firmware + core catalogs to reflect the always-on camera capture, the \`tracker\` crate's role inside the camera task, the new \`AttentionFromTracking\` cognition modifier, and the \`HeadFromAttention\` / \`GazeFromAttention\` reactions that came in #109–#112.

## What changes

- **firmware/README.md** — modifier-stack diagram updated to include \`AttentionFromTracking\` + \`GazeFromAttention\`. \`src/camera.rs\` line added to Key Files describing always-on capture + \`CAMERA_TRACKING_SIGNAL\`. Driver-consumer paragraph mentions gc0308 is now wired (no longer "scaffolded-only").
- **core/README.md** — modifier table grows three rows (\`HeadFromAttention\` updated for the Tracking case; \`GazeFromAttention\` and \`AttentionFromTracking\` added). Key Files line for modifiers points at \`docs/naming.md\` for the convention. Adds \`src/perception.rs\` mention.

## Open follow-up

On-device threshold tuning (\`TRACKING_LOCK_TICKS\`, \`TRACKING_RELEASE_MS\`, \`GAZE_PIXELS_PER_DEG\`) — the user runs \`just fmr\`, waves a hand at the camera, and adjusts the constants if the lock feels too eager / too sluggish.

## Test plan

- [x] No code changes; \`just check\` + firmware build green
- [ ] User flashes via \`just fmr\` and ear/eye-tests the full chain