### PR TITLE
fix(ci): switch release-please to component-prefixed tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "rust",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
-  "include-component-in-tag": false,
+  "include-component-in-tag": true,
   "packages": {
     "crates/stackchan-core": {
       "package-name": "stackchan-core"


### PR DESCRIPTION
## Summary
- Per-crate releases were colliding on plain `vX.Y.Z` tags because multiple workspace crates share the same SemVer (e.g. `aw9523`, `gc0308`, `scservo`, `si12t` all at 0.5.0). The cargo-workspace plugin's `merge: true` consolidates the release PR but each tracked package still requests its own GitHub Release. Without component prefixes those collide and tagging fails with `tag_name already_exists` (PR #118 hit this).
- Set `include-component-in-tag: true` so each release tag is unique: `stackchan-core-v0.11.0`, `si12t-v0.5.0`, `stackchan-firmware-v0.12.0`, etc.
- Backfilled the five missing tags from PR #118's bumps as GitHub Releases on the merge commit (`ee1e242`) so they aren't orphaned: `stackchan-core-v0.11.0`, `stackchan-sim-v0.10.1`, `stackchan-firmware-v0.12.0`, `si12t-v0.5.0`, `tracker-v0.10.0`. Historical `vX.Y.Z` tags remain in place — release-please reads versions from `.release-please-manifest.json`, not git tags.
- Also relabeled PR #89 from `autorelease: pending` → `autorelease: tagged` (its v0.10.0 was backfilled manually via PR #114, so release-please's bookkeeping was out of sync — that's why no new release PRs were opening).

## Test plan
- [x] Backfilled 5 component-prefixed releases visible at https://github.com/andymai/stackchan-kai/releases
- [ ] After merge, next release-please run (any commit to main) should open a new PR using component-prefixed tags
- [ ] Subsequent releases tag cleanly with no collisions