### PR TITLE
feat(firmware): HTTP GET/PUT /settings (atomic SD writeback)

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -838,16 +838,22 @@ async fn main(spawner: Spawner) -> ! {
     // not fatal: the firmware logs a warn and uses `Config::default`.
     let sd_cs = Output::new(peripherals.GPIO4, Level::High, OutputConfig::default());
     let net_config = match storage::Storage::mount(spi_bus, sd_cs) {
-        Ok(mut sd) => match sd.read_config() {
-            Ok(cfg) => {
-                storage::log_config_summary(&cfg);
-                cfg
-            }
-            Err(e) => {
-                defmt::warn!("SD: read /sd/STACKCHAN.RON failed ({}); using defaults", e);
-                stackchan_net::Config::default()
-            }
-        },
+        Ok(mut sd) => {
+            let cfg = match sd.read_config() {
+                Ok(c) => {
+                    storage::log_config_summary(&c);
+                    c
+                }
+                Err(e) => {
+                    defmt::warn!("SD: read /sd/STACKCHAN.RON failed ({}); using defaults", e);
+                    stackchan_net::Config::default()
+                }
+            };
+            // Park the mounted storage handle in the shared mutex so
+            // PUT /settings can write back without re-mounting.
+            storage::install_storage(sd).await;
+            cfg
+        }
         Err(e) => {
             defmt::warn!(
                 "SD: mount failed ({}); booting offline-first with defaults",
@@ -856,6 +862,8 @@ async fn main(spawner: Spawner) -> ! {
             stackchan_net::Config::default()
         }
     };
+    // Snapshot the live config for GET /settings.
+    *storage::CONFIG_SNAPSHOT.lock().await = Some(net_config.clone());
     // Bring up the radio + Wi-Fi station + embassy-net TCP/IP stack.
     // `esp_rtos::start` ran at boot (line above), which `esp_radio::init`
     // requires before claiming the WIFI peripheral. Both the

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -850,8 +850,11 @@ async fn main(spawner: Spawner) -> ! {
                 }
             };
             // Park the mounted storage handle in the shared mutex so
-            // PUT /settings can write back without re-mounting.
+            // PUT /settings can write back without re-mounting, and
+            // mirror the read config into the snapshot so GET /settings
+            // sees what's actually persisted.
             storage::install_storage(sd).await;
+            *storage::CONFIG_SNAPSHOT.lock().await = Some(cfg.clone());
             cfg
         }
         Err(e) => {
@@ -859,11 +862,11 @@ async fn main(spawner: Spawner) -> ! {
                 "SD: mount failed ({}); booting offline-first with defaults",
                 e
             );
+            // No SD ⇒ leave CONFIG_SNAPSHOT as None so GET /settings
+            // returns 503 (matches PUT /settings, which also 503s).
             stackchan_net::Config::default()
         }
     };
-    // Snapshot the live config for GET /settings.
-    *storage::CONFIG_SNAPSHOT.lock().await = Some(net_config.clone());
     // Bring up the radio + Wi-Fi station + embassy-net TCP/IP stack.
     // `esp_rtos::start` ran at boot (line above), which `esp_radio::init`
     // requires before claiming the WIFI peripheral. Both the

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -15,11 +15,21 @@
 //!   asserting the operator's target against camera tracking.
 //! - `POST /reset` — empty body. Clears any active emotion or
 //!   look-at hold and returns the avatar to autonomous behaviour.
+//! - `GET /settings` — current persisted [`stackchan_net::Config`]
+//!   as JSON, with `wifi.psk` redacted.
+//! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
+//!   Validates, writes back atomically to `/sd/STACKCHAN.RON`, and
+//!   responds `{"reboot_required": true}`. Wi-Fi keeps using the
+//!   boot-time config; reboot to apply.
 //!
-//! All write routes funnel through [`REMOTE_COMMAND_SIGNAL`]; the
-//! render task drains the signal into
-//! `entity.input.remote_command` ahead of `Director::run`, where
-//! [`stackchan_core::modifiers::RemoteCommandModifier`] picks it up.
+//! Avatar-state writes (POST /emotion, /look-at, /reset) funnel
+//! through [`REMOTE_COMMAND_SIGNAL`]; the render task drains it
+//! into `entity.input.remote_command` ahead of `Director::run`,
+//! where [`stackchan_core::modifiers::RemoteCommandModifier`] picks
+//! it up. PUT /settings goes through
+//! [`crate::storage::with_storage`] for the atomic SD writeback;
+//! the new value is mirrored into [`crate::storage::CONFIG_SNAPSHOT`]
+//! so subsequent GETs see it without a re-read.
 //!
 //! No external HTTP crate. The wire format is small, the surface
 //! is fixed, and a hand-roll dodges the impl-trait-in-assoc-type
