### PR TITLE
feat(core): dormant mode quiets head servos when nothing's happening

### DIFF
--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -184,6 +184,8 @@ pub enum Field {
     Attention,
     /// `entity.mind.engagement`
     Engagement,
+    /// `entity.mind.dormancy`
+    Dormancy,
 
     // ---- Voice ----
     /// `entity.voice.chirp_request`
@@ -268,9 +270,12 @@ impl Field {
             | Self::AudioRms
             | Self::BodyTouch
             | Self::Tracking => FieldGroup::Perception,
-            Self::Emotion | Self::Autonomy | Self::Intent | Self::Attention | Self::Engagement => {
-                FieldGroup::Mind
-            }
+            Self::Emotion
+            | Self::Autonomy
+            | Self::Intent
+            | Self::Attention
+            | Self::Engagement
+            | Self::Dormancy => FieldGroup::Mind,
             Self::ChirpRequest => FieldGroup::Voice,
             Self::TapPending | Self::RemotePending => FieldGroup::Input,
         }
@@ -361,6 +366,7 @@ impl Field {
             Self::Intent => before.mind.intent != after.mind.intent,
             Self::Attention => before.mind.attention != after.mind.attention,
             Self::Engagement => before.mind.engagement != after.mind.engagement,
+            Self::Dormancy => before.mind.dormancy != after.mind.dormancy,
             Self::ChirpRequest => before.voice.chirp_request != after.voice.chirp_request,
             Self::TapPending => before.input.tap_pending != after.input.tap_pending,
             Self::RemotePending => before.input.remote_pending != after.input.remote_pending,

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -57,7 +57,7 @@ pub use face::{Eye, EyePhase, Face, Mouth, Point, SCALE_DEFAULT, Style};
 pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
 pub use input::Input;
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
-pub use mind::{Affect, Attention, Autonomy, Engagement, Intent, Mind, OverrideSource};
+pub use mind::{Affect, Attention, Autonomy, Dormancy, Engagement, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
 pub use motor::Motor;
 pub use perception::{

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -242,6 +242,47 @@ impl Engagement {
     }
 }
 
+/// Activity-driven sleep state.
+///
+/// `Awake` while any of `intent`, `attention`, or `engagement` are
+/// non-default; `Asleep { since }` after a timeout of full quiet.
+/// Modifiers that produce continuous per-tick servo motion (the
+/// triangle-wave [`crate::modifiers::IdleSway`]) gate on this so the
+/// hardware servos stop chattering when the avatar is alone in the
+/// room. Set by [`crate::modifiers::DormancyFromActivity`]; read by
+/// [`crate::modifiers::IdleSway`].
+///
+/// Wake conditions: any change that bumps `intent`, `attention`, or
+/// `engagement` away from their defaults. That covers face detection
+/// (engagement), sustained voice / mic VAD (attention=Listening),
+/// loud audio transients (intent=Startled), pickup (intent=PickedUp),
+/// body touch (intent=Petted), and IR remote (intent change).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Dormancy {
+    /// Active state — autonomous background motion runs normally.
+    #[default]
+    Awake,
+    /// No wake signals for the configured timeout.
+    /// [`crate::modifiers::IdleSway`] holds at zero contribution
+    /// while in this state, so the head servos stay still.
+    Asleep {
+        /// When the dormant transition fired. Consumers can use this
+        /// for an ease-in / ease-out animation, or to gate other
+        /// behaviour by dormancy duration.
+        since: Instant,
+    },
+}
+
+impl Dormancy {
+    /// `true` if currently in [`Self::Asleep`]. Convenience for
+    /// modifiers that gate their per-tick contribution on dormancy.
+    #[must_use]
+    pub const fn is_asleep(&self) -> bool {
+        matches!(self, Self::Asleep { .. })
+    }
+}
+
 /// Persistent facts the entity remembers across boots. Placeholder
 /// marker type; not yet populated.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -267,6 +308,11 @@ pub struct Mind {
     /// [`crate::modifiers::AttentionFromTracking`] from the firmware-side
     /// cascade observations; read by engagement modifiers.
     pub engagement: Engagement,
+    /// Activity-driven sleep state. Default `Awake`. Set by
+    /// [`crate::modifiers::DormancyFromActivity`]; read by
+    /// [`crate::modifiers::IdleSway`] to silence the head servos
+    /// when nothing's happening in the room.
+    pub dormancy: Dormancy,
     /// Persistent facts.
     pub memory: Memory,
 }

--- a/crates/stackchan-core/src/modifiers/dormancy_from_activity.rs
+++ b/crates/stackchan-core/src/modifiers/dormancy_from_activity.rs
@@ -1,0 +1,320 @@
+//! `DormancyFromActivity`: cognition-phase modifier that flips
+//! [`crate::mind::Dormancy`] between [`Dormancy::Awake`] and
+//! [`Dormancy::Asleep`] based on how recently any activity-bearing
+//! mind field changed away from its default.
+//!
+//! ## Why
+//!
+//! The avatar's idle background motion ([`crate::modifiers::IdleSway`]'s
+//! triangle wave on `motor.head_pose`) keeps the `SCServo` head
+//! continuously slewing even when no one is in the room — audible
+//! from the next room and a small but real battery drain. Gating the
+//! sway when nothing has happened for a while silences the head
+//! without changing the avatar's behaviour while a person is present.
+//!
+//! ## Activity signals
+//!
+//! Any of the following counts as activity, resetting the timeout:
+//!
+//! - `mind.intent != Intent::Idle` — body touch, IR remote, loud
+//!   audio, pickup, shake, sustained voice all flip intent.
+//! - `mind.attention != Attention::None` — sustained voice via
+//!   [`crate::skills::Listening`], camera motion via
+//!   [`crate::modifiers::AttentionFromTracking`].
+//! - `mind.engagement != Engagement::Idle` — the cascade is
+//!   reporting a face (Locking / Locked / Releasing).
+//!
+//! These three together cover every modality the firmware exposes
+//! today (audio, vision, touch, remote, IMU). A future modality
+//! (e.g. an explicit "user spoke their name" event) should land on
+//! one of these three so it wakes the avatar without a code change
+//! here.
+//!
+//! ## Phase + priority
+//!
+//! Runs in [`Phase::Cognition`] at priority `10`, after
+//! [`crate::modifiers::AttentionFromTracking`] (priority `0`) so
+//! `engagement` and `attention` reflect *this* tick's observation
+//! before we read them. Writing happens before [`Phase::Expression`]
+//! and [`Phase::Motion`] so [`crate::modifiers::IdleSway`] sees the
+//! fresh dormancy value the same tick.
+//!
+//! ## Boot
+//!
+//! Boot is treated as activity — `last_active_at` anchors on the
+//! first tick — so the avatar wakes on power-on and the dormant
+//! transition fires `DORMANCY_TIMEOUT_MS` after boot if nothing
+//! engages it in that window.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::{Attention, Dormancy, Engagement, Intent};
+use crate::modifier::Modifier;
+
+/// How long, in ms, all three activity signals must stay at their
+/// defaults before the modifier transitions to [`Dormancy::Asleep`].
+///
+/// `30_000` ms reads as "the room has been quiet for half a minute"
+/// — long enough that brief silences during a real interaction
+/// don't trip dormancy, short enough that walking away from the desk
+/// silences the head before it becomes background-noise irritating.
+pub const DORMANCY_TIMEOUT_MS: u64 = 30_000;
+
+/// Modifier that drives [`crate::mind::Dormancy`] from the activity
+/// signals on `entity.mind`.
+#[derive(Debug, Clone, Copy)]
+pub struct DormancyFromActivity {
+    /// Per-instance timeout. Defaults to [`DORMANCY_TIMEOUT_MS`];
+    /// override via [`Self::with_timeout`] for tests or unusual
+    /// deployments.
+    pub timeout_ms: u64,
+    /// Wall-clock instant of the most recent active tick. `None`
+    /// before the first tick; the modifier seeds this on its first
+    /// invocation so boot itself counts as activity.
+    last_active_at: Option<Instant>,
+}
+
+impl DormancyFromActivity {
+    /// Construct with the default [`DORMANCY_TIMEOUT_MS`].
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            timeout_ms: DORMANCY_TIMEOUT_MS,
+            last_active_at: None,
+        }
+    }
+
+    /// Construct with a custom timeout, in ms.
+    #[must_use]
+    pub const fn with_timeout(timeout_ms: u64) -> Self {
+        Self {
+            timeout_ms,
+            last_active_at: None,
+        }
+    }
+}
+
+impl Default for DormancyFromActivity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `true` when any activity-bearing mind field is non-default.
+const fn is_active(entity: &Entity) -> bool {
+    !matches!(entity.mind.intent, Intent::Idle)
+        || !matches!(entity.mind.attention, Attention::None)
+        || !matches!(entity.mind.engagement, Engagement::Idle)
+}
+
+impl Modifier for DormancyFromActivity {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DormancyFromActivity",
+            description: "Watches mind.{intent, attention, engagement}; sets \
+                          mind.dormancy = Awake on any non-default activity, \
+                          and Asleep after DORMANCY_TIMEOUT_MS of full quiet. \
+                          Lets IdleSway gate its triangle-wave contribution so \
+                          the head servos stay still when nothing's happening \
+                          in the room.",
+            phase: Phase::Cognition,
+            // After AttentionFromTracking (priority 0) so engagement /
+            // attention reflect this tick's observation before we read.
+            priority: 10,
+            reads: &[
+                Field::Intent,
+                Field::Attention,
+                Field::Engagement,
+                Field::Dormancy,
+            ],
+            writes: &[Field::Dormancy],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+
+        // Seed on first tick so boot counts as activity. Without
+        // this, `last_active_at` stays `None` forever in a totally
+        // quiet room and the dormant transition fires immediately
+        // (since `now - 0` is large).
+        if self.last_active_at.is_none() {
+            self.last_active_at = Some(now);
+        }
+
+        if is_active(entity) {
+            self.last_active_at = Some(now);
+            entity.mind.dormancy = Dormancy::Awake;
+            return;
+        }
+
+        // Quiet tick. Compare elapsed-since-last-active against the
+        // timeout; transition to Asleep on the crossing.
+        let last = self.last_active_at.unwrap_or(now);
+        let elapsed = now.saturating_duration_since(last);
+        if elapsed >= self.timeout_ms && !entity.mind.dormancy.is_asleep() {
+            entity.mind.dormancy = Dormancy::Asleep { since: now };
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    reason = "let-else with panic is the cleanest pattern for value extraction \
+              on enum variants in tests"
+)]
+mod tests {
+    use super::*;
+
+    fn at(now_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.tick.now = Instant::from_millis(now_ms);
+        e
+    }
+
+    #[test]
+    fn fresh_modifier_keeps_avatar_awake_until_timeout() {
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+        assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+        // Just shy of the timeout: still awake.
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS - 1);
+        m.update(&mut entity);
+        assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+    }
+
+    #[test]
+    fn quiet_past_timeout_flips_to_asleep() {
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS);
+        m.update(&mut entity);
+        match entity.mind.dormancy {
+            Dormancy::Asleep { since } => {
+                assert_eq!(since, Instant::from_millis(DORMANCY_TIMEOUT_MS));
+            }
+            other => panic!("expected Asleep, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn intent_activity_keeps_avatar_awake() {
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+
+        // Sustained activity past the timeout: must stay Awake.
+        for t in (0..DORMANCY_TIMEOUT_MS + 1_000).step_by(100) {
+            entity.tick.now = Instant::from_millis(t);
+            entity.mind.intent = Intent::Petted;
+            m.update(&mut entity);
+            assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+        }
+    }
+
+    #[test]
+    fn engagement_activity_keeps_avatar_awake() {
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+
+        for t in (0..DORMANCY_TIMEOUT_MS + 1_000).step_by(100) {
+            entity.tick.now = Instant::from_millis(t);
+            entity.mind.engagement = Engagement::Locking { hits: 1 };
+            m.update(&mut entity);
+            assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+        }
+    }
+
+    #[test]
+    fn attention_activity_keeps_avatar_awake() {
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+
+        for t in (0..DORMANCY_TIMEOUT_MS + 1_000).step_by(100) {
+            entity.tick.now = Instant::from_millis(t);
+            entity.mind.attention = Attention::Listening {
+                since: Instant::from_millis(t),
+            };
+            m.update(&mut entity);
+            assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+        }
+    }
+
+    #[test]
+    fn activity_after_asleep_wakes_immediately() {
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+
+        // Sleep.
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS);
+        m.update(&mut entity);
+        assert!(entity.mind.dormancy.is_asleep());
+
+        // Activity arrives one tick later: wake immediately.
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS + 33);
+        entity.mind.intent = Intent::Startled;
+        m.update(&mut entity);
+        assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+    }
+
+    #[test]
+    fn brief_activity_then_quiet_resets_timeout() {
+        // Activity → quiet for slightly less than the timeout →
+        // brief activity → quiet for the full timeout from the
+        // brief-activity point. Must NOT fall asleep at the original
+        // timeout; only after the full timeout from the most recent
+        // activity.
+        let mut m = DormancyFromActivity::new();
+        let mut entity = at(0);
+        m.update(&mut entity);
+
+        // Activity at tick 0; clear at tick 100.
+        entity.mind.intent = Intent::Petted;
+        m.update(&mut entity);
+
+        entity.tick.now = Instant::from_millis(100);
+        entity.mind.intent = Intent::Idle;
+        m.update(&mut entity);
+
+        // Wait until just shy of the original timeout.
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS - 100);
+        m.update(&mut entity);
+        assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+
+        // Brief activity bump.
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS - 50);
+        entity.mind.intent = Intent::Petted;
+        m.update(&mut entity);
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS);
+        entity.mind.intent = Intent::Idle;
+        m.update(&mut entity);
+        // At the original timeout, the second-activity reset means
+        // we're still awake.
+        assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+
+        // Now wait the full timeout from the second activity.
+        entity.tick.now = Instant::from_millis(DORMANCY_TIMEOUT_MS - 50 + DORMANCY_TIMEOUT_MS);
+        m.update(&mut entity);
+        assert!(entity.mind.dormancy.is_asleep());
+    }
+
+    #[test]
+    fn custom_timeout_overrides_default() {
+        let mut m = DormancyFromActivity::with_timeout(1_000);
+        let mut entity = at(0);
+        m.update(&mut entity);
+        // Default timeout would NOT fire here, but our custom 1 s does.
+        entity.tick.now = Instant::from_millis(1_000);
+        m.update(&mut entity);
+        assert!(entity.mind.dormancy.is_asleep());
+    }
+}

