### PR TITLE
feat(firmware): HTTP POST control plane (emotion, look-at, reset)

### DIFF
--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -78,6 +78,7 @@ render tick. Listed roughly in application order:
 | `GazeFromAttention`  | Eye centers shift toward target while `Tracking` (eyes lead head) |
 | `MicrosaccadeFromAttention` | 0.5–1.5 s involuntary eye darts during `Tracking` (Disney IROS realism contributor) |
 | `AttentionFromTracking` | Cognition: latches `mind.attention=Tracking{target}` on sustained camera motion |
+| `RemoteCommandModifier` | Cognition: drains `entity.input.remote_command` (firmware HTTP), holds emotion or look-at target for the requested window |
 | `Blink` / `Breath`   | Engagement-aware: blink rate halves and breath cycle stretches ×1.67 while attention is non-`None` |
 | `IdleDrift`       | Slow randomized gaze drift                                     |
 | `IdleHeadDrift`   | Occasional brief head glances at randomized intervals          |

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -202,6 +202,8 @@ pub enum Field {
     TapPending,
     /// `entity.input.remote_pending`
     RemotePending,
+    /// `entity.input.remote_command`
+    RemoteCommand,
 }
 
 impl Field {
@@ -248,6 +250,7 @@ impl Field {
         Self::IsSpeaking,
         Self::TapPending,
         Self::RemotePending,
+        Self::RemoteCommand,
     ];
 
     /// Coarse grouping for human-readable reports.
@@ -288,7 +291,7 @@ impl Field {
             | Self::Engagement
             | Self::Dormancy => FieldGroup::Mind,
             Self::ChirpRequest | Self::UtteranceRequest | Self::IsSpeaking => FieldGroup::Voice,
-            Self::TapPending | Self::RemotePending => FieldGroup::Input,
+            Self::TapPending | Self::RemotePending | Self::RemoteCommand => FieldGroup::Input,
         }
     }
 
@@ -394,6 +397,7 @@ impl Field {
             Self::IsSpeaking => before.voice.is_speaking != after.voice.is_speaking,
             Self::TapPending => before.input.tap_pending != after.input.tap_pending,
             Self::RemotePending => before.input.remote_pending != after.input.remote_pending,
+            Self::RemoteCommand => before.input.remote_command != after.input.remote_command,
         }
     }
 }
@@ -801,7 +805,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            39,
+            40,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -12,12 +12,56 @@
 //! Consumer side: the modifier checks the field each tick, and if set,
 //! reads + clears it.
 
+use crate::emotion::Emotion;
+use crate::head::Pose;
+
+/// External command delivered through the firmware control plane.
+///
+/// Producer: the firmware HTTP task parses a request body into one of
+/// these variants and writes [`Input::remote_command`].
+///
+/// Consumer: [`crate::modifiers::RemoteCommandModifier`] drains the
+/// slot, stashes any hold timer internally, and re-asserts emotion or
+/// attention each frame until the timer expires.
+///
+/// Only `PartialEq` (not `Eq`) because [`RemoteCommand::LookAt`]
+/// carries a [`Pose`] with `f32` fields.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RemoteCommand {
+    /// Set [`crate::Affect::emotion`] and hold the autonomy gate for
+    /// `hold_ms` so autonomous emotion drivers stand down. Source is
+    /// recorded as [`crate::OverrideSource::Remote`].
+    SetEmotion {
+        /// Emotion to assert.
+        emotion: Emotion,
+        /// Hold duration in milliseconds. Zero is fire-and-forget:
+        /// emotion is asserted once and autonomy is released on the
+        /// same tick.
+        hold_ms: u32,
+    },
+    /// Set [`crate::Attention::Tracking`] toward `target` and hold for
+    /// `hold_ms` so the tracking modifier does not stomp the target.
+    LookAt {
+        /// Head pose to look at, in the same coordinate system as
+        /// `motor.head_pose`.
+        target: Pose,
+        /// Hold duration in milliseconds.
+        hold_ms: u32,
+    },
+    /// Clear any active emotion or look-at hold and return to
+    /// autonomous behavior.
+    Reset,
+}
+
 /// Pending inputs the modifier graph consumes.
 ///
 /// Persistent across frames: the [`Director`](crate::Director) does
 /// not clear `Input`. Modifiers consume explicitly by setting fields
 /// back to their default.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+///
+/// Only `PartialEq` (not `Eq`) because [`RemoteCommand`] carries a
+/// [`Pose`] with `f32` fields.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Input {
     /// Tap edge from the touch sensor or power button. Consumed by
     /// [`crate::modifiers::EmotionFromTouch`].
@@ -25,4 +69,7 @@ pub struct Input {
     /// Most recent decoded IR-remote `(address, command)` pair.
     /// Consumed by [`crate::modifiers::EmotionFromRemote`].
     pub remote_pending: Option<(u16, u8)>,
+    /// Most recent external control-plane command. Consumed by
+    /// [`crate::modifiers::RemoteCommandModifier`].
+    pub remote_command: Option<RemoteCommand>,
 }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -56,7 +56,7 @@ pub use entity::{Entity, Tick};
 pub use events::Events;
 pub use face::{Eye, EyePhase, Face, Mouth, Point, SCALE_DEFAULT, Style};
 pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
-pub use input::Input;
+pub use input::{Input, RemoteCommand};
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use lipsync::{LipSync, Viseme};
 pub use mind::{Affect, Attention, Autonomy, Dormancy, Engagement, Intent, Mind, OverrideSource};

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -68,6 +68,13 @@
 //!   1. [`AttentionFromTracking`] — reads `perception.tracking`,
 //!      writes `mind.attention=Tracking{target}` after sustained
 //!      camera motion; releases after the quiet window.
+//!   2. [`RemoteCommandModifier`] — drains
+//!      `entity.input.remote_command` set by an external control
+//!      plane (firmware HTTP), holds emotion + autonomy
+//!      ([`crate::RemoteCommand::SetEmotion`]) or attention
+//!      ([`crate::RemoteCommand::LookAt`]) for a configurable
+//!      window, and re-asserts each tick so cooperative cognition
+//!      modifiers cannot stomp the operator's hold.
 //!
 //! Empty phases today (slots reserved for v2.x):
 //! [`crate::director::Phase::Perception`],
@@ -96,6 +103,7 @@ mod intent_from_loud;
 mod lost_target_search;
 mod microsaccade_from_attention;
 mod mouth_from_audio;
+mod remote_command;
 mod style_from_emotion;
 mod style_from_intent;
 
