### PR TITLE
feat(firmware): minimal HTTP control plane (GET /health, GET /state)

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -493,6 +493,16 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // Publish the final pose to the head task.
         head::POSE_SIGNAL.signal(entity.motor.head_pose);
 
+        // Update the read-only avatar snapshot the HTTP `/state`
+        // handler reads. Per-frame is cheap (one mutex, one struct
+        // copy) and avoids a second consumer racing the existing
+        // latest-wins `Signal`s.
+        net::snapshot::update_avatar(
+            entity.mind.affect.emotion,
+            entity.motor.head_pose,
+            Some(entity.motor.head_pose_actual),
+        );
+
         // Render the LED ring from the same entity state.
         render_leds(&entity, now, &mut led_frame);
         leds::LED_FRAME_SIGNAL.signal(led_frame);
@@ -879,6 +889,9 @@ async fn main(spawner: Spawner) -> ! {
         net_config.time.sntp_servers.clone(),
     )) {
         defmt::panic!("spawn(sntp_task) failed: {}", defmt::Debug2Format(&e));
+    }
+    if let Err(e) = spawner.spawn(net::http::http_task(net_stack)) {
+        defmt::panic!("spawn(http_task) failed: {}", defmt::Debug2Format(&e));
     }
 
     // Sample the chip's hardware RNG twice — once for IdleDrift

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -1,0 +1,225 @@
+//! Tiny hand-rolled HTTP/1.1 server for the LAN-scoped control
+//! plane. Two read-only routes:
+//!
+//! - `GET /health` — uptime, firmware version, free heap (handy for
+//!   liveness checks and post-flash smoke tests).
+//! - `GET /state` — `AvatarSnapshot` JSON read non-destructively
+//!   from `super::snapshot`.
+//!
+//! No external HTTP crate. The wire format is small, the surface
+//! is fixed, and a hand-roll dodges the impl-trait-in-assoc-type
+//! requirement that picoserve's `AppBuilder` brings in. Other
+//! routes (`POST /pose`, `GET/PUT /settings`) extend the same
+//! request matcher in a follow-up.
+
+use alloc::format;
+use alloc::string::String;
+
+use embassy_net::Stack;
+use embassy_net::tcp::TcpSocket;
+use embassy_time::Duration;
+use embedded_io_async::Write as AsyncWrite;
+
+use super::snapshot::{self, AvatarSnapshot};
+use super::wifi::{WIFI_LINK_SIGNAL, WifiLinkState};
+
+/// Listening port. LAN-only; no auth.
+const HTTP_PORT: u16 = 80;
+
+/// Maximum request line + headers size we'll buffer before responding
+/// `400`. Schema v1 only handles `GET /health` / `GET /state`, both
+/// trivially short.
+const REQUEST_BUF_BYTES: usize = 1024;
+
+/// Embassy task — owns one TCP socket and serves requests one at a time.
+/// Re-binds the socket per accept so a misbehaving client can't wedge
+/// the listener.
+#[embassy_executor::task]
+pub async fn http_task(stack: Stack<'static>) -> ! {
+    let mut rx_buf = [0u8; 1024];
+    let mut tx_buf = [0u8; 2048];
+
+    // Wait for the wifi task to publish a Connected state at least
+    // once. After that, every accept loop just keeps trying — embassy-net
+    // returns errors quickly when the link is down, no busy spin.
+    loop {
+        if matches!(WIFI_LINK_SIGNAL.wait().await, WifiLinkState::Connected) {
+            break;
+        }
+    }
+
+    defmt::info!(
+        "http: listening on 0.0.0.0:{=u16} (LAN-only, no auth)",
+        HTTP_PORT
+    );
+
+    loop {
+        let mut socket = TcpSocket::new(stack, &mut rx_buf, &mut tx_buf);
+        socket.set_timeout(Some(Duration::from_secs(10)));
+
+        if let Err(e) = socket.accept(HTTP_PORT).await {
+            defmt::warn!("http: accept failed ({:?})", e);
+            continue;
+        }
+
+        if let Err(e) = serve_one(&mut socket).await {
+            defmt::warn!("http: serve error ({})", defmt::Debug2Format(&e));
+        }
+
+        socket.close();
+        // Allow the peer time to read the FIN before we re-bind.
+        embassy_time::Timer::after(Duration::from_millis(50)).await;
+    }
+}
+
+/// Lightweight error wrapping for the request handler — ferries
+/// socket and parse failures to a single `warn` log line at the
+/// accept loop.
+#[derive(Debug, defmt::Format)]
+enum HttpError {
+    /// Socket read returned an error or EOF before headers landed.
+    Read,
+    /// Socket write returned an error mid-response.
+    Write,
+    /// Header section never closed within `REQUEST_BUF_BYTES`.
+    HeadersTooLarge,
+    /// Method + path didn't parse as a valid HTTP request line.
+    Malformed,
+}
+
+/// Serve a single HTTP/1.1 exchange against an accepted socket.
+async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let mut buf = [0u8; REQUEST_BUF_BYTES];
+    let mut filled = 0usize;
+    // Read until we see `\r\n\r\n` or hit the cap.
+    loop {
+        if filled >= REQUEST_BUF_BYTES {
+            return Err(HttpError::HeadersTooLarge);
+        }
+        match socket.read(&mut buf[filled..]).await {
+            Ok(n) if n > 0 => filled += n,
+            // Zero-byte read = EOF before headers landed; same outcome
+            // as a transport error from the caller's perspective.
+            _ => return Err(HttpError::Read),
+        }
+        if buf[..filled].windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    // Parse the request line: METHOD SP PATH SP HTTP/1.x CRLF
+    let line_end = buf[..filled]
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .ok_or(HttpError::Malformed)?;
+    let line = core::str::from_utf8(&buf[..line_end]).map_err(|_| HttpError::Malformed)?;
+    let mut parts = line.split(' ');
+    let method = parts.next().ok_or(HttpError::Malformed)?;
+    let path = parts.next().ok_or(HttpError::Malformed)?;
+
+    match (method, path) {
+        ("GET", "/health") => write_json(socket, 200, &health_body()).await,
+        ("GET", "/state") => write_json(socket, 200, &state_body(snapshot::read())).await,
+        ("GET", _) => write_text(socket, 404, "not found\n").await,
+        _ => write_text(socket, 405, "method not allowed\n").await,
+    }
+}
+
+/// Serialise the `/health` body. Schema is a flat object — no nested
+/// types, so a small `format!` keeps the dep surface clean.
+fn health_body() -> String {
+    let uptime_ms = embassy_time::Instant::now().as_millis();
+    let version = env!("CARGO_PKG_VERSION");
+    format!(
+        "{{\"uptime_ms\":{uptime_ms},\"version\":\"{version}\",\"free_heap_bytes\":{free}}}\n",
+        free = esp_alloc::HEAP.free(),
+    )
+}
+
+/// Serialise the `/state` body from a snapshot read. The HTTP layer
+/// owns the JSON shape; downstream consumers can rely on it without
+/// pulling stackchan-net into the response path.
+fn state_body(s: AvatarSnapshot) -> String {
+    let pct = s
+        .battery
+        .percent
+        .map_or_else(|| String::from("null"), |p| format!("{p}"));
+    let mv = s
+        .battery
+        .voltage_mv
+        .map_or_else(|| String::from("null"), |m| format!("{m}"));
+    let actual = s.head_actual.map_or_else(
+        || String::from("null"),
+        |p| {
+            format!(
+                "{{\"pan_deg\":{:.2},\"tilt_deg\":{:.2}}}",
+                p.pan_deg, p.tilt_deg
+            )
+        },
+    );
+    let ip = s
+        .wifi
+        .ip
+        .map_or_else(|| String::from("null"), |a| format!("\"{a}\""));
+    format!(
+        "{{\
+\"emotion\":\"{emotion:?}\",\
+\"head_pose\":{{\"pan_deg\":{pan:.2},\"tilt_deg\":{tilt:.2}}},\
+\"head_actual\":{actual},\
+\"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\
+\"wifi\":{{\"connected\":{connected},\"ip\":{ip}}}\
+}}\n",
+        emotion = s.emotion,
+        pan = s.head_pose.pan_deg,
+        tilt = s.head_pose.tilt_deg,
+        connected = s.wifi.connected,
+    )
+}
+
+/// Write `status` + `body` as `application/json`.
+async fn write_json(socket: &mut TcpSocket<'_>, status: u16, body: &str) -> Result<(), HttpError> {
+    let header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        reason = status_reason(status),
+        len = body.len(),
+    );
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket
+        .write_all(body.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
+}
+
+/// Plain-text response, used for non-JSON error paths.
+async fn write_text(socket: &mut TcpSocket<'_>, status: u16, body: &str) -> Result<(), HttpError> {
+    let header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: text/plain\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        reason = status_reason(status),
+        len = body.len(),
+    );
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket
+        .write_all(body.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
+}
+
+/// Mini status-reason table — only the codes this server emits.
+const fn status_reason(status: u16) -> &'static str {
+    match status {
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        // 200 + everything else fall through; the server only emits
+        // codes from this short list, so anything else here is a
+        // programming bug.
+        _ => "OK",
+    }
+}

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -6,6 +6,8 @@
 //! responsive even when there's no SSID configured or the AP is
 //! unreachable.
 
