### PR TITLE
feat(firmware): esp-radio Wi-Fi station with offline-first retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +548,30 @@ name = "bmm150"
 version = "0.1.0"
 dependencies = [
  "embedded-hal-async",
+]
+
+[[package]]
+name = "bt-hci"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb938a3b4c5cc6c2409275bad789c0346a0495fa071a0acc5d72b9bd3175a2f7"
+dependencies = [
+ "btuuid",
+ "defmt 1.0.1",
+ "embassy-sync 0.7.2",
+ "embedded-io 0.6.1",
+ "embedded-io-async 0.6.1",
+ "futures-intrusive",
+ "heapless 0.9.2",
+]
+
+[[package]]
+name = "btuuid"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f48f1e9b0aad0a4f05d17bdeae0fa20ff798e272a03a6940ca27ad9c5a6ae7"
+dependencies = [
+ "defmt 0.3.100",
 ]
 
 [[package]]
@@ -1240,6 +1270,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-net"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347bc855bdbdf50ed9c5a1d80e8204badb0ba149b8732dde38e1e9708ed9d313"
+dependencies = [
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-net-driver",
+ "embassy-sync 0.8.0",
+ "embassy-time",
+ "embedded-io-async 0.7.0",
+ "embedded-nal-async",
+ "heapless 0.9.2",
+ "managed",
+ "smoltcp 0.13.0",
+]
+
+[[package]]
+name = "embassy-net-driver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
+dependencies = [
+ "defmt 0.3.100",
+]
+
+[[package]]
 name = "embassy-sync"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1498,25 @@ checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
 dependencies = [
  "defmt 1.0.1",
  "embedded-io 0.7.1",
+]
+
+[[package]]
+name = "embedded-nal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56a28be191a992f28f178ec338a0bf02f63d7803244add736d026a471e6ed77"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embedded-nal-async"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5a1bd585135d302f8f6d7de329310938093da6271b37a6c94b8798795c0c6d"
+dependencies = [
+ "embedded-io-async 0.7.0",
+ "embedded-nal",
 ]
 
 [[package]]
@@ -1708,6 +1784,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42c2ee95b945a4780796e4359e72c033aed3b45073880e8029458f538532db8a"
 
 [[package]]
+name = "esp-phy"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1facf348e1e251517278fc0f5dc134e95e518251f5796cfbb532ca226a29bf"
+dependencies = [
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "esp-config",
+ "esp-hal",
+ "esp-metadata-generated 0.3.0",
+ "esp-sync 0.1.1",
+ "esp-wifi-sys",
+]
+
+[[package]]
 name = "esp-println"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1811,42 @@ dependencies = [
  "esp-sync 0.2.1",
  "log",
  "portable-atomic",
+]
+
+[[package]]
+name = "esp-radio"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
+dependencies = [
+ "allocator-api2 0.3.1",
+ "bt-hci",
+ "cfg-if",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-net-driver",
+ "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
+ "enumset",
+ "esp-alloc",
+ "esp-config",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated 0.3.0",
+ "esp-phy",
+ "esp-radio-rtos-driver",
+ "esp-sync 0.1.1",
+ "esp-wifi-sys",
+ "heapless 0.9.2",
+ "instability",
+ "num-derive",
+ "num-traits",
+ "portable-atomic",
+ "portable_atomic_enum",
+ "smoltcp 0.12.0",
+ "xtensa-lx-rt",
 ]
 
 [[package]]
@@ -1818,6 +1946,16 @@ dependencies = [
  "ral-registers",
  "usb-device",
  "vcell",
+]
+
+[[package]]
+name = "esp-wifi-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b6544f6f0cb86169d1f93ba2101a8d50358a040c5043676ed86b793e09b12c"
+dependencies = [
+ "anyhow",
+ "defmt 1.0.1",
 ]
 
 [[package]]
@@ -2090,6 +2228,16 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+]
 
 [[package]]
 name = "futures-io"
