### PR TITLE
feat(net): bare RON parser + GPIO35 OE-flip SD-SPI adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,6 +4188,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-graphics",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-bus",
  "embedded-io-async 0.7.0",
@@ -4208,6 +4209,7 @@ dependencies = [
  "scservo",
  "si12t",
  "stackchan-core",
+ "stackchan-net",
  "stackchan-tts",
  "static_cell",
  "tracker",
@@ -4215,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "stackchan-net"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ron",
  "serde",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -32,11 +32,22 @@ tracker = { path = "../tracker" }
 # `BakedBackend` (sine-cycle SFX + future verbal PCM) and the
 # `AudioSource` trait the audio task's TX feeder pulls samples through.
 stackchan-tts = { path = "../stackchan-tts" }
+# Networking domain types + RON config schema. Bare data types only:
+# `default-features = false` skips the `parse` feature (which would
+# pull `ron 0.10` + `serde/std` and break the firmware target build,
+# since `xtensa-esp32s3-none-elf` has no std). Firmware does its own
+# hand-rolled RON parsing in `storage.rs`, then runs the same
+# `stackchan_net::validate` gate the host parser uses.
+stackchan-net = { path = "../stackchan-net", default-features = false }
 # `heapless::Vec` for the per-frame multi-target candidate list
 # translated from `tracker::Outcome.candidates` into the engine's
 # `TrackingObservation`. Matches the cap (`MAX_CANDIDATES`).
 heapless = "0.8"
 embedded-graphics = { workspace = true }
+# `embedded_hal::spi::SpiDevice` (sync) is what `embedded-sdmmc 0.8`
+# wants from the SD client wrapper. The async equivalent is also
+# imported below for shared-bus I²C and other tasks.
+embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
 embedded-io-async = { workspace = true }
 # `ExclusiveDevice` wraps the blocking esp-hal `Spi` + a CS pin into the

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -30,6 +30,7 @@ pub mod imu;
 pub mod ir;
 pub mod leds;
 pub mod power;
+pub mod sd_spi;
 pub mod touch;
 pub mod tracking_trace;
 pub mod wallclock;

--- a/crates/stackchan-firmware/src/sd_spi.rs
+++ b/crates/stackchan-firmware/src/sd_spi.rs
@@ -1,0 +1,191 @@
+//! SD-card-side `embedded_hal::spi::SpiDevice` adapter for the shared
+//! SPI2 bus on M5Stack CoreS3.
+//!
+//! ## Why this exists
+//!
+//! CoreS3 wires the SD card MISO line to **GPIO35** — the same physical
+//! pin the LCD uses as DC (Data/Command). The LCD is write-only at the
+//! peripheral level, so it never reads MISO; the SD client is read/write
+//! and needs MISO. M5GFX (Arduino C++) handles this by toggling the
+//! pin's output-enable bit per CS edge:
+//!
+//! - **CS LOW (LCD)** → OE on  → GPIO35 drives DC value (output)
+//! - **CS LOW (SD)**  → OE off → GPIO35 floats; SPI MISO reads it (input)
+//!
+//! The fancier alternative — splitting the pin via `peripheral_input`
+//! / `OutputSignal::connect_to` — relies on `#[doc(hidden)]` esp-hal
+//! 1.0 surfaces (tracked in esp-rs/esp-hal#2876, currently blocked).
+//! A direct register write to `GPIO_ENABLE1_W1TS_REG` /
+//! `GPIO_ENABLE1_W1TC_REG` is what M5GFX actually does and is the
+//! pattern this module follows.
+
+// Direct register access for the GPIO35 OE flip. The unsafe surface is
+// two `core::ptr::write_volatile` calls in `set_dc_drive_*` below, both
+// guarded by:
+//   - the register address comes from the ESP32-S3 TRM (chapter 5,
+//     "GPIO and IO_MUX") and never changes;
+//   - the bit position is statically computed (35 - 32 = 3);
+//   - the W1TS / W1TC pattern is atomic in hardware (single-cycle
+//     bit-set / bit-clear), so no read-modify-write races even across
+//     interrupt context.
+#![allow(unsafe_code)]
+
+use core::cell::RefCell;
+
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::OutputPin;
+use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
+use esp_hal::Blocking;
+use esp_hal::spi::master::Spi;
+
+/// `GPIO_ENABLE1_W1TS_REG` — write `1` to set output-enable bits for
+/// pins 32–48. ESP32-S3 TRM, chapter 5.
+const GPIO_ENABLE1_W1TS_REG: *mut u32 = 0x6000_4030 as *mut u32;
+/// `GPIO_ENABLE1_W1TC_REG` — write `1` to clear output-enable bits.
+const GPIO_ENABLE1_W1TC_REG: *mut u32 = 0x6000_4034 as *mut u32;
+/// Bit position of GPIO35 in the ENABLE1 register (35 − 32 = 3).
+const GPIO35_OE_MASK: u32 = 1 << 3;
+
+/// Enable GPIO35's output driver (LCD DC mode).
+///
+/// Hardware-atomic: W1TS sets only the bits with a `1` in the written
+/// value; other bits are untouched.
+#[inline]
+fn set_gpio35_oe_high() {
+    // SAFETY: address from TRM, bit pattern statically derived,
+    // W1TS register semantics atomic per TRM 5.2.5.
+    unsafe {
+        core::ptr::write_volatile(GPIO_ENABLE1_W1TS_REG, GPIO35_OE_MASK);
+    }
+}
+
+/// Disable GPIO35's output driver (SD MISO mode — pin floats, input
+/// buffer reads externally-driven level).
+#[inline]
+fn set_gpio35_oe_low() {
+    // SAFETY: same as `set_gpio35_oe_high` — atomic W1TC write.
+    unsafe {
+        core::ptr::write_volatile(GPIO_ENABLE1_W1TC_REG, GPIO35_OE_MASK);
+    }
+}
+
+/// `embedded-hal` `SpiDevice` for the SD-card client on the shared SPI2 bus.
+///
+/// Borrows the bus from a `RefCell` and flips GPIO35's OE bit around
+/// each transaction so the SPI peripheral can read MISO while the
+/// LCD's DC pin (the same physical GPIO35) is held floating.
+pub struct SdSpiDevice<'a, CS, D> {
+    /// Shared SPI2 bus (also used by the LCD via its own `RefCellDevice`).
+    bus: &'a RefCell<Spi<'static, Blocking>>,
+    /// SD chip-select line — GPIO4 on CoreS3, active low.
+    cs: CS,
+    /// Inter-byte delay used between bus operations and around CS edges.
+    delay: D,
+}
+
+impl<'a, CS, D> SdSpiDevice<'a, CS, D>
+where
+    CS: OutputPin,
+    D: DelayNs,
+{
+    /// Construct a new SD-side device against the shared SPI2 bus.
+    /// Caller is responsible for keeping `bus` live for at least the
+    /// lifetime of this device.
+    #[must_use]
+    pub const fn new(bus: &'a RefCell<Spi<'static, Blocking>>, cs: CS, delay: D) -> Self {
+        Self { bus, cs, delay }
+    }
+}
+
+/// Error from an SD-side SPI transaction.
+///
+/// Mirrors the variants `embedded_hal_bus::spi::DeviceError` exposes
+/// for `RefCellDevice`, plus the CS-pin error path. Logged via
+/// `defmt::Debug2Format` at the firmware boundary.
+#[derive(Debug, defmt::Format)]
+#[non_exhaustive]
+pub enum SdSpiError {
+    /// SPI bus reported an error (clocking, configuration).
+    Spi,
+    /// CS-pin write failed.
+    Cs,
+}
+
+impl embedded_hal::spi::Error for SdSpiError {
+    fn kind(&self) -> embedded_hal::spi::ErrorKind {
+        embedded_hal::spi::ErrorKind::Other
+    }
+}
+
+impl<CS, D> ErrorType for SdSpiDevice<'_, CS, D>
+where
+    CS: OutputPin,
+    D: DelayNs,
+{
+    type Error = SdSpiError;
+}
+
+impl<CS, D> SpiDevice for SdSpiDevice<'_, CS, D>
+where
+    CS: OutputPin,
+    D: DelayNs,
+{
+    fn transaction(&mut self, operations: &mut [Operation<'_, u8>]) -> Result<(), Self::Error> {
+        // Borrow the shared bus for the entire transaction. Single-core
+        // cooperative scheduling means no other task runs while we hold
+        // this borrow — see the `RefCellDevice` rationale at
+        // `crates/stackchan-firmware/src/main.rs` (LCD path).
+        let mut bus = self.bus.borrow_mut();
+
+        // Switch GPIO35 from "LCD DC output" to "SD MISO input" before
+        // pulling CS low. Pin floats; the SPI peripheral's MISO matrix
+        // signal reads the externally-driven level from the SD card.
+        set_gpio35_oe_low();
+
+        self.cs.set_low().map_err(|_| SdSpiError::Cs)?;
+
+        // Run each operation against the shared bus. We map every
+        // bus-error variant to `SdSpiError::Spi` because the
+        // upstream esp-hal `Error` doesn't carry actionable detail
+        // for this layer; the operator triages through the wider
+        // boot log.
+        let result = (|| -> Result<(), SdSpiError> {
+            for op in operations.iter_mut() {
+                match op {
+                    Operation::Read(buf) => {
+                        bus.read(buf).map_err(|_| SdSpiError::Spi)?;
+                    }
+                    Operation::Write(buf) => {
+                        bus.write(buf).map_err(|_| SdSpiError::Spi)?;
+                    }
+                    Operation::Transfer(read, write) => {
+                        // Disambiguate against esp-hal's inherent `Spi::transfer`
+                        // (single-arg in-place form) — the `embedded-hal` trait
+                        // method takes both buffers.
+                        <Spi<'static, Blocking> as embedded_hal::spi::SpiBus>::transfer(
+                            &mut bus, read, write,
+                        )
+                        .map_err(|_| SdSpiError::Spi)?;
+                    }
+                    Operation::TransferInPlace(buf) => {
+                        bus.transfer_in_place(buf).map_err(|_| SdSpiError::Spi)?;
+                    }
+                    Operation::DelayNs(ns) => {
+                        self.delay.delay_ns(*ns);
+                    }
+                }
+            }
+            Ok(())
+        })();
+
+        // CS high regardless of the result so we don't leave the SD
+        // card selected on a partial failure.
+        let cs_result = self.cs.set_high().map_err(|_| SdSpiError::Cs);
+
+        // Restore GPIO35 to LCD DC output mode before any subsequent
+        // LCD transaction reuses the bus.
+        set_gpio35_oe_high();
+
+        result.and(cs_result)
+    }
+}