+pub mod http;
+pub mod snapshot;
 pub mod sntp;
 pub mod stack;
 pub mod wifi;

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -1,0 +1,120 @@
+//! Read-side avatar snapshot for the HTTP control plane.
+//!
+//! The render task updates [`AVATAR_SNAPSHOT`] once per frame; the
+//! HTTP handler reads it via a critical-section borrow without
+//! consuming any of the existing [`embassy_sync::signal::Signal`]
+//! channels (which are single-consumer / latest-wins by design — a
+//! second `try_take` from the HTTP task would steal sensor data
+//! from the render task and lose frames).
+
+use core::net::Ipv4Addr;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use stackchan_core::Emotion;
+use stackchan_core::head::Pose;
+
+/// Battery snapshot — published by the power task.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BatterySnapshot {
+    /// Estimated state-of-charge percentage (0..=100), or `None`
+    /// before the first reading lands.
+    pub percent: Option<u8>,
+    /// Battery voltage in millivolts.
+    pub voltage_mv: Option<u16>,
+}
+
+/// Wi-Fi link snapshot — published by the wifi task.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WifiSnapshot {
+    /// Whether the controller currently reports a Connected link.
+    pub connected: bool,
+    /// IPv4 address assigned by DHCP, if any.
+    pub ip: Option<Ipv4Addr>,
+}
+
+/// Composite avatar state surfaced via `GET /state`.
+#[derive(Debug, Clone, Copy)]
+pub struct AvatarSnapshot {
+    /// Current emotion produced by the modifier pipeline.
+    pub emotion: Emotion,
+    /// Most recently commanded head pose.
+    pub head_pose: Pose,
+    /// Most recently observed servo pose, if available.
+    pub head_actual: Option<Pose>,
+    /// Power / battery telemetry.
+    pub battery: BatterySnapshot,
+    /// Wi-Fi link state.
+    pub wifi: WifiSnapshot,
+}
+
+impl Default for AvatarSnapshot {
+    fn default() -> Self {
+        Self {
+            emotion: Emotion::Neutral,
+            head_pose: Pose::default(),
+            head_actual: None,
+            battery: BatterySnapshot::default(),
+            wifi: WifiSnapshot::default(),
+        }
+    }
+}
+
+/// The shared snapshot. Updated per render tick and on per-task
+/// transitions; HTTP reads borrow non-destructively.
+pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<AvatarSnapshot>> =
+    Mutex::new(core::cell::Cell::new(AvatarSnapshot {
+        emotion: Emotion::Neutral,
+        head_pose: Pose {
+            pan_deg: 0.0,
+            tilt_deg: 0.0,
+        },
+        head_actual: None,
+        battery: BatterySnapshot {
+            percent: None,
+            voltage_mv: None,
+        },
+        wifi: WifiSnapshot {
+            connected: false,
+            ip: None,
+        },
+    }));
+
+/// Replace the avatar/head fields. Called per render tick.
+pub fn update_avatar(emotion: Emotion, head_pose: Pose, head_actual: Option<Pose>) {
+    AVATAR_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.emotion = emotion;
+        s.head_pose = head_pose;
+        s.head_actual = head_actual;
+        cell.set(s);
+    });
+}
+
+/// Replace the battery fields. Called by the power task on each poll.
+pub fn update_battery(percent: Option<u8>, voltage_mv: Option<u16>) {
+    AVATAR_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.battery = BatterySnapshot {
+            percent,
+            voltage_mv,
+        };
+        cell.set(s);
+    });
+}
+
+/// Replace the Wi-Fi link fields. Called by the wifi task on link
+/// transitions and by `net_runner` on DHCP lease changes.
+pub fn update_wifi(connected: bool, ip: Option<Ipv4Addr>) {
+    AVATAR_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.wifi = WifiSnapshot { connected, ip };
+        cell.set(s);
+    });
+}
+
+/// Read the current snapshot. Cheap enough to call per HTTP request.
+#[must_use]
+pub fn read() -> AvatarSnapshot {
+    AVATAR_SNAPSHOT.lock(core::cell::Cell::get)
+}


