### PR TITLE
feat(net): scaffold stackchan-net crate with RON config schema v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +488,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block2"
@@ -3785,6 +3794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,6 +4214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "stackchan-net"
+version = "0.1.0"
+dependencies = [
+ "ron",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "stackchan-sim"
 version = "0.11.1"
 dependencies = [
@@ -4262,7 +4293,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/si12t",
     "crates/tracker",
     "crates/stackchan-tts",
+    "crates/stackchan-net",
     "crates/stackchan-firmware",
     "xtask",
 ]
@@ -41,6 +42,7 @@ default-members = [
     "crates/si12t",
     "crates/tracker",
     "crates/stackchan-tts",
+    "crates/stackchan-net",
 ]
 
 [workspace.package]

--- a/crates/stackchan-net/Cargo.toml
+++ b/crates/stackchan-net/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "stackchan-net"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Networking domain types + offline-first RON config schema for the Stack-chan avatar (no_std + alloc)."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+# `no_std` serde with derive macros. The `alloc` feature lets `String`
+# / `Vec<T>` participate in the schema — the firmware reads the config
+# off SD into a heap-allocated `String`, then parses through this crate.
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+# RON (Rusty Object Notation) — chosen for ergonomic Rust-shaped config
+# (enums, comments, trailing commas). 0.10 is `no_std + alloc`-compatible
+# with `default-features = false` — `alloc` support is implicit, not a
+# named feature. The full `Serialize`/`Deserialize` round trip is what
+# `PUT /settings` and `GET /settings` lean on.
+ron = { version = "0.10", default-features = false }
+# Typed errors without `std`. v2 supports `no_std` natively; firmware
+# wraps with `defmt::Debug2Format` rather than this crate deriving
+# `defmt::Format` — keeps the host crate independent of the firmware
+# log transport.
+thiserror = { version = "2", default-features = false }

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -56,6 +56,15 @@ propagates a `ConfigError` up to a panic — it logs and uses defaults.
 - Persona / character data — belongs to the AI tier (deferred).
 - BLE pairing config — companion-app pairing is a later round.
 
+## Security note for the upcoming HTTP layer
+
+`render_ron` is lossless — `wifi.psk` round-trips verbatim so SD reads
+and writes stay symmetric. The v1 HTTP control plane (PR #5) is
+LAN-scoped and unauthed, so its `GET /settings` handler **must** redact
+the PSK on the read path (separate read/write DTOs or a masked-render
+variant) before the endpoint ships. Don't expose `render_ron`'s output
+to the network as-is.
+
 [`Config`]: src/config.rs
 [`WifiConfig`]: src/config.rs
 [`MdnsConfig`]: src/config.rs

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -1,0 +1,63 @@
+---
+crate: stackchan-net
+role: Networking domain types + RON config schema (host-testable)
+bus: none
+transport: "pure data + parsers"
+no_std: true
+unsafe: forbidden
+status: experimental (v0.x)
+---
+
+# stackchan-net
+
+Networking domain types for Stack-chan. Pure data and parsers — no
+transport, no I/O, no esp-hal. The firmware does the I/O wrapping;
+this crate is what the firmware (and host tests) agree on as the
+shape of the on-disk config and the RON file `PUT /settings` round-trips.
+
+## Schema v1
+
+```ron
+(
+    wifi: ( ssid: "home", psk: "redacted", country: "US" ),
+    mdns: ( hostname: "stackchan" ),
+    time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+)
+```
+
+- `WifiConfig` — credentials + ISO-3166 alpha-2 country code (default `"US"`).
+- `MdnsConfig` — hostname advertised on `.local` (default `"stackchan"`).
+- `TimeConfig` — IANA timezone label + SNTP servers (default `"UTC"`,
+  `["pool.ntp.org"]`). The TZ field is parsed but currently unused;
+  the BM8563 RTC stores UTC.
+
+## Key Files
+
+- `src/lib.rs` — crate root, re-exports
+- `src/config.rs` — `Config`, `WifiConfig`, `MdnsConfig`, `TimeConfig`,
+  `parse_ron`, `render_ron`, validators
+- `src/error.rs` — `ConfigError` (parse / serialize / validation variants)
+- `tests/golden_config.rs` + `tests/fixtures/*.ron` — round-trip and
+  validation coverage against hand-written fixtures
+
+## Offline-first stance
+
+The avatar must boot fully and animate even with no SD card and no
+Wi-Fi. The firmware therefore treats `Config` as **always available**:
+missing SD or missing file falls back to `Config::default`. Validators
+in `parse_ron` reject malformed input, but the firmware never
+propagates a `ConfigError` up to a panic — it logs and uses defaults.
+
+## Defer-list (out of scope for v1)
+
+- TLS / HTTPS config — the v1 control plane is LAN-scoped, no auth.
+- OTA manifests — firmware updates are a separate concern.
+- Captive portal / soft-AP setup flow — first-boot UX deferred.
+- Persona / character data — belongs to the AI tier (deferred).
+- BLE pairing config — companion-app pairing is a later round.
+
+[`Config`]: src/config.rs
+[`WifiConfig`]: src/config.rs
+[`MdnsConfig`]: src/config.rs
+[`TimeConfig`]: src/config.rs
+[`ConfigError`]: src/error.rs

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -1,0 +1,208 @@
+//! Schema v1 of the Stack-chan RON config — `wifi`, `mdns`, `time`.
+//!
+//! Held deliberately minimal: avatar geometry and modifier params
+//! stay hardcoded in `stackchan-core` for now. The shape this crate
+//! commits to is the surface that `PUT /settings` round-trips and
+//! that the SD-card boot reader populates.
+
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConfigError;
+
+/// Top-level on-disk config.
+///
+/// Defaults are tuned for offline-first boot: an empty SSID is a
+/// no-op at the Wi-Fi layer, hostname `"stackchan"` is the canonical
+/// mDNS label, and `time` points at `pool.ntp.org` so SNTP picks up
+/// once Wi-Fi is configured.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    /// Wi-Fi station credentials and regulatory country code.
+    pub wifi: WifiConfig,
+    /// Local hostname advertised on `.local` via mDNS.
+    pub mdns: MdnsConfig,
+    /// Timezone label + SNTP server list.
+    pub time: TimeConfig,
+}
+
+/// Wi-Fi station credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WifiConfig {
+    /// SSID of the access point to join. An empty string disables the
+    /// Wi-Fi join attempt entirely (avatar runs offline-first).
+    pub ssid: String,
+    /// WPA2/WPA3 pre-shared key. Empty string permitted for open APs.
+    pub psk: String,
+    /// ISO-3166 alpha-2 country code. Default `"US"`. Determines
+    /// channel availability and TX power per regulatory domain.
+    pub country: String,
+}
+
+impl Default for WifiConfig {
+    fn default() -> Self {
+        Self {
+            ssid: String::new(),
+            psk: String::new(),
+            country: "US".to_string(),
+        }
+    }
+}
+
+/// mDNS hostname configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MdnsConfig {
+    /// Hostname advertised on `.local`. Default `"stackchan"` →
+    /// device reachable as `stackchan.local`.
+    pub hostname: String,
+}
+
+impl Default for MdnsConfig {
+    fn default() -> Self {
+        Self {
+            hostname: "stackchan".to_string(),
+        }
+    }
+}
+
+/// Time / SNTP configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimeConfig {
+    /// IANA timezone label (e.g. `"UTC"`, `"America/Los_Angeles"`).
+    /// Currently parsed but unused — the BM8563 RTC stores UTC.
+    pub tz: String,
+    /// SNTP servers to query in order. The firmware tries each with
+    /// a 5-second timeout before falling back to the next.
+    pub sntp_servers: Vec<String>,
+}
+
+impl Default for TimeConfig {
+    fn default() -> Self {
+        Self {
+            tz: "UTC".to_string(),
+            sntp_servers: vec!["pool.ntp.org".to_string()],
+        }
+    }
+}
+
+/// Parse + validate a RON document into a [`Config`].
+///
+/// # Errors
+///
+/// Returns [`ConfigError::Parse`] on malformed RON, or one of the
+/// validation variants ([`ConfigError::EmptySsid`],
+/// [`ConfigError::InvalidCountry`], [`ConfigError::InvalidHostname`],
+/// [`ConfigError::NoSntpServers`]) on out-of-range values.
+pub fn parse_ron(input: &str) -> Result<Config, ConfigError> {
+    let config: Config = ron::from_str(input)?;
+    validate(&config)?;
+    Ok(config)
+}
+
+/// Render a [`Config`] back to a pretty-printed RON string.
+///
+/// Used by `PUT /settings` to persist user changes back to SD, and
+/// by `GET /settings` to expose the current state.
+///
+/// # Errors
+///
+/// Returns [`ConfigError::Serialize`] on serializer failure. Should
+/// not happen with a well-formed [`Config`].
+pub fn render_ron(config: &Config) -> Result<String, ConfigError> {
+    let pretty = ron::ser::PrettyConfig::new();
+    ron::ser::to_string_pretty(config, pretty).map_err(ConfigError::Serialize)
+}
+
+/// Run the v1 schema validators against a parsed [`Config`]. Public
+/// entry is via [`parse_ron`]; this fn is the post-deserialize gate.
+fn validate(config: &Config) -> Result<(), ConfigError> {
+    // SSID: empty *file value* is rejected. `Config::default()` uses
+    // an empty SSID as a sentinel for "no wifi configured" and never
+    // routes through this validator.
+    if config.wifi.ssid.trim().is_empty() {
+        return Err(ConfigError::EmptySsid);
+    }
+    if !is_valid_country(&config.wifi.country) {
+        return Err(ConfigError::InvalidCountry(config.wifi.country.clone()));
+    }
+    if !is_valid_hostname(&config.mdns.hostname) {
+        return Err(ConfigError::InvalidHostname(config.mdns.hostname.clone()));
+    }
+    if config.time.sntp_servers.is_empty() {
+        return Err(ConfigError::NoSntpServers);
+    }
+    Ok(())
+}
+
+/// True iff `s` is exactly two ASCII letters (ISO-3166 alpha-2).
+fn is_valid_country(s: &str) -> bool {
+    s.len() == 2 && s.bytes().all(|b| b.is_ascii_alphabetic())
+}
+
+/// True iff `s` is an RFC-952 subset hostname: ASCII letters / digits
+/// / hyphens, must start with a letter, must not end with a hyphen,
+/// length 1-63.
+fn is_valid_hostname(s: &str) -> bool {
+    // RFC-952 subset: 1-63 chars; ASCII alphanumerics + hyphen; must
+    // start with a letter; must not end with a hyphen.
+    if s.is_empty() || s.len() > 63 {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    if !bytes[0].is_ascii_alphabetic() {
+        return false;
+    }
+    if bytes[bytes.len() - 1] == b'-' {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|&b| b.is_ascii_alphanumeric() || b == b'-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_offline_first() {
+        let c = Config::default();
+        assert!(c.wifi.ssid.is_empty(), "empty SSID = no Wi-Fi attempt");
+        assert_eq!(c.wifi.country, "US");
+        assert_eq!(c.mdns.hostname, "stackchan");
+        assert_eq!(c.time.tz, "UTC");
+        assert_eq!(c.time.sntp_servers, vec!["pool.ntp.org".to_string()]);
+    }
+
+    #[test]
+    fn validates_country_length() {
+        assert!(is_valid_country("US"));
+        assert!(is_valid_country("JP"));
+        assert!(!is_valid_country("USA"));
+        assert!(!is_valid_country("U"));
+        assert!(!is_valid_country("U1"));
+        assert!(!is_valid_country(""));
+    }
+
+    #[test]
+    fn validates_hostname_rfc952_subset() {
+        assert!(is_valid_hostname("stackchan"));
+        assert!(is_valid_hostname("stackchan-01"));
+        assert!(is_valid_hostname("a"));
+        // Too long.
+        assert!(!is_valid_hostname(&"a".repeat(64)));
+        // Empty.
+        assert!(!is_valid_hostname(""));
+        // Starts with digit.
+        assert!(!is_valid_hostname("1stackchan"));
+        // Starts with hyphen.
+        assert!(!is_valid_hostname("-stackchan"));
+        // Ends with hyphen.
+        assert!(!is_valid_hostname("stackchan-"));
+        // Underscore not allowed in RFC-952.
+        assert!(!is_valid_hostname("stack_chan"));
+    }
+}

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -105,7 +105,19 @@ pub fn parse_ron(input: &str) -> Result<Config, ConfigError> {
 /// Render a [`Config`] back to a pretty-printed RON string.
 ///
 /// Used by `PUT /settings` to persist user changes back to SD, and
-/// by `GET /settings` to expose the current state.
+/// internally by the firmware's snapshot path. **Not directly safe
+/// for `GET /settings`** — see Security below.
+///
+/// # Security
+///
+/// This serializer faithfully renders every field, including
+/// `wifi.psk`. The v1 HTTP control plane is LAN-scoped and unauthed,
+/// so a `GET /settings` handler that returns this verbatim would
+/// leak the WPA2 PSK to any host on the LAN. The HTTP layer in PR #5
+/// must redact the PSK on the read path (separate read/write DTOs,
+/// or a masked-render variant) before the endpoint ships. The
+/// `parse_ron` ↔ `render_ron` round trip is preserved here so SD
+/// reads/writes stay lossless.
 ///
 /// # Errors
 ///
@@ -134,12 +146,24 @@ fn validate(config: &Config) -> Result<(), ConfigError> {
     if config.time.sntp_servers.is_empty() {
         return Err(ConfigError::NoSntpServers);
     }
+    if let Some(idx) = config
+        .time
+        .sntp_servers
+        .iter()
+        .position(|s| s.trim().is_empty())
+    {
+        return Err(ConfigError::EmptySntpServer(idx));
+    }
     Ok(())
 }
 
-/// True iff `s` is exactly two ASCII letters (ISO-3166 alpha-2).
+/// True iff `s` is exactly two uppercase ASCII letters (ISO-3166
+/// alpha-2). esp-wifi's regulatory-domain API expects the canonical
+/// uppercase form (`"US"`, `"JP"`); a lowercase value would silently
+/// pass an alphabetic check and then mis-apply the channel/TX mask
+/// at the driver layer, so the validator pins the case here.
 fn is_valid_country(s: &str) -> bool {
-    s.len() == 2 && s.bytes().all(|b| b.is_ascii_alphabetic())
+    s.len() == 2 && s.bytes().all(|b| b.is_ascii_uppercase())
 }
 
 /// True iff `s` is an RFC-952 subset hostname: ASCII letters / digits
@@ -178,13 +202,23 @@ mod tests {
     }
 
     #[test]
-    fn validates_country_length() {
+    fn validates_country_length_and_case() {
+        // Canonical ISO-3166 alpha-2.
         assert!(is_valid_country("US"));
         assert!(is_valid_country("JP"));
+        // Length wrong.
         assert!(!is_valid_country("USA"));
         assert!(!is_valid_country("U"));
-        assert!(!is_valid_country("U1"));
         assert!(!is_valid_country(""));
+        // Non-letter content.
+        assert!(!is_valid_country("U1"));
+        // Lowercase rejected — esp-wifi expects uppercase, and a
+        // case-insensitive validator would silently pass through to
+        // the wrong regulatory mask.
+        assert!(!is_valid_country("us"));
+        assert!(!is_valid_country("jp"));
+        // Mixed case rejected too.
+        assert!(!is_valid_country("Us"));
     }
 
     #[test]

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -34,10 +34,12 @@ pub enum ConfigError {
     #[error("wifi.ssid is empty or whitespace-only")]
     EmptySsid,
 
-    /// `wifi.country` was not exactly two ASCII letters. ESP-WIFI
-    /// expects an ISO-3166 alpha-2 country code (e.g. `"US"`, `"JP"`)
-    /// to set channel availability and TX power per regulatory domain.
-    #[error("wifi.country must be exactly two ASCII letters; got {0:?}")]
+    /// `wifi.country` was not exactly two **uppercase** ASCII letters.
+    /// ESP-WIFI expects an ISO-3166 alpha-2 country code in canonical
+    /// case (e.g. `"US"`, `"JP"`) to set channel availability and TX
+    /// power per regulatory domain; lowercase silently mis-applies the
+    /// regulatory mask at the driver layer.
+    #[error("wifi.country must be exactly two uppercase ASCII letters (e.g. \"US\"); got {0:?}")]
     InvalidCountry(String),
 
     /// `mdns.hostname` failed RFC-952 subset: ASCII letters / digits /

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -1,0 +1,49 @@
+//! Error types for RON config parsing and validation.
+
+use alloc::string::String;
+
+/// Parse / validate failure for [`crate::Config`] round-trips.
+///
+/// Variants carry the offending value where it aids debugging — the
+/// firmware logs these via `defmt::Debug2Format`, and the catalog at
+/// `docs/errors.md` mirrors the same per-variant guidance.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// RON deserialize failure — syntax error, missing field, or
+    /// type mismatch. The wrapped [`ron::error::SpannedError`] carries
+    /// `(line, col)` so callers can surface a precise diagnostic.
+    #[error("RON parse error: {0}")]
+    Parse(#[from] ron::error::SpannedError),
+
+    /// RON serialize failure on round-trip. Should not happen with a
+    /// well-formed [`crate::Config`]; treat as a bug if observed.
+    #[error("RON serialize error: {0}")]
+    Serialize(#[from] ron::Error),
+
+    /// `wifi.ssid` was empty or whitespace-only after trim. The
+    /// firmware treats an empty SSID as "no Wi-Fi configured" via
+    /// `WifiConfig::default`, but an explicitly-blank value in the
+    /// file is almost always a mistake.
+    #[error("wifi.ssid is empty or whitespace-only")]
+    EmptySsid,
+
+    /// `wifi.country` was not exactly two ASCII letters. ESP-WIFI
+    /// expects an ISO-3166 alpha-2 country code (e.g. `"US"`, `"JP"`)
+    /// to set channel availability and TX power per regulatory domain.
+    #[error("wifi.country must be exactly two ASCII letters; got {0:?}")]
+    InvalidCountry(String),
+
+    /// `mdns.hostname` failed RFC-952 subset: ASCII letters / digits /
+    /// hyphens, must start with a letter, must not end with a hyphen,
+    /// length 1-63. The hostname is advertised on `.local` so a
+    /// malformed value would never resolve.
+    #[error("mdns.hostname is not a valid RFC-952 label: {0:?}")]
+    InvalidHostname(String),
+
+    /// `time.sntp_servers` was empty. The firmware needs at least one
+    /// candidate to attempt SNTP; an empty list would mean the RTC
+    /// never advances past whatever the backup battery preserved.
+    #[error("time.sntp_servers must contain at least one entry")]
+    NoSntpServers,
+}

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -18,8 +18,14 @@ pub enum ConfigError {
 
     /// RON serialize failure on round-trip. Should not happen with a
     /// well-formed [`crate::Config`]; treat as a bug if observed.
+    ///
+    /// No `#[from]` on this variant: `ron::Error` is also the inner
+    /// error code embedded in [`ron::error::SpannedError`] (the parse
+    /// path), so an automatic `From<ron::Error>` would silently tag
+    /// any deserialize-side error as a serialize one. Callers map
+    /// explicitly via `Result::map_err`.
     #[error("RON serialize error: {0}")]
-    Serialize(#[from] ron::Error),
+    Serialize(ron::Error),
 
     /// `wifi.ssid` was empty or whitespace-only after trim. The
     /// firmware treats an empty SSID as "no Wi-Fi configured" via
@@ -46,4 +52,12 @@ pub enum ConfigError {
     /// never advances past whatever the backup battery preserved.
     #[error("time.sntp_servers must contain at least one entry")]
     NoSntpServers,
+
+    /// A `time.sntp_servers` entry was empty or whitespace-only.
+    /// Caught at parse time so the firmware's "try in order" loop
+    /// doesn't burn its full per-server timeout on an unresolvable
+    /// hostname before falling back. The `usize` carries the offending
+    /// index in the original list.
+    #[error("time.sntp_servers[{0}] is empty or whitespace-only")]
+    EmptySntpServer(usize),
 }

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -1,0 +1,45 @@
+//! # stackchan-net
+//!
+//! Networking domain types for the Stack-chan firmware. Pure data
+//! and parsers — no transport, no I/O, no esp-hal. The firmware does
+//! the I/O wrapping; this crate is what the firmware (and host tests)
+//! agree on as the shape of the on-disk config and the RON file
+//! [`PUT /settings`] round-trips.
+//!
+//! ## Schema v1
+//!
+//! ```ron
+//! (
+//!     wifi: ( ssid: "home", psk: "redacted", country: "US" ),
+//!     mdns: ( hostname: "stackchan" ),
+//!     time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+//! )
+//! ```
+//!
+//! - [`WifiConfig`] — credentials + regulatory country code (default `"US"`).
+//! - [`MdnsConfig`] — hostname advertised on `.local` (default `"stackchan"`).
+//! - [`TimeConfig`] — timezone label + SNTP servers (default `"UTC"`,
+//!   `["pool.ntp.org"]`). The TZ field is parsed but currently unused;
+//!   the BM8563 RTC stores UTC.
+//!
+//! ## Offline-first stance
+//!
+//! The avatar must boot fully and animate even with no SD card and
+//! no Wi-Fi. The firmware therefore treats this crate's [`Config`]
+//! as **always available**: missing SD or missing file falls back to
+//! [`Config::default`]. The validators in [`parse_ron`] reject
+//! malformed input, but the firmware never propagates a
+//! [`ConfigError`] up to a panic — it logs and uses defaults.
+//!
+//! [`PUT /settings`]: # "see crates/stackchan-firmware/src/net/http.rs once it lands"
+
+#![cfg_attr(not(test), no_std)]
+#![deny(unsafe_code)]
+
+extern crate alloc;
+
+pub mod config;
+pub mod error;
+
+pub use config::{Config, MdnsConfig, TimeConfig, WifiConfig, parse_ron, render_ron};
+pub use error::ConfigError;

--- a/crates/stackchan-net/tests/fixtures/bad-country.ron
+++ b/crates/stackchan-net/tests/fixtures/bad-country.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "USA",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org"],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/bad-hostname.ron
+++ b/crates/stackchan-net/tests/fixtures/bad-hostname.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "US",
+    ),
+    mdns: (
+        hostname: "stack_chan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org"],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/empty-sntp-entry.ron
+++ b/crates/stackchan-net/tests/fixtures/empty-sntp-entry.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "US",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org", "   "],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/empty-ssid.ron
+++ b/crates/stackchan-net/tests/fixtures/empty-ssid.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "",
+        psk: "redacted",
+        country: "US",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org"],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/full.ron
+++ b/crates/stackchan-net/tests/fixtures/full.ron
@@ -1,0 +1,20 @@
+// Full fixture exercising every field with non-default values.
+// Used to confirm the round-trip preserves SNTP server ordering.
+(
+    wifi: (
+        ssid: "andy-iot",
+        psk: "supersecret123",
+        country: "JP",
+    ),
+    mdns: (
+        hostname: "kai-stackchan-01",
+    ),
+    time: (
+        tz: "America/Los_Angeles",
+        sntp_servers: [
+            "time.nist.gov",
+            "time.cloudflare.com",
+            "pool.ntp.org",
+        ],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/lowercase-country.ron
+++ b/crates/stackchan-net/tests/fixtures/lowercase-country.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "us",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org"],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/minimal.ron
+++ b/crates/stackchan-net/tests/fixtures/minimal.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "US",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org"],
+    ),
+)

--- a/crates/stackchan-net/tests/fixtures/no-sntp-servers.ron
+++ b/crates/stackchan-net/tests/fixtures/no-sntp-servers.ron
@@ -1,0 +1,14 @@
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "US",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: [],
+    ),
+)

--- a/crates/stackchan-net/tests/golden_config.rs
+++ b/crates/stackchan-net/tests/golden_config.rs
@@ -1,0 +1,103 @@
+//! Host-side integration tests for the RON config schema v1.
+//!
+//! Layout mirrors `stackchan-sim`'s `tests/` dir convention. Fixtures
+//! under `tests/fixtures/` are `include_str!`'d so the binary owns
+//! them — a missing file fails the build, not the test.
+
+#![allow(clippy::unwrap_used, clippy::panic, missing_docs)]
+
+use stackchan_net::{Config, ConfigError, parse_ron, render_ron};
+
+const MINIMAL_RON: &str = include_str!("fixtures/minimal.ron");
+const FULL_RON: &str = include_str!("fixtures/full.ron");
+const EMPTY_SSID_RON: &str = include_str!("fixtures/empty-ssid.ron");
+const BAD_COUNTRY_RON: &str = include_str!("fixtures/bad-country.ron");
+const BAD_HOSTNAME_RON: &str = include_str!("fixtures/bad-hostname.ron");
+const NO_SNTP_SERVERS_RON: &str = include_str!("fixtures/no-sntp-servers.ron");
+
+#[test]
+fn parses_minimal_fixture() {
+    let cfg = parse_ron(MINIMAL_RON).unwrap();
+    assert_eq!(cfg.wifi.ssid, "home");
+    assert_eq!(cfg.wifi.psk, "redacted");
+    assert_eq!(cfg.wifi.country, "US");
+    assert_eq!(cfg.mdns.hostname, "stackchan");
+    assert_eq!(cfg.time.tz, "UTC");
+    assert_eq!(cfg.time.sntp_servers, vec!["pool.ntp.org".to_string()]);
+}
+
+#[test]
+fn parses_full_fixture() {
+    let cfg = parse_ron(FULL_RON).unwrap();
+    assert_eq!(cfg.wifi.ssid, "andy-iot");
+    assert_eq!(cfg.wifi.country, "JP");
+    assert_eq!(cfg.mdns.hostname, "kai-stackchan-01");
+    assert_eq!(cfg.time.tz, "America/Los_Angeles");
+    // SNTP server ordering must be preserved end-to-end so the
+    // firmware's "try in order" loop hits the user's preferred
+    // servers first.
+    assert_eq!(
+        cfg.time.sntp_servers,
+        vec![
+            "time.nist.gov".to_string(),
+            "time.cloudflare.com".to_string(),
+            "pool.ntp.org".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn roundtrip_preserves_values() {
+    let original = parse_ron(FULL_RON).unwrap();
+    let rendered = render_ron(&original).unwrap();
+    let reparsed = parse_ron(&rendered).unwrap();
+    assert_eq!(original, reparsed);
+}
+
+#[test]
+fn default_config_does_not_validate_through_parse_ron() {
+    // Defaults have an empty SSID — they're the firmware fallback for
+    // "no SD / no config", not a thing you'd ever write to disk and
+    // re-parse. Confirm: rendering and reparsing the default fails
+    // the validator with `EmptySsid`.
+    let default = Config::default();
+    let rendered = render_ron(&default).unwrap();
+    let err = parse_ron(&rendered).unwrap_err();
+    assert!(matches!(err, ConfigError::EmptySsid), "got {err:?}");
+}
+
+#[test]
+fn rejects_empty_ssid() {
+    let err = parse_ron(EMPTY_SSID_RON).unwrap_err();
+    assert!(matches!(err, ConfigError::EmptySsid), "got {err:?}");
+}
+
+#[test]
+fn rejects_bad_country() {
+    let err = parse_ron(BAD_COUNTRY_RON).unwrap_err();
+    match err {
+        ConfigError::InvalidCountry(c) => assert_eq!(c, "USA"),
+        other => panic!("expected InvalidCountry, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_bad_hostname() {
+    let err = parse_ron(BAD_HOSTNAME_RON).unwrap_err();
+    match err {
+        ConfigError::InvalidHostname(h) => assert_eq!(h, "stack_chan"),
+        other => panic!("expected InvalidHostname, got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_empty_sntp_servers() {
+    let err = parse_ron(NO_SNTP_SERVERS_RON).unwrap_err();
+    assert!(matches!(err, ConfigError::NoSntpServers), "got {err:?}");
+}
+
+#[test]
+fn rejects_malformed_ron() {
+    let err = parse_ron("not valid ron at all").unwrap_err();
+    assert!(matches!(err, ConfigError::Parse(_)), "got {err:?}");
+}

--- a/crates/stackchan-net/tests/golden_config.rs
+++ b/crates/stackchan-net/tests/golden_config.rs
@@ -14,6 +14,8 @@ const EMPTY_SSID_RON: &str = include_str!("fixtures/empty-ssid.ron");
 const BAD_COUNTRY_RON: &str = include_str!("fixtures/bad-country.ron");
 const BAD_HOSTNAME_RON: &str = include_str!("fixtures/bad-hostname.ron");
 const NO_SNTP_SERVERS_RON: &str = include_str!("fixtures/no-sntp-servers.ron");
+const EMPTY_SNTP_ENTRY_RON: &str = include_str!("fixtures/empty-sntp-entry.ron");
+const LOWERCASE_COUNTRY_RON: &str = include_str!("fixtures/lowercase-country.ron");
 
 #[test]
 fn parses_minimal_fixture() {
@@ -94,6 +96,26 @@ fn rejects_bad_hostname() {
 fn rejects_empty_sntp_servers() {
     let err = parse_ron(NO_SNTP_SERVERS_RON).unwrap_err();
     assert!(matches!(err, ConfigError::NoSntpServers), "got {err:?}");
+}
+
+#[test]
+fn rejects_empty_sntp_entry() {
+    let err = parse_ron(EMPTY_SNTP_ENTRY_RON).unwrap_err();
+    match err {
+        // Index 1 — first entry is "pool.ntp.org" (valid), second is
+        // whitespace-only, so the validator fires on index 1.
+        ConfigError::EmptySntpServer(idx) => assert_eq!(idx, 1),
+        other => panic!("expected EmptySntpServer(1), got {other:?}"),
+    }
+}
+
+#[test]
+fn rejects_lowercase_country() {
+    let err = parse_ron(LOWERCASE_COUNTRY_RON).unwrap_err();
+    match err {
+        ConfigError::InvalidCountry(c) => assert_eq!(c, "us"),
+        other => panic!("expected InvalidCountry, got {other:?}"),
+    }
 }
 
 #[test]

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -101,6 +101,15 @@ Half-duplex serial servo bus.
 ### `ir-nec`
 No `Error` enum — decoder returns `Option<NecCommand>` and treats noise as "no decode" rather than an error.
 
+### `stackchan_net::ConfigError`
+RON config parse + validation. Host crate; firmware wraps with `Debug2Format` for `defmt` logging. Validators only fire through `parse_ron` — the firmware's `Config::default()` fallback path never trips them.
+- `Parse(SpannedError)` — RON syntax error / missing field / type mismatch. Inner value carries `(line, col)`.
+- `Serialize(ron::Error)` — RON round-trip failure on `render_ron`. Should not happen with well-formed `Config`; treat as a bug.
+- `EmptySsid` — `wifi.ssid` empty / whitespace-only on disk. Default `WifiConfig` has an empty SSID by design (the offline-first sentinel), but explicit blanks in a written file are almost always mistakes.
+- `InvalidCountry(String)` — `wifi.country` not exactly two ASCII letters. ESP-WIFI expects ISO-3166 alpha-2.
+- `InvalidHostname(String)` — `mdns.hostname` failed RFC-952 subset (alphanumerics + hyphen, must start with letter, no trailing hyphen, length 1-63).
+- `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
+
 ## Firmware-side error wrapping
 
 `stackchan-firmware` does not introduce its own typed-error enum. Init

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -106,9 +106,10 @@ RON config parse + validation. Host crate; firmware wraps with `Debug2Format` fo
 - `Parse(SpannedError)` — RON syntax error / missing field / type mismatch. Inner value carries `(line, col)`.
 - `Serialize(ron::Error)` — RON round-trip failure on `render_ron`. Should not happen with well-formed `Config`; treat as a bug.
 - `EmptySsid` — `wifi.ssid` empty / whitespace-only on disk. Default `WifiConfig` has an empty SSID by design (the offline-first sentinel), but explicit blanks in a written file are almost always mistakes.
-- `InvalidCountry(String)` — `wifi.country` not exactly two ASCII letters. ESP-WIFI expects ISO-3166 alpha-2.
+- `InvalidCountry(String)` — `wifi.country` not exactly two **uppercase** ASCII letters. esp-wifi expects ISO-3166 alpha-2 in canonical case (`"US"`, `"JP"`); lowercase silently mis-applies the regulatory mask at the driver layer, so the validator pins the case here.
 - `InvalidHostname(String)` — `mdns.hostname` failed RFC-952 subset (alphanumerics + hyphen, must start with letter, no trailing hyphen, length 1-63).
 - `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
+- `EmptySntpServer(usize)` — a `time.sntp_servers` entry was empty / whitespace-only. The `usize` carries the offending index. Caught at parse time so the firmware's "try in order" loop doesn't burn its full per-server timeout on an unresolvable hostname before falling back.
 
 ## Firmware-side error wrapping
 


### PR DESCRIPTION
## Summary

- New `crates/stackchan-net/` — pure host-testable, `no_std + alloc`, modeled on `stackchan-tts`. Single workspace crate dep (none — depends only on `serde` / `ron` / `thiserror`).
- Schema v1 is intentionally minimal: `wifi { ssid, psk, country }`, `mdns { hostname }`, `time { tz, sntp_servers }`. Firmware-side state (avatar geometry, modifier params, etc.) stays hardcoded for now.
- `parse_ron` / `render_ron` cover the round-trip surface that `PUT /settings` and `GET /settings` will rely on in PR #5.
- `Config::default()` is tuned for offline-first: empty SSID = "no Wi-Fi configured" sentinel, hostname `"stackchan"`, country `"US"` (esp-wifi regulatory domain), SNTP `pool.ntp.org`.

This is PR #1 of a stacked 6-PR networking foundation. PR #2 brings up SD via SPI3, PR #3 adds esp-wifi join, then PR #4-#6 fan out into SNTP, HTTP control plane, mDNS. The full plan and decision sheet (24 strategic choices) lives in the orchestrator's plan file.

## Why this shape

Every Stack-chan fork in the wider ecosystem (canonical Moddable JS, AI_StackChan2, hrs, AI_StackChan_Ex, m5stack official factory firmware) builds the same network substrate before plugging in any AI/voice/companion-app stack. Landing the substrate cleanly in Rust idioms — RON config, picoserve, embassy tasks, typed errors — keeps the option open for any future AI pipeline without committing to a specific provider, and avoids the trap the AI_StackChan2 / hrs forks hit where the AI code and the network code are tangled into one Arduino sketch.

`stackchan-net` will be the first crate in the workspace to depend on `serde`/`ron`. Both are MSRV-1.56 / 1.64 — well below the workspace `rust-version = "1.88"`. `cargo-deny` is happy (Apache-2.0 / MIT licenses across the new tree).

`thiserror 2` carries no `defmt::Format` — that's deliberate. The firmware will wrap `ConfigError` with `defmt::Debug2Format` rather than this host crate carrying a firmware-side log transport.

## Test plan

- [x] `cargo test -p stackchan-net` — 12 tests pass (3 inline unit tests + 9 integration tests against hand-written RON fixtures).
- [x] `just check` — fmt + workspace clippy (`pedantic` + `nursery` + `missing_docs warn` + `unwrap/expect/panic warn`) + host tests, all green.
- [x] `just ci` — adds `cargo deny check` + `RUSTDOCFLAGS="-D warnings" cargo doc`, all green.
- [x] `just msrv` — Rust 1.88 build of the workspace host crates, green.
- [x] Pre-commit hook passes (fmt + clippy + test + doctest + workspace check + Cargo.lock drift guard).

Test coverage:
- Parse + assert minimal fixture (every field).
- Parse + assert full fixture (SNTP server ordering preserved).
- Round-trip: `parse_ron(render_ron(c))? == c`.
- Reject empty SSID, non-alpha-2 country code, RFC-952 hostname violations, empty SNTP server list, malformed RON.
- Confirm `Config::default()` does **not** validate through `parse_ron` (the empty-SSID sentinel is firmware-only).

## Risks

The plan flagged `ron 0.10` `no_std + alloc` compatibility as the main spike. The crate exposes `default-features = false` and the `alloc` support is implicit (not a named feature). Verified locally: compiles + tests pass, transitive `serde` resolves to a `no_std + alloc + derive` configuration.

## Out of scope (named, deferred to later PRs)

- SD-card SPI bring-up + boot config load → PR #2
- Wi-Fi station join + offline-first retry → PR #3
- SNTP → BM8563 RTC sync → PR #4
- HTTP control plane (`/health`, `/state`, `POST /pose`, `GET/PUT /settings`) → PR #5
- mDNS hostname-only advertisement → PR #6
- AI tier (LLM, persona, STT, cloud TTS, MCP) — explicitly deferred entirely.