### PR TITLE
feat(firmware): tracking-trace cargo feature for camera-pipeline observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,16 @@ jobs:
       # `core` isn't precompiled for xtensa-esp32s3-none-elf. The
       # previous workspace-root invocation bypassed this config and
       # failed with `error[E0463]: can't find crate for 'core'`.
-      - name: Clippy (firmware)
+      # Lint both feature configurations: default-features (the
+      # production build) and --all-features (every optional
+      # observability / debug feature on). A `#[cfg(feature = "...")]`
+      # module that compiles only in one config would slip past a
+      # single-invocation lint and only fail in the other release
+      # build. No user-controlled inputs in either invocation.
+      - name: Clippy (firmware, default features)
+        working-directory: crates/stackchan-firmware
+        run: cargo clippy -- -D warnings
+      - name: Clippy (firmware, all features)
         working-directory: crates/stackchan-firmware
         run: cargo clippy --all-features -- -D warnings
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -95,6 +95,18 @@ static_cell = "2.1.1"
 # dB mapping; sharing the dep keeps the workspace libm-free.
 micromath = "2"
 
+[features]
+# Default: zero-overhead production build. The `tracking_trace`
+# module's no-op `TraceState` ZST + empty methods compile to nothing.
+default = []
+# Enable structured `defmt` traces of the camera-tracking pipeline:
+# attention + engagement state transitions, lock-fire latency,
+# observation cadence. Use `just fmr-trace` (or `cargo +esp build
+# --release --features tracking-trace`) to flash a build that emits
+# these. Off in production to keep the JTAG channel quiet and avoid
+# perturbing scheduler timing.
+tracking-trace = []
+
 [lib]
 name = "stackchan_firmware"
 path = "src/lib.rs"

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -108,6 +108,7 @@ and talk to it through `I2cDevice` handles. Addresses on the bus:
 source ~/export-esp.sh       # adds the esp Xtensa toolchain to PATH
 just build-firmware          # cargo +esp build --release
 just fmr                     # flash + monitor in one go
+just fmr-trace               # flash + monitor with `tracking-trace` feature on
 just bench                   # flash the calibration-bench example
 just mag-bench               # magnetometer bench
 just leds-bench              # WS2812 LED ring bench
@@ -117,6 +118,14 @@ just es7210-bench            # mic-ADC control-path bench
 
 See the [justfile](../../justfile) for the full recipe set. Default
 port is `/dev/ttyACM1`; override with `just PORT=/dev/ttyACM0 flash`.
+
+### Cargo features
+
+- **`tracking-trace`** — emits structured `defmt` events from the
+  camera-tracking pipeline (attention + engagement transitions, lock-fire
+  latency, observation cadence). Off by default so production builds carry
+  no runtime cost. Filter the live stream with `grep trk:`. See
+  `src/tracking_trace.rs` for the full event catalog.
 
 ## Integration
 

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -31,5 +31,6 @@ pub mod ir;
 pub mod leds;
 pub mod power;
 pub mod touch;
