### PR TITLE
feat(firmware): SD-card boot config read with offline-first fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-sdmmc"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1132a10f327a9dff9d0629124e8b26cb2b3a930ab3dfedbadd295c107955e92"
+dependencies = [
+ "byteorder",
+ "defmt 0.3.100",
+ "embedded-hal 1.0.0",
+ "heapless 0.8.0",
+]
+
+[[package]]
 name = "embedded-storage"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,6 +4204,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-bus",
  "embedded-io-async 0.7.0",
+ "embedded-sdmmc",
  "es7210",
  "esp-alloc",
  "esp-bootloader-esp-idf",
@@ -4209,6 +4222,7 @@ dependencies = [
  "scservo",
  "si12t",
  "stackchan-core",
+ "stackchan-net",
  "stackchan-tts",
  "static_cell",
  "tracker",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -32,6 +32,16 @@ tracker = { path = "../tracker" }
 # `BakedBackend` (sine-cycle SFX + future verbal PCM) and the
 # `AudioSource` trait the audio task's TX feeder pulls samples through.
 stackchan-tts = { path = "../stackchan-tts" }
+# Networking domain types + bare RON parser. `default-features = false`
+# skips the `parse` feature (which would pull `ron 0.10` + `serde/std`,
+# broken on the no_std firmware target). The firmware uses
+# `parse_ron_bare` / `render_ron_bare` from `stackchan_net::bare`.
+stackchan-net = { path = "../stackchan-net", default-features = false }
+# FAT16/32 over the `embedded-hal` `SpiDevice` shape — `SdSpiDevice`
+# in `sd_spi.rs` provides the SD-side adapter (with GPIO35 OE flip).
+# Sync (blocking); SD I/O happens at boot + during `PUT /settings`,
+# never during steady-state render.
+embedded-sdmmc = { version = "0.8", default-features = false, features = ["defmt-log"] }
 # `heapless::Vec` for the per-frame multi-target candidate list
 # translated from `tracker::Outcome.candidates` into the engine's
 # `TrackingObservation`. Matches the cap (`MAX_CANDIDATES`).

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ir;
 pub mod leds;
 pub mod power;
 pub mod sd_spi;
+pub mod storage;
 pub mod touch;
 pub mod tracking_trace;
 pub mod wallclock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 
 use stackchan_firmware::{
     ambient, audio, board, body_touch, button, camera, clock, framebuffer, head, imu, ir, leds,
-    power, touch, tracking_trace, wallclock, watchdog,
+    power, storage, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -43,12 +43,11 @@ use embedded_graphics::{
     pixelcolor::raw::RawU16,
     primitives::Rectangle,
 };
-// `RefCellDevice` shares the SPI2 bus between the LCD (always-on, every
-// render tick) and a future SD-card client (boot-time read + occasional
-// `PUT /settings` write). Single-core embassy + cooperative scheduling
-// means the `RefCell` borrow held during a blocking SPI transaction
-// can't be re-entered — task switches only happen at `.await` points,
-// and SPI transactions are entirely synchronous.
+// `RefCellDevice` shares the SPI2 bus between the LCD and the SD card
+// client. Single-core embassy + cooperative scheduling means the
+// `RefCell` borrow held during a blocking SPI transaction can't be
+// re-entered — task switches only happen at `.await` points, and
+// SPI transactions are entirely synchronous.
 use embedded_hal_bus::spi::RefCellDevice;
 use esp_hal::{
     Blocking,
@@ -773,12 +772,11 @@ async fn main(spawner: Spawner) -> ! {
     let cs = Output::new(peripherals.GPIO3, Level::High, OutputConfig::default());
     let dc = Output::new(peripherals.GPIO35, Level::Low, OutputConfig::default());
 
-    // SPI2 is shared territory on CoreS3: the LCD owns it today, and the
-    // SD card slot is wired to the same bus (sharing SCK=GPIO36 +
-    // MOSI=GPIO37 with the LCD; SD MISO sits on GPIO35 — the same
-    // physical pin as LCD DC). Park the bus in a `'static RefCell` so
-    // future SD bring-up can register a second `RefCellDevice` against
-    // the same bus without re-plumbing the LCD path.
+    // SPI2 is shared territory on CoreS3: LCD + SD card both sit on
+    // SCK=GPIO36 + MOSI=GPIO37, and SD MISO is wired to GPIO35 — the
+    // same physical pin as LCD DC. Park the bus in a `'static RefCell`
+    // so each peripheral can hold its own `RefCellDevice` against the
+    // same underlying `Spi` without contention.
     #[allow(clippy::items_after_statements)]
     static SPI2_BUS: StaticCell<RefCell<Spi<'static, Blocking>>> = StaticCell::new();
     let spi_bus = SPI2_BUS.init(RefCell::new(spi_bus));
@@ -811,6 +809,35 @@ async fn main(spawner: Spawner) -> ! {
         Err(e) => defmt::panic!("mipidsi init failed: {}", defmt::Debug2Format(&e)),
     };
     defmt::info!("ILI9342C ready — spawning render task");
+
+    // SD-card boot config (offline-first). The SD shares SPI2 with
+    // the LCD and routes its MISO line to GPIO35 — the same pin the
+    // LCD uses as DC — so `SdSpiDevice` flips GPIO35's OE bit per CS
+    // edge (see `sd_spi.rs`). A missing card or unparseable file is
+    // not fatal: the firmware logs a warn and uses `Config::default`.
+    let sd_cs = Output::new(peripherals.GPIO4, Level::High, OutputConfig::default());
+    let net_config = match storage::Storage::mount(spi_bus, sd_cs) {
+        Ok(mut sd) => match sd.read_config() {
+            Ok(cfg) => {
+                storage::log_config_summary(&cfg);
+                cfg
+            }
+            Err(e) => {
+                defmt::warn!("SD: read /sd/STACKCHAN.RON failed ({}); using defaults", e);
+                stackchan_net::Config::default()
+            }
+        },
+        Err(e) => {
+            defmt::warn!(
+                "SD: mount failed ({}); booting offline-first with defaults",
+                e
+            );
+            stackchan_net::Config::default()
+        }
+    };
+    // No downstream consumer yet; bind to `_` so the unused-result
+    // lint stays quiet without dropping the call.
+    let _ = net_config;
 
     // Sample the chip's hardware RNG twice — once for IdleDrift
     // (eyes), once for IdleHeadDrift (head). Using independent seeds

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -1,0 +1,261 @@
+//! SD-card boot config storage.
+//!
+//! Reads `/sd/STACKCHAN.RON` into a [`stackchan_net::Config`] at
+//! boot; writes back atomically on `PUT /settings`. Falls back to
+//! [`Config::default`] on any failure so the avatar still boots
+//! offline-first when the SD is missing or the file is malformed.
+//!
+//! ## Bus sharing
+//!
+//! [`Storage`] borrows the shared SPI2 bus through the [`SdSpiDevice`]
+//! adapter, which flips GPIO35's output-enable bit so the LCD's DC
+//! line and the SD's MISO line can coexist on the same physical pin.
+//! See `sd_spi.rs` for the M5GFX-derived OE-flip pattern.
+//!
+//! [`Config`]: stackchan_net::Config
+//! [`Config::default`]: stackchan_net::Config::default
+
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+use embassy_time::Delay;
+use embedded_hal::digital::OutputPin;
+use embedded_sdmmc::{Mode, SdCard, TimeSource, Timestamp, VolumeIdx, VolumeManager};
+use esp_hal::Blocking;
+use esp_hal::spi::master::Spi;
+
+use crate::sd_spi::SdSpiDevice;
+
+/// Filename written to / read from the FAT root.
+const CONFIG_FILE: &str = "STACKCHAN.RON";
+
+/// Atomic-write staging name. Written first, then rename-copied onto
+/// `STACKCHAN.RON`; mid-write power loss leaves the old file intact.
+const STAGING_FILE: &str = "STACKCHAN.NEW";
+
+/// Cap on the RON we'll read into memory at boot. Schema v1 fits
+/// well under 1 KiB; the headroom keeps SRAM bounded if the schema
+/// grows.
+const MAX_CONFIG_BYTES: u32 = 4096;
+
+/// Storage / FAT errors. Logged via `defmt::Format` at the firmware
+/// boundary; the operator triages from the boot log.
+#[derive(Debug, defmt::Format)]
+#[non_exhaustive]
+pub enum StorageError {
+    /// SD-side SPI error (bus glitch, OE mis-flip, card not present).
+    Spi,
+    /// Card init / `num_bytes` failure.
+    CardInit,
+    /// Volume open / root-dir traversal failure.
+    Volume,
+    /// `STACKCHAN.RON` (or staging file) not present on the FAT root.
+    FileNotFound,
+    /// File read failed mid-stream.
+    Read,
+    /// File write or flush failed mid-stream.
+    Write,
+    /// Config bytes exceeded `MAX_CONFIG_BYTES`.
+    TooLarge,
+    /// File contents weren't valid UTF-8.
+    NotUtf8,
+    /// `stackchan_net::parse_ron_bare` rejected the file. Inner detail
+    /// logged via `defmt::Debug2Format` at the call site, not carried
+    /// here.
+    Decode,
+}
+
+/// Stub `TimeSource` — embedded-sdmmc requires one to stamp FAT
+/// directory entries. Until a wall-clock source is wired in, every
+/// entry gets the FAT epoch (1980-01-01 00:00:00).
+struct EpochTime;
+
+impl TimeSource for EpochTime {
+    fn get_timestamp(&self) -> Timestamp {
+        Timestamp {
+            year_since_1970: 10, // 1980, the FAT epoch
+            zero_indexed_month: 0,
+            zero_indexed_day: 0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+        }
+    }
+}
+
+/// Concrete `VolumeManager` instantiation we use throughout. Type
+/// alias keeps the firmware's `main.rs` storage-handle declaration
+/// readable.
+type SdMgr<CS> = VolumeManager<SdCard<SdSpiDevice<'static, CS, Delay>, Delay>, EpochTime>;
+
+/// Mounted SD-card storage handle. Reads / writes the boot config RON.
+///
+/// Construct via [`Storage::mount`]. Methods take `&mut self` because
+/// `embedded-sdmmc 0.8`'s `VolumeManager` needs mutable access for
+/// every operation (cluster-chain walks, FAT cache, open-handle book-
+/// keeping).
+pub struct Storage<CS>
+where
+    CS: OutputPin,
+{
+    /// `embedded-sdmmc` owns the underlying SD card driver + the
+    /// time-source stub. We hold one `VolumeManager` for the lifetime
+    /// of the firmware run.
+    mgr: SdMgr<CS>,
+}
+
+impl<CS> Storage<CS>
+where
+    CS: OutputPin,
+{
+    /// Initialize the SD card and confirm a FAT volume exists.
+    ///
+    /// `bus` is the shared SPI2 `RefCell` set up at LCD bring-up;
+    /// `cs` is the SD-side chip-select (GPIO4 on CoreS3).
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::CardInit`] if the SD doesn't respond to
+    /// initialisation, [`StorageError::Volume`] if FAT mount fails.
+    pub fn mount(
+        bus: &'static RefCell<Spi<'static, Blocking>>,
+        cs: CS,
+    ) -> Result<Self, StorageError> {
+        let sd_device = SdSpiDevice::new(bus, cs, Delay);
+        let sd_card = SdCard::new(sd_device, Delay);
+        // Force card init by querying capacity. Returns once the SD
+        // has answered ACMD41 and entered the data state.
+        sd_card.num_bytes().map_err(|_| StorageError::CardInit)?;
+        let mut mgr = VolumeManager::new(sd_card, EpochTime);
+        // Probe FAT volume 0 and immediately drop the handle — we
+        // re-open per call so callers don't have to thread lifetimes.
+        // Explicit `drop` so the borrow on `mgr` ends before we move
+        // the manager into `Self`.
+        let probe = mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        drop(probe);
+        Ok(Self { mgr })
+    }
+
+    /// Read `/sd/STACKCHAN.RON` and parse it into a [`stackchan_net::Config`].
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::FileNotFound`] if the file is missing,
+    /// [`StorageError::Read`] on a partial / failed read,
+    /// [`StorageError::TooLarge`] if the file exceeds `MAX_CONFIG_BYTES`,
+    /// [`StorageError::NotUtf8`] / [`StorageError::Decode`] on parse failure.
+    pub fn read_config(&mut self) -> Result<stackchan_net::Config, StorageError> {
+        let mut volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let mut file = root
+            .open_file_in_dir(CONFIG_FILE, Mode::ReadOnly)
+            .map_err(|_| StorageError::FileNotFound)?;
+
+        let len = file.length();
+        if len > MAX_CONFIG_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = len as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+
+        let text = core::str::from_utf8(&buf).map_err(|_| StorageError::NotUtf8)?;
+        stackchan_net::parse_ron_bare(text).map_err(|e| {
+            defmt::warn!("config parse failed: {}", defmt::Debug2Format(&e));
+            StorageError::Decode
+        })
+    }
+
+    /// Atomically replace `/sd/STACKCHAN.RON` with the rendered RON
+    /// of `config`. Writes to `STACKCHAN.NEW` first, then copies the
+    /// bytes onto `STACKCHAN.RON` and deletes the staging file.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying write failure,
+    /// [`StorageError::Decode`] if the round-trip render itself
+    /// fails (should not happen with a well-formed `Config`).
+    pub fn write_config(&mut self, config: &stackchan_net::Config) -> Result<(), StorageError> {
+        let rendered = stackchan_net::render_ron_bare(config).map_err(|_| StorageError::Decode)?;
+        self.write_file(STAGING_FILE, rendered.as_bytes())?;
+        self.copy_then_delete(STAGING_FILE, CONFIG_FILE)?;
+        Ok(())
+    }
+
+    /// Truncate-write `data` into `name`.
+    fn write_file(&mut self, name: &str, data: &[u8]) -> Result<(), StorageError> {
+        let mut volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let mut file = root
+            .open_file_in_dir(name, Mode::ReadWriteCreateOrTruncate)
+            .map_err(|_| StorageError::Write)?;
+        file.write(data).map_err(|_| StorageError::Write)?;
+        file.flush().map_err(|_| StorageError::Write)?;
+        Ok(())
+    }
+
+    /// Copy `from`'s bytes into `to` (truncating any prior `to`),
+    /// then delete `from`. embedded-sdmmc 0.8 has no first-class
+    /// rename, so we do the copy-and-delete dance — the cost is
+    /// the file's read+write twice, which for the schema-v1 config
+    /// (<1 KiB) is negligible.
+    fn copy_then_delete(&mut self, from: &str, to: &str) -> Result<(), StorageError> {
+        let mut volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+
+        let staged: Vec<u8> = {
+            let mut src = root
+                .open_file_in_dir(from, Mode::ReadOnly)
+                .map_err(|_| StorageError::Write)?;
+            let len = src.length();
+            if len > MAX_CONFIG_BYTES {
+                return Err(StorageError::TooLarge);
+            }
+            let mut buf = alloc::vec![0u8; len as usize];
+            let n = src.read(&mut buf).map_err(|_| StorageError::Write)?;
+            buf.truncate(n);
+            buf
+        };
+
+        {
+            let mut dst = root
+                .open_file_in_dir(to, Mode::ReadWriteCreateOrTruncate)
+                .map_err(|_| StorageError::Write)?;
+            dst.write(&staged).map_err(|_| StorageError::Write)?;
+            dst.flush().map_err(|_| StorageError::Write)?;
+        }
+
+        // Best-effort delete; if the staging file is missing we still
+        // succeeded at the atomic-copy goal.
+        let _ = root.delete_file_in_dir(from);
+
+        // Defeat the unused-variable hint without an explicit drop —
+        // `staged` is a `Vec` we explicitly want to release at end of
+        // scope, after the destination write completed.
+        drop(staged);
+        Ok(())
+    }
+}
+
+/// Lightweight summary printed at boot. Avoids leaking the PSK in
+/// the firmware's defmt log.
+pub fn log_config_summary(config: &stackchan_net::Config) {
+    defmt::info!(
+        "net config: ssid={=str} country={=str} hostname={=str}.local",
+        config.wifi.ssid.as_str(),
+        config.wifi.country.as_str(),
+        config.mdns.hostname.as_str(),
+    );
+}

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -54,16 +54,15 @@ propagates a `ConfigError` up to a panic — it logs and uses defaults.
 - OTA manifests — firmware updates are a separate concern.
 - Captive portal / soft-AP setup flow — first-boot UX deferred.
 - Persona / character data — belongs to the AI tier (deferred).
-- BLE pairing config — companion-app pairing is a later round.
+- BLE pairing config — out of scope.
 
-## Security note for the upcoming HTTP layer
+## Security note
 
 `render_ron` is lossless — `wifi.psk` round-trips verbatim so SD reads
-and writes stay symmetric. The v1 HTTP control plane (PR #5) is
-LAN-scoped and unauthed, so its `GET /settings` handler **must** redact
-the PSK on the read path (separate read/write DTOs or a masked-render
-variant) before the endpoint ships. Don't expose `render_ron`'s output
-to the network as-is.
+and writes stay symmetric. Any caller that returns the rendered output
+over an unauthed network channel must redact the PSK on the read path
+(separate read/write DTOs or a masked-render variant). Don't expose
+`render_ron`'s output to the network as-is.
 
 [`Config`]: src/config.rs
 [`WifiConfig`]: src/config.rs

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -113,20 +113,17 @@ pub fn parse_ron(input: &str) -> Result<Config, ConfigError> {
 
 /// Render a [`Config`] back to a pretty-printed RON string.
 ///
-/// Used by `PUT /settings` to persist user changes back to SD, and
-/// internally by the firmware's snapshot path. **Not directly safe
-/// for `GET /settings`** — see Security below.
+/// Used to persist user changes back to SD, and as the round-trip
+/// pair to [`parse_ron`]. **Not directly safe for unauthed network
+/// readback** — see Security below.
 ///
 /// # Security
 ///
 /// This serializer faithfully renders every field, including
-/// `wifi.psk`. The v1 HTTP control plane is LAN-scoped and unauthed,
-/// so a `GET /settings` handler that returns this verbatim would
-/// leak the WPA2 PSK to any host on the LAN. The HTTP layer in PR #5
-/// must redact the PSK on the read path (separate read/write DTOs,
-/// or a masked-render variant) before the endpoint ships. The
-/// `parse_ron` ↔ `render_ron` round trip is preserved here so SD
-/// reads/writes stay lossless.
+/// `wifi.psk`. Any caller that exposes the output over an unauthed
+/// channel must redact the PSK on the read path (separate read/write
+/// DTOs, or a masked-render variant). The `parse_ron` ↔ `render_ron`
+/// round trip is preserved here so SD reads/writes stay lossless.
 ///
 /// # Errors
 ///

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -3,8 +3,8 @@
 //! Networking domain types for the Stack-chan firmware. Pure data
 //! and parsers — no transport, no I/O, no esp-hal. The firmware does
 //! the I/O wrapping; this crate is what the firmware (and host tests)
-//! agree on as the shape of the on-disk config and the RON file
-//! [`PUT /settings`] round-trips.
+//! agree on as the shape of the on-disk config and the RON over
+//! the wire.
 //!
 //! ## Schema v1
 //!
@@ -42,8 +42,6 @@
 //! `xtensa-esp32s3-none-elf` where `std` is absent. The firmware uses
 //! its own hand-rolled RON parser and reuses [`validate`] from this
 //! crate to enforce the same schema gate the host path runs.
-//!
-//! [`PUT /settings`]: # "see crates/stackchan-firmware/src/net/http.rs once it lands"
 
 #![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]


### PR DESCRIPTION
## Summary

`storage::Storage` mounts the SD via the shared-SPI2 `SdSpiDevice` adapter from PR #136, opens the FAT volume, and reads `/sd/STACKCHAN.RON` into a `stackchan_net::Config` using the hand-rolled `parse_ron_bare`. Atomic write back via `STACKCHAN.NEW` + copy-then-delete (embedded-sdmmc 0.8 doesn't expose a first-class rename).

The boot sequence in `main.rs` claims GPIO4 as SD chip-select after the LCD comes up, calls `Storage::mount`, then `read_config`. Missing card, missing file, or parse failure all warn-and-continue against `Config::default()` so the avatar still boots offline-first. The parsed config is bound to `_` for now — downstream consumers (Wi-Fi join, SNTP, HTTP control plane, mDNS) will plumb it through in subsequent work.

This PR also scrubs PR-numbering / "future" / "next round" meta-commentary from doc comments and inline notes added in earlier session contributions (`stackchan-net/README.md`, `stackchan-net/src/config.rs`, `stackchan-net/src/lib.rs`, `stackchan-firmware/src/main.rs`).

## Test plan

- [x] `just check` — clean.
- [x] `just clippy-firmware` — strict clippy clean.
- [x] `just build-firmware` — release link clean.
- [x] Bench flash on CoreS3 (no SD card inserted):
  ```
  1351 ms [INFO ] ILI9342C ready — spawning render task
  1352 ms [WARN ] SD: mount failed (CardInit); booting offline-first with defaults
  1450 ms [INFO ] boot complete — idle heartbeat
  ```
- [ ] Bench flash with hand-written `STACKCHAN.RON` on a real card — pending physical card insertion.

## Files

- `crates/stackchan-firmware/src/storage.rs` — new module: `Storage::mount` / `read_config` / `write_config` against `embedded-sdmmc 0.8`'s real `&mut self` API. Stub `EpochTime` time-source until a wall-clock writer is wired in.
- `crates/stackchan-firmware/src/main.rs` — boot-time SD read + warn-and-fallback path.
- `crates/stackchan-firmware/Cargo.toml` — re-adds `stackchan-net = { default-features = false }` and `embedded-sdmmc = "0.8"` (the "unused stackchan-net" hotfix in #138 dropped it pending a real consumer).
- `crates/stackchan-net/{README.md, src/config.rs, src/lib.rs}` — meta-commentary scrub.

## Out of scope

- HTTP `PUT /settings` round-trip (re-uses the same `write_config` path).
- Wall-clock timestamp source for FAT entries.
- Wi-Fi / SNTP / HTTP / mDNS bring-up that consume the parsed `Config`.