### PR TITLE
fix(firmware): time-bound log_angle_limits read so headless boot doesn't hang

### DIFF
--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -309,10 +309,21 @@ async fn ping_servo(driver: &mut HeadDriverImpl, id: u8) {
 /// Failure logs at `warn` — the diagnostic isn't load-bearing.
 async fn log_angle_limits(driver: &mut HeadDriverImpl, id: u8) {
     const ADDR_MIN_ANGLE_LIMIT: u8 = 0x09;
+    /// Same budget as `ping_servo`'s `PING_TIMEOUT_MS`. A silent
+    /// servo (e.g. head detached from the bench) would otherwise
+    /// stall boot here forever — `read_memory` itself has no
+    /// internal deadline; the UART RX waits on bytes that never
+    /// arrive.
+    const READ_TIMEOUT_MS: u64 = 10;
     let mut buf = [0u8; 4];
     let bus = driver.bus_mut();
-    match bus.read_memory(id, ADDR_MIN_ANGLE_LIMIT, &mut buf).await {
-        Ok(_err_byte) => {
+    let result = with_timeout(
+        Duration::from_millis(READ_TIMEOUT_MS),
+        bus.read_memory(id, ADDR_MIN_ANGLE_LIMIT, &mut buf),
+    )
+    .await;
+    match result {
+        Ok(Ok(_err_byte)) => {
             let min = (u16::from(buf[0]) << 8) | u16::from(buf[1]);
             let max = (u16::from(buf[2]) << 8) | u16::from(buf[3]);
             defmt::debug!(
@@ -322,10 +333,15 @@ async fn log_angle_limits(driver: &mut HeadDriverImpl, id: u8) {
                 max,
             );
         }
-        Err(e) => defmt::warn!(
+        Ok(Err(e)) => defmt::warn!(
             "SCServo[{=u8}]: read angle-limits failed: {}",
             id,
             defmt::Debug2Format(&e)
+        ),
+        Err(_) => defmt::warn!(
+            "SCServo[{=u8}]: read angle-limits timed out after {=u64} ms (head detached?)",
+            id,
+            READ_TIMEOUT_MS
         ),
     }
 }


### PR DESCRIPTION
## Summary

`log_angle_limits` (`crates/stackchan-firmware/src/board.rs:310`) was awaiting `bus.read_memory` directly, with no deadline. The underlying UART RX blocks indefinitely waiting on bytes that never arrive. On a bench unit booted without the head attached (servo cables disconnected, or head module physically detached), that pinned boot at the angle-limit read after the SCServo presence check completed — the render task never spawned, the LCD never came up, the device looked frozen.

This is a pre-existing issue, surfaced today while bench-verifying #135's LCD shared-SPI2 refactor. The fix matches `ping_servo`'s pattern: wrap the read in `with_timeout(10 ms)` and log a head-detached hint on the elapsed branch.

## Verification

Flashed onto Andy's CoreS3 with the head detached:

```
1350 ms [INFO ] ILI9342C ready — spawning render task
1370 ms [INFO ] render task: 33 ms tick, ...
1447 ms [INFO ] boot complete — idle heartbeat
```

Boot now reaches the heartbeat in <1.5 s. Each `read_memory` call against the absent servo logs the timeout warning and the bring-up continues.

This also definitively bench-validates #135's LCD bring-up — `ILI9342C ready` only logs after `mipidsi::Builder::init` returns `Ok(d)` against the shared `RefCellDevice<'static, Spi<...>, ...>`.

## Test plan

- [x] `just check-firmware` — clean.
- [x] `just clippy-firmware` — clean.
- [x] `just build-firmware` — release link clean.
- [x] Bench flash (head detached) — boot reaches "boot complete — idle heartbeat" at 1447 ms; per-tick warnings continue but don't block bring-up.