+pub mod tracking_trace;
 pub mod wallclock;
 pub mod watchdog;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 
 use stackchan_firmware::{
     ambient, audio, board, body_touch, button, camera, clock, framebuffer, head, imu, ir, leds,
-    power, touch, wallclock, watchdog,
+    power, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -213,6 +213,10 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     // tail of the audio_rms gate so the mic doesn't pick up the
     // speaker's residual response immediately after a chirp ends.
     let mut last_tx_active_at: Option<stackchan_core::Instant> = None;
+    // Camera-tracking observability. Compiles to a ZST + no-op methods
+    // unless the `tracking-trace` cargo feature is on; see
+    // [`tracking_trace`] for what the feature-on path emits.
+    let mut tracking_trace = tracking_trace::TraceState::new();
 
     // Build the Director and register the canonical modifier stack
     // plus skills (via add_skill).
@@ -403,6 +407,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         // modifiers read entity.perception.tracking to decide whether
         // to flip mind.attention to Tracking{target}.
         if let Some(observation) = camera::CAMERA_TRACKING_SIGNAL.try_take() {
+            tracking_trace.note_observation(now);
             entity.perception.tracking = Some(observation);
         }
 
@@ -410,6 +415,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
         // by (phase, priority, registration order) and ticks each
         // modifier — see `crate::director` for the full pipeline.
         director.run(&mut entity, now);
+        tracking_trace.observe(&entity, now);
 
         // Drain the chirp request modifiers raised this tick. Modifiers
         // (`EmotionFromIntent`, `EmotionFromVoice`, `EmotionFromBattery`) set

--- a/crates/stackchan-firmware/src/tracking_trace.rs
+++ b/crates/stackchan-firmware/src/tracking_trace.rs
@@ -1,0 +1,283 @@
+//! Camera-tracking pipeline observability.
+//!
+//! Compiled to a zero-size no-op when the `tracking-trace` feature
+//! is off, so the production firmware build pays no runtime cost.
+//! Enable with `cargo +esp build --release --features tracking-trace`
+//! (or `just fmr-trace`) when measuring the lock/release path on a
+//! live unit.
+//!
+//! ## What it traces
+//!
+//! After each `Director::run` in the render task, [`TraceState::observe`]
+//! compares this tick's `entity.mind.attention` and `entity.mind.engagement`
+//! against the previous tick's snapshot and emits a structured `defmt`
+//! event on every transition. It also tracks lock-fire latency (time
+//! from the first `Tracking` observation in a burst to the
+//! `Attention::Tracking` lock) and a periodic observation cadence
+//! gauge.
+//!
+//! All emitted events use the prefix `trk:` so they're easy to filter
+//! with `espflash monitor … | grep trk:` (or via a defmt log filter
+//! once that lands in espflash).
+//!
+//! ## Why firmware-side, not core?
+//!
+//! Keeping the trace logic out of `stackchan-core` preserves core's
+//! `no_std` + defmt-free posture and avoids dragging the dep into the
+//! sim and host-test paths. The firmware already runs the Director;
+//! it just needs to look at the entity afterward.
+
+use stackchan_core::Entity;
+
+#[cfg(feature = "tracking-trace")]
+use stackchan_core::{Attention, Engagement, Instant};
+
+/// Per-render-tick state for transition detection.
+///
+/// When the `tracking-trace` feature is **off**, this is a zero-size
+/// type and all methods compile to no-ops. When **on**, it carries
+/// the prior tick's attention + engagement snapshots and the
+/// observation-counter / cadence-gauge state.
+///
+/// Construct once in the render task; call [`Self::note_observation`]
+/// whenever the firmware drains a `TrackingObservation` from the
+/// camera signal, and [`Self::observe`] right after `Director::run`.
+#[cfg(feature = "tracking-trace")]
+#[derive(Debug)]
+pub struct TraceState {
+    /// Previous-tick attention snapshot. Used for edge detection.
+    prev_attention: Attention,
+    /// Previous-tick engagement snapshot. Used for edge detection
+    /// against the variant kind (we don't compare the inner Pose /
+    /// centroid because both change every tick during a lock).
+    prev_engagement: EngagementKind,
+    /// `Some(t)` once the firmware has drained a Tracking-class
+    /// observation since the last attention release; `None` between
+    /// bursts. Used to measure lock-fire latency.
+    burst_started_at: Option<Instant>,
+    /// Observations seen since the last cadence report. Reset on
+    /// each periodic emission.
+    obs_count: u32,
+    /// Wall-clock millis at the last cadence report. The first call
+    /// to [`Self::observe`] anchors this so the first interval is
+    /// measured from boot.
+    last_cadence_at_ms: Option<u64>,
+}
+
+#[cfg(feature = "tracking-trace")]
+impl TraceState {
+    /// Cadence gauge interval, in ms. Two seconds is short enough to
+    /// notice a stalled camera task quickly, long enough to avoid
+    /// flooding the JTAG channel.
+    pub const CADENCE_REPORT_INTERVAL_MS: u64 = 2_000;
+
+    /// Construct a fresh trace state. Both prev-state slots seed at
+    /// the boot defaults (`Attention::None`, `Engagement::Idle`), so
+    /// the first transition into either non-default state fires a
+    /// trace.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            prev_attention: Attention::None,
+            prev_engagement: EngagementKind::Idle,
+            burst_started_at: None,
+            obs_count: 0,
+            last_cadence_at_ms: None,
+        }
+    }
+
+    /// Note that the firmware just drained a `TrackingObservation`.
+    /// Drives the cadence gauge and seeds the lock-fire latency
+    /// stopwatch on the first observation of a burst.
+    ///
+    /// The anchor seeds whenever no burst is in flight AND attention
+    /// is *not* already `Tracking`. Anchoring only on `Attention::None`
+    /// would silently miss the common "audio engagement, then face
+    /// arrives" handoff (`Listening` → `Tracking`) — those bursts'
+    /// `lock_latency_ms` would never emit. Anchoring while `Tracking`
+    /// would reset the stopwatch mid-burst on every fresh observation.
+    pub const fn note_observation(&mut self, now: Instant) {
+        self.obs_count = self.obs_count.saturating_add(1);
+        if self.burst_started_at.is_none()
+            && !matches!(self.prev_attention, Attention::Tracking { .. })
+        {
+            self.burst_started_at = Some(now);
+        }
+    }
+
+    /// Observe entity state after `Director::run` and emit any
+    /// transition or cadence events.
+    pub fn observe(&mut self, entity: &Entity, now: Instant) {
+        let now_ms = now.as_millis();
+
+        let curr_attention = entity.mind.attention;
+        let curr_engagement = EngagementKind::from(&entity.mind.engagement);
+
+        // Attention transitions.
+        if !attention_kind_eq(&self.prev_attention, &curr_attention) {
+            let prev = AttentionKind::from(&self.prev_attention);
+            let curr = AttentionKind::from(&curr_attention);
+            defmt::info!("trk: attention {} -> {} @ {}ms", prev, curr, now_ms);
+            // Lock-fire latency: report the (start_of_burst -> lock) interval
+            // the first time attention enters Tracking.
+            if matches!(curr_attention, Attention::Tracking { .. })
+                && let Some(start) = self.burst_started_at
+            {
+                let latency = now_ms.saturating_sub(start.as_millis());
+                defmt::info!("trk: lock_latency_ms={}", latency);
+                self.burst_started_at = None;
+            }
+            // Reset latency stopwatch on release so the next burst
+            // starts with a fresh anchor.
+            if matches!(curr_attention, Attention::None) {
+                self.burst_started_at = None;
+            }
+        }
+
+        // Engagement transitions.
+        if self.prev_engagement != curr_engagement {
+            defmt::info!(
+                "trk: engagement {} -> {} @ {}ms",
+                self.prev_engagement,
+                curr_engagement,
+                now_ms
+            );
+        }
+
+        // Periodic cadence gauge.
+        let last = self.last_cadence_at_ms.unwrap_or(now_ms);
+        if now_ms.saturating_sub(last) >= Self::CADENCE_REPORT_INTERVAL_MS {
+            // Per-second rate over the elapsed window.
+            let elapsed_ms = (now_ms - last).max(1);
+            let per_sec = (u64::from(self.obs_count).saturating_mul(1_000)) / elapsed_ms;
+            defmt::debug!(
+                "trk: obs={} over {}ms (~{}/s)",
+                self.obs_count,
+                elapsed_ms,
+                per_sec
+            );
+            self.obs_count = 0;
+            self.last_cadence_at_ms = Some(now_ms);
+        } else if self.last_cadence_at_ms.is_none() {
+            self.last_cadence_at_ms = Some(now_ms);
+        }
+
+        self.prev_attention = curr_attention;
+        self.prev_engagement = curr_engagement;
+    }
+}
+
+#[cfg(feature = "tracking-trace")]
+impl Default for TraceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `defmt::Format`-friendly projection of [`Attention`]. Bare variant
+/// names without payload — Pose + Instant inside Tracking aren't
+/// useful for transition logs and would bloat each frame. Future
+/// `Attention` variants (the enum is `#[non_exhaustive]`) fall back
+/// to `Unknown` so they'd be visible in the log rather than silently
+/// matching an existing kind.
+#[cfg(feature = "tracking-trace")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, defmt::Format)]
+enum AttentionKind {
+    /// No focus.
+    None,
+    /// Listening to a sound source.
+    Listening,
+    /// Tracking a moving target.
+    Tracking,
+    /// Attention variant added in core after this build was compiled.
+    Unknown,
+}
+
+#[cfg(feature = "tracking-trace")]
+impl From<&Attention> for AttentionKind {
+    fn from(a: &Attention) -> Self {
+        match a {
+            Attention::None => Self::None,
+            Attention::Listening { .. } => Self::Listening,
+            Attention::Tracking { .. } => Self::Tracking,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// `defmt::Format`-friendly projection of [`Engagement`]. Bare
+/// variant names without payload — centroid + Instant change every
+/// tick and aren't useful in transition logs. Future variants fall
+/// back to `Unknown` (see [`AttentionKind`]).
+#[cfg(feature = "tracking-trace")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, defmt::Format)]
+enum EngagementKind {
+    /// No face seen recently.
+    Idle,
+    /// Face seen for fewer than the lock-hits threshold.
+    Locking,
+    /// Face lock engaged.
+    Locked,
+    /// Face missed but inside the release-misses window.
+    Releasing,
+    /// Engagement variant added in core after this build was compiled.
+    Unknown,
+}
+
+#[cfg(feature = "tracking-trace")]
+impl From<&Engagement> for EngagementKind {
+    fn from(e: &Engagement) -> Self {
+        match e {
+            Engagement::Idle => Self::Idle,
+            Engagement::Locking { .. } => Self::Locking,
+            Engagement::Locked { .. } => Self::Locked,
+            Engagement::Releasing { .. } => Self::Releasing,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// True when two attention values map to the same `AttentionKind`.
+/// Used so the trace fires once on enter / exit, not every tick the
+/// inner pose changes during a Tracking lock.
+#[cfg(feature = "tracking-trace")]
+#[allow(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "matches the From impl signature for symmetry; cheap to ignore"
+)]
+fn attention_kind_eq(a: &Attention, b: &Attention) -> bool {
+    AttentionKind::from(a) == AttentionKind::from(b)
+}
+
+// ---------- No-op variant for production builds ----------
+
+/// Zero-size no-op variant. All methods compile to nothing when the
+/// `tracking-trace` feature is off, so production builds carry no
+/// runtime cost.
+#[cfg(not(feature = "tracking-trace"))]
+#[derive(Debug, Default)]
+pub struct TraceState;
+
+#[cfg(not(feature = "tracking-trace"))]
+impl TraceState {
+    /// Construct the no-op trace state.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// No-op stub matching the feature-on signature.
+    #[allow(
+        clippy::unused_self,
+        clippy::needless_pass_by_value,
+        reason = "matches the feature-on signature so callers compile under both configs"
+    )]
+    pub const fn note_observation(&mut self, _now: stackchan_core::Instant) {}
+
+    /// No-op stub matching the feature-on signature.
+    #[allow(
+        clippy::unused_self,
+        reason = "matches the feature-on signature so callers compile under both configs"
+    )]
+    pub const fn observe(&mut self, _entity: &Entity, _now: stackchan_core::Instant) {}
+}

