### PR TITLE
chore: add top-level LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+stackchan-kai is licensed under either of
+
+  Apache License, Version 2.0 (see LICENSE-APACHE or
+    https://www.apache.org/licenses/LICENSE-2.0)
+  MIT License (see LICENSE-MIT or
+    https://opensource.org/licenses/MIT)
+
+at your option.
+
+SPDX-License-Identifier: MIT OR Apache-2.0


### PR DESCRIPTION
## Summary

- Add a single root `LICENSE` file alongside the existing `LICENSE-APACHE` / `LICENSE-MIT` so GitHub's [licensee](https://github.com/licensee/licensee) detector and OSS-program scanners (Greptile, FOSSA, etc.) pick up the dual license cleanly.
- The file is a short pointer that names both license files and ends with `SPDX-License-Identifier: MIT OR Apache-2.0`, mirroring the workspace `Cargo.toml`'s `license` field.
- No change to the canonical license texts, the README's License section, or any crate metadata.

## Test plan

- [x] `LICENSE` exists at repo root
- [x] `LICENSE-APACHE` and `LICENSE-MIT` unchanged
- [x] SPDX expression matches `Cargo.toml` (`MIT OR Apache-2.0`)
- [ ] After merge, GitHub's repo sidebar shows a detected license rather than "Other"