--- a/crates/stackchan-core/src/modifiers/idle_sway.rs
+++ b/crates/stackchan-core/src/modifiers/idle_sway.rs
@@ -159,10 +159,14 @@ impl Modifier for IdleSway {
         static META: ModifierMeta = ModifierMeta {
             name: "IdleSway",
             description: "Slow two-axis triangle-wave wander on motor.head_pose so the head \
-                          looks alive at rest. Composes additively with upstream pose writes.",
+                          looks alive at rest. Composes additively with upstream pose writes. \
+                          Gates to no contribution while mind.dormancy == Asleep so the SCServo \
+                          stays still when nothing's happening in the room.",
             phase: Phase::Motion,
             priority: 0,
-            reads: &[Field::HeadPose],
+            // `Field::Dormancy` is a read so the writes-checker
+            // permits us to consult it; we only write `HeadPose`.
+            reads: &[Field::HeadPose, Field::Dormancy],
             writes: &[Field::HeadPose],
         };
         &META
@@ -170,8 +174,20 @@ impl Modifier for IdleSway {
 
     fn update(&mut self, entity: &mut Entity) {
         let now = entity.tick.now;
-        let pan = Self::unit_triangle(self.pan_period_ms, now) * self.pan_amplitude_deg;
-        let tilt = Self::unit_triangle(self.tilt_period_ms, now) * self.tilt_amplitude_deg;
+        // Gate by dormancy: when asleep, the requested contribution
+        // is zero. The diff-and-undo path then subtracts the prior
+        // contribution and adds nothing, returning the head exactly
+        // to upstream — silently and without a snap, since the prior
+        // contribution was the small triangle-wave value we wrote
+        // last tick.
+        let (pan, tilt) = if entity.mind.dormancy.is_asleep() {
+            (0.0, 0.0)
+        } else {
+            (
+                Self::unit_triangle(self.pan_period_ms, now) * self.pan_amplitude_deg,
+                Self::unit_triangle(self.tilt_period_ms, now) * self.tilt_amplitude_deg,
+            )
+        };
         let upstream_pan = entity.motor.head_pose.pan_deg - self.last_pan_deg;
         let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_tilt_deg;
         let new_pose = Pose::new(upstream_pan + pan, upstream_tilt + tilt).clamped();

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -77,6 +77,7 @@
 mod attention_from_tracking;
 mod blink;
 mod breath;
+mod dormancy_from_activity;
 mod emotion_cycle;
 mod emotion_from_ambient;
 mod emotion_from_battery;
@@ -104,6 +105,7 @@ pub use attention_from_tracking::{
 };
 pub use blink::Blink;
 pub use breath::Breath;
+pub use dormancy_from_activity::{DORMANCY_TIMEOUT_MS, DormancyFromActivity};
 pub use emotion_cycle::EmotionCycle;
 pub use emotion_from_ambient::{
     AMBIENT_HOLD_MS, EmotionFromAmbient, SLEEPY_ENTER_LUX, SLEEPY_EXIT_LUX,

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -65,11 +65,11 @@ use mipidsi::{
 use stackchan_core::{
     Clock, Director, Entity, Face, HeadDriver, LedFrame,
     modifiers::{
-        AttentionFromTracking, Blink, Breath, EmotionCycle, EmotionFromAmbient, EmotionFromBattery,
-        EmotionFromIntent, EmotionFromRemote, EmotionFromTouch, EmotionFromVoice,
-        GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleSway,
-        IntentFromBodyTouch, IntentFromLoud, MicrosaccadeFromAttention, MouthFromAudio,
-        StyleFromEmotion, StyleFromIntent,
+        AttentionFromTracking, Blink, Breath, DormancyFromActivity, EmotionCycle,
+        EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
+        EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion,
+        HeadFromIntent, IdleDrift, IdleSway, IntentFromBodyTouch, IntentFromLoud,
+        MicrosaccadeFromAttention, MouthFromAudio, StyleFromEmotion, StyleFromIntent,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -187,6 +187,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     let mut emotion_from_voice = EmotionFromVoice::new();
     let mut intent_from_loud = IntentFromLoud::new();
     let mut attention_from_tracking = AttentionFromTracking::new();
+    let mut dormancy_from_activity = DormancyFromActivity::new();
     let mut cycle = EmotionCycle::new();
     let mut style = StyleFromEmotion::new();
     let mut style_from_intent = StyleFromIntent::new();
@@ -250,6 +251,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
     director
         .add_modifier(&mut attention_from_tracking)
         .expect("registry full");
+    director
+        .add_modifier(&mut dormancy_from_activity)
+        .expect("registry full");
     director.add_modifier(&mut cycle).expect("registry full");
     director.add_modifier(&mut style).expect("registry full");
     director
@@ -304,7 +308,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32) {
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleSway + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-sim/tests/dormancy_sway.rs
+++ b/crates/stackchan-sim/tests/dormancy_sway.rs
@@ -1,0 +1,152 @@
+//! Sim coverage for the dormancy → IdleSway gating handoff.
+//!
+//! `DormancyFromActivity` writes `mind.dormancy`; `IdleSway` reads
+//! it. This test pins the architectural contract that solves the
+//! office-noise problem: when no activity has happened for the
+//! configured timeout, the head pose stops varying frame-to-frame
+//! so the SCServo stays still.
+//!
+//! In-module unit tests cover the dormancy state machine in
+//! isolation. The sim test here pins the cross-modifier composition
+//! through the real Director:
+//!
+//! - Activity → IdleSway sweeps normally (the head actually moves).
+//! - Quiet past timeout → dormancy flips to Asleep → IdleSway holds
+//!   at zero contribution → captured pose trajectory becomes flat.
+//! - Activity returns → wake → sway resumes.
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::unwrap_used,
+    reason = "test-only relaxations: doc comments freely reference type names \
+              without backticks; assertions use unwrap/expect/panic; long setup \
+              blocks; baseline_*_x/y bindings share a common shape"
+)]
+
+use stackchan_core::modifiers::{DORMANCY_TIMEOUT_MS, DormancyFromActivity, IdleSway};
+use stackchan_core::{Director, Dormancy, Entity, Instant, Intent};
+
+const TICK_MS: u64 = 33;
+
+/// Drive the director for `ticks` frames at `TICK_MS` cadence,
+/// starting at `start_ms`. Optionally inject activity at every tick
+/// via the `intent` callback.
+fn run_for<F>(
+    director: &mut Director<'_>,
+    entity: &mut Entity,
+    start_ms: u64,
+    ticks: u64,
+    intent: F,
+) -> Instant
+where
+    F: Fn() -> Intent,
+{
+    let mut last = Instant::from_millis(start_ms);
+    for t in 0..ticks {
+        last = Instant::from_millis(start_ms + t * TICK_MS);
+        entity.mind.intent = intent();
+        director.run(entity, last);
+    }
+    last
+}
+
+#[test]
+fn quiet_past_timeout_flattens_head_pose_trajectory() {
+    let mut sway = IdleSway::new();
+    let mut dormancy = DormancyFromActivity::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut dormancy).unwrap();
+    director.add_modifier(&mut sway).unwrap();
+    let mut entity = Entity::default();
+
+    // Phase 1: short window of no activity (well under the timeout).
+    // Head must move during this period — IdleSway is sweeping.
+    let phase1_ticks = 60; // ~2 s
+    run_for(&mut director, &mut entity, 0, phase1_ticks, || Intent::Idle);
+    assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+    let phase1_pose = entity.motor.head_pose;
+
+    // Phase 2: cross the dormancy timeout still with no activity.
+    let after_timeout_ms = DORMANCY_TIMEOUT_MS + 200;
+    let after_timeout_ticks = after_timeout_ms / TICK_MS;
+    run_for(
+        &mut director,
+        &mut entity,
+        phase1_ticks * TICK_MS,
+        after_timeout_ticks - phase1_ticks,
+        || Intent::Idle,
+    );
+    assert!(
+        entity.mind.dormancy.is_asleep(),
+        "should be Asleep after >= DORMANCY_TIMEOUT_MS of quiet, got {:?}",
+        entity.mind.dormancy,
+    );
+
+    // Capture the pose at the dormant boundary, then drive 30 more
+    // ticks (~1 s) of asleep state. The head pose must not change
+    // tick-to-tick — that's the SCServo-quietness contract.
+    let dormant_pose = entity.motor.head_pose;
+    for t in after_timeout_ticks..after_timeout_ticks + 30 {
+        let now = Instant::from_millis(t * TICK_MS);
+        entity.tick.now = now;
+        entity.mind.intent = Intent::Idle;
+        director.run(&mut entity, now);
+        assert_eq!(
+            entity.motor.head_pose,
+            dormant_pose,
+            "head pose must not vary tick-to-tick while Asleep at {}ms",
+            (t * TICK_MS),
+        );
+    }
+
+    // And the dormant pose itself must be different from the active
+    // sway pose — proves IdleSway was actually sweeping during phase
+    // 1 and is not just stuck at the same value.
+    assert_ne!(
+        phase1_pose, dormant_pose,
+        "phase-1 sway pose should differ from the dormant pose — \
+         otherwise the test isn't actually exercising sway motion",
+    );
+}
+
+#[test]
+fn activity_after_dormancy_resumes_sway() {
+    let mut sway = IdleSway::new();
+    let mut dormancy = DormancyFromActivity::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut dormancy).unwrap();
+    director.add_modifier(&mut sway).unwrap();
+    let mut entity = Entity::default();
+
+    // Sleep first.
+    let after_timeout_ticks = (DORMANCY_TIMEOUT_MS + 200) / TICK_MS;
+    run_for(&mut director, &mut entity, 0, after_timeout_ticks, || {
+        Intent::Idle
+    });
+    assert!(entity.mind.dormancy.is_asleep());
+    let dormant_pose = entity.motor.head_pose;
+
+    // Now fire activity for 60 ticks (~2 s) and verify that:
+    //  1. dormancy flips Awake immediately,
+    //  2. the head pose changes from its dormant value at least
+    //     once during the active window.
+    let mut saw_motion = false;
+    for t in after_timeout_ticks..after_timeout_ticks + 60 {
+        let now = Instant::from_millis(t * TICK_MS);
+        entity.tick.now = now;
+        entity.mind.intent = Intent::Petted;
+        director.run(&mut entity, now);
+        if entity.motor.head_pose != dormant_pose {
+            saw_motion = true;
+        }
+    }
+    assert_eq!(entity.mind.dormancy, Dormancy::Awake);
+    assert!(
+        saw_motion,
+        "head pose should vary from the dormant pose during activity",
+    );
+}


### PR DESCRIPTION
## Summary

Reported pain point: with the avatar sitting in the office unattended, `IdleSway`'s continuous triangle wave keeps the SCServo head slewing — audible from the next room and a small but real battery drain.

This PR adds an activity-driven sleep state that gates `IdleSway`'s contribution after 30 s of full quiet. The head goes still until the next interaction (face, voice, body touch, IR remote, loud audio, pickup, shake — anything that bumps `mind.intent` / `attention` / `engagement` off their defaults).

### Design

- **New `mind.dormancy: Dormancy` field** (`Awake` / `Asleep { since }`). Default `Awake`. Re-exported from `stackchan-core`.
- **`DormancyFromActivity` modifier** (Phase::Cognition, priority 10 — after `AttentionFromTracking` so `engagement` reflects this tick's observation). Watches the union of `intent`/`attention`/`engagement`; flips to `Asleep` after `DORMANCY_TIMEOUT_MS` (30 s) of full quiet, back to `Awake` on any activity.
- **`IdleSway` reads `mind.dormancy`** and zeros its triangle-wave contribution while `Asleep`. Diff-and-undo handles the transition cleanly — the prior contribution unwinds and nothing new gets added, so the head returns to upstream baseline silently (no snap).
- **`Field::Dormancy`** variant for the writes-checker.
- **Wired into the firmware `Director`** after `AttentionFromTracking`.

### Wake signals

The activity check is `intent != Idle || attention != None || engagement != Idle`. That covers every wake modality the firmware exposes today:

| Modality | Field that bumps |
|---|---|
| Camera face detection | `engagement` (Locking / Locked) |
| Sustained voice (mic VAD) | `attention` = Listening |
| Loud audio transient | `intent` = Startled |
| Body touch | `intent` = Petted |
| Pickup / shake | `intent` = PickedUp / Shaken |
| IR remote | `intent` change |

A future modality should land on one of those three fields and it'll wake the avatar without a code change here.

## Test plan

- [x] `just ci` (host fmt + workspace clippy strict + tests + doctests + cargo-deny + doc-lint)
- [x] `just clippy-firmware` (default features) and `cargo +esp clippy --release --features tracking-trace -- -D warnings`
- [x] 8 in-module unit tests cover the state machine (timeout, wake signals from each field, custom timeout, brief-activity-resets-timeout)
- [x] Sim composition test (`crates/stackchan-sim/tests/dormancy_sway.rs`) pins the office-noise contract: after the timeout, head pose stops varying tick-to-tick; activity reawakens immediately
- [ ] On-device smoke (`just fmr`): leave the avatar alone for ~30 s, confirm the head stops moving (and stays quiet); wave at the camera to wake; confirm sway resumes

## Arc context

PR3 of 4 in the face-tracking polish arc. Pivoted from the original "robustness" plan since the office-noise issue is the actual user pain point and the original "robustness" PR was waiting on a few days of trace data from #126 anyway.

- PR1 #125 — sim coverage (merged)
- PR2 #126 — `tracking-trace` cargo feature (merged)
- **PR3 (this) — dormant mode**
- PR4 — engagement depth + (maybe) robustness, after a few days of trace data