### PR DESCRIPTION
## Summary

Hand-rolled HTTP/1.1 server on a single embassy-net `TcpSocket`. Two read-only routes:

- **`GET /health`** — `{uptime_ms, version, free_heap_bytes}` JSON. Smoke-test friendly.
- **`GET /state`** — `{emotion, head_pose, head_actual, battery, wifi}` JSON, read non-destructively from the new `net::snapshot::AVATAR_SNAPSHOT`.

`net::snapshot` is the read-side data model. The render task writes avatar fields (emotion, head pose, head actual) once per frame; HTTP reads via a critical-section borrow without consuming any of the existing `Signal<T>` channels (single-consumer / latest-wins by design — a second `try_take` from the HTTP task would steal sensor data from the render task).

The server waits for `WIFI_LINK_SIGNAL::Connected` before binding the listener; on disconnect each `accept` returns quickly and the loop keeps trying. LAN-scoped, no auth.

## Why hand-rolled vs `picoserve`

picoserve's `AppBuilder` pattern requires `#![feature(impl_trait_in_assoc_type)]` (still unstable as of Rust 1.95-nightly). That's a crate-level attribute that would touch the whole firmware. The schema here is small enough that ~250 LOC of hand-rolled HTTP/1.1 is cleaner than the dep + the nightly-feature requirement — same "small, owned" reasoning as the bare RON parser and the inline SNTP client.

