### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  "crates/stackchan-core": "0.9.0",
-  "crates/stackchan-sim": "0.9.0",
+  "crates/stackchan-core": "0.10.0",
+  "crates/stackchan-sim": "0.10.0",
   "crates/axp2101": "0.7.0",
   "crates/aw9523": "0.5.0",
   "crates/bm8563": "0.7.0",
@@ -9,11 +9,10 @@
   "crates/ir-nec": "0.7.0",
   "crates/ltr553": "0.7.0",
   "crates/scservo": "0.5.0",
-  "crates/stackchan-firmware": "0.10.0",
+  "crates/stackchan-firmware": "0.11.0",
   "crates/aw88298": "0.3.0",
   "crates/es7210": "0.3.0",
   "crates/gc0308": "0.5.0",
-  "crates/si12t": "0.3.0",
-  "crates/st25r3916": "0.3.0",
+  "crates/si12t": "0.4.0",
   "crates/tracker": "0.9.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "si12t"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "embedded-hal-async",
 ]
@@ -4136,7 +4136,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stackchan-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "embedded-graphics",
  "heapless 0.8.0",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "stackchan-firmware"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aw88298",
  "aw9523",
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "stackchan-sim"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "eframe",
  "embedded-graphics",

--- a/crates/si12t/CHANGELOG.md
+++ b/crates/si12t/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.0](https://github.com/andymai/stackchan-kai/compare/v0.9.7...v0.10.0) (2026-04-26)
+
+
+
+### Features
+
+* **si12t:** real driver implementation + bench ([#98](https://github.com/andymai/stackchan-kai/issues/98))
+
 ## [0.3.0](https://github.com/andymai/stackchan-kai/compare/v0.2.0...v0.3.0) (2026-04-25)
 
 

--- a/crates/si12t/Cargo.toml
+++ b/crates/si12t/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "si12t"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-core/CHANGELOG.md
+++ b/crates/stackchan-core/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.10.0](https://github.com/andymai/stackchan-kai/compare/v0.9.7...v0.10.0) (2026-04-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* engine architecture — Entity + Director + Modifier/Skill ([#90](https://github.com/andymai/stackchan-kai/issues/90))
+
+
+### Features
+
+* **core:** LookAtSound skill + ListenHead motion modifier ([#92](https://github.com/andymai/stackchan-kai/issues/92))
+* **core:** debug-mode enforcement of ModifierMeta + SkillMeta writes ([#95](https://github.com/andymai/stackchan-kai/issues/95))
+* **core:** BodyGesture modifier — Press/Swipe/Release on Si12T strip ([#101](https://github.com/andymai/stackchan-kai/issues/101))
+* **core:** Petting skill — sustained body-touch → mind.intent=Petted ([#102](https://github.com/andymai/stackchan-kai/issues/102))
+* **core:** IntentStyle modifier — visible reaction to mind.intent ([#103](https://github.com/andymai/stackchan-kai/issues/103))
+* **core:** Handling skill — IMU → mind.intent (PickedUp/Shaken/Tilted) ([#105](https://github.com/andymai/stackchan-kai/issues/105))
+* **core:** StartleOnLoud modifier — sound-reactive startle chain ([#106](https://github.com/andymai/stackchan-kai/issues/106))
+* **core:** perception.tracking field + firmware drain ([#110](https://github.com/andymai/stackchan-kai/issues/110))
+* **core:** AttentionFromTracking — Cognition modifier + Attention::Tracking ([#111](https://github.com/andymai/stackchan-kai/issues/111))
+* **core:** head + eye reactions to Attention::Tracking ([#112](https://github.com/andymai/stackchan-kai/issues/112))
+
+
+### Bug Fixes
+
+* **core:** repair Style::* intra-doc links in draw.rs (CI hotfix) ([#93](https://github.com/andymai/stackchan-kai/issues/93))
+
+
+### Refactors
+
+* apply naming convention sweep across the inventory ([#108](https://github.com/andymai/stackchan-kai/issues/108))
+* **core:** align ModifierMeta reads/writes with actual access ([#94](https://github.com/andymai/stackchan-kai/issues/94))
+
 ## [0.9.0](https://github.com/andymai/stackchan-kai/compare/v0.8.0...v0.9.0) (2026-04-25)
 
 

--- a/crates/stackchan-core/Cargo.toml
+++ b/crates/stackchan-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-core"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-firmware/CHANGELOG.md
+++ b/crates/stackchan-firmware/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.11.0](https://github.com/andymai/stackchan-kai/compare/v0.9.7...v0.10.0) (2026-04-26)
+
+
+### Features
+
+* **firmware:** I²C bus probe bench ([#97](https://github.com/andymai/stackchan-kai/issues/97))
+* **firmware:** wire Si12T body-touch into engine perception ([#99](https://github.com/andymai/stackchan-kai/issues/99))
+* **firmware:** i2c_probe also reads register 0x00 for chip-ID disambiguation ([#104](https://github.com/andymai/stackchan-kai/issues/104))
+* **firmware:** drop time-of-day boot greeting + tx-active gating for sound-reactive modifiers ([#106](https://github.com/andymai/stackchan-kai/issues/106))
+* **firmware:** always-on camera capture + tracker wired into engine signal ([#109](https://github.com/andymai/stackchan-kai/issues/109))
+
+
+### Refactors
+
+* apply naming convention sweep across the inventory ([#108](https://github.com/andymai/stackchan-kai/issues/108))
+
 ## [0.10.0](https://github.com/andymai/stackchan-kai/compare/v0.9.7...v0.10.0) (2026-04-25)
 
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-firmware"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-sim/CHANGELOG.md
+++ b/crates/stackchan-sim/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.10.0](https://github.com/andymai/stackchan-kai/compare/v0.9.7...v0.10.0) (2026-04-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* engine architecture — Entity + Director + Modifier/Skill ([#90](https://github.com/andymai/stackchan-kai/issues/90))
+
+
+### Features
+
+* **sim:** end-to-end Director-driven sim tests for new skills + modifiers (LookAtSound #92, BodyGesture #101, Petting #102, Handling #105, StartleOnLoud #106, AttentionFromTracking #111, head + eye reactions #112)
+
+
+### Refactors
+
+* **sim:** route firmware-stack tests through Director ([#96](https://github.com/andymai/stackchan-kai/issues/96))
+* apply naming convention sweep across the inventory ([#108](https://github.com/andymai/stackchan-kai/issues/108))
+
 ## [0.9.0](https://github.com/andymai/stackchan-kai/compare/v0.8.0...v0.9.0) (2026-04-25)
 
 

--- a/crates/stackchan-sim/Cargo.toml
+++ b/crates/stackchan-sim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-sim"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Backfill release covering #90–#113 (work merged after v0.9.7 in the old merge-commit format that release-please's commit walker silently skipped).

## Version bumps

| Crate | Before | After | Reason |
|---|---|---|---|
| \`stackchan-core\` | 0.9.0 | **0.10.0** | engine refactor (#90), 9 new modifiers/skills, naming convention, fix |
| \`stackchan-sim\` | 0.9.0 | **0.10.0** | Director-driven test refactor + new sim coverage for every new modifier |
| \`stackchan-firmware\` | 0.10.0 | **0.11.0** | I²C probe bench, Si12T integration, audio cleanup, always-on camera + tracker |
| \`si12t\` | 0.3.0 | **0.4.0** | scaffold → real driver implementation |

Drivers without code changes since v0.9.7 stay at their current versions. \`st25r3916\` removed from the release-please manifest (crate was deleted in #100).

## Per-crate CHANGELOGs

Each affected crate's CHANGELOG.md gets a release-please-format entry summarizing the relevant PRs. See the diff.

## After merge

I'll manually:
1. Create the \`v0.10.0\` workspace git tag pointing at the squash-merge commit
2. Create a GitHub Release for \`v0.10.0\` with aggregated release notes

Future release-please runs will use the updated manifest as the new baseline; the next \`feat:\` or \`fix:\` PR will trigger a normal release PR via the (now squash-only) merge flow.

## Test plan

- [x] \`just check\` (host) — green
- [x] \`just clippy-firmware\` + \`just build-firmware\` — green
- [ ] After merge: tag + release + verify release-please picks up from the new manifest