### PR TITLE
feat(core): tracking realism — multi-target detection + microsaccades + eye-leads-head + engagement-aware blink/breath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,7 @@ dependencies = [
  "esp-rtos",
  "ft6336u",
  "gc0308",
+ "heapless 0.8.0",
  "ir-nec",
  "ltr553",
  "micromath",
@@ -4463,6 +4464,7 @@ dependencies = [
 name = "tracker"
 version = "0.9.0"
 dependencies = [
+ "heapless 0.8.0",
  "stackchan-core",
 ]
 

--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -76,7 +76,9 @@ render tick. Listed roughly in application order:
 | `HeadFromAttention`      | Upward tilt while `Listening`; snap-to-target while `Tracking`  |
 | `HeadFromIntent`     | Brief asymmetric pan/tilt recoil on entry to `Startled`     |
 | `GazeFromAttention`  | Eye centers shift toward target while `Tracking` (eyes lead head) |
+| `MicrosaccadeFromAttention` | 0.5–1.5 s involuntary eye darts during `Tracking` (Disney IROS realism contributor) |
 | `AttentionFromTracking` | Cognition: latches `mind.attention=Tracking{target}` on sustained camera motion |
+| `Blink` / `Breath`   | Engagement-aware: blink rate halves and breath cycle stretches ×1.67 while attention is non-`None` |
 | `IdleDrift`       | Slow randomized gaze drift                                     |
 | `IdleSway`        | Subtle head-pan sway when idle                                 |
 | `Blink`           | Lid close / open pulses                                        |

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -583,7 +583,7 @@ impl<'a> Director<'a> {
 
         for slot in &mut self.modifiers {
             #[cfg(debug_assertions)]
-            let before = *entity;
+            let before = entity.clone();
             slot.modifier.update(entity);
             #[cfg(debug_assertions)]
             assert_only_writes(
@@ -597,7 +597,7 @@ impl<'a> Director<'a> {
         for s in &mut self.skills {
             if s.should_fire(entity) {
                 #[cfg(debug_assertions)]
-                let before = *entity;
+                let before = entity.clone();
                 // `should_fire` is the only gate; `SkillStatus::Done`
                 // vs `Continuing` is reserved for skill state-tracking.
                 let _status: SkillStatus = s.invoke(entity);

--- a/crates/stackchan-core/src/entity.rs
+++ b/crates/stackchan-core/src/entity.rs
@@ -50,9 +50,11 @@ pub struct Tick {
 ///
 /// `Eq` is not derived because [`Face`] contains `f32` fields
 /// (`Mouth::mouth_open`) and [`Motor`] contains `Pose`s with `f32`
-/// fields. Use `PartialEq` for tests; the renderer uses
-/// [`Entity::frame_eq`] for its dirty-check (visual fields only).
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+/// fields. `Copy` is not derived either: [`Perception`] holds a
+/// `heapless::Vec` of tracker candidates which can't be `Copy`.
+/// Use `PartialEq` for tests; the renderer uses [`Entity::frame_eq`]
+/// for its dirty-check (visual fields only).
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Entity {
     /// Visual surface. Read by the renderer.
     pub face: Face,

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -60,6 +60,9 @@ pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use mind::{Affect, Attention, Autonomy, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
 pub use motor::Motor;
-pub use perception::{BodyTouch, Perception, TrackingMotion, TrackingObservation};
+pub use perception::{
+    BodyTouch, MAX_TRACKING_CANDIDATES, Perception, TargetCandidate, TrackingMotion,
+    TrackingObservation,
+};
 pub use skill::{Skill, SkillStatus};
 pub use voice::{ChirpKind, Voice};

--- a/crates/stackchan-core/src/modifiers/attention_from_tracking.rs
+++ b/crates/stackchan-core/src/modifiers/attention_from_tracking.rs
@@ -130,7 +130,7 @@ impl Modifier for AttentionFromTracking {
 
     fn update(&mut self, entity: &mut Entity) {
         let now = entity.tick.now;
-        let Some(obs) = entity.perception.tracking else {
+        let Some(obs) = entity.perception.tracking.as_ref() else {
             // No observation yet — leave attention alone, reset
             // counter so the next non-None obs starts fresh.
             self.consecutive_tracking = 0;
@@ -202,6 +202,7 @@ mod tests {
                 0
             },
             motion,
+            candidates: heapless::Vec::new(),
         }
     }
 

--- a/crates/stackchan-core/src/modifiers/blink.rs
+++ b/crates/stackchan-core/src/modifiers/blink.rs
@@ -14,12 +14,20 @@ use crate::clock::Instant;
 use crate::director::{Field, ModifierMeta, Phase};
 use crate::entity::Entity;
 use crate::face::{EyePhase, SCALE_DEFAULT};
+use crate::mind::Attention;
 use crate::modifier::Modifier;
 
 /// Default time eyes stay open between blinks, in milliseconds.
 const DEFAULT_OPEN_MS: u64 = 5_200;
 /// Default duration of a blink (eyes closed), in milliseconds.
 const DEFAULT_CLOSED_MS: u64 = 180;
+
+/// Divisor applied to `blink_rate_scale` when `mind.attention` is
+/// non-`None`. Halving the rate doubles the open-phase duration —
+/// blinks happen ~half as often during engagement, matching the
+/// physiological pattern (cognitive load suppresses blink rate;
+/// Nature Sci Rep 2025).
+pub const ENGAGED_BLINK_DIVISOR: u8 = 2;
 
 /// A modifier that periodically closes both eyes for a short duration.
 ///
@@ -125,6 +133,7 @@ impl Modifier for Blink {
             priority: 0,
             reads: &[
                 Field::BlinkRateScale,
+                Field::Attention,
                 Field::LeftEyeOpenWeight,
                 Field::RightEyeOpenWeight,
             ],
@@ -140,7 +149,16 @@ impl Modifier for Blink {
 
     fn update(&mut self, entity: &mut Entity) {
         let now = entity.tick.now;
-        let rate = entity.face.style.blink_rate_scale;
+        // Halve the effective rate when attention is engaged so the
+        // open-phase doubles. Explicit suppression (raw_rate == 0)
+        // always wins; the engagement branch floors at 1 so we don't
+        // accidentally cross into the suppression branch ourselves.
+        let raw_rate = entity.face.style.blink_rate_scale;
+        let rate = if raw_rate == 0 || matches!(entity.mind.attention, Attention::None) {
+            raw_rate
+        } else {
+            (raw_rate / ENGAGED_BLINK_DIVISOR).max(1)
+        };
 
         // Suppression path: scale == 0 forces eyes open. Stored as an
         // explicit state so a later non-zero scale cleanly resumes the

--- a/crates/stackchan-core/src/modifiers/breath.rs
+++ b/crates/stackchan-core/src/modifiers/breath.rs
@@ -14,12 +14,21 @@ use crate::clock::Instant;
 use crate::director::{Field, ModifierMeta, Phase};
 use crate::entity::Entity;
 use crate::face::SCALE_DEFAULT;
+use crate::mind::Attention;
 use crate::modifier::Modifier;
 
 /// Default full breath cycle (inhale + exhale), in milliseconds.
 const DEFAULT_CYCLE_MS: u64 = 6_000;
 /// Default peak-to-peak vertical amplitude, in pixels.
 const DEFAULT_AMPLITUDE_PX: i32 = 2;
+
+/// Numerator of the cycle-period scale applied while
+/// `mind.attention` is non-`None`. `5/3` ≈ ×1.67 stretch maps to ~0.6×
+/// breath rate during engagement (animation-12-principles intuition;
+/// person-holding-still-while-attentive cue).
+pub const ENGAGED_BREATH_CYCLE_NUM: u64 = 5;
+/// Denominator paired with [`ENGAGED_BREATH_CYCLE_NUM`].
+pub const ENGAGED_BREATH_CYCLE_DEN: u64 = 3;
 
 /// A modifier that applies a slow rise-and-fall vertical offset to every
 /// facial feature (both eyes + mouth), evoking breathing.
@@ -68,14 +77,15 @@ impl Breath {
     }
 
     /// Compute the current offset for time `now` as an integer-pixel triangle
-    /// wave in `[-amplitude/2, +amplitude/2]` at the given scale.
-    fn offset_at(&self, now: Instant, scale: u8) -> i32 {
+    /// wave in `[-amplitude/2, +amplitude/2]` at the given scale, using
+    /// `cycle_ms` for the period.
+    fn offset_at(&self, now: Instant, scale: u8, cycle_ms: u64) -> i32 {
         let amplitude = self.scaled_amplitude(scale);
-        if self.cycle_ms == 0 || amplitude == 0 {
+        if cycle_ms == 0 || amplitude == 0 {
             return 0;
         }
-        let phase = now.as_millis() % self.cycle_ms;
-        let half = self.cycle_ms / 2;
+        let phase = now.as_millis() % cycle_ms;
+        let half = cycle_ms / 2;
         // Ascend in the first half, descend in the second half.
         let ascending = phase < half;
         let within_half = if ascending { phase } else { phase - half };
@@ -110,6 +120,7 @@ impl Modifier for Breath {
             priority: 0,
             reads: &[
                 Field::BreathDepthScale,
+                Field::Attention,
                 Field::LeftEyeCenter,
                 Field::RightEyeCenter,
                 Field::MouthCenter,
@@ -124,7 +135,17 @@ impl Modifier for Breath {
     }
 
     fn update(&mut self, entity: &mut Entity) {
-        let target = self.offset_at(entity.tick.now, entity.face.style.breath_depth_scale);
+        // Slow the breath cycle while attention is engaged.
+        let cycle_ms = if matches!(entity.mind.attention, Attention::None) {
+            self.cycle_ms
+        } else {
+            self.cycle_ms.saturating_mul(ENGAGED_BREATH_CYCLE_NUM) / ENGAGED_BREATH_CYCLE_DEN
+        };
+        let target = self.offset_at(
+            entity.tick.now,
+            entity.face.style.breath_depth_scale,
+            cycle_ms,
+        );
         let delta = target - self.last_offset_px;
         if delta == 0 {
             return;
@@ -159,7 +180,7 @@ mod tests {
         let breath = Breath::with_params(1000, 4);
         // Sample across an entire cycle; offset must never exceed amplitude/2.
         for ms in 0..1000 {
-            let o = breath.offset_at(Instant::from_millis(ms), SCALE_DEFAULT);
+            let o = breath.offset_at(Instant::from_millis(ms), SCALE_DEFAULT, 1000);
             assert!((-2..=2).contains(&o), "offset {o} at ms {ms} out of range");
         }
     }
@@ -184,7 +205,11 @@ mod tests {
         let breath = Breath::with_params(1000, 4);
         let max_at = |scale: u8| {
             (0..1000)
-                .map(|ms| breath.offset_at(Instant::from_millis(ms), scale).abs())
+                .map(|ms| {
+                    breath
+                        .offset_at(Instant::from_millis(ms), scale, 1000)
+                        .abs()
+                })
                 .max()
                 .unwrap_or(0)
         };

--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -43,6 +43,14 @@ pub const LISTEN_HEAD_TILT_DEG: f32 = 8.0;
 /// reads as deliberate without feeling sluggish.
 pub const LISTEN_HEAD_EASE_MS: u64 = 200;
 
+/// Number of render frames the head's tracking-target lags behind the
+/// instantaneous `Attention::Tracking{target}`. Eyes update without
+/// delay (via `GazeFromAttention` in `Phase::Expression`); the head
+/// reads a frame from this many ticks ago. At 30 FPS this is
+/// ~132 ms — within the 100–150 ms ILM/Disney convention for
+/// eyes-lead-head.
+pub const HEAD_TRACKING_LAG_FRAMES: usize = 4;
+
 /// Modifier that translates `mind.attention` variants into a
 /// `motor.head_pose` contribution.
 ///
@@ -69,6 +77,16 @@ pub struct HeadFromAttention {
     /// Instant attention transitioned `Listening` → `None`. `None`
     /// unless currently easing out.
     release_since: Option<Instant>,
+    /// Ring buffer of recent `Tracking{target}` poses, oldest at
+    /// `lag_idx`. The head consumes the entry at `lag_idx` (oldest)
+    /// before overwriting it with the current target — producing the
+    /// eye-leads-head delay without a separate timing buffer.
+    /// Cleared on transition out of `Tracking`.
+    lag_buf: [Option<Pose>; HEAD_TRACKING_LAG_FRAMES],
+    /// Next write index into [`Self::lag_buf`] (also the read index
+    /// — entries form a circular buffer where the oldest pose is at
+    /// the next-to-overwrite slot).
+    lag_idx: u8,
 }
 
 impl HeadFromAttention {
@@ -80,6 +98,8 @@ impl HeadFromAttention {
             last_tilt_deg: 0.0,
             listen_since: None,
             release_since: None,
+            lag_buf: [None; HEAD_TRACKING_LAG_FRAMES],
+            lag_idx: 0,
         }
     }
 }
@@ -155,16 +175,27 @@ impl Modifier for HeadFromAttention {
         // Pick the contribution shape per attention variant.
         let (target_pan_contrib, target_tilt_contrib) = match entity.mind.attention {
             Attention::Tracking { target, .. } => {
-                // Snap pose to the tracker's target by contributing
-                // (target - upstream). The result is `combined.pose
-                // == target` (post-clamp), so the tracker's already-
-                // slewed motion shows through directly.
+                // Eye-leads-head: the head consumes a target from
+                // ~HEAD_TRACKING_LAG_FRAMES ticks ago; eyes already
+                // moved to the current target via GazeFromAttention
+                // earlier in Phase::Expression. Read the oldest entry
+                // (the slot we're about to overwrite) before pushing
+                // the current target.
+                let idx = usize::from(self.lag_idx);
+                let delayed = self.lag_buf[idx].unwrap_or(target);
+                self.lag_buf[idx] = Some(target);
+                self.lag_idx =
+                    (self.lag_idx + 1) % u8::try_from(HEAD_TRACKING_LAG_FRAMES).unwrap_or(u8::MAX);
                 (
-                    target.pan_deg - upstream_pan,
-                    target.tilt_deg - upstream_tilt,
+                    delayed.pan_deg - upstream_pan,
+                    delayed.tilt_deg - upstream_tilt,
                 )
             }
             Attention::Listening { .. } | Attention::None => {
+                // Clear the lag buffer so a future Tracking run
+                // starts with an empty history (no stale targets).
+                self.lag_buf = [None; HEAD_TRACKING_LAG_FRAMES];
+                self.lag_idx = 0;
                 // Tilt-only contribution, eased by the listen / release
                 // anchors. Pan stays at zero (no contribution).
                 let target_tilt = match (self.listen_since, self.release_since) {

--- a/crates/stackchan-core/src/modifiers/microsaccade_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/microsaccade_from_attention.rs
@@ -1,0 +1,284 @@
+//! `MicrosaccadeFromAttention`: small involuntary eye darts during
+//! sustained gaze. Disney's IROS 2020 robot-gaze paper identifies
+//! these as the single biggest realism contributor for tracking
+//! behaviour — without them, even a perfectly-locked gaze reads as
+//! "dead stare."
+//!
+//! ## Mechanism
+//!
+//! While `mind.attention` is `Tracking{..}`, schedule a tiny eye
+//! displacement every [`MICROSACCADE_INTERVAL_MIN_MS`] to
+//! [`MICROSACCADE_INTERVAL_MAX_MS`] ms. Each displacement is up to
+//! [`MICROSACCADE_AMPLITUDE_PX`] pixels in either axis, persists for
+//! [`MICROSACCADE_DURATION_MS`], then snaps back to zero before the
+//! next interval starts.
+//!
+//! Composes additively with [`super::GazeFromAttention`] (the gross
+//! tracking offset) via diff-and-undo on `face.{left,right}_eye.center`.
+//!
+//! Resets to zero on transition out of `Tracking`.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::Attention;
+use crate::modifier::Modifier;
+use core::num::NonZeroU32;
+
+/// Minimum interval between microsaccades, in ms.
+///
+/// Real human microsaccades occur at 0.5–1.5 s during fixation
+/// (Tobii / NCBI references). Lower bound is the floor.
+pub const MICROSACCADE_INTERVAL_MIN_MS: u64 = 500;
+
+/// Maximum interval between microsaccades, in ms.
+pub const MICROSACCADE_INTERVAL_MAX_MS: u64 = 1_500;
+
+/// How long a single microsaccade displacement is held, in ms.
+///
+/// Real saccades transit in ~30 ms; at 30 FPS this is one frame.
+/// Holding the displacement for one extra frame (~66 ms total) makes
+/// it visible without being jittery.
+pub const MICROSACCADE_DURATION_MS: u64 = 66;
+
+/// Maximum per-axis displacement, in pixels.
+///
+/// `2 px` matches the Disney IROS guidance of 0.5–2° amplitude on a
+/// QVGA face (where the iris radius is ≈ 30 px and the 0.5° FOV
+/// projection lands around 1–2 px).
+pub const MICROSACCADE_AMPLITUDE_PX: i32 = 2;
+
+/// Default xorshift32 seed used by [`MicrosaccadeFromAttention::new`].
+/// Firmware overrides via [`Self::with_seed`] from the ESP32-S3 RNG
+/// so two units don't synchronise.
+const DEFAULT_SEED: NonZeroU32 = match NonZeroU32::new(0xA17E_5ACC) {
+    Some(s) => s,
+    None => unreachable!(),
+};
+
+/// Modifier that adds microsaccade jitter to both eye centres while
+/// `mind.attention` is `Tracking`.
+#[derive(Debug, Clone, Copy)]
+pub struct MicrosaccadeFromAttention {
+    /// xorshift32 state for the per-saccade direction + interval rolls.
+    rng_state: u32,
+    /// Currently-applied per-axis offset in pixels. Subtracted on the
+    /// next tick before the new offset is applied (diff-and-undo with
+    /// other Expression modifiers that touch eye centres).
+    last_offset: (i32, i32),
+    /// Instant the currently-active microsaccade ends (offset returns
+    /// to zero). `None` between events.
+    saccade_until: Option<Instant>,
+    /// Instant the next microsaccade fires. `None` until the first
+    /// `Tracking` tick anchors the schedule.
+    next_saccade_at: Option<Instant>,
+}
+
+impl MicrosaccadeFromAttention {
+    /// Construct with the default seed.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::with_seed(DEFAULT_SEED)
+    }
+
+    /// Construct with a custom xorshift32 seed. Pass a fresh seed
+    /// per device so multi-unit deployments don't tick in unison.
+    #[must_use]
+    pub const fn with_seed(seed: NonZeroU32) -> Self {
+        Self {
+            rng_state: seed.get(),
+            last_offset: (0, 0),
+            saccade_until: None,
+            next_saccade_at: None,
+        }
+    }
+
+    /// Advance the xorshift32 state and return the next pseudo-random
+    /// `u32`. Same algorithm as `IdleDrift::next_u32`.
+    const fn next_u32(&mut self) -> u32 {
+        let mut x = self.rng_state;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.rng_state = x;
+        x
+    }
+
+    /// Pick a uniform `i32` in `[-max, max]` from the next PRNG draw.
+    /// Caller must pass `max >= 0`; negative values are clamped to 0.
+    fn rand_offset(&mut self, max: i32) -> i32 {
+        let max_abs = u32::try_from(max.max(0)).unwrap_or(0);
+        let span = max_abs.saturating_mul(2).saturating_add(1);
+        let draw = self.next_u32() % span.max(1);
+        let signed = i32::try_from(draw).unwrap_or(i32::MAX);
+        signed - i32::try_from(max_abs).unwrap_or(i32::MAX)
+    }
+
+    /// Pick a uniform `u64` in `[lo, hi]` from the next PRNG draw.
+    fn rand_interval(&mut self, lo: u64, hi: u64) -> u64 {
+        if hi <= lo {
+            return lo;
+        }
+        let span = hi - lo + 1;
+        let draw = u64::from(self.next_u32()) % span;
+        lo + draw
+    }
+}
+
+impl Default for MicrosaccadeFromAttention {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for MicrosaccadeFromAttention {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "MicrosaccadeFromAttention",
+            description: "Adds 0.5–1.5 s involuntary eye darts (≤±2 px) to both eye centres \
+                          while mind.attention is Tracking. Disney IROS 2020 calls this the \
+                          single biggest realism contributor for tracking behaviour. Composes \
+                          via diff-and-undo with GazeFromAttention.",
+            phase: Phase::Expression,
+            // After GazeFromAttention (priority 5) so the gross
+            // tracking offset is in place before we add jitter.
+            priority: 6,
+            reads: &[
+                Field::Attention,
+                Field::LeftEyeCenter,
+                Field::RightEyeCenter,
+            ],
+            writes: &[Field::LeftEyeCenter, Field::RightEyeCenter],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        let tracking = matches!(entity.mind.attention, Attention::Tracking { .. });
+
+        // Compute the desired offset for this tick.
+        let mut target_offset: (i32, i32) = (0, 0);
+        if tracking {
+            // Anchor schedule on entry.
+            if self.next_saccade_at.is_none() {
+                let dwell =
+                    self.rand_interval(MICROSACCADE_INTERVAL_MIN_MS, MICROSACCADE_INTERVAL_MAX_MS);
+                self.next_saccade_at = Some(now + dwell);
+            }
+
+            // End an in-flight microsaccade if its duration elapsed.
+            if let Some(until) = self.saccade_until
+                && now >= until
+            {
+                self.saccade_until = None;
+                let dwell =
+                    self.rand_interval(MICROSACCADE_INTERVAL_MIN_MS, MICROSACCADE_INTERVAL_MAX_MS);
+                self.next_saccade_at = Some(now + dwell);
+            }
+
+            // Fire a new microsaccade if scheduled and not currently
+            // mid-saccade.
+            if self.saccade_until.is_none()
+                && let Some(at) = self.next_saccade_at
+                && now >= at
+            {
+                let dx = self.rand_offset(MICROSACCADE_AMPLITUDE_PX);
+                let dy = self.rand_offset(MICROSACCADE_AMPLITUDE_PX);
+                target_offset = (dx, dy);
+                self.saccade_until = Some(now + MICROSACCADE_DURATION_MS);
+            } else if self.saccade_until.is_some() {
+                // Hold the existing offset; we keep it in
+                // `last_offset` and propagate by re-applying.
+                target_offset = self.last_offset;
+            }
+        } else {
+            // Reset on transition out of Tracking so a future Tracking
+            // run starts with an empty schedule.
+            self.next_saccade_at = None;
+            self.saccade_until = None;
+        }
+
+        // Diff-and-undo: subtract previous, add current.
+        let (prev_x, prev_y) = self.last_offset;
+        let (curr_x, curr_y) = target_offset;
+        let delta_x = curr_x - prev_x;
+        let delta_y = curr_y - prev_y;
+        if delta_x != 0 || delta_y != 0 {
+            entity.face.left_eye.center.x += delta_x;
+            entity.face.left_eye.center.y += delta_y;
+            entity.face.right_eye.center.x += delta_x;
+            entity.face.right_eye.center.y += delta_y;
+        }
+        self.last_offset = target_offset;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Pose;
+
+    fn tracking() -> Attention {
+        Attention::Tracking {
+            target: Pose::new(0.0, 0.0),
+            since: Instant::from_millis(0),
+        }
+    }
+
+    #[test]
+    fn no_attention_leaves_eyes_alone() {
+        let mut m = MicrosaccadeFromAttention::new();
+        let mut entity = Entity::default();
+        let baseline = entity.face.left_eye.center;
+        for ms in (0..3000).step_by(33) {
+            entity.tick.now = Instant::from_millis(ms);
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.face.left_eye.center, baseline);
+    }
+
+    #[test]
+    fn tracking_eventually_jitters_eyes() {
+        // Drive long enough that a microsaccade has to fire (max
+        // interval is 1500 ms, microsaccade lasts 66 ms — within
+        // 5 s we should see the offset depart from zero at least
+        // once).
+        let mut m = MicrosaccadeFromAttention::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = tracking();
+        let baseline_x = entity.face.left_eye.center.x;
+        let mut saw_jitter = false;
+        for ms in (0..5000).step_by(33) {
+            entity.tick.now = Instant::from_millis(ms);
+            m.update(&mut entity);
+            if entity.face.left_eye.center.x != baseline_x {
+                saw_jitter = true;
+                break;
+            }
+        }
+        assert!(saw_jitter, "no microsaccade fired in 5s of Tracking");
+    }
+
+    #[test]
+    fn transition_out_of_tracking_clears_offset() {
+        let mut m = MicrosaccadeFromAttention::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = tracking();
+        let baseline_x = entity.face.left_eye.center.x;
+        // Drive until we observe a jitter.
+        for ms in (0..5000).step_by(33) {
+            entity.tick.now = Instant::from_millis(ms);
+            m.update(&mut entity);
+            if entity.face.left_eye.center.x != baseline_x {
+                break;
+            }
+        }
+        // Now drop attention. After the next tick, last_offset must
+        // get subtracted out → eyes back to baseline.
+        entity.mind.attention = Attention::None;
+        entity.tick.now = Instant::from_millis(5_100);
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.center.x, baseline_x);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -92,6 +92,7 @@ mod idle_drift;
 mod idle_sway;
 mod intent_from_body_touch;
 mod intent_from_loud;
+mod microsaccade_from_attention;
 mod mouth_from_audio;
 mod style_from_emotion;
 mod style_from_intent;
@@ -129,6 +130,10 @@ pub use intent_from_body_touch::{
     SWIPE_DELTA,
 };
 pub use intent_from_loud::{IntentFromLoud, STARTLE_HOLD_MS, STARTLE_RMS_THRESHOLD};
+pub use microsaccade_from_attention::{
+    MICROSACCADE_AMPLITUDE_PX, MICROSACCADE_DURATION_MS, MICROSACCADE_INTERVAL_MAX_MS,
+    MICROSACCADE_INTERVAL_MIN_MS, MicrosaccadeFromAttention,
+};
 pub use mouth_from_audio::{
     DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthFromAudio,
 };

--- a/crates/stackchan-core/src/perception.rs
+++ b/crates/stackchan-core/src/perception.rs
@@ -62,28 +62,57 @@ impl BodyTouch {
     }
 }
 
+/// Maximum tracker candidates surfaced to the engine per frame.
+/// Mirrors `tracker::MAX_CANDIDATES`; kept here so the engine doesn't
+/// import the tracker crate just for the const.
+pub const MAX_TRACKING_CANDIDATES: usize = 4;
+
+/// One detected motion blob from the firmware tracker, after
+/// temporal + connected-component filtering.
+///
+/// Mirrors `tracker::TargetCandidate` — the engine doesn't depend on
+/// `tracker`, so we duplicate the shape. Used by
+/// `AttentionFromTracking` for multi-target arbitration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TargetCandidate {
+    /// Normalised centroid in `[-1, 1]` per axis. `(0, 0)` is frame
+    /// centre. Already honours `flip_x` / `flip_y` from the tracker
+    /// config.
+    pub centroid: (f32, f32),
+    /// Number of grid cells in this blob. Used as a saliency proxy
+    /// (bigger blob = more interesting target).
+    pub cell_count: u16,
+}
+
 /// One-frame summary of the firmware-side camera tracker's analysis.
 ///
 /// The firmware's `tracker` crate runs the block-grid motion analysis
 /// inside the camera task and publishes one of these per processed
 /// frame. The engine consumes it via `entity.perception.tracking`
-/// (added in the next PR) and decides what to do — see the
-/// `TrackingFromCamera` `Phase::Perception` modifier and the
-/// `AttentionFromTracking` `Phase::Cognition` modifier.
+/// and decides what to do — see the `AttentionFromTracking`
+/// `Phase::Cognition` modifier.
 ///
-/// The shape mirrors `tracker::Outcome` minus the centroid, which is
-/// already baked into `target_pose` by the tracker.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// `target_pose` is the tracker's legacy single-target pose (centroid
+/// of all valid blobs, slewed via dead zone + P-gain + step limit).
+/// `candidates` is the post-CCL per-blob list — engine cognition can
+/// arbitrate among these via saliency / novelty / habituation scoring
+/// instead of trusting the aggregate centroid.
+#[derive(Debug, Clone, PartialEq)]
 pub struct TrackingObservation {
-    /// Where the tracker thinks the head should look — already through
-    /// the tracker's dead zone, P-gain, slew limit, and clamp.
+    /// Where the tracker thinks the head should look — aggregate
+    /// centroid of all surviving blobs, already through the tracker's
+    /// dead zone, P-gain, slew limit, and clamp.
     pub target_pose: Pose,
-    /// Number of grid cells whose per-block luma delta exceeded the
-    /// tracker's threshold this frame. `0` during warmup or genuine
-    /// stillness; saturates at the grid's cell count.
+    /// Total number of grid cells across all surviving blobs. `0`
+    /// during warmup or genuine stillness; saturates at the grid's
+    /// cell count.
     pub fired_cells: u16,
     /// Classification of this analysis step.
     pub motion: TrackingMotion,
+    /// Per-blob detections after temporal filtering + CCL, sorted by
+    /// `cell_count` descending. Cap [`MAX_TRACKING_CANDIDATES`].
+    /// Empty on `Warmup` / `GlobalEvent` / no-motion.
+    pub candidates: heapless::Vec<TargetCandidate, MAX_TRACKING_CANDIDATES>,
 }
 
 /// Why the tracker chose its current target. Mirrors `tracker::Motion`
@@ -107,7 +136,10 @@ pub enum TrackingMotion {
 }
 
 /// Raw sensor readings that drive reactive modifiers.
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// `Clone` only (not `Copy`) — `tracking` carries a `heapless::Vec`
+/// of multi-target candidates which can't be `Copy`.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Perception {
     /// Accelerometer reading in gravitational units `(x, y, z)`.
     /// Resting face-up on a flat surface reads `(0, 0, 1)`. Written by

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -28,6 +28,10 @@ py32 = { path = "../py32" }
 scservo = { path = "../scservo" }
 si12t = { path = "../si12t" }
 tracker = { path = "../tracker" }
+# `heapless::Vec` for the per-frame multi-target candidate list
+# translated from `tracker::Outcome.candidates` into the engine's
+# `TrackingObservation`. Matches the cap (`MAX_CANDIDATES`).
+heapless = "0.8"
 embedded-graphics = { workspace = true }
 embedded-hal-async = { workspace = true }
 embedded-io-async = { workspace = true }

--- a/crates/stackchan-firmware/src/camera.rs
+++ b/crates/stackchan-firmware/src/camera.rs
@@ -72,7 +72,7 @@ use esp_hal::{
     },
     time::Rate,
 };
-use stackchan_core::{TrackingMotion, TrackingObservation};
+use stackchan_core::{TargetCandidate, TrackingMotion, TrackingObservation};
 use tracker::{Motion, Tracker, TrackerConfig};
 
 use crate::board::SharedI2c;
@@ -429,10 +429,21 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
                 u32::try_from(now.duration_since(last_step_at).as_millis()).unwrap_or(u32::MAX);
             last_step_at = now;
             let outcome = tracker.step(view, dt_ms);
+            // Translate the firmware-side per-blob list into the
+            // engine-side mirror type. Both are heapless::Vec with
+            // the same cap so this can never overflow.
+            let mut candidates = heapless::Vec::new();
+            for c in &outcome.candidates {
+                let _ = candidates.push(TargetCandidate {
+                    centroid: c.centroid,
+                    cell_count: c.cell_count,
+                });
+            }
             CAMERA_TRACKING_SIGNAL.signal(TrackingObservation {
                 target_pose: outcome.target,
                 fired_cells: outcome.fired_cells,
                 motion: motion_to_engine(outcome.motion),
+                candidates,
             });
 
             // Honour any pending capture request — log frame stats +

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -68,7 +68,8 @@ use stackchan_core::{
         AttentionFromTracking, Blink, Breath, EmotionCycle, EmotionFromAmbient, EmotionFromBattery,
         EmotionFromIntent, EmotionFromRemote, EmotionFromTouch, EmotionFromVoice,
         GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleSway,
-        IntentFromBodyTouch, IntentFromLoud, MouthFromAudio, StyleFromEmotion, StyleFromIntent,
+        IntentFromBodyTouch, IntentFromLoud, MicrosaccadeFromAttention, MouthFromAudio,
+        StyleFromEmotion, StyleFromIntent,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -190,6 +191,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut style = StyleFromEmotion::new();
     let mut style_from_intent = StyleFromIntent::new();
     let mut gaze_from_attention = GazeFromAttention::new();
+    let mut microsaccade = MicrosaccadeFromAttention::new();
     let mut blink = Blink::new();
     let mut breath = Breath::new();
     // Seed comes from the ESP32-S3 hardware RNG (`esp_hal::rng::Rng`),
@@ -252,6 +254,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     director
         .add_modifier(&mut gaze_from_attention)
         .expect("registry full");
+    director
+        .add_modifier(&mut microsaccade)
+        .expect("registry full");
     director.add_modifier(&mut blink).expect("registry full");
     director.add_modifier(&mut breath).expect("registry full");
     director.add_modifier(&mut drift).expect("registry full");
@@ -295,7 +300,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/tracker/Cargo.toml
+++ b/crates/tracker/Cargo.toml
@@ -16,3 +16,6 @@ workspace = true
 # directly into the firmware's existing `POSE_SIGNAL` plumbing without
 # a marshalling layer.
 stackchan-core = { path = "../stackchan-core" }
+# `heapless::Vec` for the multi-target candidate list emitted per
+# `step` — fixed cap (`MAX_CANDIDATES`) so no `alloc` needed.
+heapless = "0.8"

--- a/crates/tracker/src/lib.rs
+++ b/crates/tracker/src/lib.rs
@@ -74,6 +74,22 @@ pub struct TrackerConfig {
     /// If more than this fraction of cells fire on a single frame the
     /// event is treated as a global lighting change and ignored.
     pub max_fired_fraction: f32,
+    /// Length of the per-cell temporal window used to suppress
+    /// single-frame noise. A cell only counts as fired if it crossed
+    /// `block_threshold` on at least [`Self::temporal_required`] of
+    /// the most recent `temporal_window` frames. `1` disables the
+    /// filter (every frame stands alone). Capped at `8`.
+    pub temporal_window: u8,
+    /// Number of fires required within [`Self::temporal_window`] to
+    /// count a cell as fired this step. Must satisfy
+    /// `1 <= temporal_required <= temporal_window`.
+    pub temporal_required: u8,
+    /// Minimum cell count of a connected blob. After temporal
+    /// filtering, fired cells are grouped into 4-connected blobs;
+    /// blobs smaller than this are dropped (treated as scatter
+    /// noise). `1` disables the filter (every fired cell is its own
+    /// candidate).
+    pub min_blob_cells: u16,
     /// Proportional gain on centroid-offset error in `[0.0, 1.0]`.
     /// `1.0` jumps the head all the way to centre the target on every
     /// frame; `0.4` damps the loop pleasantly given typical servo lag.
@@ -104,9 +120,21 @@ pub struct TrackerConfig {
 impl TrackerConfig {
     /// Defaults tuned for QVGA GC0308 → `SCServo` head on a CoreS3.
     ///
-    /// 8×6 grid (40×40 pixel blocks), 5 % per-block luma threshold,
-    /// 70 % global-event ceiling, P=0.4, ±10 % dead zone, 4 °/frame
-    /// slew, 3 s idle timeout, 1 °/step return-to-centre.
+    /// 8×6 grid (40×40 pixel blocks), 12 % per-block luma threshold,
+    /// 50 % global-event ceiling, ≥3 cells required, ≥2-cell blob
+    /// filter, P=0.4, ±10 % dead zone, 4 °/frame slew, 3 s idle
+    /// timeout, 1 °/step return-to-centre.
+    ///
+    /// `block_threshold` + `max_fired_fraction` were retuned from
+    /// the original 5 % / 70 % values to suppress monitor flicker
+    /// and shadow drift; `min_blob_cells` rejects scatter noise that
+    /// passes the per-cell threshold but isn't a coherent target.
+    ///
+    /// The temporal filter is **off** by default
+    /// (`temporal_window: 1` collapses the per-cell history to "this
+    /// frame only"). Frame-differencing only fires once when a new
+    /// object appears and stays still, so a 3-of-5-frames temporal
+    /// filter would block stationary-presence detection.
     pub const DEFAULT: Self = Self {
         frame_width: 320,
         frame_height: 240,
@@ -115,9 +143,12 @@ impl TrackerConfig {
         subsample_step: 2,
         fov_h_deg: 62.0,
         fov_v_deg: 49.0,
-        block_threshold: 0.05,
-        min_fired_cells: 2,
-        max_fired_fraction: 0.70,
+        block_threshold: 0.12,
+        min_fired_cells: 3,
+        max_fired_fraction: 0.50,
+        temporal_window: 1,
+        temporal_required: 1,
+        min_blob_cells: 2,
         p_gain: 0.4,
         dead_zone: 0.10,
         max_step_deg: 4.0,
@@ -128,24 +159,53 @@ impl TrackerConfig {
     };
 }
 
+/// Maximum number of distinct connected-blob candidates emitted per
+/// [`Tracker::step`]. Excess blobs are dropped (largest-first).
+pub const MAX_CANDIDATES: usize = 4;
+
+/// Maximum value of [`TrackerConfig::temporal_window`]. Bounds the
+/// per-cell history buffer baked into the [`Tracker`].
+pub const MAX_TEMPORAL_WINDOW: usize = 8;
+
+/// One detected motion blob, after temporal filtering + connected-
+/// component grouping. Engine cognition layer arbitrates among these
+/// to pick the focus target.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TargetCandidate {
+    /// Normalised centroid in `[-1.0, 1.0]` per axis. `(0, 0)` is
+    /// frame centre.
+    pub centroid: (f32, f32),
+    /// Number of grid cells in this connected blob.
+    pub cell_count: u16,
+}
+
 /// Outcome of one [`Tracker::step`] call.
 ///
 /// Returned for diagnostic logging in the bench example and for unit
 /// tests. The new target pose is always available as [`Outcome::target`];
 /// [`Outcome::motion`] distinguishes the *why*.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Outcome {
-    /// Number of grid cells whose per-block delta exceeded the threshold.
-    /// Capped at `blocks_x * blocks_y`.
+    /// Total number of grid cells that survived per-cell temporal
+    /// filtering this step (i.e. fired on at least
+    /// `TrackerConfig::temporal_required` of the last
+    /// `temporal_window` frames). Capped at `blocks_x * blocks_y`.
     pub fired_cells: u16,
     /// Normalised centroid in `[-1.0, 1.0]` per axis when motion was
-    /// detected, else `None`. `(0, 0)` means the centre of the frame.
+    /// detected, else `None`. Centroid of all fired cells across all
+    /// blobs (the legacy single-target mode); engine cognition can
+    /// instead arbitrate over [`Self::candidates`] for richer picks.
     pub centroid: Option<(f32, f32)>,
     /// Classification of this step.
     pub motion: Motion,
     /// New target pose after this step. Always within
     /// [`Pose::clamped`]'s safe range.
     pub target: Pose,
+    /// Per-blob detections after connected-component labelling on the
+    /// temporally-filtered fired-cell grid. Sorted by `cell_count`
+    /// descending. Capped at [`MAX_CANDIDATES`]; smaller blobs are
+    /// dropped. Empty on `Warmup` / `GlobalEvent` / no-motion.
+    pub candidates: heapless::Vec<TargetCandidate, MAX_CANDIDATES>,
 }
 
 /// Why the tracker chose this pose.
@@ -181,6 +241,12 @@ pub struct Tracker {
     /// Whether [`Self::prev_grid`] holds a real previous frame.
     /// `false` until the first [`Self::step`].
     have_prev: bool,
+    /// Per-cell ring buffer of fire decisions over the last
+    /// `MAX_TEMPORAL_WINDOW` frames. Each `u8` is a bitfield where
+    /// bit `i` is `1` iff the cell crossed `block_threshold` `i`
+    /// frames ago. The temporal filter is `popcount(bits & mask) >=
+    /// temporal_required` where `mask = (1 << temporal_window) - 1`.
+    fire_history: [u8; MAX_BLOCKS],
     /// Running commanded target pose. Always inside the [`Pose::clamped`]
     /// safe range.
     target_pose: Pose,
@@ -203,6 +269,7 @@ impl Tracker {
             config,
             prev_grid: [0; MAX_BLOCKS],
             have_prev: false,
+            fire_history: [0; MAX_BLOCKS],
             target_pose: Pose::NEUTRAL,
             idle_ms: 0,
         }
@@ -226,6 +293,13 @@ impl Tracker {
         self.have_prev = false;
         self.target_pose = Pose::NEUTRAL;
         self.idle_ms = 0;
+        // Reset the per-cell history so a re-entry starts fresh
+        // (matches "the next step reports Warmup" contract).
+        let mut i = 0;
+        while i < MAX_BLOCKS {
+            self.fire_history[i] = 0;
+            i += 1;
+        }
     }
 
     /// Process one frame.
@@ -244,11 +318,15 @@ impl Tracker {
         clippy::cast_precision_loss,
         clippy::cast_sign_loss,
         clippy::similar_names,
+        clippy::too_many_lines,
         reason = "block-grid arithmetic: cell counts ≤ MAX_BLOCKS (256) so \
                   usize→u32 / u32→f32 casts cannot lose information; the \
                   f32→u16 casts are bounded by inputs that have already been \
                   clamped to [0, 255] / [0, total_cells]; per-axis \
-                  `nx`/`ny`/`*_eff` pairs are the algorithm's natural names"
+                  `nx`/`ny`/`*_eff` pairs are the algorithm's natural names; \
+                  step composes 7 sequential pipeline stages (luma fill → \
+                  raw fire → temporal → CCL → blob filter → centroid → pose) \
+                  that are clearer inline than fragmented across helpers"
     )]
     pub fn step(&mut self, frame: &[u8], dt_ms: u32) -> Outcome {
         let cfg = &self.config;
@@ -263,6 +341,7 @@ impl Tracker {
                 centroid: None,
                 motion: Motion::Warmup,
                 target: self.target_pose,
+                candidates: heapless::Vec::new(),
             };
         }
 
@@ -285,24 +364,44 @@ impl Tracker {
                 centroid: None,
                 motion: Motion::Warmup,
                 target: self.target_pose,
+                candidates: heapless::Vec::new(),
             };
         }
 
         let threshold_u = ((cfg.block_threshold.clamp(0.0, 1.0)) * 255.0) as u16;
         let max_fired = ((cfg.max_fired_fraction.clamp(0.0, 1.0)) * total as f32) as u16;
+
+        // Temporal filter parameters. Clamp the window to
+        // MAX_TEMPORAL_WINDOW (8) so the bitfield fits in a u8; clamp
+        // `required` to at least 1 and at most `window` so the
+        // popcount comparison can fire.
+        let temporal_window = cfg.temporal_window.clamp(1, MAX_TEMPORAL_WINDOW as u8);
+        let temporal_required = cfg.temporal_required.clamp(1, temporal_window);
+        let history_mask: u8 = if temporal_window >= 8 {
+            0xFF
+        } else {
+            (1u8 << temporal_window) - 1
+        };
+
+        // Compute raw per-cell fire bits, advance the per-cell
+        // history bitfield, and apply the temporal filter.
+        let mut filtered: [bool; MAX_BLOCKS] = [false; MAX_BLOCKS];
         let mut fired_cells: u16 = 0;
-        let mut sum_x: u32 = 0;
-        let mut sum_y: u32 = 0;
         for iy in 0..usize::from(by) {
             for ix in 0..usize::from(bx) {
                 let idx = iy * usize::from(bx) + ix;
                 let curr = u16::from(curr_grid[idx]);
                 let prev = u16::from(self.prev_grid[idx]);
                 let delta = curr.abs_diff(prev);
-                if delta > threshold_u {
+                let raw_fired = delta > threshold_u;
+                // Shift the history left by 1, drop bits beyond the
+                // window, OR in the new fire bit.
+                let shifted = (self.fire_history[idx] << 1) & history_mask;
+                let new_history = shifted | u8::from(raw_fired);
+                self.fire_history[idx] = new_history;
+                if new_history.count_ones() >= u32::from(temporal_required) {
+                    filtered[idx] = true;
                     fired_cells += 1;
-                    sum_x += ix as u32;
-                    sum_y += iy as u32;
                 }
             }
         }
@@ -321,17 +420,41 @@ impl Tracker {
                 centroid: None,
                 motion: Motion::GlobalEvent,
                 target: self.target_pose,
+                candidates: heapless::Vec::new(),
             };
         }
 
-        if fired_cells < cfg.min_fired_cells {
-            return self.no_motion_outcome(dt_ms, fired_cells);
+        // Connected-component labelling on the filtered grid. Each
+        // blob below `min_blob_cells` is dropped (treated as scatter
+        // noise that the temporal filter happened to let through).
+        let mut blobs = label_blobs(&filtered, bx, by);
+        blobs.retain(|b| b.cell_count >= cfg.min_blob_cells);
+
+        // Aggregate centroid + cell count over surviving blobs only;
+        // this is the legacy single-pose-target signal that tracker's
+        // pose math uses. Engine cognition can instead arbitrate over
+        // `candidates` for richer focus selection.
+        let mut sum_x: u32 = 0;
+        let mut sum_y: u32 = 0;
+        let mut valid_cells: u16 = 0;
+        for blob in &blobs {
+            sum_x += u32::from(blob.sum_x);
+            sum_y += u32::from(blob.sum_y);
+            valid_cells += blob.cell_count;
         }
+
+        if valid_cells < cfg.min_fired_cells {
+            return self.no_motion_outcome(dt_ms, valid_cells);
+        }
+
+        // Build the candidates list: blobs sorted by cell_count
+        // descending, capped at MAX_CANDIDATES, normalised centroids.
+        let candidates = build_candidates(&mut blobs, bx, by, cfg.flip_x, cfg.flip_y);
 
         // Centroid in block-index space, then normalised to [-1, 1].
         let (cell_cx, cell_cy) = (
-            (sum_x as f32) / f32::from(fired_cells),
-            (sum_y as f32) / f32::from(fired_cells),
+            (sum_x as f32) / f32::from(valid_cells),
+            (sum_y as f32) / f32::from(valid_cells),
         );
         // Centre of a block-index axis of length N is at (N-1)/2;
         // dividing by that maps the index-space centroid to [-1, 1].
@@ -371,10 +494,11 @@ impl Tracker {
         self.idle_ms = 0;
 
         Outcome {
-            fired_cells,
+            fired_cells: valid_cells,
             centroid: Some((nx, ny)),
             motion: Motion::Tracking,
             target: self.target_pose,
+            candidates,
         }
     }
 
@@ -389,6 +513,7 @@ impl Tracker {
                 centroid: None,
                 motion: Motion::Holding,
                 target: self.target_pose,
+                candidates: heapless::Vec::new(),
             };
         }
         let step = self.config.idle_step_deg.max(0.0);
@@ -402,8 +527,119 @@ impl Tracker {
             centroid: None,
             motion: Motion::Returning,
             target: self.target_pose,
+            candidates: heapless::Vec::new(),
         }
     }
+}
+
+/// One blob from connected-component labelling. Internal to the
+/// step's bookkeeping; a final pass converts surviving blobs into
+/// public [`TargetCandidate`]s with normalised centroids.
+#[derive(Debug, Clone, Copy)]
+struct Blob {
+    /// Sum of x-indices of cells in this blob.
+    sum_x: u16,
+    /// Sum of y-indices of cells in this blob.
+    sum_y: u16,
+    /// Number of cells in this blob.
+    cell_count: u16,
+}
+
+/// Run 4-connected CCL on the filtered fired-cell grid via iterative
+/// flood-fill. Visits each fired cell exactly once. Stack capacity
+/// equals [`MAX_BLOCKS`] — sufficient because the worst-case blob
+/// fills the entire grid.
+fn label_blobs(filtered: &[bool; MAX_BLOCKS], bx: u16, by: u16) -> heapless::Vec<Blob, MAX_BLOCKS> {
+    let mut visited = [false; MAX_BLOCKS];
+    let mut blobs: heapless::Vec<Blob, MAX_BLOCKS> = heapless::Vec::new();
+    let cols = usize::from(bx);
+    let rows = usize::from(by);
+    for sy in 0..rows {
+        for sx in 0..cols {
+            let seed_idx = sy * cols + sx;
+            if !filtered[seed_idx] || visited[seed_idx] {
+                continue;
+            }
+            // Iterative flood-fill from (sx, sy).
+            let mut stack: heapless::Vec<(u8, u8), MAX_BLOCKS> = heapless::Vec::new();
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "bx/by ≤ MAX_BLOCKS_X/Y ≤ 16, fits in u8 trivially"
+            )]
+            let _ = stack.push((sx as u8, sy as u8));
+            visited[seed_idx] = true;
+            let mut blob = Blob {
+                sum_x: 0,
+                sum_y: 0,
+                cell_count: 0,
+            };
+            while let Some((cx, cy)) = stack.pop() {
+                blob.sum_x += u16::from(cx);
+                blob.sum_y += u16::from(cy);
+                blob.cell_count += 1;
+                // 4-neighbours.
+                let neighbours = [
+                    (cx.wrapping_sub(1), cy, cx > 0),
+                    (cx + 1, cy, usize::from(cx) + 1 < cols),
+                    (cx, cy.wrapping_sub(1), cy > 0),
+                    (cx, cy + 1, usize::from(cy) + 1 < rows),
+                ];
+                for (nx, ny, in_bounds) in neighbours {
+                    if !in_bounds {
+                        continue;
+                    }
+                    let nidx = usize::from(ny) * cols + usize::from(nx);
+                    if filtered[nidx] && !visited[nidx] {
+                        visited[nidx] = true;
+                        let _ = stack.push((nx, ny));
+                    }
+                }
+            }
+            // `blobs` is bounded by MAX_BLOCKS — push always succeeds
+            // because we visit each cell once and a blob owns ≥1 cell.
+            let _ = blobs.push(blob);
+        }
+    }
+    blobs
+}
+
+/// Sort `blobs` by `cell_count` descending and convert the top
+/// [`MAX_CANDIDATES`] into public [`TargetCandidate`]s with
+/// normalised centroids in `[-1, 1]`. Honours `flip_x` / `flip_y` so
+/// engine-side arbitration sees centroids in the same coordinate
+/// frame the tracker's pose math uses.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "cell counts ≤ MAX_BLOCKS = 256 ≪ 2^24, exact in f32"
+)]
+fn build_candidates(
+    blobs: &mut heapless::Vec<Blob, MAX_BLOCKS>,
+    bx: u16,
+    by: u16,
+    flip_x: bool,
+    flip_y: bool,
+) -> heapless::Vec<TargetCandidate, MAX_CANDIDATES> {
+    blobs.sort_unstable_by_key(|b| core::cmp::Reverse(b.cell_count));
+    let half_x = (f32::from(bx) - 1.0) * 0.5;
+    let half_y = (f32::from(by) - 1.0) * 0.5;
+    let mut out: heapless::Vec<TargetCandidate, MAX_CANDIDATES> = heapless::Vec::new();
+    for blob in blobs.iter().take(MAX_CANDIDATES) {
+        let cx = f32::from(blob.sum_x) / f32::from(blob.cell_count);
+        let cy = f32::from(blob.sum_y) / f32::from(blob.cell_count);
+        let mut nx = (cx - half_x) / half_x.max(0.5);
+        let mut ny = (cy - half_y) / half_y.max(0.5);
+        if flip_x {
+            nx = -nx;
+        }
+        if flip_y {
+            ny = -ny;
+        }
+        let _ = out.push(TargetCandidate {
+            centroid: (nx, ny),
+            cell_count: blob.cell_count,
+        });
+    }
+    out
 }
 
 /// Step `value` toward `target` by at most `step` units.


### PR DESCRIPTION
## Summary

Multi-front realism upgrade for the camera/tracking arc. Five concurrent improvements to address "too eager false-triggers" + "feels mechanical, not lifelike."

## What changes

### Tracker (firmware-side false-trigger reduction)

- **Tightened `TrackerConfig::DEFAULT`**: \`block_threshold\` 0.05 → 0.12; \`max_fired_fraction\` 0.70 → 0.50; \`min_fired_cells\` 2 → 3 — rejects monitor flicker, shadow drift, single-cell sensor noise.
- **Connected-component labelling** on the post-threshold fired-cell grid via 4-connected iterative flood-fill. Blobs smaller than \`min_blob_cells\` (default 2) are dropped — kills scatter noise that survives the per-cell threshold.
- **Multi-target candidate output**: \`Outcome.candidates: heapless::Vec<TargetCandidate, 4>\`, sorted by \`cell_count\` desc. Per-blob normalised centroids in \`[-1, 1]\`, honour the tracker's \`flip_x\` / \`flip_y\` flags.
- **Per-cell temporal filter infrastructure** (\`temporal_window\` / \`temporal_required\`) wired through but defaulted off (\`window=1\`) — frame-differencing only fires once when a stationary new object appears, so an aggressive temporal filter would block legitimate detection. Available for tuning experiments.

### Engine (lifelike behaviours per Disney IROS / ILM convention)

- **\`MicrosaccadeFromAttention\`** — new \`Phase::Expression\` modifier (priority 6). 0.5–1.5 s involuntary eye darts (≤±2 px) during \`Tracking\`. Disney IROS 2020 calls this the single biggest realism contributor for tracking; without it even a perfectly-locked gaze reads as "dead stare."
- **Eye-leads-head delay** — \`HeadFromAttention\` carries a 4-frame ring buffer of \`Tracking\` targets; head reads the ~132 ms-old entry. Eyes update without delay (via \`GazeFromAttention\`), so eyes lock first and head catches up. ILM/Disney 100–150 ms convention.
- **Engagement-aware Blink** — when \`mind.attention\` is non-\`None\`, blink rate halves (\`ENGAGED_BLINK_DIVISOR = 2\`); reads as "the avatar is paying attention." Cited: Nature Sci Rep 2025 + PMC cognitive-load studies.
- **Engagement-aware Breath** — when \`mind.attention\` is non-\`None\`, breath cycle stretches ×1.67 (~0.6× rate); reads as "person holding still while attentive." Animation 12-principles intuition.

### Engine (multi-target plumbing)

- **\`TrackingObservation\`** grows a \`candidates: heapless::Vec<TargetCandidate, 4>\` field. Firmware drain in \`camera.rs\` translates \`tracker::Outcome.candidates\` → engine candidates.
- \`Perception\` / \`Entity\` drop their \`Copy\` derive (heapless::Vec isn't Copy); the dirty-check uses \`Entity::frame_eq\` for pixel comparisons, so the loss is purely API surface.

## Deferred

- **Kismet-style multi-target arbitration** (saliency × novelty × (1 - habituation)) over \`TrackingObservation.candidates\`. The plumbing is in place; \`AttentionFromTracking\` still uses \`obs.target_pose\` directly (the tracker's dominant-blob pose). Follow-up PR will add per-bin habituation EMA + scoring + \`fov_h_deg\` / \`fov_v_deg\` on \`TrackingObservation\` for engine-side normalised-centroid → pose mapping.

## Constants of record (for on-device tuning)

| Constant | Value | Source |
|---|---|---|
| \`MICROSACCADE_INTERVAL_MIN_MS\` / \`MAX_MS\` | 500 / 1500 | Tobii / NCBI eye-movement reference |
| \`MICROSACCADE_AMPLITUDE_PX\` | 2 | Disney IROS 2020 |
| \`HEAD_TRACKING_LAG_FRAMES\` | 4 (~132ms @ 30Hz) | ILM convention 100–150ms |
| \`ENGAGED_BLINK_DIVISOR\` | 2 | Nature Sci Rep 2025 |
| \`ENGAGED_BREATH_CYCLE_NUM\` / \`DEN\` | 5 / 3 (×1.67 stretch) | Animation 12 principles |
| \`TrackerConfig::DEFAULT.block_threshold\` | 0.12 | retuned from 0.05 |
| \`TrackerConfig::DEFAULT.max_fired_fraction\` | 0.50 | retuned from 0.70 |
| \`TrackerConfig::DEFAULT.min_blob_cells\` | 2 | new |

## Test plan

- [x] \`just check\` — host (240+ tests including new microsaccade tests + tracker tests with new defaults)
- [x] \`just clippy-firmware\` + \`just build-firmware\` — embedded targets clean
- [ ] \`just fmr\` — wave hand at camera, observe: smaller false-trigger rate, eyes dart slightly during sustained gaze, head lags eyes by ~4 frames, blink rate visibly slower while engaged, breath visibly slower while engaged