--- a/justfile
+++ b/justfile
@@ -92,6 +92,13 @@ clippy-firmware:
 build-firmware:
     cd crates/stackchan-firmware && cargo +esp build --release
 
+# Release build with the `tracking-trace` cargo feature on. Emits
+# structured defmt events from the camera-tracking pipeline (attention
+# / engagement transitions, lock-fire latency, observation cadence).
+# Use when measuring face-tracking behavior on the live unit.
+build-firmware-trace:
+    cd crates/stackchan-firmware && cargo +esp build --release --features tracking-trace
+
 # ----- Flash + monitor ----------------------------------------------------
 #
 # These recipes go through espflash over the serial-JTAG port. On Linux
@@ -132,6 +139,13 @@ reattach:
 # default inner-loop verb. Build first, then flash, then stream logs.
 # One port-open, one reset — preferred over split `flash; monitor`.
 fmr: build-firmware
+    {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{firmware_elf}}{{_serial_suffix}}
+
+# Flash + monitor a `tracking-trace`-feature build in one shot. Emits
+# structured defmt events from the camera-tracking pipeline
+# (attention / engagement transitions, lock-fire latency, observation
+# cadence). Filter the stream with `grep trk:` to isolate them.
+fmr-trace: build-firmware-trace
     {{_serial_prefix}}espflash flash --monitor --log-format defmt --port {{PORT}} {{firmware_elf}}{{_serial_suffix}}
 
 # Agent-friendly fmr: kicks `just fmr` off inside a tmux session, tees