@@ -182,11 +192,65 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     match (method, path) {
         ("GET", "/health") => write_json(socket, 200, &health_body()).await,
         ("GET", "/state") => write_json(socket, 200, &state_body(snapshot::read())).await,
+        ("GET", "/settings") => handle_get_settings(socket).await,
+        ("PUT", "/settings") => handle_put_settings(socket, body).await,
         ("POST", "/emotion") => handle_remote(socket, json::parse_set_emotion(body)).await,
         ("POST", "/look-at") => handle_remote(socket, json::parse_look_at(body)).await,
         ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
-        ("GET" | "POST", _) => write_text(socket, 404, "not found\n").await,
+        ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
+    }
+}
+
+/// `GET /settings` — render the current snapshot with `wifi.psk`
+/// redacted.
+async fn handle_get_settings(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let snapshot = crate::storage::CONFIG_SNAPSHOT.lock().await.clone();
+    let Some(config) = snapshot else {
+        return write_text(socket, 503, "config snapshot unavailable\n").await;
+    };
+    match stackchan_net::render_settings_json(&config, true) {
+        Ok(body) => write_json(socket, 200, &body).await,
+        Err(_) => write_text(socket, 500, "render failed\n").await,
+    }
+}
+
+/// `PUT /settings` — full replace, atomic SD writeback. Returns
+/// `{"reboot_required": true}` on success; the firmware doesn't
+/// re-bring-up Wi-Fi mid-flight (avoids dropping the operator's
+/// session when the SSID changes).
+async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let new_config = match stackchan_net::parse_settings_json(body) {
+        Ok(c) => c,
+        Err(e) => {
+            defmt::warn!(
+                "http: PUT /settings parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    let write_result =
+        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
+    match write_result {
+        Some(Ok(())) => {
+            defmt::info!(
+                "http: PUT /settings persisted (ssid={=str} hostname={=str}.local)",
+                new_config.wifi.ssid.as_str(),
+                new_config.mdns.hostname.as_str()
+            );
+            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
+            write_json(socket, 200, "{\"reboot_required\":true}\n").await
+        }
+        Some(Err(e)) => {
+            defmt::warn!("http: PUT /settings write failed ({})", e);
+            write_text(socket, 500, "config write failed\n").await
+        }
+        None => {
+            defmt::warn!("http: PUT /settings rejected (no SD mounted)");
+            write_text(socket, 503, "no SD card mounted\n").await
+        }
     }
 }
 

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -18,13 +18,87 @@
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::mutex::Mutex;
 use embassy_time::Delay;
 use embedded_hal::digital::OutputPin;
 use embedded_sdmmc::{Mode, SdCard, TimeSource, Timestamp, VolumeIdx, VolumeManager};
 use esp_hal::Blocking;
+use esp_hal::gpio::Output;
 use esp_hal::spi::master::Spi;
 
 use crate::sd_spi::SdSpiDevice;
+
+/// Concrete `Storage` instantiation used by the firmware. CS is the
+/// SD chip-select pin (GPIO4 on CoreS3).
+pub type FirmwareStorage = Storage<Output<'static>>;
+
+/// `Send` wrapper for [`FirmwareStorage`].
+///
+/// `FirmwareStorage` is `!Send` because its underlying
+/// [`crate::sd_spi::SdSpiDevice`] holds a `&'static RefCell<Spi>`
+/// (the SPI2 bus shared with the LCD), and `&RefCell<_>` is `!Send`
+/// for cross-thread aliasing reasons.
+///
+/// In this firmware those reasons don't apply: the embassy executor
+/// runs on a single core in a single thread, and bus access is
+/// already serialized at the `RefCellDevice` layer. Holding the
+/// storage in a static [`Mutex`] further enforces single-task access.
+///
+/// We document the invariant in this wrapper so the unsafe stays
+/// scoped to one place rather than leaking into every static-borrow
+/// call site.
+struct StorageHolder(Option<FirmwareStorage>);
+
+// SAFETY: single-core embassy executor — no cross-thread aliasing.
+// Bus access is serialized via `RefCellDevice` (LCD side) and via
+// the enclosing `Mutex` (storage side). See `StorageHolder` doc.
+#[allow(
+    unsafe_code,
+    clippy::non_send_fields_in_send_ty,
+    reason = "see StorageHolder doc for the single-core invariant"
+)]
+unsafe impl Send for StorageHolder {}
+
+/// Mounted SD-card storage, populated at boot when the card is
+/// present and FAT-mountable. `None` when the card is missing or
+/// the mount failed — `PUT /settings` returns `503` in that case.
+///
+/// Async mutex (yields under contention) because SD writes can take
+/// tens of ms and we don't want to hold the lock across a render
+/// frame. Access through [`install_storage`] / [`with_storage`].
+static SHARED_STORAGE: Mutex<CriticalSectionRawMutex, StorageHolder> =
+    Mutex::new(StorageHolder(None));
+
+/// Latest persisted [`stackchan_net::Config`].
+///
+/// Initialised at boot from the SD read (or
+/// [`stackchan_net::Config::default`] when the card is missing);
+/// updated on each successful `PUT /settings`. `GET /settings`
+/// reads from this to avoid re-reading the SD on every request.
+///
+/// `None` only during the brief window between firmware start and
+/// the boot path's first write — HTTP isn't accepting requests yet,
+/// so consumers see `Some(_)` for the lifetime of the run.
+pub static CONFIG_SNAPSHOT: Mutex<CriticalSectionRawMutex, Option<stackchan_net::Config>> =
+    Mutex::new(None);
+
+/// Move `storage` into [`SHARED_STORAGE`], replacing whatever was
+/// there. Called once from the boot path after a successful mount.
+pub async fn install_storage(storage: FirmwareStorage) {
+    SHARED_STORAGE.lock().await.0 = Some(storage);
+}
+
+/// Run `f` against the currently installed [`FirmwareStorage`], if
+/// any. Returns `None` when no SD is mounted — callers should map
+/// that to a `503 Service Unavailable` response.
+pub async fn with_storage<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&mut FirmwareStorage) -> R,
+{
+    let mut guard = SHARED_STORAGE.lock().await;
+    guard.0.as_mut().map(f)
+}
 
 /// Filename written to / read from the FAT root.
 const CONFIG_FILE: &str = "STACKCHAN.RON";

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -36,6 +36,10 @@ shape of the on-disk config and the RON file `PUT /settings` round-trips.
 - `src/lib.rs` — crate root, re-exports
 - `src/config.rs` — `Config`, `WifiConfig`, `MdnsConfig`, `TimeConfig`,
   `parse_ron`, `render_ron`, validators
