### PR TITLE
fix(firmware): drop unused stackchan-net dep until SD I/O lands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,7 +4209,6 @@ dependencies = [
  "scservo",
  "si12t",
  "stackchan-core",
- "stackchan-net",
  "stackchan-tts",
  "static_cell",
  "tracker",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -32,13 +32,6 @@ tracker = { path = "../tracker" }
 # `BakedBackend` (sine-cycle SFX + future verbal PCM) and the
 # `AudioSource` trait the audio task's TX feeder pulls samples through.
 stackchan-tts = { path = "../stackchan-tts" }
-# Networking domain types + RON config schema. Bare data types only:
-# `default-features = false` skips the `parse` feature (which would
-# pull `ron 0.10` + `serde/std` and break the firmware target build,
-# since `xtensa-esp32s3-none-elf` has no std). Firmware does its own
-# hand-rolled RON parsing in `storage.rs`, then runs the same
-# `stackchan_net::validate` gate the host parser uses.
-stackchan-net = { path = "../stackchan-net", default-features = false }
 # `heapless::Vec` for the per-frame multi-target candidate list
 # translated from `tracker::Outcome.candidates` into the engine's
 # `TrackingObservation`. Matches the cap (`MAX_CANDIDATES`).


### PR DESCRIPTION
## Summary

PR #136 (just merged) added `stackchan-net` to the firmware Cargo.toml speculatively — for the in-progress `storage.rs` that ended up deferred to a follow-up PR (#2c) when bench access is restored. Without a consumer, `cargo-machete` correctly flags it as unused, and the CI on `main` is now red.

Per workspace memory (`feedback_no_lint_suppressions.md`), machete findings get fixed at the source rather than ignored — drop the dep until PR #2c re-adds it alongside `storage.rs`.

The `SdSpiDevice` adapter that did land in PR #136 doesn't depend on `stackchan-net` — it's pure SPI plumbing.

## Test plan

- [x] `just check-firmware` — clean.
- [x] `just clippy-firmware` — clean.
- [x] `cargo machete` — "didn't find any unused dependencies in this directory. Good job!"