@@ -2367,6 +2515,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
+ "defmt 0.3.100",
  "hash32",
  "stable_deref_trait",
 ]
@@ -2377,6 +2526,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
+ "defmt 1.0.1",
  "hash32",
  "stable_deref_trait",
 ]
@@ -2795,6 +2945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +3100,17 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -3531,6 +3698,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portable_atomic_enum"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d48f60c43e0120bb2bb48589a16d4bed2f4b911be41e299f2d0fc0e0e20885"
+dependencies = [
+ "portable-atomic",
+ "portable_atomic_enum_macros",
+]
+
+[[package]]
+name = "portable_atomic_enum_macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4145,6 +4333,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoltcp"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt 0.3.100",
+ "heapless 0.8.0",
+ "managed",
+]
+
+[[package]]
+name = "smoltcp"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac729b0a77bd092a3f06ddaddc59fe0d67f48ba0de45a9abe707c2842c7f8767"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt 0.3.100",
+ "heapless 0.9.2",
+ "managed",
+]
+
+[[package]]
 name = "somni-expr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,6 +4413,7 @@ dependencies = [
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-futures",
+ "embassy-net",
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-graphics",
@@ -4210,6 +4427,7 @@ dependencies = [
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-println",
+ "esp-radio",
  "esp-rtos",
  "ft6336u",
  "gc0308",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -69,9 +69,18 @@ mipidsi = "0.10"
 # lockstep). `esp-rtos` is the current embassy integration; it replaced
 # `esp-hal-embassy` for the 1.0 line.
 esp-hal = { version = "~1.0", features = ["defmt", "esp32s3", "psram", "unstable"] }
-esp-rtos = { version = "0.2.0", features = ["defmt", "embassy", "esp-alloc", "esp32s3"] }
+esp-rtos = { version = "0.2.0", features = ["defmt", "embassy", "esp-alloc", "esp-radio", "esp32s3"] }
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["defmt", "esp32s3"] }
 esp-alloc = { version = "0.9.0", features = ["defmt"] }