@@ -151,5 +159,6 @@ pub use microsaccade_from_attention::{
 pub use mouth_from_audio::{
     DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthFromAudio,
 };
+pub use remote_command::RemoteCommandModifier;
 pub use style_from_emotion::StyleFromEmotion;
 pub use style_from_intent::{PETTING_BLUSH_BUMP, StyleFromIntent};

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -1,0 +1,428 @@
+//! `RemoteCommandModifier`: external control-plane commands assert
+//! emotion or attention with a hold timer.
+//!
+//! ## Trigger shape
+//!
+//! Reads `entity.input.remote_command` set by the firmware HTTP task
+//! (or any other producer). Three command shapes:
+//!
+//! - [`RemoteCommand::SetEmotion`] — writes `mind.affect.emotion` and
+//!   pins `mind.autonomy.manual_until = now + hold_ms` with
+//!   [`OverrideSource::Remote`]. Autonomous emotion drivers in
+//!   [`Phase::Affect`] (which runs after [`Phase::Cognition`]) gate
+//!   on `manual_until` and stand down for the hold's duration —
+//!   same idiom as
+//!   [`super::EmotionFromRemote`].
+//! - [`RemoteCommand::LookAt`] — writes
+//!   `mind.attention = Attention::Tracking { target, since: now }`
+//!   and stashes a hold timer. While the hold is active the modifier
+//!   re-asserts the same target each tick at higher priority than
+//!   [`super::AttentionFromTracking`], so a face entering the frame
+//!   mid-hold cannot stomp the operator's target. `since` is pinned
+//!   to the entry frame so consumer ease-in animations stay smooth.
+//! - [`RemoteCommand::Reset`] — clears any active emotion or look-at
+//!   hold and resets `mind.autonomy.manual_until` /
+//!   `mind.attention` to defaults.
+//!
+//! ## Why a Modifier, not a Skill
+//!
+//! [`Skill`](crate::Skill) writes are framework-restricted to
+//! [`Mind`](crate::director::FieldGroup::Mind) /
+//! [`Voice`](crate::director::FieldGroup::Voice) — a skill can't
+//! drain [`Input::remote_command`](crate::Input::remote_command).
+//! Modifiers can. The hold-timer state lives inside the modifier the
+//! same way [`super::AttentionFromTracking`] holds its lock counter.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::emotion::Emotion;
+use crate::entity::Entity;
+use crate::head::Pose;
+use crate::input::RemoteCommand;
+use crate::mind::{Attention, OverrideSource};
+use crate::modifier::Modifier;
+
+/// External control-plane modifier — see module docs for trigger shape.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RemoteCommandModifier {
+    /// Active emotion hold, if any. `(emotion, hold_until)`.
+    emotion_hold: Option<(Emotion, Instant)>,
+    /// Active look-at hold, if any. `(target, since, hold_until)`.
+    /// `since` is captured at the first frame of the hold so the
+    /// rendered ease-in does not restart every tick.
+    lookat_hold: Option<(Pose, Instant, Instant)>,
+}
+
+impl RemoteCommandModifier {
+    /// Construct with no active holds.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            emotion_hold: None,
+            lookat_hold: None,
+        }
+    }
+
+    /// Apply a freshly received command: write the matching mind
+    /// fields and stash any hold timer for re-assertion in subsequent
+    /// ticks.
+    fn apply(&mut self, command: RemoteCommand, now: Instant, entity: &mut Entity) {
+        match command {
+            RemoteCommand::SetEmotion { emotion, hold_ms } => {
+                let until = now + u64::from(hold_ms);
+                entity.mind.affect.emotion = emotion;
+                entity.mind.autonomy.manual_until = Some(until);
+                entity.mind.autonomy.source = Some(OverrideSource::Remote);
+                self.emotion_hold = Some((emotion, until));
+            }
+            RemoteCommand::LookAt { target, hold_ms } => {
+                let until = now + u64::from(hold_ms);
+                entity.mind.attention = Attention::Tracking { target, since: now };
+                self.lookat_hold = Some((target, now, until));
+            }
+            RemoteCommand::Reset => {
+                entity.mind.autonomy.manual_until = None;
+                entity.mind.autonomy.source = None;
+                entity.mind.attention = Attention::None;
+                self.emotion_hold = None;
+                self.lookat_hold = None;
+            }
+        }
+    }
+}
+
+impl Modifier for RemoteCommandModifier {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "RemoteCommandModifier",
+            description: "Drains entity.input.remote_command into mind.affect.emotion + \
+                          mind.autonomy (SetEmotion) or mind.attention (LookAt) and re-asserts \
+                          the value each tick until the hold timer expires. Reset clears all \
+                          active holds. Priority 100 in Phase::Cognition runs after \
+                          AttentionFromTracking so a tracking observation cannot stomp the \
+                          operator's target during a hold.",
+            phase: Phase::Cognition,
+            priority: 100,
+            reads: &[Field::RemoteCommand, Field::Autonomy, Field::Attention],
+            writes: &[
+                Field::Emotion,
+                Field::Autonomy,
+                Field::Attention,
+                Field::RemoteCommand,
+            ],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+
+        if let Some(command) = entity.input.remote_command.take() {
+            self.apply(command, now, entity);
+        }
+
+        if let Some((emotion, until)) = self.emotion_hold {
+            if now < until {
+                entity.mind.affect.emotion = emotion;
+                entity.mind.autonomy.manual_until = Some(until);
+                entity.mind.autonomy.source = Some(OverrideSource::Remote);
+            } else {
+                self.emotion_hold = None;
+                if entity.mind.autonomy.source == Some(OverrideSource::Remote) {
+                    entity.mind.autonomy.manual_until = None;
+                    entity.mind.autonomy.source = None;
+                }
+            }
+        }
+
+        if let Some((target, since, until)) = self.lookat_hold {
+            if now < until {
+                entity.mind.attention = Attention::Tracking { target, since };
+            } else {
+                self.lookat_hold = None;
+                if matches!(entity.mind.attention, Attention::Tracking { target: t, .. } if t == target)
+                {
+                    entity.mind.attention = Attention::None;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::panic,
+    reason = "test-only: f32 fields compared exactly against the literal we wrote; \
+              let-else / match-with-panic is the cleanest pattern for value extraction \
+              on enum variants in tests"
+)]
+mod tests {
+    use super::*;
+    use crate::Affect;
+    use crate::mind::Autonomy;
+
+    fn entity_at(now_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.tick.now = Instant::from_millis(now_ms);
+        e
+    }
+
+    fn step(modifier: &mut RemoteCommandModifier, entity: &mut Entity, now_ms: u64) {
+        entity.tick.now = Instant::from_millis(now_ms);
+        modifier.update(entity);
+    }
+
+    #[test]
+    fn set_emotion_writes_emotion_and_autonomy() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 1_000,
+        });
+
+        step(&mut m, &mut entity, 0);
+
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+        assert_eq!(
+            entity.mind.autonomy.manual_until,
+            Some(Instant::from_millis(1_000))
+        );
+        assert_eq!(entity.mind.autonomy.source, Some(OverrideSource::Remote));
+        assert!(entity.input.remote_command.is_none());
+    }
+
+    #[test]
+    fn emotion_hold_re_asserts_each_tick_against_stomping() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 1_000,
+        });
+        step(&mut m, &mut entity, 0);
+
+        entity.mind.affect = Affect {
+            emotion: Emotion::Sleepy,
+        };
+        step(&mut m, &mut entity, 100);
+        assert_eq!(
+            entity.mind.affect.emotion,
+            Emotion::Happy,
+            "hold must re-assert against mid-frame stomps"
+        );
+    }
+
+    #[test]
+    fn emotion_hold_releases_after_timer_expires() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 500,
+        });
+        step(&mut m, &mut entity, 0);
+        step(&mut m, &mut entity, 600);
+
+        assert!(entity.mind.autonomy.manual_until.is_none());
+        assert!(entity.mind.autonomy.source.is_none());
+    }
+
+    #[test]
+    fn emotion_release_does_not_clear_a_different_owner() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 100,
+        });
+        step(&mut m, &mut entity, 0);
+
+        entity.mind.autonomy = Autonomy {
+            manual_until: Some(Instant::from_millis(10_000)),
+            source: Some(OverrideSource::LowBattery),
+        };
+        step(&mut m, &mut entity, 200);
+
+        assert_eq!(
+            entity.mind.autonomy.manual_until,
+            Some(Instant::from_millis(10_000))
+        );
+        assert_eq!(
+            entity.mind.autonomy.source,
+            Some(OverrideSource::LowBattery)
+        );
+    }
+
+    #[test]
+    fn lookat_writes_attention_with_since_pinned_to_entry() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(5_000);
+        entity.input.remote_command = Some(RemoteCommand::LookAt {
+            target: Pose {
+                pan_deg: 12.0,
+                tilt_deg: -3.0,
+            },
+            hold_ms: 1_000,
+        });
+
+        step(&mut m, &mut entity, 5_000);
+
+        let entry = match entity.mind.attention {
+            Attention::Tracking { target, since } => {
+                assert_eq!(target.pan_deg, 12.0);
+                assert_eq!(target.tilt_deg, -3.0);
+                since
+            }
+            other => panic!("expected Tracking, got {other:?}"),
+        };
+
+        step(&mut m, &mut entity, 5_033);
+        step(&mut m, &mut entity, 5_066);
+        match entity.mind.attention {
+            Attention::Tracking { since, .. } => {
+                assert_eq!(since, entry, "since must pin to entry frame");
+            }
+            other => panic!("expected Tracking still, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookat_hold_re_asserts_against_tracking_mid_hold() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::LookAt {
+            target: Pose {
+                pan_deg: 20.0,
+                tilt_deg: 0.0,
+            },
+            hold_ms: 1_000,
+        });
+        step(&mut m, &mut entity, 0);
+
+        entity.mind.attention = Attention::Tracking {
+            target: Pose {
+                pan_deg: -45.0,
+                tilt_deg: 10.0,
+            },
+            since: Instant::from_millis(100),
+        };
+
+        step(&mut m, &mut entity, 100);
+        match entity.mind.attention {
+            Attention::Tracking { target, .. } => {
+                assert_eq!(
+                    target.pan_deg, 20.0,
+                    "remote target must override tracking during hold"
+                );
+            }
+            other => panic!("expected Tracking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookat_release_clears_when_target_unchanged() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        let target = Pose {
+            pan_deg: 5.0,
+            tilt_deg: 0.0,
+        };
+        entity.input.remote_command = Some(RemoteCommand::LookAt {
+            target,
+            hold_ms: 200,
+        });
+        step(&mut m, &mut entity, 0);
+
+        step(&mut m, &mut entity, 300);
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn lookat_release_does_not_clear_a_different_target() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::LookAt {
+            target: Pose {
+                pan_deg: 5.0,
+                tilt_deg: 0.0,
+            },
+            hold_ms: 100,
+        });
+        step(&mut m, &mut entity, 0);
+
+        let face_target = Pose {
+            pan_deg: -30.0,
+            tilt_deg: 5.0,
+        };
+        entity.mind.attention = Attention::Tracking {
+            target: face_target,
+            since: Instant::from_millis(150),
+        };
+        step(&mut m, &mut entity, 200);
+
+        match entity.mind.attention {
+            Attention::Tracking { target, .. } => {
+                assert_eq!(
+                    target, face_target,
+                    "release must not clobber a fresh tracking target"
+                );
+            }
+            other => panic!("expected fresh Tracking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reset_clears_both_holds_and_returns_to_default() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Angry,
+            hold_ms: 10_000,
+        });
+        step(&mut m, &mut entity, 0);
+        entity.input.remote_command = Some(RemoteCommand::LookAt {
+            target: Pose {
+                pan_deg: 12.0,
+                tilt_deg: 0.0,
+            },
+            hold_ms: 10_000,
+        });
+        step(&mut m, &mut entity, 50);
+
+        entity.input.remote_command = Some(RemoteCommand::Reset);
+        step(&mut m, &mut entity, 100);
+
+        assert!(entity.mind.autonomy.manual_until.is_none());
+        assert!(entity.mind.autonomy.source.is_none());
+        assert_eq!(entity.mind.attention, Attention::None);
+
+        entity.mind.affect = Affect {
+            emotion: Emotion::Sleepy,
+        };
+        step(&mut m, &mut entity, 200);
+        assert_eq!(
+            entity.mind.affect.emotion,
+            Emotion::Sleepy,
+            "reset must drop the emotion hold"
+        );
+    }
+
+    #[test]
+    fn zero_hold_ms_is_fire_and_forget() {
+        // hold_ms=0 sets emotion + autonomy, then the same-tick
+        // re-assert sees `now < now == false` and releases the
+        // autonomy. Operators who want a sticky override pass a
+        // non-zero hold_ms.
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 0,
+        });
+        step(&mut m, &mut entity, 0);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+        assert!(entity.mind.autonomy.manual_until.is_none());
+    }
+}

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -75,7 +75,8 @@ use stackchan_core::{
         EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
         EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion,
         HeadFromIntent, IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud,
-        MicrosaccadeFromAttention, MouthFromAudio, StyleFromEmotion, StyleFromIntent,
+        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, StyleFromEmotion,
+        StyleFromIntent,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -193,6 +194,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut emotion_from_voice = EmotionFromVoice::new();
     let mut intent_from_loud = IntentFromLoud::new();
     let mut attention_from_tracking = AttentionFromTracking::new();
+    let mut remote_command = RemoteCommandModifier::new();
     let mut dormancy_from_activity = DormancyFromActivity::new();
     let mut cycle = EmotionCycle::new();
     let mut style = StyleFromEmotion::new();
@@ -257,6 +259,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         .expect("registry full");
     director
         .add_modifier(&mut attention_from_tracking)
+        .expect("registry full");
+    director
+        .add_modifier(&mut remote_command)
         .expect("registry full");
     director
         .add_modifier(&mut dormancy_from_activity)
@@ -371,6 +376,12 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // Drain IR-remote decoded commands, if any.
         if let Some(cmd) = ir::REMOTE_SIGNAL.try_take() {
             entity.input.remote_pending = Some((cmd.address, cmd.command));
+        }
+        // Drain HTTP control-plane commands, if any. RemoteCommandModifier
+        // (Phase::Cognition) consumes the slot, asserts emotion or
+        // attention, and re-asserts each tick until the hold expires.
+        if let Some(cmd) = net::http::REMOTE_COMMAND_SIGNAL.try_take() {
+            entity.input.remote_command = Some(cmd);
         }
         // Drain the latest IMU reading.
         if let Some(m) = imu::IMU_SIGNAL.try_take() {

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -1,35 +1,65 @@
-//! Tiny hand-rolled HTTP/1.1 server for the LAN-scoped control
-//! plane. Two read-only routes:
+//! Tiny hand-rolled HTTP/1.1 server for the LAN-scoped control plane.
+//!
+//! ## Routes
 //!
 //! - `GET /health` — uptime, firmware version, free heap (handy for
 //!   liveness checks and post-flash smoke tests).
 //! - `GET /state` — `AvatarSnapshot` JSON read non-destructively
 //!   from `super::snapshot`.
+//! - `POST /emotion` — JSON `{"emotion": "...", "hold_ms": ...}`.
+//!   Sets affect + holds `mind.autonomy` against the autonomous
+//!   emotion drivers for `hold_ms` (default
+//!   [`super::json::DEFAULT_HOLD_MS`]).
+//! - `POST /look-at` — JSON `{"pan_deg": f32, "tilt_deg": f32, "hold_ms": ...}`.
+//!   Sets `mind.attention = Tracking { target }` for `hold_ms`,
+//!   asserting the operator's target against camera tracking.
+//! - `POST /reset` — empty body. Clears any active emotion or
+//!   look-at hold and returns the avatar to autonomous behaviour.
+//!
+//! All write routes funnel through [`REMOTE_COMMAND_SIGNAL`]; the
+//! render task drains the signal into
+//! `entity.input.remote_command` ahead of `Director::run`, where
+//! [`stackchan_core::modifiers::RemoteCommandModifier`] picks it up.
 //!
 //! No external HTTP crate. The wire format is small, the surface
 //! is fixed, and a hand-roll dodges the impl-trait-in-assoc-type
-//! requirement that picoserve's `AppBuilder` brings in. Other
-//! routes (`POST /pose`, `GET/PUT /settings`) extend the same
-//! request matcher in a follow-up.
+//! requirement that picoserve's `AppBuilder` brings in.
 
 use alloc::format;
 use alloc::string::String;
 
 use embassy_net::Stack;
 use embassy_net::tcp::TcpSocket;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
+use stackchan_core::RemoteCommand;
 
+use super::json::{self, JsonError};
 use super::snapshot::{self, AvatarSnapshot};
 use super::wifi::{WIFI_LINK_SIGNAL, WifiLinkState};
 
 /// Listening port. LAN-only; no auth.
 const HTTP_PORT: u16 = 80;
 
-/// Maximum request line + headers size we'll buffer before responding
-/// `400`. Schema v1 only handles `GET /health` / `GET /state`, both
-/// trivially short.
+/// Maximum request line + headers + body size we'll buffer before
+/// responding `400`. POST bodies for the current write surface are
+/// at most a few dozen bytes; 1 KiB is generous.
 const REQUEST_BUF_BYTES: usize = 1024;
+
+/// Cap on the `Content-Length` header. Anything larger is rejected
+/// before any body bytes are read — the write surface only accepts
+/// short JSON object bodies.
+const MAX_BODY_BYTES: usize = 256;
+
+/// Latest control-plane command.
+///
+/// Set by the HTTP task on a successful POST; drained by the render
+/// task into `entity.input.remote_command` before `Director::run`.
+/// Latest-wins semantics — a second POST that lands before the
+/// render task drains will overwrite the first.
+pub static REMOTE_COMMAND_SIGNAL: Signal<CriticalSectionRawMutex, RemoteCommand> = Signal::new();
 
 /// Embassy task — owns one TCP socket and serves requests one at a time.
 /// Re-binds the socket per accept so a misbehaving client can't wedge
@@ -77,12 +107,16 @@ pub async fn http_task(stack: Stack<'static>) -> ! {
 /// accept loop.
 #[derive(Debug, defmt::Format)]
 enum HttpError {
-    /// Socket read returned an error or EOF before headers landed.
+    /// Socket read returned an error or EOF before the request was
+    /// complete.
     Read,
     /// Socket write returned an error mid-response.
     Write,
     /// Header section never closed within `REQUEST_BUF_BYTES`.
     HeadersTooLarge,
+    /// `Content-Length` exceeded [`MAX_BODY_BYTES`] or wasn't a valid
+    /// non-negative integer.
+    BodyTooLarge,
     /// Method + path didn't parse as a valid HTTP request line.
     Malformed,
 }
@@ -92,7 +126,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     let mut buf = [0u8; REQUEST_BUF_BYTES];
     let mut filled = 0usize;
     // Read until we see `\r\n\r\n` or hit the cap.
-    loop {
+    let header_end = loop {
         if filled >= REQUEST_BUF_BYTES {
             return Err(HttpError::HeadersTooLarge);
         }
@@ -102,27 +136,126 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
             // as a transport error from the caller's perspective.
             _ => return Err(HttpError::Read),
         }
-        if buf[..filled].windows(4).any(|w| w == b"\r\n\r\n") {
-            break;
+        if let Some(idx) = find_subsequence(&buf[..filled], b"\r\n\r\n") {
+            break idx;
         }
-    }
+    };
 
-    // Parse the request line: METHOD SP PATH SP HTTP/1.x CRLF
+    // Parse request-line bounds. Capture method/path as `(start, end)`
+    // ranges instead of `&str` borrows so the borrow on `buf` ends
+    // before the body read needs `&mut buf`.
     let line_end = buf[..filled]
         .windows(2)
         .position(|w| w == b"\r\n")
         .ok_or(HttpError::Malformed)?;
-    let line = core::str::from_utf8(&buf[..line_end]).map_err(|_| HttpError::Malformed)?;
-    let mut parts = line.split(' ');
-    let method = parts.next().ok_or(HttpError::Malformed)?;
-    let path = parts.next().ok_or(HttpError::Malformed)?;
+    let first_sp = buf[..line_end]
+        .iter()
+        .position(|&b| b == b' ')
+        .ok_or(HttpError::Malformed)?;
+    let path_start = first_sp + 1;
+    let second_sp = buf[path_start..line_end]
+        .iter()
+        .position(|&b| b == b' ')
+        .ok_or(HttpError::Malformed)?
+        + path_start;
+    let body_start = header_end + 4;
+    let content_length = parse_content_length(&buf[line_end + 2..header_end])?;
+    if content_length > MAX_BODY_BYTES {
+        return Err(HttpError::BodyTooLarge);
+    }
+    while filled < body_start + content_length {
+        if filled >= REQUEST_BUF_BYTES {
+            return Err(HttpError::BodyTooLarge);
+        }
+        match socket.read(&mut buf[filled..]).await {
+            Ok(n) if n > 0 => filled += n,
+            _ => return Err(HttpError::Read),
+        }
+    }
+
+    let method = core::str::from_utf8(&buf[..first_sp]).map_err(|_| HttpError::Malformed)?;
+    let path =
+        core::str::from_utf8(&buf[path_start..second_sp]).map_err(|_| HttpError::Malformed)?;
+    let body = core::str::from_utf8(&buf[body_start..body_start + content_length])
+        .map_err(|_| HttpError::Malformed)?;
 
     match (method, path) {
         ("GET", "/health") => write_json(socket, 200, &health_body()).await,
         ("GET", "/state") => write_json(socket, 200, &state_body(snapshot::read())).await,
-        ("GET", _) => write_text(socket, 404, "not found\n").await,
+        ("POST", "/emotion") => handle_remote(socket, json::parse_set_emotion(body)).await,
+        ("POST", "/look-at") => handle_remote(socket, json::parse_look_at(body)).await,
+        ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
+        ("GET" | "POST", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
     }
+}
+
+/// Apply a parsed remote command (or surface the parser error to the
+/// client). On success: signal the render task and respond `204 No
+/// Content`. On parse failure: respond `400 Bad Request` with a
+/// short plain-text reason.
+async fn handle_remote(
+    socket: &mut TcpSocket<'_>,
+    command: Result<RemoteCommand, JsonError>,
+) -> Result<(), HttpError> {
+    match command {
+        Ok(cmd) => {
+            defmt::info!("http: remote command {}", defmt::Debug2Format(&cmd));
+            REMOTE_COMMAND_SIGNAL.signal(cmd);
+            write_text(socket, 204, "").await
+        }
+        Err(e) => {
+            defmt::warn!("http: bad request body ({})", e);
+            let body = format!("invalid request body: {e:?}\n");
+            write_text(socket, 400, &body).await
+        }
+    }
+}
+
+/// Parse the `Content-Length` header value out of a header block.
+/// Returns `0` when absent (correct for GET / 0-body POST). Returns
+/// [`HttpError::Malformed`] if the header is present but not a valid
+/// non-negative integer.
+fn parse_content_length(headers: &[u8]) -> Result<usize, HttpError> {
+    for line in headers.split(|&b| b == b'\n') {
+        // Trim trailing CR.
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some((name, value)) = split_once(line, b':') else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case(b"content-length") {
+            continue;
+        }
+        let value = trim_ascii(value);
+        let s = core::str::from_utf8(value).map_err(|_| HttpError::Malformed)?;
+        return s.parse::<usize>().map_err(|_| HttpError::Malformed);
+    }
+    Ok(0)
+}
+
+/// Index of the first occurrence of `needle` in `haystack`, or `None`.
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Split `slice` at the first occurrence of `delim`. Returns `None`
+/// if the delimiter is absent.
+fn split_once(slice: &[u8], delim: u8) -> Option<(&[u8], &[u8])> {
+    let idx = slice.iter().position(|&b| b == delim)?;
+    Some((&slice[..idx], &slice[idx + 1..]))
+}
+
+/// Strip ASCII whitespace from both ends of `slice`.
+fn trim_ascii(slice: &[u8]) -> &[u8] {
+    let start = slice
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(slice.len());
+    let end = slice
+        .iter()
+        .rposition(|b| !b.is_ascii_whitespace())
+        .map_or(start, |i| i + 1);
+    &slice[start..end]
 }
 
 /// Serialise the `/health` body. Schema is a flat object — no nested
@@ -194,7 +327,7 @@ async fn write_json(socket: &mut TcpSocket<'_>, status: u16, body: &str) -> Resu
     socket.flush().await.map_err(|_| HttpError::Write)
 }
 
-/// Plain-text response, used for non-JSON error paths.
+/// Plain-text response, used for non-JSON paths (errors, `204`).
 async fn write_text(socket: &mut TcpSocket<'_>, status: u16, body: &str) -> Result<(), HttpError> {
     let header = format!(
         "HTTP/1.1 {status} {reason}\r\nContent-Type: text/plain\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
@@ -215,6 +348,8 @@ async fn write_text(socket: &mut TcpSocket<'_>, status: u16, body: &str) -> Resu
 /// Mini status-reason table — only the codes this server emits.
 const fn status_reason(status: u16) -> &'static str {
     match status {
+        204 => "No Content",
+        400 => "Bad Request",
         404 => "Not Found",
         405 => "Method Not Allowed",
         // 200 + everything else fall through; the server only emits

--- a/crates/stackchan-firmware/src/net/json.rs
+++ b/crates/stackchan-firmware/src/net/json.rs
@@ -1,0 +1,387 @@
+//! Hand-rolled JSON-ish parser for the HTTP control plane's POST
+//! bodies.
+//!
+//! The HTTP server only accepts a handful of body shapes:
+//!
+//! - `POST /emotion` — `{"emotion": "happy", "hold_ms": 30000}`
+//! - `POST /look-at` — `{"pan_deg": 12.0, "tilt_deg": -3.0, "hold_ms": 30000}`
+//!
+//! Each route knows its own schema; this module exposes one parser per
+//! route. `hold_ms` is optional and defaults to [`DEFAULT_HOLD_MS`]
+//! when absent. Keys may appear in any order. Whitespace tolerant.
+//!
+//! No quoted-string escapes (`\"`, `\n`, ...) are supported — the
+//! emotion vocabulary doesn't need them, and a hand-rolled parser
+//! that handles full JSON belongs in a real crate. Numbers are
+//! parsed in their entirety with [`core::str::FromStr`].
+
+use stackchan_core::{Emotion, Pose, RemoteCommand};
+
+/// Default hold window when the request body omits `hold_ms`.
+pub const DEFAULT_HOLD_MS: u32 = 30_000;
+
+/// Parser error surface — kept small; routes turn these into
+/// `400 Bad Request` plain-text responses.
+#[derive(Debug, defmt::Format)]
+pub enum JsonError {
+    /// Body did not start with `{` after optional whitespace.
+    NotAnObject,
+    /// Body did not end with `}` after consuming all key/value pairs.
+    Unterminated,
+    /// Missing a required key.
+    MissingKey(&'static str),
+    /// Unknown key — schemas are closed.
+    UnknownKey,
+    /// Value type doesn't match the schema (e.g. number where a
+    /// string was expected).
+    BadValue,
+    /// Emotion string didn't match any known variant.
+    UnknownEmotion,
+}
+
+/// Parse a `POST /emotion` body into a [`RemoteCommand::SetEmotion`].
+///
+/// Required: `emotion` (string). Optional: `hold_ms` (integer,
+/// defaults to [`DEFAULT_HOLD_MS`]).
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys, unknown
+/// keys, malformed JSON shape, or unrecognised emotion strings.
+pub fn parse_set_emotion(body: &str) -> Result<RemoteCommand, JsonError> {
+    let mut emotion: Option<Emotion> = None;
+    let mut hold_ms: Option<u32> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "emotion" => emotion = Some(parse_emotion(scanner)?),
+            "hold_ms" => hold_ms = Some(parse_u32(scanner)?),
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    Ok(RemoteCommand::SetEmotion {
+        emotion: emotion.ok_or(JsonError::MissingKey("emotion"))?,
+        hold_ms: hold_ms.unwrap_or(DEFAULT_HOLD_MS),
+    })
+}
+
+/// Parse a `POST /look-at` body into a [`RemoteCommand::LookAt`].
+///
+/// Required: `pan_deg`, `tilt_deg` (both numbers). Optional:
+/// `hold_ms` (integer, defaults to [`DEFAULT_HOLD_MS`]).
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys, unknown
+/// keys, or malformed JSON shape.
+pub fn parse_look_at(body: &str) -> Result<RemoteCommand, JsonError> {
+    let mut pan_deg: Option<f32> = None;
+    let mut tilt_deg: Option<f32> = None;
+    let mut hold_ms: Option<u32> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "pan_deg" => pan_deg = Some(parse_f32(scanner)?),
+            "tilt_deg" => tilt_deg = Some(parse_f32(scanner)?),
+            "hold_ms" => hold_ms = Some(parse_u32(scanner)?),
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    Ok(RemoteCommand::LookAt {
+        target: Pose {
+            pan_deg: pan_deg.ok_or(JsonError::MissingKey("pan_deg"))?,
+            tilt_deg: tilt_deg.ok_or(JsonError::MissingKey("tilt_deg"))?,
+        },
+        hold_ms: hold_ms.unwrap_or(DEFAULT_HOLD_MS),
+    })
+}
+
+/// Single-pass byte cursor over the body. Each parse helper advances
+/// past the value it consumes (without consuming the trailing comma
+/// or `}` — those belong to [`visit_object`]).
+struct Scanner<'a> {
+    /// The body's raw bytes.
+    bytes: &'a [u8],
+    /// Read position into [`Scanner::bytes`].
+    pos: usize,
+}
+
+impl<'a> Scanner<'a> {
+    /// Construct a scanner positioned at the start of `input`.
+    const fn new(input: &'a str) -> Self {
+        Self {
+            bytes: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    /// Advance past any ASCII whitespace at the current position.
+    fn skip_ws(&mut self) {
+        while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    /// Peek the byte at the current position without advancing.
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    /// Read the byte at the current position and advance one byte.
+    fn bump(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    /// Skip whitespace and require the next byte to be `byte`.
+    fn expect(&mut self, byte: u8) -> Result<(), JsonError> {
+        self.skip_ws();
+        if self.bump() == Some(byte) {
+            Ok(())
+        } else {
+            Err(JsonError::BadValue)
+        }
+    }
+
+    /// Read a `"..."` literal without escape support. The opening
+    /// quote is consumed when the helper enters; on success returns
+    /// the inner slice and the trailing quote has been consumed.
+    fn read_string(&mut self) -> Result<&'a str, JsonError> {
+        self.skip_ws();
+        if self.bump() != Some(b'"') {
+            return Err(JsonError::BadValue);
+        }
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            if b == b'"' {
+                let end = self.pos;
+                self.pos += 1;
+                return core::str::from_utf8(&self.bytes[start..end])
+                    .map_err(|_| JsonError::BadValue);
+            }
+            if b == b'\\' {
+                return Err(JsonError::BadValue);
+            }
+            self.pos += 1;
+        }
+        Err(JsonError::Unterminated)
+    }
+
+    /// Read a contiguous run of number-shaped bytes (`-`, digits,
+    /// `.`, `e`, `E`, `+`). The slice is parsed by the typed
+    /// `parse_*` helpers via [`core::str::FromStr`].
+    fn read_number(&mut self) -> Result<&'a str, JsonError> {
+        self.skip_ws();
+        let start = self.pos;
+        while let Some(b) = self.peek() {
+            let is_num = matches!(b, b'-' | b'+' | b'.' | b'0'..=b'9' | b'e' | b'E');
+            if !is_num {
+                break;
+            }
+            self.pos += 1;
+        }
+        if start == self.pos {
+            return Err(JsonError::BadValue);
+        }
+        core::str::from_utf8(&self.bytes[start..self.pos]).map_err(|_| JsonError::BadValue)
+    }
+}
+
+/// Walk a JSON object body, calling `visit(key, scanner)` for each
+/// key. The visitor is responsible for consuming the value; the
+/// caller handles the surrounding `{`, `}`, `:`, and `,`.
+fn visit_object<F>(body: &str, mut visit: F) -> Result<(), JsonError>
+where
+    F: FnMut(&str, &mut Scanner<'_>) -> Result<(), JsonError>,
+{
+    let mut scanner = Scanner::new(body);
+    scanner.skip_ws();
+    if scanner.bump() != Some(b'{') {
+        return Err(JsonError::NotAnObject);
+    }
+    scanner.skip_ws();
+    if scanner.peek() == Some(b'}') {
+        // Empty object: consume the closing brace.
+        let _ = scanner.bump();
+    } else {
+        loop {
+            let key = scanner.read_string()?;
+            scanner.expect(b':')?;
+            visit(key, &mut scanner)?;
+            scanner.skip_ws();
+            match scanner.bump() {
+                Some(b',') => {}
+                Some(b'}') => break,
+                _ => return Err(JsonError::Unterminated),
+            }
+        }
+    }
+    scanner.skip_ws();
+    if scanner.pos != scanner.bytes.len() {
+        return Err(JsonError::Unterminated);
+    }
+    Ok(())
+}
+
+/// Parse a quoted emotion string into the corresponding [`Emotion`]
+/// variant. Vocabulary is closed and lowercase.
+fn parse_emotion(scanner: &mut Scanner<'_>) -> Result<Emotion, JsonError> {
+    let raw = scanner.read_string()?;
+    match raw {
+        "neutral" => Ok(Emotion::Neutral),
+        "happy" => Ok(Emotion::Happy),
+        "sad" => Ok(Emotion::Sad),
+        "sleepy" => Ok(Emotion::Sleepy),
+        "surprised" => Ok(Emotion::Surprised),
+        "angry" => Ok(Emotion::Angry),
+        _ => Err(JsonError::UnknownEmotion),
+    }
+}
+
+/// Parse a contiguous number-shaped run as a `u32`.
+fn parse_u32(scanner: &mut Scanner<'_>) -> Result<u32, JsonError> {
+    scanner
+        .read_number()?
+        .parse::<u32>()
+        .map_err(|_| JsonError::BadValue)
+}
+
+/// Parse a contiguous number-shaped run as an `f32`.
+fn parse_f32(scanner: &mut Scanner<'_>) -> Result<f32, JsonError> {
+    scanner
+        .read_number()?
+        .parse::<f32>()
+        .map_err(|_| JsonError::BadValue)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: literal compares, match-with-panic for variant extraction"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_emotion_with_explicit_hold() {
+        let body = r#"{"emotion":"happy","hold_ms":15000}"#;
+        match parse_set_emotion(body).unwrap() {
+            RemoteCommand::SetEmotion { emotion, hold_ms } => {
+                assert_eq!(emotion, Emotion::Happy);
+                assert_eq!(hold_ms, 15_000);
+            }
+            other => panic!("expected SetEmotion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_emotion_defaults_hold_when_omitted() {
+        let body = r#"{"emotion":"sleepy"}"#;
+        match parse_set_emotion(body).unwrap() {
+            RemoteCommand::SetEmotion { emotion, hold_ms } => {
+                assert_eq!(emotion, Emotion::Sleepy);
+                assert_eq!(hold_ms, DEFAULT_HOLD_MS);
+            }
+            other => panic!("expected SetEmotion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_emotion_keys_in_any_order() {
+        let body = r#"{ "hold_ms" : 500 , "emotion" : "angry" }"#;
+        match parse_set_emotion(body).unwrap() {
+            RemoteCommand::SetEmotion { emotion, hold_ms } => {
+                assert_eq!(emotion, Emotion::Angry);
+                assert_eq!(hold_ms, 500);
+            }
+            other => panic!("expected SetEmotion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_emotion_rejects_missing_emotion() {
+        let body = r#"{"hold_ms":1000}"#;
+        assert!(matches!(
+            parse_set_emotion(body),
+            Err(JsonError::MissingKey("emotion"))
+        ));
+    }
+
+    #[test]
+    fn set_emotion_rejects_unknown_emotion() {
+        let body = r#"{"emotion":"jealous"}"#;
+        assert!(matches!(
+            parse_set_emotion(body),
+            Err(JsonError::UnknownEmotion)
+        ));
+    }
+
+    #[test]
+    fn set_emotion_rejects_unknown_key() {
+        let body = r#"{"emotion":"happy","priority":3}"#;
+        assert!(matches!(
+            parse_set_emotion(body),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn look_at_with_explicit_hold() {
+        let body = r#"{"pan_deg":12.5,"tilt_deg":-3.0,"hold_ms":2000}"#;
+        match parse_look_at(body).unwrap() {
+            RemoteCommand::LookAt { target, hold_ms } => {
+                assert_eq!(target.pan_deg, 12.5);
+                assert_eq!(target.tilt_deg, -3.0);
+                assert_eq!(hold_ms, 2_000);
+            }
+            other => panic!("expected LookAt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_defaults_hold_when_omitted() {
+        let body = r#"{"pan_deg":0,"tilt_deg":0}"#;
+        match parse_look_at(body).unwrap() {
+            RemoteCommand::LookAt { hold_ms, .. } => assert_eq!(hold_ms, DEFAULT_HOLD_MS),
+            other => panic!("expected LookAt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_rejects_missing_axis() {
+        let body = r#"{"pan_deg":12.0}"#;
+        assert!(matches!(
+            parse_look_at(body),
+            Err(JsonError::MissingKey("tilt_deg"))
+        ));
+    }
+
+    #[test]
+    fn rejects_non_object_body() {
+        assert!(matches!(
+            parse_set_emotion("\"happy\""),
+            Err(JsonError::NotAnObject)
+        ));
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        let body = r#"{"emotion":"happy"} extra"#;
+        assert!(matches!(
+            parse_set_emotion(body),
+            Err(JsonError::Unterminated)
+        ));
+    }
+
+    #[test]
+    fn empty_object_is_missing_required() {
+        // No keys → required-key error surfaces, not a parser error.
+        assert!(matches!(
+            parse_set_emotion("{}"),
+            Err(JsonError::MissingKey("emotion"))
+        ));
+    }
+}

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -7,6 +7,7 @@
 //! unreachable.
 
 pub mod http;
+pub mod json;
 pub mod mdns;
 pub mod snapshot;
 pub mod sntp;

--- a/crates/stackchan-sim/tests/remote_command.rs
+++ b/crates/stackchan-sim/tests/remote_command.rs
@@ -1,0 +1,179 @@
+//! End-to-end sim coverage for the `RemoteCommandModifier` — the
+//! firmware HTTP control plane's host-side translator.
+//!
+//! Pinned contracts:
+//!
+//! - **LookAt → motor pose**: a `RemoteCommand::LookAt` with a held
+//!   target, run through the `RemoteCommandModifier` + `HeadFromAttention`
+//!   stack, drives `motor.head_pose` toward the requested pose.
+//! - **Hold beats tracking**: while a LookAt hold is alive, fresh
+//!   `TrackingObservation`s feeding `AttentionFromTracking` cannot
+//!   stomp the operator's target. After the hold expires, tracking
+//!   resumes ownership of attention.
+//! - **Reset returns to autonomous**: after `RemoteCommand::Reset`,
+//!   subsequent ticks let normal modifiers run unimpeded.
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: doc comments freely reference type names without backticks; \
+              match-with-panic is the cleanest pattern for value extraction on enum \
+              variants in tests; registry capacity is a compile-time constant"
+)]
+
+use stackchan_core::modifiers::{
+    AttentionFromTracking, HeadFromAttention, HeadFromEmotion, IdleHeadDrift, RemoteCommandModifier,
+};
+use stackchan_core::{Attention, Director, Emotion, Entity, Instant, Pose, RemoteCommand};
+use stackchan_sim::TrackingScenario;
+
+const TICK_MS: u64 = 33;
+
+fn run_for(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, ticks: u64) -> Instant {
+    let mut last = Instant::from_millis(start_ms);
+    for t in 0..ticks {
+        last = Instant::from_millis(start_ms + t * TICK_MS);
+        director.run(entity, last);
+    }
+    last
+}
+
+#[test]
+fn lookat_drives_motor_head_pose_through_head_from_attention() {
+    let target = Pose::new(20.0, -5.0);
+    let mut entity = Entity::default();
+    let mut head_drift = IdleHeadDrift::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut head_drift).unwrap();
+    director.add_modifier(&mut emo).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
+    director.add_modifier(&mut remote).unwrap();
+
+    entity.input.remote_command = Some(RemoteCommand::LookAt {
+        target,
+        hold_ms: 2_000,
+    });
+
+    // Drive long enough for HeadFromAttention's ease window to ramp
+    // toward the target.
+    run_for(&mut director, &mut entity, 0, 60);
+
+    let pan = entity.motor.head_pose.pan_deg;
+    assert!(
+        pan > 5.0,
+        "expected head pan to track toward target (20°), got {pan}"
+    );
+    assert!(
+        matches!(entity.mind.attention, Attention::Tracking { target: t, .. } if t == target),
+        "expected attention to hold operator's target, got {:?}",
+        entity.mind.attention
+    );
+}
+
+#[test]
+fn lookat_hold_beats_tracking_observation() {
+    // Operator-supplied target wins against fresh tracking input
+    // while the hold is active. After release, tracking takes over.
+    let operator_target = Pose::new(25.0, 0.0);
+    let mut entity = Entity::default();
+    let mut afm = AttentionFromTracking::new();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut afm).unwrap();
+    director.add_modifier(&mut remote).unwrap();
+
+    entity.input.remote_command = Some(RemoteCommand::LookAt {
+        target: operator_target,
+        hold_ms: 1_000,
+    });
+
+    // While the hold is alive, feed AttentionFromTracking a different
+    // target. RemoteCommandModifier runs after AttentionFromTracking
+    // in Phase::Cognition (priority 100 > 0) and re-asserts.
+    let tracker_target = Pose::new(-30.0, 8.0);
+    let mut last = Instant::ZERO;
+    let scenario = TrackingScenario::new(TICK_MS).tracking(tracker_target, 20 * TICK_MS);
+    for (now, obs) in scenario.iter() {
+        entity.perception.tracking = obs;
+        director.run(&mut entity, now);
+        last = now;
+    }
+
+    match entity.mind.attention {
+        Attention::Tracking { target, .. } => {
+            assert_eq!(
+                target, operator_target,
+                "operator target must hold against tracking observations"
+            );
+        }
+        other => panic!("expected Tracking, got {other:?}"),
+    }
+
+    // Step past the hold. Now AttentionFromTracking should be free to
+    // write its own target on the next observation that meets its lock
+    // criteria.
+    let after_hold = last.as_millis() + 2_000;
+    entity.perception.tracking = None;
+    run_for(&mut director, &mut entity, after_hold, 60);
+
+    // After release, attention is no longer pinned to operator_target.
+    // (Either None, or AttentionFromTracking re-locked on the silent
+    // observation — both prove our hold stopped re-asserting.)
+    if let Attention::Tracking { target, .. } = entity.mind.attention {
+        assert_ne!(
+            target, operator_target,
+            "after release, operator target should not be re-asserted"
+        );
+    }
+}
+
+#[test]
+fn reset_returns_attention_to_default() {
+    let mut entity = Entity::default();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut remote).unwrap();
+
+    entity.input.remote_command = Some(RemoteCommand::LookAt {
+        target: Pose::new(15.0, 0.0),
+        hold_ms: 10_000,
+    });
+    run_for(&mut director, &mut entity, 0, 5);
+    assert!(matches!(entity.mind.attention, Attention::Tracking { .. }));
+
+    entity.input.remote_command = Some(RemoteCommand::Reset);
+    run_for(&mut director, &mut entity, 1_000, 2);
+    assert_eq!(entity.mind.attention, Attention::None);
+    assert!(entity.mind.autonomy.manual_until.is_none());
+}
+
+#[test]
+fn set_emotion_holds_against_autonomous_overwrite() {
+    // The hold timer keeps emotion + autonomy pinned even if the test
+    // poke-mutates emotion mid-hold (proxy for an autonomous emotion
+    // driver writing during the same frame stack).
+    let mut entity = Entity::default();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut remote).unwrap();
+
+    entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+        emotion: Emotion::Happy,
+        hold_ms: 1_000,
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+
+    // Autonomous driver picks Sleepy.
+    entity.mind.affect.emotion = Emotion::Sleepy;
+    director.run(&mut entity, Instant::from_millis(100));
+
+    assert_eq!(
+        entity.mind.affect.emotion,
+        Emotion::Happy,
+        "hold must re-assert emotion across ticks while hold is active"
+    );
+}


### PR DESCRIPTION
## Summary

Adds three write routes on top of the GET surface from #148/#150:

- `POST /emotion` — `{"emotion": "happy", "hold_ms": 30000}`
- `POST /look-at` — `{"pan_deg": 12.0, "tilt_deg": -3.0, "hold_ms": 30000}`
- `POST /reset` — empty body, clears any active hold

Routes funnel through `REMOTE_COMMAND_SIGNAL` into `entity.input.remote_command`. A new `RemoteCommandModifier` (`Phase::Cognition`, priority 100) drains the slot, asserts emotion + autonomy or attention, and re-asserts each tick until the hold timer expires so `AttentionFromTracking` and the autonomous emotion drivers can't stomp the operator's hold mid-window. `hold_ms` is optional; default 30 s.

`RemoteCommandModifier` writes the same fields existing input-consumers do — `Field::Emotion`, `Field::Autonomy`, `Field::Attention`, `Field::RemoteCommand` — so the framework's debug-mode write enforcement still applies. JSON parser is hand-rolled in `net/json.rs` (closed schemas, tiny dep surface).

## Test plan

- [x] `just check` — fmt + workspace clippy + 303 host tests + 4 new sim tests pass
- [x] `just clippy-firmware` — strict firmware clippy clean
- [x] `just ci` — workspace doc-lint + cargo-deny pass
- [ ] Flash + curl from LAN: verify `POST /emotion`, `POST /look-at`, `POST /reset` produce visible behavior; confirm hold release returns to autonomous
- [ ] Greptile review

## What's tested

- Unit (`crates/stackchan-core/src/modifiers/remote_command.rs`): apply / hold re-assertion / release / multi-source autonomy guard / pinned `since` / Reset / fire-and-forget
- Integration (`crates/stackchan-sim/tests/remote_command.rs`): LookAt drives `motor.head_pose` via `HeadFromAttention`; LookAt hold beats fresh tracking observations; SetEmotion holds across autonomous overwrites; Reset returns to defaults
- JSON parser (`crates/stackchan-firmware/src/net/json.rs`): explicit hold, default hold, key-order independence, unknown emotion / unknown key / missing-required / non-object body / trailing garbage