### PR TITLE
refactor(firmware): park SPI2 in a static RefCell for shared-bus access

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -31,6 +31,7 @@ use stackchan_firmware::{
 
 use board::{HeadDriverImpl, SharedI2c};
 use clock::HalClock;
+use core::cell::RefCell;
 use core::num::NonZeroU32;
 use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
@@ -42,7 +43,13 @@ use embedded_graphics::{
     pixelcolor::raw::RawU16,
     primitives::Rectangle,
 };
-use embedded_hal_bus::spi::ExclusiveDevice;
+// `RefCellDevice` shares the SPI2 bus between the LCD (always-on, every
+// render tick) and a future SD-card client (boot-time read + occasional
+// `PUT /settings` write). Single-core embassy + cooperative scheduling
+// means the `RefCell` borrow held during a blocking SPI transaction
+// can't be re-entered — task switches only happen at `.await` points,
+// and SPI transactions are entirely synchronous.
+use embedded_hal_bus::spi::RefCellDevice;
 use esp_hal::{
     Blocking,
     clock::CpuClock,
@@ -133,7 +140,7 @@ const HEAD_PERIOD_MS: u64 = 20;
 type LcdDisplay = mipidsi::Display<
     SpiInterface<
         'static,
-        ExclusiveDevice<Spi<'static, Blocking>, Output<'static>, Delay>,
+        RefCellDevice<'static, Spi<'static, Blocking>, Output<'static>, Delay>,
         Output<'static>,
     >,
     ILI9342CRgb565,
@@ -766,9 +773,19 @@ async fn main(spawner: Spawner) -> ! {
     let cs = Output::new(peripherals.GPIO3, Level::High, OutputConfig::default());
     let dc = Output::new(peripherals.GPIO35, Level::Low, OutputConfig::default());
 
-    let spi_device = match ExclusiveDevice::new(spi_bus, cs, Delay) {
+    // SPI2 is shared territory on CoreS3: the LCD owns it today, and the
+    // SD card slot is wired to the same bus (sharing SCK=GPIO36 +
+    // MOSI=GPIO37 with the LCD; SD MISO sits on GPIO35 — the same
+    // physical pin as LCD DC). Park the bus in a `'static RefCell` so
+    // future SD bring-up can register a second `RefCellDevice` against
+    // the same bus without re-plumbing the LCD path.
+    #[allow(clippy::items_after_statements)]
+    static SPI2_BUS: StaticCell<RefCell<Spi<'static, Blocking>>> = StaticCell::new();
+    let spi_bus = SPI2_BUS.init(RefCell::new(spi_bus));
+
+    let spi_device = match RefCellDevice::new(spi_bus, cs, Delay) {
         Ok(dev) => dev,
-        Err(e) => defmt::panic!("ExclusiveDevice init failed: {}", defmt::Debug2Format(&e)),
+        Err(e) => defmt::panic!("RefCellDevice init failed: {}", defmt::Debug2Format(&e)),
     };
 
     // mipidsi's `SpiInterface` batches pixel writes through a caller-owned


### PR DESCRIPTION
## Summary

Structural prerequisite for adding the SD card. CoreS3 wires SD SCK/MOSI to the same GPIO36/37 the LCD uses, so the SPI2 bus has to be shareable before SD can mount at all. This PR moves the LCD off `ExclusiveDevice<Spi<Blocking>, ...>` onto `RefCellDevice<'static, Spi<Blocking>, ...>` parked behind a `StaticCell<RefCell<Spi>>`. No behavior change — same peripheral, same pins, same construction path.

The `RefCell` borrow is held for the duration of one blocking SPI transaction, and single-core embassy + cooperative scheduling means no other task runs until that transaction ends — so the borrow can't be re-entered. Confirmed by the existing `#![allow(clippy::future_not_send)]` at `main.rs:23`.

## Why this shape (rather than async)

`mipidsi 0.10` is blocking-only — its `SpiInterface` requires `embedded_hal::spi::SpiDevice`, not the async variant. SD operations on this firmware happen at boot (read config) and during `PUT /settings` (write config) — never during steady-state render. Keeping SPI blocking means:

- LCD path stays unchanged.
- Upcoming SD client uses upstream `embedded-sdmmc 0.8` (sync) — no git fork needed.
- Mutex contention is bounded: SD reads block render at boot (before render task starts) and during HTTP PUT (user-facing latency, not visual flicker).

## Why GPIO35 sharing matters for the next PR

CoreS3 also wires SD MISO to **GPIO35** — the same physical pin as LCD DC. M5GFX handles this in C++ by toggling `GPIO_ENABLE1_W1TS_REG` / `W1TC_REG` per CS edge (LCD CS LOW → OE on, drive DC; SD CS LOW → OE off, MISO works). The follow-up PR brings up that OE-flip pattern in a custom `SpiDevice` wrapper for the SD client. The LCD's `RefCellDevice` doesn't need to change again — it just shares the bus.

## Test plan

- [x] `just check-firmware` — clean.
- [x] `just clippy-firmware` — strict clippy clean.
- [x] `just build-firmware` — release link clean.
- [ ] `just fmr-agent` + visual confirmation the LCD still draws the avatar (currently blocked: bench unit went into AXP2101-shutdown — needs side-button wake).

## Out of scope

- SD-card client + GPIO35 OE flip → next PR (`feat/firmware-sd-card`)
- `storage.rs` + `stackchan_net::Config` boot read → same PR
- Wi-Fi / SNTP / HTTP / mDNS → PRs #3-#6

Stacked on `main`. Independent of #134 (that PR is the host-side `stackchan-net` crate; this is a pure firmware refactor).