+# Wi-Fi station-mode driver. `esp-radio` replaces `esp-wifi` on the
+# esp-hal 1.0 release line. Pinned to 0.17.x because 0.18 requires
+# esp-hal ~1.1.0-rc.0 which would force a wider toolchain bump.
+# `unstable` is required because esp-hal itself runs with `unstable`
+# enabled here.
+esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "unstable"] }
+# embassy-net's TCP / UDP / DHCPv4 stack on top of smoltcp. 0.9.x
+# pairs with esp-radio 0.18 (both ride the embassy-sync 0.7 line).
+embassy-net = { version = "0.9", features = ["defmt", "proto-ipv4", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 
 embassy-executor = { version = "0.9.1", features = ["defmt"] }
 embassy-time = { version = "0.5.0", features = ["defmt"] }

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -29,6 +29,7 @@ pub mod head;
 pub mod imu;
 pub mod ir;
 pub mod leds;
+pub mod net;
 pub mod power;
 pub mod sd_spi;
 pub mod storage;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 
 use stackchan_firmware::{
     ambient, audio, board, body_touch, button, camera, clock, framebuffer, head, imu, ir, leds,
-    power, storage, touch, tracking_trace, wallclock, watchdog,
+    net, power, storage, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -835,9 +835,43 @@ async fn main(spawner: Spawner) -> ! {
             stackchan_net::Config::default()
         }
     };
-    // No downstream consumer yet; bind to `_` so the unused-result
-    // lint stays quiet without dropping the call.
-    let _ = net_config;
+    // Bring up the radio + Wi-Fi station + embassy-net TCP/IP stack.
+    // `esp_rtos::start` ran at boot (line above), which `esp_radio::init`
+    // requires before claiming the WIFI peripheral. Both the
+    // `Controller` and `WifiController` live in static cells so the
+    // spawned tasks can borrow them for `'static`.
+    #[allow(clippy::items_after_statements)]
+    static RADIO: StaticCell<esp_radio::Controller<'static>> = StaticCell::new();
+    let radio = match esp_radio::init() {
+        Ok(c) => RADIO.init(c),
+        Err(e) => defmt::panic!("esp-radio init failed: {}", defmt::Debug2Format(&e)),
+    };
+    let (wifi_controller, interfaces) =
+        match esp_radio::wifi::new(radio, peripherals.WIFI, esp_radio::wifi::Config::default()) {
+            Ok(r) => r,
+            Err(e) => defmt::panic!("wifi::new failed: {}", defmt::Debug2Format(&e)),
+        };
+
+    let net_rng = Rng::new();
+    let net_seed: u64 = u64::from(net_rng.random()) | (u64::from(net_rng.random()) << 32);
+    let stack_resources = net::stack::STACK_RESOURCES
+        .init(embassy_net::StackResources::<{ net::stack::STACK_SOCKETS }>::new());
+    let (_net_stack, net_runner) = embassy_net::new(
+        interfaces.sta,
+        embassy_net::Config::dhcpv4(embassy_net::DhcpConfig::default()),
+        stack_resources,
+        net_seed,
+    );
+    if let Err(e) = spawner.spawn(net::stack::net_runner_task(net_runner)) {
+        defmt::panic!("spawn(net_runner_task) failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(net::wifi::wifi_task(
+        wifi_controller,
+        net_config.wifi.ssid.clone(),
+        net_config.wifi.psk.clone(),
+    )) {
+        defmt::panic!("spawn(wifi_task) failed: {}", defmt::Debug2Format(&e));
+    }
 
     // Sample the chip's hardware RNG twice — once for IdleDrift
     // (eyes), once for IdleHeadDrift (head). Using independent seeds

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -1,0 +1,10 @@
+//! Networking surface for the Stack-chan firmware.
+//!
+//! Holds the Wi-Fi station task and the link-state signal that
+//! downstream consumers (SNTP, HTTP, mDNS) wait on. Boot order:
+//! avatar tasks first, then `wifi_task` — the avatar must remain
+//! responsive even when there's no SSID configured or the AP is
+//! unreachable.
+
+pub mod stack;
+pub mod wifi;

--- a/crates/stackchan-firmware/src/net/stack.rs
+++ b/crates/stackchan-firmware/src/net/stack.rs
@@ -1,0 +1,24 @@
+//! embassy-net runner task. Drives the TCP/IP stack on top of the
+//! esp-radio station-mode `WifiDevice` and runs `DHCPv4` once the
+//! link is up.
+
+use embassy_net::{Runner, StackResources};
+use esp_radio::wifi::WifiDevice;
+use static_cell::StaticCell;
+
+/// Maximum number of concurrent sockets the firmware ever needs:
+/// one for SNTP (UDP), one or two for the HTTP server (listen +
+/// accepted), one for mDNS responder, plus a couple of slack.
+pub const STACK_SOCKETS: usize = 6;
+
+/// Static cell for the embassy-net resource pool. Sized at compile
+/// time to avoid heap fragmentation under SNTP/HTTP/mDNS churn.
+pub static STACK_RESOURCES: StaticCell<StackResources<STACK_SOCKETS>> = StaticCell::new();
+
+/// embassy-net runner task. Spins forever processing the network
+/// stack's internal queues; reading or writing on the corresponding
+/// `Stack` borrows from the same instance.
+#[embassy_executor::task]
+pub async fn net_runner_task(mut runner: Runner<'static, WifiDevice<'static>>) -> ! {
+    runner.run().await
+}

--- a/crates/stackchan-firmware/src/net/wifi.rs
+++ b/crates/stackchan-firmware/src/net/wifi.rs
@@ -1,0 +1,118 @@
+//! Wi-Fi station-mode task with offline-first retry.
+//!
+//! Owns the [`WifiController`] for the duration of the firmware run.
+//! On boot, checks the SSID from [`stackchan_net::WifiConfig`] — an
+//! empty value means "no Wi-Fi configured", and the task parks
+//! silently so the avatar runs offline-first without any retry storm.
+//! With a non-empty SSID it configures station mode, attempts to
+//! connect, and on disconnection retries with exponential backoff.
+
+use alloc::string::String;
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_time::{Duration, Timer};
+use esp_radio::wifi::{ClientConfig, ModeConfig, WifiController, WifiEvent};
+
+/// Public link-state signal — downstream tasks (SNTP, HTTP, mDNS)
+/// `wait()` on it to gate their own startup against the connect.
+pub static WIFI_LINK_SIGNAL: Signal<CriticalSectionRawMutex, WifiLinkState> = Signal::new();
+
+/// Coarse-grained Wi-Fi link state. Published on every transition.
+#[derive(Clone, Copy, Debug, defmt::Format)]
+pub enum WifiLinkState {
+    /// No SSID configured, or the controller is currently between
+    /// connect attempts.
+    Disconnected,
+    /// Connect attempt in progress.
+    Connecting,
+    /// Joined the AP. The DHCP lease + IP assignment happen in the
+    /// embassy-net runner task once the link is up.
+    Connected,
+}
+
+/// Backoff schedule for connect retries. Saturates at the last entry.
+const RETRY_BACKOFF_MS: [u64; 5] = [1_000, 2_000, 5_000, 10_000, 30_000];
+
+/// Wi-Fi station task entry point. Owns the [`WifiController`] for
+/// the firmware lifetime. Empty SSID parks silently — the avatar
+/// runs offline-first and downstream `WIFI_LINK_SIGNAL` consumers
+/// see `Disconnected` and `wait()` indefinitely.
+///
+/// The task never returns: the embassy-net runner shares a
+/// `WifiDevice` borrowed from the same controller, and dropping the
+/// controller would null its backing radio state. On any setup
+/// error we log and park rather than `return`.
+#[embassy_executor::task]
+pub async fn wifi_task(mut controller: WifiController<'static>, ssid: String, psk: String) -> ! {
+    if ssid.trim().is_empty() {
+        defmt::info!("wifi: no SSID configured, idle");
+        WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+        park_forever().await;
+    }
+
+    let client_cfg = ClientConfig::default()
+        .with_ssid(ssid.clone())
+        .with_password(psk);
+    if let Err(e) = controller.set_config(&ModeConfig::Client(client_cfg)) {
+        defmt::error!(
+            "wifi: set_config rejected ({}); parking",
+            defmt::Debug2Format(&e)
+        );
+        park_forever().await;
+    }
+    if let Err(e) = controller.start_async().await {
+        defmt::error!(
+            "wifi: start_async failed ({}); parking",
+            defmt::Debug2Format(&e)
+        );
+        park_forever().await;
+    }
+
+    connect_loop(controller, ssid).await
+}
+
+/// Sleeps forever without dropping the caller's stack — used by
+/// `wifi_task`'s error / no-SSID paths. The embassy-net runner
+/// borrows the `WifiDevice` from the controller this task owns, so
+/// returning would null the runner's backing state and trip a
+/// `LoadProhibited` exception.
+async fn park_forever() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(3600)).await;
+    }
+}
+
+/// Connect / reconnect loop with exponential backoff. Owns the
+/// controller for the firmware lifetime.
+async fn connect_loop(mut controller: WifiController<'static>, ssid: String) -> ! {
+    let mut backoff_idx: usize = 0;
+    loop {
+        defmt::info!("wifi: connecting to ssid={=str}", ssid.as_str());
+        WIFI_LINK_SIGNAL.signal(WifiLinkState::Connecting);
+        match controller.connect_async().await {
+            Ok(()) => {
+                defmt::info!("wifi: connected");
+                WIFI_LINK_SIGNAL.signal(WifiLinkState::Connected);
+                backoff_idx = 0;
+                // Park until the controller reports a disconnect.
+                controller.wait_for_event(WifiEvent::StaDisconnected).await;
+                defmt::warn!("wifi: link dropped; reconnecting");
+                WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+            }
+            Err(e) => {
+                let backoff_ms = RETRY_BACKOFF_MS[backoff_idx];
+                defmt::warn!(
+                    "wifi: connect failed ({}); retry in {=u64} ms",
+                    defmt::Debug2Format(&e),
+                    backoff_ms
+                );
+                WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+                Timer::after(Duration::from_millis(backoff_ms)).await;
+                if backoff_idx + 1 < RETRY_BACKOFF_MS.len() {
+                    backoff_idx += 1;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Brings up the radio + Wi-Fi station controller after LCD init, with two new embassy tasks that own everything for the firmware lifetime:

- **`wifi_task`** owns the `WifiController`. Reads SSID/PSK from the loaded `stackchan_net::WifiConfig`. Empty SSID = offline-first sentinel (parks silently, no retry storm). Otherwise: configure as station, attempt connect, on disconnect retry with exponential backoff `[1s, 2s, 5s, 10s, 30s]`.
- **`net_runner_task`** drives the embassy-net stack on top of the station-mode `WifiDevice`. DHCPv4 enabled.

`WIFI_LINK_SIGNAL` (`Disconnected | Connecting | Connected`) is the public handoff for downstream tasks (SNTP, HTTP, mDNS) to gate their own startup.

### Why `wifi_task` never returns

First flash panicked at `LoadProhibited` immediately after `wifi: no SSID configured, idle`. Diagnosis: `wifi_task` `return`ed when SSID was empty, dropping `WifiController` and its backing radio state. `net_runner_task` was still alive holding a `WifiDevice<'static>` borrowed from the now-deinited radio → null deref. Fixed by re-shaping `wifi_task` as `-> !`: every error / no-SSID path falls through to a `park_forever` loop instead of returning. Bench re-verified clean.

## Version pinning notes

- `esp-radio 0.18` requires `esp-hal ~1.1.0-rc.0`, which would force a wider toolchain bump. Pinned to `~0.17` (compatible with `esp-hal ^1.0.0`).
- Added `esp-radio` to `esp-rtos`'s feature list — that's the missing link for `esp_rtos_yield_task` / `esp_rtos_usleep` symbols esp-radio resolves at link time.
- `embassy-net 0.9` pairs cleanly with esp-radio 0.17 / embassy-sync 0.7.

## Test plan

- [x] `just check-firmware` clean.
- [x] `just clippy-firmware` strict clean.
- [x] `just build-firmware` release link clean.
- [x] Bench flash on CoreS3 (no SD card, defaults / empty SSID):
  ```
  1441 ms [INFO ] ILI9342C ready — spawning render task
  1614 ms [INFO ] wifi: no SSID configured, idle
  1617 ms [INFO ] boot complete — idle heartbeat
  ```
  Avatar fully animating; head servos responding; LED ring + camera + audio all up.
- [ ] Bench with valid SD-card creds — pending physical card insertion.

## Files

- `crates/stackchan-firmware/src/net/mod.rs` — module root.
- `crates/stackchan-firmware/src/net/wifi.rs` — `wifi_task`, `WIFI_LINK_SIGNAL`, `WifiLinkState`.
- `crates/stackchan-firmware/src/net/stack.rs` — `net_runner_task`, `STACK_RESOURCES`, `STACK_SOCKETS`.
- `crates/stackchan-firmware/src/main.rs` — radio init + Stack construction + task spawn.
- `crates/stackchan-firmware/Cargo.toml` — `esp-radio = "~0.17"`, `embassy-net = "0.9"`, `esp-rtos` gains the `esp-radio` feature.

## Out of scope

- Real Wi-Fi join verification (needs SD card with creds).
- SNTP / HTTP / mDNS consumers of `WIFI_LINK_SIGNAL` — separate PRs.