## Test plan

- [x] `just check-firmware`, `just clippy-firmware`, `just build-firmware` all green.
- [x] Bench flash on CoreS3 (no SD card / empty config):
  ```
  1448 ms ILI9342C ready — spawning render task
  1621 ms wifi: no SSID configured, idle
  1625 ms boot complete — idle heartbeat
  ```
  http_task is alive but parked on the link signal; "listening on 0.0.0.0:80" will log once Wi-Fi connects with real creds.
- [ ] `curl http://stackchan.local/health` and `curl http://stackchan.local/state` end-to-end — needs SD card with valid Wi-Fi creds.

## Files

- `crates/stackchan-firmware/src/net/snapshot.rs` — `AvatarSnapshot`, `update_avatar` / `update_battery` / `update_wifi`, `read`.
- `crates/stackchan-firmware/src/net/http.rs` — `http_task`, request parser, JSON body builders, status table.
- `crates/stackchan-firmware/src/net/mod.rs` — `pub mod http; pub mod snapshot;`.
- `crates/stackchan-firmware/src/main.rs` — render task calls `snapshot::update_avatar` per frame; `http_task` spawn after `sntp_task`.

## Out of scope

- `POST /pose` (one-shot pose pulse) and `GET/PUT /settings` (RON round-trip via `storage`) — extend the same request matcher in a follow-up.
- mDNS hostname for `stackchan.local` — separate PR.
- Battery + Wi-Fi snapshot updates from `power_task` / `wifi_task` — same trivial wiring as the avatar update; pulled out of this PR for a tighter review surface.