### PR DESCRIPTION
## Summary
- Adds a `tracking-trace` cargo feature that emits structured `defmt` events from the face-tracking pipeline (attention + engagement transitions, lock-fire latency, observation cadence). Off by default; on, it covers the measurement gap PR1 left so future tuning (engagement depth, robustness) can be data-driven.
- Feature-off path is a ZST `TraceState` with `const fn` no-op methods — optimizer drops the call sites entirely. Production builds carry no runtime cost.
- Firmware-side instrumentation only: `stackchan-core` stays defmt-free, sim/host paths unaffected. `Attention` and `Engagement` are projected into local `defmt::Format` enums (`AttentionKind`/`EngagementKind`) with an `Unknown` fallback for safety under `#[non_exhaustive]`.
- New `just fmr-trace` and `just build-firmware-trace` recipes for the feature-on flash path. Firmware README updated.

### What it emits

- `trk: attention <prev> -> <curr> @ <ms>` on every attention state transition
- `trk: engagement <prev> -> <curr> @ <ms>` on every engagement state transition
- `trk: lock_latency_ms=<ms>` once per burst, reporting the time from the first `Tracking` observation to the `Attention::Tracking` lock
- `trk: obs=<n> over <ms>ms (~<n>/s)` every ~2 s, gauging the camera task's publish cadence

## Test plan
- [x] `just ci` (host: fmt + workspace clippy strict + tests + doctests + cargo-deny + doc-lint)
- [x] `just clippy-firmware` (feature off; matches the CI firmware job)
- [x] `cargo +esp clippy --release --features tracking-trace -- -D warnings` (feature on)
- [ ] On-device smoke (`just fmr-trace`): wave at the camera, confirm `trk: attention None -> Tracking @ <ms>` then `trk: lock_latency_ms=<ms>` fire at the expected timing (~100 ms for the 3-tick lock window at 30 FPS)
- [ ] Confirm the default `just fmr` build is unchanged (no `trk:` events in the log)

## Arc context
PR2 of 4 in the face-tracking polish arc:
- PR1 #125 — sim coverage (foundation, merged)
- **PR2 (this) — defmt instrumentation**
- PR3 — robustness (camera dropout / I²C timeout handling, perf measurements informed by PR2 data)
- PR4 — engagement depth + dormant-mode (informed by PR2 data)