+- `src/bare.rs` — hand-rolled RON parser/renderer used by the firmware
+  (no `serde`, no `ron` — see the module doc for why)
+- `src/bare_json.rs` — hand-rolled JSON parser/renderer used by the
+  firmware HTTP control plane on `GET /settings` / `PUT /settings`
 - `src/error.rs` — `ConfigError` (parse / serialize / validation variants)
 - `tests/golden_config.rs` + `tests/fixtures/*.ron` — round-trip and
   validation coverage against hand-written fixtures

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -1,0 +1,499 @@
+//! Hand-rolled JSON parser + renderer for [`crate::Config`].
+//!
+//! Symmetric with [`crate::bare::parse_ron_bare`] /
+//! [`crate::bare::render_ron_bare`] but for the wire format the
+//! firmware HTTP control plane uses on `GET /settings` and
+//! `PUT /settings`. SD persistence stays RON; HTTP stays JSON.
+//!
+//! Keeping the parser hand-rolled (no `serde`, no `serde_json`)
+//! mirrors the RON approach: the firmware crate disables
+//! [`stackchan-net`'s default `parse` feature](crate) to avoid
+//! pulling `serde/std` onto `xtensa-esp32s3-none-elf`. See
+//! [`crate::bare`] for the full rationale.
+//!
+//! Schema is fixed to v1: top-level object, three nested objects,
+//! string fields, one `Vec<String>`. Anything outside that surface
+//! returns [`ConfigError::BareParse`].
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+use crate::error::ConfigError;
+
+/// Parse a schema-v1 JSON object into a [`Config`].
+///
+/// Whitespace tolerant. Unknown keys are rejected (typo guard).
+/// String escapes: `\\`, `\"`, `\n`, `\t`, `\r`. Numbers, booleans,
+/// nulls, and `\u{...}` escapes are not supported — the schema
+/// doesn't need them.
+///
+/// # Errors
+///
+/// Returns [`ConfigError::BareParse`] on any structural mismatch
+/// (missing field, unknown key, bad string escape, runaway literal),
+/// then runs the shared [`validate`] gate so out-of-range values
+/// surface the same `Invalid*` variants as [`crate::parse_ron`].
+pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
+    let mut p = Parser::new(input);
+    let config = p.parse_config()?;
+    p.skip_ws();
+    if !p.input.is_empty() {
+        return Err(bare_err("trailing data after object", ""));
+    }
+    validate(&config)?;
+    Ok(config)
+}
+
+/// Render a [`Config`] to a compact JSON string.
+///
+/// `redact_psk = true` replaces `wifi.psk` with `"***"` so the
+/// output is safe to expose to unauthed callers (HTTP `GET /settings`
+/// passes `true`). `redact_psk = false` round-trips losslessly with
+/// [`parse_settings_json`].
+///
+/// # Errors
+///
+/// Currently infallible — kept as `Result` for symmetry with
+/// [`crate::render_ron`].
+pub fn render_settings_json(config: &Config, redact_psk: bool) -> Result<String, ConfigError> {
+    let mut out = String::new();
+    out.push('{');
+    out.push_str("\"wifi\":{");
+    push_string_field(&mut out, "ssid", &config.wifi.ssid, false);
+    out.push(',');
+    push_string_field(
+        &mut out,
+        "psk",
+        if redact_psk { "***" } else { &config.wifi.psk },
+        false,
+    );
+    out.push(',');
+    push_string_field(&mut out, "country", &config.wifi.country, false);
+    out.push_str("},\"mdns\":{");
+    push_string_field(&mut out, "hostname", &config.mdns.hostname, false);
+    out.push_str("},\"time\":{");
+    push_string_field(&mut out, "tz", &config.time.tz, false);
+    out.push_str(",\"sntp_servers\":[");
+    for (idx, s) in config.time.sntp_servers.iter().enumerate() {
+        if idx > 0 {
+            out.push(',');
+        }
+        push_string_literal(&mut out, s);
+    }
+    out.push_str("]}}");
+    Ok(out)
+}
+
+/// Helper: emit `"name":"value"` (no leading comma — the caller
+/// places commas between fields).
+fn push_string_field(out: &mut String, name: &str, value: &str, _trailing: bool) {
+    out.push('"');
+    out.push_str(name);
+    out.push_str("\":");
+    push_string_literal(out, value);
+}
+
+/// Helper: emit a quoted JSON string with `\\`, `\"`, `\n`, `\t`,
+/// `\r` escapes. Other control characters pass through unescaped —
+/// this is firmware-emitted output bound for a trusted client, not
+/// arbitrary user data.
+fn push_string_literal(out: &mut String, value: &str) {
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+}
+
+/// Recursive-descent parser over a `&str` cursor. Mirrors the
+/// shape of [`crate::bare::Parser`] but for JSON delimiters.
+struct Parser<'a> {
+    /// Remaining input. `advance` slides the start pointer; nothing
+    /// is allocated for tokens.
+    input: &'a str,
+}
+
+impl<'a> Parser<'a> {
+    /// Construct a fresh parser over `input`.
+    const fn new(input: &'a str) -> Self {
+        Self { input }
+    }
+
+    /// Top-level grammar: parse the schema-v1 outer object.
+    fn parse_config(&mut self) -> Result<Config, ConfigError> {
+        self.skip_ws();
+        self.expect_char('{')?;
+        let mut wifi: Option<WifiConfig> = None;
+        let mut mdns: Option<MdnsConfig> = None;
+        let mut time: Option<TimeConfig> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "wifi" => wifi = Some(self.parse_wifi()?),
+                "mdns" => mdns = Some(self.parse_mdns()?),
+                "time" => time = Some(self.parse_time()?),
+                other => return Err(bare_err("unknown top-level field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}'", ""));
+            }
+        }
+        Ok(Config {
+            wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
+            mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
+            time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
+        })
+    }
+
+    /// Parse the `"wifi": { "ssid": ..., "psk": ..., "country": ... }` block.
+    fn parse_wifi(&mut self) -> Result<WifiConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut ssid: Option<String> = None;
+        let mut psk: Option<String> = None;
+        let mut country: Option<String> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            let value = self.parse_string()?;
+            match key.as_str() {
+                "ssid" => ssid = Some(value),
+                "psk" => psk = Some(value),
+                "country" => country = Some(value),
+                other => return Err(bare_err("unknown wifi field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in wifi", ""));
+            }
+        }
+        Ok(WifiConfig {
+            ssid: ssid.ok_or_else(|| bare_err("missing wifi.ssid", ""))?,
+            psk: psk.ok_or_else(|| bare_err("missing wifi.psk", ""))?,
+            country: country.ok_or_else(|| bare_err("missing wifi.country", ""))?,
+        })
+    }
+
+    /// Parse the `"mdns": { "hostname": ... }` block.
+    fn parse_mdns(&mut self) -> Result<MdnsConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut hostname: Option<String> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            let value = self.parse_string()?;
+            match key.as_str() {
+                "hostname" => hostname = Some(value),
+                other => return Err(bare_err("unknown mdns field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in mdns", ""));
+            }
+        }
+        Ok(MdnsConfig {
+            hostname: hostname.ok_or_else(|| bare_err("missing mdns.hostname", ""))?,
+        })
+    }
+
+    /// Parse the `"time": { "tz": ..., "sntp_servers": [...] }` block.
+    fn parse_time(&mut self) -> Result<TimeConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut tz: Option<String> = None;
+        let mut sntp_servers: Option<Vec<String>> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "tz" => tz = Some(self.parse_string()?),
+                "sntp_servers" => sntp_servers = Some(self.parse_string_list()?),
+                other => return Err(bare_err("unknown time field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in time", ""));
+            }
+        }
+        Ok(TimeConfig {
+            tz: tz.ok_or_else(|| bare_err("missing time.tz", ""))?,
+            sntp_servers: sntp_servers.ok_or_else(|| bare_err("missing time.sntp_servers", ""))?,
+        })
+    }
+
+    /// Parse `[ "...", "...", ... ]` into a `Vec<String>`.
+    fn parse_string_list(&mut self) -> Result<Vec<String>, ConfigError> {
+        self.expect_char('[')?;
+        let mut out: Vec<String> = Vec::new();
+        loop {
+            self.skip_ws();
+            if self.try_consume_char(']') {
+                break;
+            }
+            let s = self.parse_string()?;
+            out.push(s);
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq(']') {
+                return Err(bare_err("expected ',' or ']' in list", ""));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Parse a `"..."` string literal with `\\`, `\"`, `\n`, `\t`,
+    /// `\r` escapes.
+    fn parse_string(&mut self) -> Result<String, ConfigError> {
+        self.expect_char('"')?;
+        let mut out = String::new();
+        loop {
+            let Some(ch) = self.peek_char() else {
+                return Err(bare_err("unterminated string literal", ""));
+            };
+            if ch == '"' {
+                self.advance(1);
+                return Ok(out);
+            }
+            if ch == '\\' {
+                self.advance(1);
+                let Some(esc) = self.peek_char() else {
+                    return Err(bare_err("dangling backslash", ""));
+                };
+                match esc {
+                    '\\' => out.push('\\'),
+                    '"' => out.push('"'),
+                    'n' => out.push('\n'),
+                    't' => out.push('\t'),
+                    'r' => out.push('\r'),
+                    other => return Err(bare_err("unsupported escape", &other.to_string())),
+                }
+                self.advance(esc.len_utf8());
+            } else {
+                out.push(ch);
+                self.advance(ch.len_utf8());
+            }
+        }
+    }
+
+    /// Peek the first byte (interpreted as a `char`) without
+    /// advancing.
+    fn peek_char(&self) -> Option<char> {
+        self.input.chars().next()
+    }
+
+    /// Drop `n` bytes from the front of [`Self::input`].
+    const fn advance(&mut self, n: usize) {
+        self.input = self.input.split_at(n).1;
+    }
+
+    /// Skip ASCII whitespace.
+    fn skip_ws(&mut self) {
+        let bytes = self.input.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        self.advance(i);
+    }
+
+    /// Require the next char to equal `expected`; advance past it
+    /// on success.
+    fn expect_char(&mut self, expected: char) -> Result<(), ConfigError> {
+        if self.try_consume_char(expected) {
+            Ok(())
+        } else {
+            Err(bare_err("expected char", &expected.to_string()))
+        }
+    }
+
+    /// Consume the next char if it equals `c`. Returns whether it
+    /// did.
+    fn try_consume_char(&mut self, c: char) -> bool {
+        if self.peek_eq(c) {
+            self.advance(c.len_utf8());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether the next char equals `c`.
+    fn peek_eq(&self, c: char) -> bool {
+        self.peek_char() == Some(c)
+    }
+}
+
+/// Build a `BareParse` error. Format mirrors [`crate::bare::bare_err`]
+/// so error strings stay homogeneous across the two parsers.
+fn bare_err(reason: &str, detail: &str) -> ConfigError {
+    let mut s = String::with_capacity(reason.len() + detail.len() + 4);
+    s.push_str(reason);
+    if !detail.is_empty() {
+        s.push_str(": ");
+        s.push_str(detail);
+    }
+    ConfigError::BareParse(s)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: match-with-panic for variant extraction"
+)]
+mod tests {
+    use super::*;
+
+    fn full_config() -> Config {
+        Config {
+            wifi: WifiConfig {
+                ssid: "myssid".to_string(),
+                psk: "secret".to_string(),
+                country: "US".to_string(),
+            },
+            mdns: MdnsConfig {
+                hostname: "stackchan".to_string(),
+            },
+            time: TimeConfig {
+                tz: "UTC".to_string(),
+                sntp_servers: vec!["pool.ntp.org".to_string(), "time.google.com".to_string()],
+            },
+        }
+    }
+
+    #[test]
+    fn round_trips_through_render_then_parse() {
+        let original = full_config();
+        let rendered = render_settings_json(&original, false).unwrap();
+        let parsed = parse_settings_json(&rendered).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn render_redacts_psk_when_requested() {
+        let original = full_config();
+        let rendered = render_settings_json(&original, true).unwrap();
+        assert!(
+            rendered.contains("\"psk\":\"***\""),
+            "expected redacted psk in: {rendered}"
+        );
+        assert!(
+            !rendered.contains("secret"),
+            "psk leaked through redaction: {rendered}"
+        );
+    }
+
+    #[test]
+    fn parses_minimal_pretty_input() {
+        let input = r#"{
+            "wifi":   { "ssid": "home", "psk": "p", "country": "US" },
+            "mdns":   { "hostname": "stackchan" },
+            "time":   { "tz": "UTC", "sntp_servers": ["pool.ntp.org"] }
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.wifi.ssid, "home");
+        assert_eq!(parsed.time.sntp_servers, vec!["pool.ntp.org".to_string()]);
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_key() {
+        let mut original = render_settings_json(&full_config(), false).unwrap();
+        // Inject an unknown key by replacing the closing brace with one.
+        original.pop(); // remove trailing }
+        original.push_str(",\"extra\":\"junk\"}");
+        let err = parse_settings_json(&original).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_missing_required_block() {
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"}}"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_missing_wifi_field() {
+        let input = r#"{"wifi":{"ssid":"a","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_trailing_garbage_after_object() {
+        let mut input = render_settings_json(&full_config(), false).unwrap();
+        input.push_str(" extra");
+        let err = parse_settings_json(&input).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn surfaces_validation_errors() {
+        // Empty SNTP server list — schema-shape valid, validation rejects.
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":[]}}"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::NoSntpServers),
+            "expected NoSntpServers, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn handles_string_escapes() {
+        let input = r#"{"wifi":{"ssid":"a\tb","psk":"\\\"x","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.wifi.ssid, "a\tb");
+        assert_eq!(parsed.wifi.psk, "\\\"x");
+    }
+
+    #[test]
+    fn ron_parsed_config_round_trips_to_json() {
+        // Pin: the bare RON parser and the bare JSON parser produce
+        // structurally identical Config values for the same logical
+        // schema instance.
+        let from_ron = crate::bare::parse_ron_bare(
+            r#"
+            (
+                wifi: ( ssid: "home", psk: "p", country: "US" ),
+                mdns: ( hostname: "stackchan" ),
+                time: ( tz: "UTC", sntp_servers: [ "pool.ntp.org" ] ),
+            )
+            "#,
+        )
+        .unwrap();
+        let json = render_settings_json(&from_ron, false).unwrap();
+        let from_json = parse_settings_json(&json).unwrap();
+        assert_eq!(from_ron, from_json);
+    }
+}

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -21,6 +21,13 @@ use alloc::vec::Vec;
 use crate::config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 use crate::error::ConfigError;
 
+/// Sentinel emitted by [`render_settings_json`] when `redact_psk = true`.
+///
+/// Rejected as a PSK value by [`parse_settings_json`] so a `GET → PUT`
+/// round trip can't accidentally persist the redacted placeholder as
+/// the real key (which would silently break Wi-Fi on next reboot).
+pub const PSK_REDACTED: &str = "***";
+
 /// Parse a schema-v1 JSON object into a [`Config`].
 ///
 /// Whitespace tolerant. Unknown keys are rejected (typo guard).
@@ -31,9 +38,10 @@ use crate::error::ConfigError;
 /// # Errors
 ///
 /// Returns [`ConfigError::BareParse`] on any structural mismatch
-/// (missing field, unknown key, bad string escape, runaway literal),
-/// then runs the shared [`validate`] gate so out-of-range values
-/// surface the same `Invalid*` variants as [`crate::parse_ron`].
+/// (missing field, unknown key, bad string escape, runaway literal,
+/// or `wifi.psk` set to the [`PSK_REDACTED`] sentinel), then runs
+/// the shared [`validate`] gate so out-of-range values surface the
+/// same `Invalid*` variants as [`crate::parse_ron`].
 pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
     let mut p = Parser::new(input);
     let config = p.parse_config()?;
@@ -60,20 +68,23 @@ pub fn render_settings_json(config: &Config, redact_psk: bool) -> Result<String,
     let mut out = String::new();
     out.push('{');
     out.push_str("\"wifi\":{");
-    push_string_field(&mut out, "ssid", &config.wifi.ssid, false);
+    push_string_field(&mut out, "ssid", &config.wifi.ssid);
     out.push(',');
     push_string_field(
         &mut out,
         "psk",
-        if redact_psk { "***" } else { &config.wifi.psk },
-        false,
+        if redact_psk {
+            PSK_REDACTED
+        } else {
+            &config.wifi.psk
+        },
     );
     out.push(',');
-    push_string_field(&mut out, "country", &config.wifi.country, false);
+    push_string_field(&mut out, "country", &config.wifi.country);
     out.push_str("},\"mdns\":{");
-    push_string_field(&mut out, "hostname", &config.mdns.hostname, false);
+    push_string_field(&mut out, "hostname", &config.mdns.hostname);
     out.push_str("},\"time\":{");
-    push_string_field(&mut out, "tz", &config.time.tz, false);
+    push_string_field(&mut out, "tz", &config.time.tz);
     out.push_str(",\"sntp_servers\":[");
     for (idx, s) in config.time.sntp_servers.iter().enumerate() {
         if idx > 0 {
@@ -87,7 +98,7 @@ pub fn render_settings_json(config: &Config, redact_psk: bool) -> Result<String,
 
 /// Helper: emit `"name":"value"` (no leading comma — the caller
 /// places commas between fields).
-fn push_string_field(out: &mut String, name: &str, value: &str, _trailing: bool) {
+fn push_string_field(out: &mut String, name: &str, value: &str) {
     out.push('"');
     out.push_str(name);
     out.push_str("\":");
@@ -188,9 +199,16 @@ impl<'a> Parser<'a> {
                 return Err(bare_err("expected ',' or '}' in wifi", ""));
             }
         }
+        let psk = psk.ok_or_else(|| bare_err("missing wifi.psk", ""))?;
+        if psk == PSK_REDACTED {
+            return Err(bare_err(
+                "wifi.psk is the redacted sentinel — supply the real key",
+                "",
+            ));
+        }
         Ok(WifiConfig {
             ssid: ssid.ok_or_else(|| bare_err("missing wifi.ssid", ""))?,
-            psk: psk.ok_or_else(|| bare_err("missing wifi.psk", ""))?,
+            psk,
             country: country.ok_or_else(|| bare_err("missing wifi.country", ""))?,
         })
     }
@@ -467,6 +485,31 @@ mod tests {
             matches!(err, ConfigError::NoSntpServers),
             "expected NoSntpServers, got {err:?}"
         );
+    }
+
+    #[test]
+    fn rejects_redacted_psk_sentinel() {
+        // GET /settings emits "psk":"***"; if an operator round-trips
+        // that through PUT /settings unchanged, the firmware would
+        // persist "***" as the real key and break Wi-Fi at next
+        // boot. parse_settings_json must catch it.
+        let body = render_settings_json(&full_config(), true).unwrap();
+        let err = parse_settings_json(&body).unwrap_err();
+        match err {
+            ConfigError::BareParse(msg) => assert!(
+                msg.contains("redacted"),
+                "expected redacted-sentinel message, got `{msg}`"
+            ),
+            other => panic!("expected BareParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn render_uses_psk_redacted_constant() {
+        // Pin: the sentinel string emitted by render is the same
+        // string parse rejects.
+        let body = render_settings_json(&full_config(), true).unwrap();
+        assert!(body.contains(&format!("\"psk\":\"{PSK_REDACTED}\"")));
     }
 
     #[test]

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -49,10 +49,12 @@
 extern crate alloc;
 
 pub mod bare;
+pub mod bare_json;
 pub mod config;
 pub mod error;
 
 pub use bare::{parse_ron_bare, render_ron_bare};
+pub use bare_json::{parse_settings_json, render_settings_json};
 pub use config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};


### PR DESCRIPTION
## Summary

Closes the loop on the SD-card config arc — operators can now read and replace `/sd/STACKCHAN.RON` over HTTP without re-flashing.

- `GET /settings` returns the current persisted Config as JSON, with `wifi.psk` redacted to `"***"`.
- `PUT /settings` accepts a full-replace Config body, runs `stackchan_net::validate`, calls `Storage::write_config` (atomic via the existing `STACKCHAN.NEW` → rename pattern), mirrors the new value into `CONFIG_SNAPSHOT`, responds `{"reboot_required": true}`. Wi-Fi keeps using the boot-time config to avoid dropping the operator's session mid-response when the SSID changes.

## What's new

- `stackchan-net/src/bare_json.rs` — hand-rolled JSON parser+renderer for `Config`, mirroring `bare.rs`'s RON pattern. Host-testable; serde-free; firmware-target friendly.
- `stackchan-firmware/src/storage.rs` — Storage handle moves into a static async `Mutex<StorageHolder>`, populated at boot via `install_storage`. `with_storage` is the single accessor for write-side callers. `StorageHolder` is `unsafe impl Send` with a documented justification (single-core embassy executor; bus aliasing already serialized at `RefCellDevice`).
- `stackchan-firmware/src/net/http.rs` — two new routes wired into the existing matcher.

## Behavioral notes

- `503 Service Unavailable` if the SD card is missing or the boot mount failed (operator triages from boot log).
- `400 Bad Request` on parse / validation failure (empty SSID, invalid country, bad hostname, empty SNTP list).
- `500 Internal Server Error` on SD write failure.
- PSK is never returned over the network — `GET /settings` always emits `\"psk\":\"***\"`.

## Test plan

- [x] `just check` — fmt + workspace clippy + 303 host tests + 10 new bare_json tests pass
- [x] `just clippy-firmware` — strict firmware clippy clean
- [x] `just ci` — workspace doc-lint + cargo-deny pass
- [ ] Flash + curl: GET /settings shows redacted PSK, PUT /settings persists, reboot picks up new SSID
- [ ] Greptile review

## What's tested

- `crates/stackchan-net/src/bare_json.rs` — round-trip render→parse, PSK redaction, missing/unknown keys, trailing garbage, validation surfacing, RON↔JSON cross-format equivalence
- `crates/stackchan-net/tests/golden_config.rs` — existing golden tests still pass against the unchanged RON path

## Notes for reviewer

The `unsafe impl Send for StorageHolder` is the first cross-thread-Send unsafe in the firmware crate. The justification (single-core embassy + already-serialized bus aliasing via RefCellDevice) is documented in the type's module-level rustdoc. If you'd rather keep that surface zero, the alternative is a dedicated `storage_task` actor that owns Storage and serves write requests over an embassy `Channel` — happy to swap if you prefer.