### PR TITLE
feat(firmware): SSE GET /state/stream + concurrent HTTP workers

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -513,6 +513,10 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
             entity.motor.head_pose,
             Some(entity.motor.head_pose_actual),
         );
+        // Push the latest snapshot to any connected SSE subscribers.
+        // Throttled internally so a 30 Hz render doesn't firehose
+        // GET /state/stream clients.
+        net::snapshot::publish_if_changed();
 
         // Render the LED ring from the same entity state.
         render_leds(&entity, now, &mut led_frame);
@@ -912,8 +916,10 @@ async fn main(spawner: Spawner) -> ! {
     )) {
         defmt::panic!("spawn(sntp_task) failed: {}", defmt::Debug2Format(&e));
     }
-    if let Err(e) = spawner.spawn(net::http::http_task(net_stack)) {
-        defmt::panic!("spawn(http_task) failed: {}", defmt::Debug2Format(&e));
+    for _ in 0..net::http::HTTP_WORKER_COUNT {
+        if let Err(e) = spawner.spawn(net::http::http_worker(net_stack)) {
+            defmt::panic!("spawn(http_worker) failed: {}", defmt::Debug2Format(&e));
+        }
     }
     if let Err(e) = spawner.spawn(net::mdns::mdns_task(
         net_stack,

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -523,6 +523,8 @@ const fn status_reason(status: u16) -> &'static str {
         400 => "Bad Request",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        500 => "Internal Server Error",
+        503 => "Service Unavailable",
         // 200 + everything else fall through; the server only emits
         // codes from this short list, so anything else here is a
         // programming bug.

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -6,6 +6,10 @@
 //!   liveness checks and post-flash smoke tests).
 //! - `GET /state` — `AvatarSnapshot` JSON read non-destructively
 //!   from `super::snapshot`.
+//! - `GET /state/stream` — Server-Sent Events stream of
+//!   `AvatarSnapshot` updates. Sends an initial event on connect,
+//!   then one event per change (throttled at the producer to ~10 Hz),
+//!   plus a `: heartbeat` SSE comment every 15 s.
 //! - `POST /emotion` — JSON `{"emotion": "...", "hold_ms": ...}`.
 //!   Sets affect + holds `mind.autonomy` against the autonomous
 //!   emotion drivers for `hold_ms` (default
@@ -38,9 +42,11 @@
 use alloc::format;
 use alloc::string::String;
 
+use embassy_futures::select::{Either, select};
 use embassy_net::Stack;
 use embassy_net::tcp::TcpSocket;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::WaitResult;
 use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
@@ -71,11 +77,25 @@ const MAX_BODY_BYTES: usize = 256;
 /// render task drains will overwrite the first.
 pub static REMOTE_COMMAND_SIGNAL: Signal<CriticalSectionRawMutex, RemoteCommand> = Signal::new();
 
-/// Embassy task — owns one TCP socket and serves requests one at a time.
-/// Re-binds the socket per accept so a misbehaving client can't wedge
-/// the listener.
-#[embassy_executor::task]
-pub async fn http_task(stack: Stack<'static>) -> ! {
+/// Number of concurrent HTTP worker tasks. Each worker holds its own
+/// rx/tx buffers and accepts one connection at a time.
+///
+/// Sized for: one long-lived `GET /state/stream` SSE client + a few
+/// short-lived requests in parallel. Bumping this requires a matching
+/// bump to [`super::snapshot::SSE_MAX_SUBSCRIBERS`] (each worker can
+/// hold one SSE subscriber at a time).
+pub const HTTP_WORKER_COUNT: usize = 4;
+
+/// Embassy worker task — one TCP socket per worker, accepts a
+/// connection, serves it, then loops back for the next accept.
+/// `pool_size` provides [`HTTP_WORKER_COUNT`] independent instances
+/// so multiple clients (including a long-lived SSE stream) can run
+/// in parallel.
+///
+/// Each worker's rx/tx buffers live on its own task stack — bumping
+/// `HTTP_WORKER_COUNT` linearly grows total buffer usage.
+#[embassy_executor::task(pool_size = HTTP_WORKER_COUNT)]
+pub async fn http_worker(stack: Stack<'static>) -> ! {
     let mut rx_buf = [0u8; 1024];
     let mut tx_buf = [0u8; 2048];
 
@@ -89,7 +109,7 @@ pub async fn http_task(stack: Stack<'static>) -> ! {
     }
 
     defmt::info!(
-        "http: listening on 0.0.0.0:{=u16} (LAN-only, no auth)",
+        "http: worker listening on 0.0.0.0:{=u16} (LAN-only, no auth)",
         HTTP_PORT
     );
 
@@ -192,6 +212,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     match (method, path) {
         ("GET", "/health") => write_json(socket, 200, &health_body()).await,
         ("GET", "/state") => write_json(socket, 200, &state_body(snapshot::read())).await,
+        ("GET", "/state/stream") => handle_state_stream(socket).await,
         ("GET", "/settings") => handle_get_settings(socket).await,
         ("PUT", "/settings") => handle_put_settings(socket, body).await,
         ("POST", "/emotion") => handle_remote(socket, json::parse_set_emotion(body)).await,
@@ -200,6 +221,92 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
     }
+}
+
+/// `GET /state/stream` — open an SSE stream of [`AvatarSnapshot`]
+/// events. The render task publishes throttled snapshots via
+/// [`super::snapshot::SNAPSHOT_PUBSUB`]; this handler subscribes,
+/// emits each new snapshot as `data: {json}\n\n`, and sends a
+/// `: heartbeat\n\n` SSE comment line every
+/// [`SSE_HEARTBEAT_SECS`] seconds so proxies and NAT idle timers
+/// don't tear the connection down.
+///
+/// Runs until the client disconnects or the socket times out.
+/// Returns an error from the loop when the write fails — the
+/// outer accept loop logs and re-binds.
+async fn handle_state_stream(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let Ok(mut subscriber) = snapshot::SNAPSHOT_PUBSUB.subscriber() else {
+        // All subscriber slots taken — every other worker is also
+        // streaming. Refuse politely.
+        return write_text(socket, 503, "stream slots exhausted\n").await;
+    };
+
+    // Disable the per-request inactivity timeout: SSE traffic is
+    // server→client only, and the client doesn't speak after the
+    // initial GET.
+    socket.set_timeout(None);
+
+    let header = "HTTP/1.1 200 OK\r\n\
+                  Content-Type: text/event-stream\r\n\
+                  Cache-Control: no-cache\r\n\
+                  Connection: keep-alive\r\n\r\n";
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+
+    // Initial event: send the current snapshot immediately so
+    // freshly-connected clients don't have to wait for the next
+    // render-tick change.
+    write_event(socket, &snapshot::read()).await?;
+
+    loop {
+        match select(
+            subscriber.next_message(),
+            embassy_time::Timer::after(Duration::from_secs(SSE_HEARTBEAT_SECS)),
+        )
+        .await
+        {
+            Either::First(WaitResult::Message(snap)) => write_event(socket, &snap).await?,
+            // `Lagged` means we missed N publishes. Skip them and
+            // wait for the next — a current snapshot is more useful
+            // than backfilling stale ones.
+            Either::First(WaitResult::Lagged(_)) => {}
+            Either::Second(()) => write_heartbeat(socket).await?,
+        }
+    }
+}
+
+/// SSE heartbeat interval. 15 s is a common default that keeps most
+/// reverse-proxy / NAT idle timers happy without bloating LAN
+/// traffic.
+const SSE_HEARTBEAT_SECS: u64 = 15;
+
+/// Write a single SSE `data: ...\n\n` event carrying the snapshot's
+/// JSON encoding.
+async fn write_event(socket: &mut TcpSocket<'_>, snap: &AvatarSnapshot) -> Result<(), HttpError> {
+    // `state_body` returns a JSON object terminated with `\n`; SSE
+    // wants a single `data: <line>` followed by a blank line, so we
+    // strip the trailing newline before formatting.
+    let body = state_body(*snap);
+    let trimmed = body.trim_end_matches('\n');
+    let event = format!("data: {trimmed}\n\n");
+    socket
+        .write_all(event.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
+}
+
+/// Write an SSE comment line (`: heartbeat\n\n`) to keep the
+/// connection alive across idle stretches. Comment lines are
+/// ignored by `EventSource` clients.
+async fn write_heartbeat(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    socket
+        .write_all(b": heartbeat\n\n")
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
 }
 
 /// `GET /settings` — render the current snapshot with `wifi.psk`

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -54,7 +54,7 @@ use stackchan_core::RemoteCommand;
 
 use super::json::{self, JsonError};
 use super::snapshot::{self, AvatarSnapshot};
-use super::wifi::{WIFI_LINK_SIGNAL, WifiLinkState};
+use super::wifi::LINK_READY;
 
 /// Listening port. LAN-only; no auth.
 const HTTP_PORT: u16 = 80;
@@ -99,13 +99,13 @@ pub async fn http_worker(stack: Stack<'static>) -> ! {
     let mut rx_buf = [0u8; 1024];
     let mut tx_buf = [0u8; 2048];
 
-    // Wait for the wifi task to publish a Connected state at least
-    // once. After that, every accept loop just keeps trying — embassy-net
+    // Gate on the latched LINK_READY flag — Signal::wait would race
+    // between workers (single stored waker), so we poll the atomic
+    // every 100 ms until the wifi task latches it on first connect.
+    // After that, every accept loop just keeps trying — embassy-net
     // returns errors quickly when the link is down, no busy spin.
-    loop {
-        if matches!(WIFI_LINK_SIGNAL.wait().await, WifiLinkState::Connected) {
-            break;
-        }
+    while !LINK_READY.load(core::sync::atomic::Ordering::Acquire) {
+        embassy_time::Timer::after(Duration::from_millis(100)).await;
     }
 
     defmt::info!(

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -38,6 +38,8 @@ pub struct WifiSnapshot {
 /// Composite avatar state surfaced via `GET /state`.
 ///
 /// Only `PartialEq` (not `Eq`) because `head_pose` carries `f32`s.
+/// Note: `==` returns `false` for NaN-vs-NaN; use [`Self::bit_eq`]
+/// when "did anything change" matters more than IEEE 754 equality.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AvatarSnapshot {
     /// Current emotion produced by the modifier pipeline.
@@ -50,6 +52,32 @@ pub struct AvatarSnapshot {
     pub battery: BatterySnapshot,
     /// Wi-Fi link state.
     pub wifi: WifiSnapshot,
+}
+
+impl AvatarSnapshot {
+    /// Bit-pattern equality across all `f32` fields, plus value
+    /// equality on everything else. Unlike `==`, this returns `true`
+    /// for NaN-vs-NaN with the same bit layout, which is what the
+    /// "did anything change since last frame?" gate wants — IEEE
+    /// 754 NaN-inequality would otherwise make every tick look
+    /// changed when a pose value gets stuck at NaN.
+    #[must_use]
+    pub fn bit_eq(&self, other: &Self) -> bool {
+        let pose_eq = |a: Pose, b: Pose| {
+            a.pan_deg.to_bits() == b.pan_deg.to_bits()
+                && a.tilt_deg.to_bits() == b.tilt_deg.to_bits()
+        };
+        let actual_eq = match (self.head_actual, other.head_actual) {
+            (Some(a), Some(b)) => pose_eq(a, b),
+            (None, None) => true,
+            _ => false,
+        };
+        self.emotion == other.emotion
+            && pose_eq(self.head_pose, other.head_pose)
+            && actual_eq
+            && self.battery == other.battery
+            && self.wifi == other.wifi
+    }
 }
 
 impl Default for AvatarSnapshot {
@@ -175,7 +203,9 @@ pub fn publish_if_changed() {
         return;
     }
     let current = read();
-    let changed = LAST_PUBLISHED.lock(|cell| cell.get() != Some(current));
+    // `bit_eq` instead of `!=`: NaN in f32 pose fields would otherwise
+    // make every tick look changed under PartialEq.
+    let changed = LAST_PUBLISHED.lock(|cell| cell.get().is_none_or(|prev| !prev.bit_eq(&current)));
     if !changed {
         return;
     }

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -11,11 +11,13 @@ use core::net::Ipv4Addr;
 
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pubsub::PubSubChannel;
+use embassy_time::Instant as EmbassyInstant;
 use stackchan_core::Emotion;
 use stackchan_core::head::Pose;
 
 /// Battery snapshot — published by the power task.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BatterySnapshot {
     /// Estimated state-of-charge percentage (0..=100), or `None`
     /// before the first reading lands.
@@ -25,7 +27,7 @@ pub struct BatterySnapshot {
 }
 
 /// Wi-Fi link snapshot — published by the wifi task.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct WifiSnapshot {
     /// Whether the controller currently reports a Connected link.
     pub connected: bool,
@@ -34,7 +36,9 @@ pub struct WifiSnapshot {
 }
 
 /// Composite avatar state surfaced via `GET /state`.
-#[derive(Debug, Clone, Copy)]
+///
+/// Only `PartialEq` (not `Eq`) because `head_pose` carries `f32`s.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AvatarSnapshot {
     /// Current emotion produced by the modifier pipeline.
     pub emotion: Emotion,
@@ -117,4 +121,66 @@ pub fn update_wifi(connected: bool, ip: Option<Ipv4Addr>) {
 #[must_use]
 pub fn read() -> AvatarSnapshot {
     AVATAR_SNAPSHOT.lock(core::cell::Cell::get)
+}
+
+/// Maximum simultaneous SSE subscribers. Matches the HTTP worker
+/// pool size — each worker holds at most one subscriber, so SSE
+/// connections beyond this aren't possible anyway.
+pub const SSE_MAX_SUBSCRIBERS: usize = 4;
+
+/// Multi-producer single-publisher channel that pushes the latest
+/// [`AvatarSnapshot`] to SSE subscribers on `GET /state/stream`.
+///
+/// Capacity 1: latest-wins. If a subscriber lags it sees a `Lagged`
+/// result and continues at the next message — operators don't need
+/// every frame, just current state.
+pub static SNAPSHOT_PUBSUB: PubSubChannel<
+    CriticalSectionRawMutex,
+    AvatarSnapshot,
+    1,
+    SSE_MAX_SUBSCRIBERS,
+    1,
+> = PubSubChannel::new();
+
+/// Minimum interval between publishes. Render runs at ~30 Hz; we
+/// throttle the SSE firehose to ~10 Hz so a slow client (or four
+/// of them) can keep up without backpressure.
+const PUBLISH_MIN_INTERVAL_MS: u64 = 100;
+
+/// Last-published-at instant, in `embassy_time::Instant` ticks.
+/// `0` is the sentinel for "never published"; the first call always
+/// publishes.
+static LAST_PUBLISH_MS: Mutex<CriticalSectionRawMutex, core::cell::Cell<u64>> =
+    Mutex::new(core::cell::Cell::new(0));
+
+/// Last-published snapshot value, used to suppress duplicate
+/// publishes when nothing visible changed between ticks.
+static LAST_PUBLISHED: Mutex<CriticalSectionRawMutex, core::cell::Cell<Option<AvatarSnapshot>>> =
+    Mutex::new(core::cell::Cell::new(None));
+
+/// Publish the current snapshot to [`SNAPSHOT_PUBSUB`] subscribers.
+///
+/// Called once per render tick by the render task. Only publishes
+/// when the snapshot has actually changed AND
+/// [`PUBLISH_MIN_INTERVAL_MS`] has elapsed since the last publish.
+///
+/// Cheap when no subscribers are connected (the publisher's
+/// `publish_immediate` returns immediately if the channel has no
+/// listeners), so this stays out of the hot path of the
+/// boot-only-no-Wi-Fi scenario.
+pub fn publish_if_changed() {
+    let now_ms = EmbassyInstant::now().as_millis();
+    let last_ms = LAST_PUBLISH_MS.lock(core::cell::Cell::get);
+    if last_ms != 0 && now_ms.saturating_sub(last_ms) < PUBLISH_MIN_INTERVAL_MS {
+        return;
+    }
+    let current = read();
+    let changed = LAST_PUBLISHED.lock(|cell| cell.get() != Some(current));
+    if !changed {
+        return;
+    }
+    LAST_PUBLISH_MS.lock(|cell| cell.set(now_ms));
+    LAST_PUBLISHED.lock(|cell| cell.set(Some(current)));
+    let publisher = SNAPSHOT_PUBSUB.immediate_publisher();
+    publisher.publish_immediate(current);
 }

--- a/crates/stackchan-firmware/src/net/wifi.rs
+++ b/crates/stackchan-firmware/src/net/wifi.rs
@@ -8,6 +8,7 @@
 //! connect, and on disconnection retries with exponential backoff.
 
 use alloc::string::String;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
@@ -16,7 +17,22 @@ use esp_radio::wifi::{ClientConfig, ModeConfig, WifiController, WifiEvent};
 
 /// Public link-state signal — downstream tasks (SNTP, HTTP, mDNS)
 /// `wait()` on it to gate their own startup against the connect.
+///
+/// `Signal` is single-consumer: it stores one waker, so multiple
+/// concurrent `.wait().await` callers will lose all but the
+/// last-registered. SNTP and mDNS each have a single instance and
+/// loop on the signal, so this works for them. Multi-instance
+/// consumers (the HTTP worker pool) must use [`LINK_READY`] instead.
 pub static WIFI_LINK_SIGNAL: Signal<CriticalSectionRawMutex, WifiLinkState> = Signal::new();
+
+/// Latched "link has been up at least once" flag.
+///
+/// Set the first time [`wifi_task`] observes a [`WifiLinkState::Connected`]
+/// transition; never cleared. Multiple consumers can read this
+/// concurrently without the single-waker contention that
+/// [`WIFI_LINK_SIGNAL`] has — used by the HTTP worker pool to gate
+/// each worker's first accept call.
+pub static LINK_READY: AtomicBool = AtomicBool::new(false);
 
 /// Coarse-grained Wi-Fi link state. Published on every transition.
 #[derive(Clone, Copy, Debug, defmt::Format)]
@@ -94,6 +110,7 @@ async fn connect_loop(mut controller: WifiController<'static>, ssid: String) -> 
             Ok(()) => {
                 defmt::info!("wifi: connected");
                 WIFI_LINK_SIGNAL.signal(WifiLinkState::Connected);
+                LINK_READY.store(true, Ordering::Release);
                 backoff_idx = 0;
                 // Park until the controller reports a disconnect.
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;


### PR DESCRIPTION
## Summary

Adds a Server-Sent Events stream of `AvatarSnapshot` updates and pools the HTTP workers so a long-lived stream doesn't block other requests.

- `GET /state/stream` opens a `text/event-stream` response. Initial event on connect = current snapshot. Subsequent events fire on snapshot change. `: heartbeat\n\n` SSE comment every 15 s keeps proxies / NAT idle timers happy.
- Render task publishes the snapshot through a new `SNAPSHOT_PUBSUB` PubSubChannel each tick. Producer-side throttle caps the firehose at ~10 Hz even though render runs at 30 Hz.
- HTTP task is now `pool_size = 4` — multiple workers accept on the same port. A long-lived SSE stream occupies one slot; the other three handle GET /health, PUT /settings, etc. in parallel.
- Up to 4 concurrent SSE subscribers; the 5th gets `503 stream slots exhausted`.

## Architectural notes

- `HTTP_WORKER_COUNT` and `snapshot::SSE_MAX_SUBSCRIBERS` are intentionally coupled — bumping concurrency requires raising both. Comment in code calls this out.
- Each worker owns its rx/tx buffers (~3 KiB) on its own task stack; total ~12 KiB for the pool. Modest on the CoreS3's 8 MB PSRAM.
- SSE handler disables the per-request inactivity timeout — SSE is server→client only and clients don't speak after the GET. The 15 s heartbeat is what proves liveness instead.
- `Lagged` from the pubsub subscriber is silently skipped: a current snapshot is more useful than backfilling stale ones.

## Test plan

- [x] `just check` — fmt + workspace clippy + 303 host tests + sim tests pass
- [x] `just clippy-firmware` — strict firmware clippy clean
- [x] `just ci` — workspace doc-lint + cargo-deny pass
- [ ] Flash + `curl -N http://stackchan.local/state/stream` — verify initial event, change events on emotion/look-at commands, heartbeat every 15 s
- [ ] Open 5 concurrent SSE clients to verify the 503 path
- [ ] Verify GET /health stays responsive while a stream is open
- [ ] Greptile review

## What's tested host-side

The SSE path itself is firmware-only (TCP + embassy + pubsub). The throttling logic in `publish_if_changed` is reachable from host tests in principle; left untested here for a follow-up if it grows. Existing host tests still cover the AvatarSnapshot shape and `state_body` JSON formatting that SSE events reuse.