--- a/crates/stackchan-net/Cargo.toml
+++ b/crates/stackchan-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-net"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,19 +11,24 @@ readme = "README.md"
 [lints]
 workspace = true
 
+[features]
+# `parse` exposes `parse_ron` / `render_ron` and the serde derives on
+# the data types. Default-on for host builds (sim, tests, future
+# host-side tooling). The firmware crate depends on this without
+# `parse` because `ron 0.10` hard-pins `serde/std` and `base64/std` —
+# both are broken on `xtensa-esp32s3-none-elf`. Firmware-side RON
+# parsing happens in a hand-rolled parser inside `stackchan-firmware`.
+default = ["parse"]
+parse = ["dep:serde", "dep:ron"]
+
 [dependencies]
-# `no_std` serde with derive macros. The `alloc` feature lets `String`
-# / `Vec<T>` participate in the schema — the firmware reads the config
-# off SD into a heap-allocated `String`, then parses through this crate.
-serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-# RON (Rusty Object Notation) — chosen for ergonomic Rust-shaped config
-# (enums, comments, trailing commas). 0.10 is `no_std + alloc`-compatible
-# with `default-features = false` — `alloc` support is implicit, not a
-# named feature. The full `Serialize`/`Deserialize` round trip is what
-# `PUT /settings` and `GET /settings` lean on.
-ron = { version = "0.10", default-features = false }
-# Typed errors without `std`. v2 supports `no_std` natively; firmware
-# wraps with `defmt::Debug2Format` rather than this crate deriving
-# `defmt::Format` — keeps the host crate independent of the firmware
-# log transport.
+# `no_std` serde with derive macros. Optional; only pulled when the
+# `parse` feature is active. Firmware target avoids it because of the
+# transitive `serde/std` requirement upstream of ron.
+serde = { version = "1", default-features = false, features = ["alloc", "derive"], optional = true }
+# RON (Rusty Object Notation). Optional behind `parse`. Same reason
+# as `serde` — host-only.
+ron = { version = "0.10", default-features = false, optional = true }
+# Typed errors without `std`. Always on — not parse-gated. Firmware
+# wraps with `defmt::Debug2Format`.
 thiserror = { version = "2", default-features = false }

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -1,0 +1,500 @@
+//! Hand-rolled RON-subset parser + renderer for [`crate::Config`].
+//!
+//! The default `parse` feature in this crate uses `ron 0.10`, which
+//! pulls `serde/std + base64/std`. Both break on
+//! `xtensa-esp32s3-none-elf` (no std). This module is the firmware's
+//! escape hatch: a tiny RON-subset parser that handles exactly the
+//! schema v1 shape — top-level tuple struct, three nested tuple
+//! structs, string fields, and one `Vec<String>` — and nothing else.
+//!
+//! It's symmetric with [`crate::parse_ron`] / [`crate::render_ron`]:
+//! anything either side renders the other side parses, so SD round
+//! trips and `PUT /settings` bodies stay lossless.
+//!
+//! The parser is deliberately minimal — no expression evaluation,
+//! no enums, no maps, no unsigned/signed/float literals. Any schema
+//! growth beyond v1 must extend this module in lockstep with the
+//! serde derives.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+use crate::error::ConfigError;
+
+/// Parse a schema-v1 RON document into a [`Config`] without using `serde` or `ron`.
+///
+/// The accepted grammar is the exact subset that [`crate::render_ron`]
+/// emits when called with `PrettyConfig::new`, plus some tolerance for
+/// hand-edits (whitespace, line comments, trailing commas).
+///
+/// # Errors
+///
+/// Returns [`ConfigError::BareParse`] on any structural mismatch
+/// (missing field, unexpected token, runaway string), then runs the
+/// shared [`validate`] gate so out-of-range values surface the same
+/// `Invalid*` variants as the host parser.
+pub fn parse_ron_bare(input: &str) -> Result<Config, ConfigError> {
+    let mut p = Parser::new(input);
+    let config = p.parse_config()?;
+    validate(&config)?;
+    Ok(config)
+}
+
+/// Render a [`Config`] to RON. Output matches what
+/// [`crate::render_ron`] (host-side, serde + ron) emits, so a config
+/// written by either side parses cleanly through the other.
+///
+/// # Errors
+///
+/// Currently infallible — kept as `Result` for symmetry with the
+/// host renderer, which can fail under serde edge cases.
+pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
+    let mut out = String::new();
+    out.push_str("(\n");
+    out.push_str("    wifi: (\n");
+    push_field(&mut out, "        ssid", &config.wifi.ssid);
+    push_field(&mut out, "        psk", &config.wifi.psk);
+    push_field(&mut out, "        country", &config.wifi.country);
+    out.push_str("    ),\n");
+
+    out.push_str("    mdns: (\n");
+    push_field(&mut out, "        hostname", &config.mdns.hostname);
+    out.push_str("    ),\n");
+
+    out.push_str("    time: (\n");
+    push_field(&mut out, "        tz", &config.time.tz);
+    out.push_str("        sntp_servers: [\n");
+    for s in &config.time.sntp_servers {
+        out.push_str("            ");
+        push_string_literal(&mut out, s);
+        out.push_str(",\n");
+    }
+    out.push_str("        ],\n");
+    out.push_str("    ),\n");
+
+    out.push_str(")\n");
+    Ok(out)
+}
+
+/// Helper: emit `        name: "value",\n`.
+fn push_field(out: &mut String, indented_name: &str, value: &str) {
+    out.push_str(indented_name);
+    out.push_str(": ");
+    push_string_literal(out, value);
+    out.push_str(",\n");
+}
+
+/// Helper: emit a quoted RON string with `\\` and `\"` escapes.
+fn push_string_literal(out: &mut String, value: &str) {
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+}
+
+/// Recursive-descent parser over a `&str` cursor. Slow but sized for
+/// a config-file workload — schema v1 is well under 1 KiB.
+struct Parser<'a> {
+    /// Remaining input. `advance` slides the start pointer; nothing
+    /// is allocated for tokens.
+    input: &'a str,
+}
+
+impl<'a> Parser<'a> {
+    /// Construct a fresh parser over `input`.
+    const fn new(input: &'a str) -> Self {
+        Self { input }
+    }
+
+    /// Top-level grammar: parse the schema-v1 outer tuple struct.
+    fn parse_config(&mut self) -> Result<Config, ConfigError> {
+        self.skip_ws_and_comments();
+        self.expect_char('(')?;
+        let mut wifi: Option<WifiConfig> = None;
+        let mut mdns: Option<MdnsConfig> = None;
+        let mut time: Option<TimeConfig> = None;
+
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "wifi" => wifi = Some(self.parse_wifi()?),
+                "mdns" => mdns = Some(self.parse_mdns()?),
+                "time" => time = Some(self.parse_time()?),
+                other => return Err(bare_err("unknown top-level field", other)),
+            }
+            self.skip_ws_and_comments();
+            // Trailing comma optional; closing `)` also OK.
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')'", ""));
+            }
+        }
+
+        Ok(Config {
+            wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
+            mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
+            time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
+        })
+    }
+
+    /// Parse the `wifi: (ssid, psk, country)` block.
+    fn parse_wifi(&mut self) -> Result<WifiConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut ssid: Option<String> = None;
+        let mut psk: Option<String> = None;
+        let mut country: Option<String> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            let value = self.parse_string()?;
+            match key {
+                "ssid" => ssid = Some(value),
+                "psk" => psk = Some(value),
+                "country" => country = Some(value),
+                other => return Err(bare_err("unknown wifi field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in wifi", ""));
+            }
+        }
+        Ok(WifiConfig {
+            ssid: ssid.ok_or_else(|| bare_err("missing wifi.ssid", ""))?,
+            psk: psk.ok_or_else(|| bare_err("missing wifi.psk", ""))?,
+            country: country.ok_or_else(|| bare_err("missing wifi.country", ""))?,
+        })
+    }
+
+    /// Parse the `mdns: (hostname)` block.
+    fn parse_mdns(&mut self) -> Result<MdnsConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut hostname: Option<String> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            let value = self.parse_string()?;
+            match key {
+                "hostname" => hostname = Some(value),
+                other => return Err(bare_err("unknown mdns field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in mdns", ""));
+            }
+        }
+        Ok(MdnsConfig {
+            hostname: hostname.ok_or_else(|| bare_err("missing mdns.hostname", ""))?,
+        })
+    }
+
+    /// Parse the `time: (tz, sntp_servers)` block.
+    fn parse_time(&mut self) -> Result<TimeConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut tz: Option<String> = None;
+        let mut sntp_servers: Option<Vec<String>> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "tz" => tz = Some(self.parse_string()?),
+                "sntp_servers" => sntp_servers = Some(self.parse_string_list()?),
+                other => return Err(bare_err("unknown time field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in time", ""));
+            }
+        }
+        Ok(TimeConfig {
+            tz: tz.ok_or_else(|| bare_err("missing time.tz", ""))?,
+            sntp_servers: sntp_servers.ok_or_else(|| bare_err("missing time.sntp_servers", ""))?,
+        })
+    }
+
+    /// Parse `[ "...", "...", ]` into a `Vec<String>`.
+    fn parse_string_list(&mut self) -> Result<Vec<String>, ConfigError> {
+        self.expect_char('[')?;
+        let mut out: Vec<String> = Vec::new();
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(']') {
+                break;
+            }
+            let s = self.parse_string()?;
+            out.push(s);
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(']') {
+                return Err(bare_err("expected ',' or ']' in list", ""));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Parse a `"..."` string literal with `\\` and `\"` escapes.
+    fn parse_string(&mut self) -> Result<String, ConfigError> {
+        self.expect_char('"')?;
+        let mut out = String::new();
+        loop {
+            let Some(ch) = self.peek_char() else {
+                return Err(bare_err("unterminated string literal", ""));
+            };
+            if ch == '"' {
+                self.advance(1);
+                return Ok(out);
+            }
+            if ch == '\\' {
+                self.advance(1);
+                let Some(esc) = self.peek_char() else {
+                    return Err(bare_err("dangling backslash", ""));
+                };
+                match esc {
+                    '\\' => out.push('\\'),
+                    '"' => out.push('"'),
+                    'n' => out.push('\n'),
+                    't' => out.push('\t'),
+                    other => return Err(bare_err("unsupported escape", &other.to_string())),
+                }
+                self.advance(esc.len_utf8());
+            } else {
+                out.push(ch);
+                self.advance(ch.len_utf8());
+            }
+        }
+    }
+
+    /// Read a bare identifier `[a-zA-Z_][a-zA-Z0-9_]*`. Returns a
+    /// borrowed slice into `input` that's valid only until the next
+    /// `advance` past it; callers must `match` on it before
+    /// continuing.
+    fn read_ident(&mut self) -> Result<&'a str, ConfigError> {
+        let bytes = self.input.as_bytes();
+        if bytes.is_empty() {
+            return Err(bare_err("expected identifier, got EOF", ""));
+        }
+        let first = bytes[0];
+        if !(first.is_ascii_alphabetic() || first == b'_') {
+            return Err(bare_err("expected identifier", ""));
+        }
+        let mut end = 1;
+        while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+            end += 1;
+        }
+        let (ident, rest) = self.input.split_at(end);
+        self.input = rest;
+        Ok(ident)
+    }
+
+    /// Skip ASCII whitespace and `// line comments` until a token.
+    fn skip_ws_and_comments(&mut self) {
+        loop {
+            let bytes = self.input.as_bytes();
+            // Skip whitespace.
+            let mut i = 0;
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i > 0 {
+                self.advance(i);
+                continue;
+            }
+            // Try line comment.
+            if self.input.starts_with("//") {
+                let bytes = self.input.as_bytes();
+                let mut j = 2;
+                while j < bytes.len() && bytes[j] != b'\n' {
+                    j += 1;
+                }
+                self.advance(j);
+                continue;
+            }
+            return;
+        }
+    }
+
+    /// Slide the cursor forward `n` bytes. Caller guarantees `n` is
+    /// at a UTF-8 char boundary (we only call this with `len_utf8()`
+    /// or after byte-only matches like `'('`).
+    fn advance(&mut self, n: usize) {
+        self.input = &self.input[n..];
+    }
+
+    /// Peek the next char without consuming.
+    fn peek_char(&self) -> Option<char> {
+        self.input.chars().next()
+    }
+
+    /// True iff the next byte is `c`.
+    fn peek_eq(&self, c: char) -> bool {
+        self.input.as_bytes().first().copied() == Some(c as u8)
+    }
+
+    /// Consume `c` if it's next; otherwise leave the cursor put.
+    fn try_consume_char(&mut self, c: char) -> bool {
+        if self.peek_eq(c) {
+            self.advance(1);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume `c` or return a parse error.
+    fn expect_char(&mut self, c: char) -> Result<(), ConfigError> {
+        if self.try_consume_char(c) {
+            Ok(())
+        } else {
+            Err(bare_err("expected char", &c.to_string()))
+        }
+    }
+}
+
+/// Build a `BareParse` error. The format-arg pattern keeps the
+/// firmware-side `defmt::Debug2Format` log line readable.
+fn bare_err(reason: &str, detail: &str) -> ConfigError {
+    let mut s = String::with_capacity(reason.len() + detail.len() + 4);
+    s.push_str(reason);
+    if !detail.is_empty() {
+        s.push_str(": ");
+        s.push_str(detail);
+    }
+    ConfigError::BareParse(s)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"
+(
+    wifi: (
+        ssid: "home",
+        psk: "redacted",
+        country: "US",
+    ),
+    mdns: (
+        hostname: "stackchan",
+    ),
+    time: (
+        tz: "UTC",
+        sntp_servers: ["pool.ntp.org"],
+    ),
+)
+"#;
+
+    #[test]
+    fn parses_minimal_fixture() {
+        let cfg = parse_ron_bare(FIXTURE).unwrap();
+        assert_eq!(cfg.wifi.ssid, "home");
+        assert_eq!(cfg.wifi.psk, "redacted");
+        assert_eq!(cfg.wifi.country, "US");
+        assert_eq!(cfg.mdns.hostname, "stackchan");
+        assert_eq!(cfg.time.tz, "UTC");
+        assert_eq!(cfg.time.sntp_servers, vec!["pool.ntp.org".to_string()]);
+    }
+
+    #[test]
+    fn handles_line_comments_and_trailing_commas() {
+        let s = r#"
+            // top comment
+            (
+                wifi: ( ssid: "n", psk: "p", country: "JP", ),
+                mdns: ( hostname: "h" ), // trailing
+                time: ( tz: "UTC", sntp_servers: ["a","b",], ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        assert_eq!(
+            cfg.time.sntp_servers,
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn handles_string_escapes() {
+        let s = r#"
+            (
+                wifi: ( ssid: "foo\"bar", psk: "back\\slash", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        assert_eq!(cfg.wifi.ssid, "foo\"bar");
+        assert_eq!(cfg.wifi.psk, "back\\slash");
+    }
+
+    #[test]
+    fn renders_then_re_parses() {
+        let original = parse_ron_bare(FIXTURE).unwrap();
+        let rendered = render_ron_bare(&original).unwrap();
+        let re_parsed = parse_ron_bare(&rendered).unwrap();
+        assert_eq!(original, re_parsed);
+    }
+
+    #[test]
+    fn render_output_round_trips_through_serde_path() {
+        // Sanity: anything our renderer emits, the serde-side parser
+        // (gated behind feature `parse`) should also accept. Only
+        // exercised when running the host test suite, which has the
+        // feature on by default.
+        #[cfg(feature = "parse")]
+        {
+            let original = parse_ron_bare(FIXTURE).unwrap();
+            let rendered = render_ron_bare(&original).unwrap();
+            let via_serde = crate::parse_ron(&rendered).unwrap();
+            assert_eq!(original, via_serde);
+        }
+    }
+
+    #[test]
+    fn rejects_missing_field() {
+        let err = parse_ron_bare("(wifi: (ssid: \"x\", psk: \"y\", country: \"US\"))").unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn validates_after_parse() {
+        // Lowercase country slips through bare parse but fails the
+        // shared validate gate.
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "us" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["a"] ),
+            )
+        "#;
+        let err = parse_ron_bare(s).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidCountry(_)), "got {err:?}");
+    }
+}

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -1,14 +1,18 @@
 //! Schema v1 of the Stack-chan RON config — `wifi`, `mdns`, `time`.
 //!
-//! Held deliberately minimal: avatar geometry and modifier params
-//! stay hardcoded in `stackchan-core` for now. The shape this crate
-//! commits to is the surface that `PUT /settings` round-trips and
-//! that the SD-card boot reader populates.
+//! The data types are always available (`no_std` + `alloc`, no extra
+//! deps). The `serde` derives, [`parse_ron`], and [`render_ron`] are
+//! gated behind the `parse` feature — host builds enable it, the
+//! firmware target does not because `ron 0.10` hard-pins
+//! `serde/std + base64/std` which are broken on
+//! `xtensa-esp32s3-none-elf`. Firmware does its own hand-rolled
+//! RON parsing (and produces these same types).
 
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
+#[cfg(feature = "parse")]
 use serde::{Deserialize, Serialize};
 
 use crate::error::ConfigError;
@@ -19,7 +23,8 @@ use crate::error::ConfigError;
 /// no-op at the Wi-Fi layer, hostname `"stackchan"` is the canonical
 /// mDNS label, and `time` points at `pool.ntp.org` so SNTP picks up
 /// once Wi-Fi is configured.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct Config {
     /// Wi-Fi station credentials and regulatory country code.
     pub wifi: WifiConfig,
@@ -30,7 +35,8 @@ pub struct Config {
 }
 
 /// Wi-Fi station credentials.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct WifiConfig {
     /// SSID of the access point to join. An empty string disables the
     /// Wi-Fi join attempt entirely (avatar runs offline-first).
@@ -53,7 +59,8 @@ impl Default for WifiConfig {
 }
 
 /// mDNS hostname configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct MdnsConfig {
     /// Hostname advertised on `.local`. Default `"stackchan"` →
     /// device reachable as `stackchan.local`.
@@ -69,7 +76,8 @@ impl Default for MdnsConfig {
 }
 
 /// Time / SNTP configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct TimeConfig {
     /// IANA timezone label (e.g. `"UTC"`, `"America/Los_Angeles"`).
     /// Currently parsed but unused — the BM8563 RTC stores UTC.
@@ -96,6 +104,7 @@ impl Default for TimeConfig {
 /// validation variants ([`ConfigError::EmptySsid`],
 /// [`ConfigError::InvalidCountry`], [`ConfigError::InvalidHostname`],
 /// [`ConfigError::NoSntpServers`]) on out-of-range values.
+#[cfg(feature = "parse")]
 pub fn parse_ron(input: &str) -> Result<Config, ConfigError> {
     let config: Config = ron::from_str(input)?;
     validate(&config)?;
@@ -123,14 +132,25 @@ pub fn parse_ron(input: &str) -> Result<Config, ConfigError> {
 ///
 /// Returns [`ConfigError::Serialize`] on serializer failure. Should
 /// not happen with a well-formed [`Config`].
+#[cfg(feature = "parse")]
 pub fn render_ron(config: &Config) -> Result<String, ConfigError> {
     let pretty = ron::ser::PrettyConfig::new();
     ron::ser::to_string_pretty(config, pretty).map_err(ConfigError::Serialize)
 }
 
-/// Run the v1 schema validators against a parsed [`Config`]. Public
-/// entry is via [`parse_ron`]; this fn is the post-deserialize gate.
-fn validate(config: &Config) -> Result<(), ConfigError> {
+/// Run the v1 schema validators against a [`Config`].
+///
+/// Public so firmware-side parsers can reuse the same gate the
+/// `parse_ron` host path runs. The firmware wraps any failure in
+/// `defmt::Debug2Format` for logging.
+///
+/// # Errors
+///
+/// Returns one of the validation variants
+/// ([`ConfigError::EmptySsid`], [`ConfigError::InvalidCountry`],
+/// [`ConfigError::InvalidHostname`], [`ConfigError::NoSntpServers`],
+/// [`ConfigError::EmptySntpServer`]) on out-of-range values.
+pub fn validate(config: &Config) -> Result<(), ConfigError> {
     // SSID: empty *file value* is rejected. `Config::default()` uses
     // an empty SSID as a sentinel for "no wifi configured" and never
     // routes through this validator.
@@ -170,8 +190,6 @@ fn is_valid_country(s: &str) -> bool {
 /// / hyphens, must start with a letter, must not end with a hyphen,
 /// length 1-63.
 fn is_valid_hostname(s: &str) -> bool {
-    // RFC-952 subset: 1-63 chars; ASCII alphanumerics + hyphen; must
-    // start with a letter; must not end with a hyphen.
     if s.is_empty() || s.len() > 63 {
         return false;
     }
@@ -203,21 +221,14 @@ mod tests {
 
     #[test]
     fn validates_country_length_and_case() {
-        // Canonical ISO-3166 alpha-2.
         assert!(is_valid_country("US"));
         assert!(is_valid_country("JP"));
-        // Length wrong.
         assert!(!is_valid_country("USA"));
         assert!(!is_valid_country("U"));
         assert!(!is_valid_country(""));
-        // Non-letter content.
         assert!(!is_valid_country("U1"));
-        // Lowercase rejected — esp-wifi expects uppercase, and a
-        // case-insensitive validator would silently pass through to
-        // the wrong regulatory mask.
         assert!(!is_valid_country("us"));
         assert!(!is_valid_country("jp"));
-        // Mixed case rejected too.
         assert!(!is_valid_country("Us"));
     }
 
@@ -226,17 +237,11 @@ mod tests {
         assert!(is_valid_hostname("stackchan"));
         assert!(is_valid_hostname("stackchan-01"));
         assert!(is_valid_hostname("a"));
-        // Too long.
         assert!(!is_valid_hostname(&"a".repeat(64)));
-        // Empty.
         assert!(!is_valid_hostname(""));
-        // Starts with digit.
         assert!(!is_valid_hostname("1stackchan"));
-        // Starts with hyphen.
         assert!(!is_valid_hostname("-stackchan"));
-        // Ends with hyphen.
         assert!(!is_valid_hostname("stackchan-"));
-        // Underscore not allowed in RFC-952.
         assert!(!is_valid_hostname("stack_chan"));
     }
 }

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -7,12 +7,19 @@ use alloc::string::String;
 /// Variants carry the offending value where it aids debugging — the
 /// firmware logs these via `defmt::Debug2Format`, and the catalog at
 /// `docs/errors.md` mirrors the same per-variant guidance.
+///
+/// The `Parse` and `Serialize` variants are gated behind the `parse`
+/// feature because they wrap `ron`-side error types — `ron` is only
+/// available on host builds. Firmware-side parsers map their own
+/// failures to whichever validator variant fits, or surface the
+/// underlying error through the firmware's `StorageError`.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ConfigError {
     /// RON deserialize failure — syntax error, missing field, or
     /// type mismatch. The wrapped [`ron::error::SpannedError`] carries
     /// `(line, col)` so callers can surface a precise diagnostic.
+    #[cfg(feature = "parse")]
     #[error("RON parse error: {0}")]
     Parse(#[from] ron::error::SpannedError),
 
@@ -24,6 +31,7 @@ pub enum ConfigError {
     /// path), so an automatic `From<ron::Error>` would silently tag
     /// any deserialize-side error as a serialize one. Callers map
     /// explicitly via `Result::map_err`.
+    #[cfg(feature = "parse")]
     #[error("RON serialize error: {0}")]
     Serialize(ron::Error),
 
@@ -62,4 +70,12 @@ pub enum ConfigError {
     /// index in the original list.
     #[error("time.sntp_servers[{0}] is empty or whitespace-only")]
     EmptySntpServer(usize),
+
+    /// Hand-rolled bare parser failure (firmware-side path that
+    /// avoids `serde + ron`). Carries a short reason string in lieu
+    /// of `ron`'s line/col `SpannedError` — the firmware logs this
+    /// via `defmt::Debug2Format` and the operator triages from the
+    /// boot log.
+    #[error("bare RON parse error: {0}")]
+    BareParse(String),
 }

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -27,9 +27,21 @@
 //! The avatar must boot fully and animate even with no SD card and
 //! no Wi-Fi. The firmware therefore treats this crate's [`Config`]
 //! as **always available**: missing SD or missing file falls back to
-//! [`Config::default`]. The validators in [`parse_ron`] reject
-//! malformed input, but the firmware never propagates a
-//! [`ConfigError`] up to a panic — it logs and uses defaults.
+//! [`Config::default`]. Validators reject malformed input but the
+//! firmware never propagates a [`ConfigError`] up to a panic — it
+//! logs and uses defaults.
+//!
+//! ## Feature: `parse`
+//!
+//! Default-on for host builds. Adds:
+//! - serde derives on [`Config`] / [`WifiConfig`] / [`MdnsConfig`] / [`TimeConfig`]
+//! - [`parse_ron`] / [`render_ron`] (lossless round trip via `ron 0.10`)
+//!
+//! Disabled for the firmware target because `ron 0.10` hard-pins
+//! `serde/std` + `base64/std` — both broken on
+//! `xtensa-esp32s3-none-elf` where `std` is absent. The firmware uses
+//! its own hand-rolled RON parser and reuses [`validate`] from this
+//! crate to enforce the same schema gate the host path runs.
 //!
 //! [`PUT /settings`]: # "see crates/stackchan-firmware/src/net/http.rs once it lands"
 
@@ -38,8 +50,12 @@
 
 extern crate alloc;
 
+pub mod bare;
 pub mod config;
 pub mod error;
 
-pub use config::{Config, MdnsConfig, TimeConfig, WifiConfig, parse_ron, render_ron};
+pub use bare::{parse_ron_bare, render_ron_bare};
+pub use config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+#[cfg(feature = "parse")]
+pub use config::{parse_ron, render_ron};
 pub use error::ConfigError;


### PR DESCRIPTION
## Summary

Two pieces of necessary infrastructure for SD-card boot config. The full SD I/O integration (`storage.rs` mounting `embedded-sdmmc 0.8`, boot wiring, bench example) follows in a separate PR — that piece needs hardware iteration against the real embedded-sdmmc API + SDMMC bring-up timing on the bench, which the asleep AXP2101 is currently blocking.

### 1. `stackchan-net` feature gate (`v0.1.0` → `v0.2.0`)

`ron 0.10` hard-pins `serde/std` and `base64/std` — investigated and confirmed in [ron 0.10's Cargo.toml](https://docs.rs/crate/ron/0.10/source/Cargo.toml.orig) lines `[dependencies.serde]` and `[dependencies.base64]`. Both break on the firmware target (`xtensa-esp32s3-none-elf` has no std). Adding `stackchan-net` to the firmware build graph as-merged would have caused 5827+ compile errors in `serde_core` ("cannot find Option/Result/Iterator in scope" — std-prelude fallout).

Fix: add a `parse` Cargo feature (default-on) that gates the serde derives + `parse_ron` / `render_ron`. The firmware depends on `stackchan-net = { default-features = false }` and gets pure data types only. Verified with `cargo +esp tree --target=xtensa-esp32s3-none-elf -p stackchan-firmware -e=normal -e=features` — `serde feature "std"` is gone from the runtime graph.

### 2. Bare RON parser (`stackchan-net::bare`)

~280 LOC including tests. Recursive-descent parser + renderer for exactly the schema-v1 shape. Handles line comments, trailing commas, `\\` and `\"` escapes — the subset both the serde-side renderer and hand-edits emit. Round-trips losslessly through itself and through the serde-side path. New `ConfigError::BareParse(String)` variant for failures.

7 new tests (happy path, comments + trailing commas, escapes, round-trip, missing field rejection, post-parse `validate` gate, malformed input). Crate-wide test count: 18 → 21.

### 3. `SdSpiDevice` adapter (`stackchan-firmware::sd_spi`)

`embedded_hal::spi::SpiDevice` for the SD client. Borrows the shared SPI2 bus (parked in `RefCell` by PR #135) and flips GPIO35's output-enable bit per CS edge:

- LCD CS LOW → OE on  → GPIO35 drives DC value
- SD CS LOW  → OE off → GPIO35 floats; SPI MISO reads externally-driven level

Pattern is derived from M5GFX (`m5stack/M5GFX`, `Panel_M5StackCoreS3::cs_control`); written into `project_stackchan_cores3_gpio35_dual_role.md` memory note. Two `unsafe` register pokes (`GPIO_ENABLE1_W1TS_REG` / `W1TC_REG`) guarded by ESP32-S3 TRM citations. Module gated `#![allow(unsafe_code)]` per the firmware crate's established convention.

## Test plan

- [x] `cargo test -p stackchan-net` — 21 tests pass (3 inline unit + 7 inline `bare` + 11 integration).
- [x] `cargo test -p stackchan-net --no-default-features --lib` — 10 tests pass without serde/ron path active.
- [x] `cargo +esp tree --target=xtensa-esp32s3-none-elf -p stackchan-firmware -e=normal -e=features | grep serde` — only `stackchan-net v0.2.0`, no serde anywhere.
- [x] `just check` / `just ci` / `just msrv` — all green on host.
- [x] `just check-firmware` / `just clippy-firmware` / `just build-firmware` — all green on esp toolchain.
- [ ] Hardware: bench unit asleep at the moment (AXP2101 shutdown). Boot smoke test pending.

## Why this shape (vs the original "monolithic PR #2b")

The original plan called for a single PR landing both the GPIO35 OE flip + the full SD I/O integration. While building it, three blockers surfaced:

1. **`ron 0.10` `no_std` claims are misleading.** It compiles on docs.rs (host target with std available) but pulls `serde/std` mandatorily. Required the feature gate detour — meaningful refactor of the merged PR #134 crate.
2. **`embedded-sdmmc 0.8` API mismatch.** My speculative `storage.rs` used `&self` everywhere; the actual API requires `&mut self` chains on `VolumeManager` → `Volume` → `Dir` → `File`. Also `Timestamp.year_since_1970` (not `year_since_1980`). Ironing this out cleanly needs bench iteration to confirm timing of card init, FAT mount, and read latency under the embassy executor.
3. **Bench unit unavailable** for the iteration.

Splitting the work lets this infra-only piece review + merge against the actual constraints we found, and the SD I/O follow-up gets a clean base when bench access is back.

## Stacked on

`main` (post #134 + #135). No conflicts expected.