### PR TITLE
chore: audit HTTP control plane (#148–#158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.5
         with:
+          # Pin: `latest` resolves through GitHub's `/releases/latest`
+          # endpoint then re-fetches the paginated listing to find the
+          # asset, and the two queries can disagree when a release was
+          # just published — espup reports `version_not_found` on
+          # versions that exist. Pin a known-good toolchain so PR
+          # merges aren't held by upstream pagination weather.
+          version: 1.94.0.0
           default: true
           buildtargets: esp32s3
           ldproxy: false

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -63,17 +63,22 @@ use super::wifi::LINK_READY;
 const HTTP_PORT: u16 = 80;
 
 /// Maximum request line + headers + body size we'll buffer before
-/// responding `400`. POST bodies for the current write surface are
-/// at most a few dozen bytes; 1 KiB is generous.
+/// responding `400`. Headers and body share this buffer, so the
+/// late-stage `filled >= REQUEST_BUF_BYTES` guard doubles as a
+/// header-overflow check.
 const REQUEST_BUF_BYTES: usize = 1024;
 
-/// Cap on the `Content-Length` header. Anything larger is rejected
-/// before any body bytes are read.
+/// Cap on the `Content-Length` header. Bodies of this size or
+/// larger are rejected before any body bytes are read.
 ///
-/// Sized for `PUT /settings`: the full schema-v1 body with a 32-char
-/// SSID, 63-char WPA2 PSK, an `America/…` IANA tz label, and a few
-/// SNTP servers lands around 320 bytes; 1024 leaves room for future
-/// fields without forcing every operator update through a re-cap.
+/// Equal to [`REQUEST_BUF_BYTES`] on purpose: the buffer holds
+/// headers + body together, so any `content_length` that hits the
+/// cap can't physically fit alongside the request line. Sized for
+/// `PUT /settings`: the full schema-v1 body with a 32-char SSID,
+/// 63-char WPA2 PSK, an `America/…` IANA tz label, and a few SNTP
+/// servers lands around 320 bytes; the 1024 ceiling leaves room
+/// for future fields without forcing every operator update through
+/// a re-cap.
 const MAX_BODY_BYTES: usize = 1024;
 
 /// Self-contained operator dashboard, embedded at compile time.
@@ -207,7 +212,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         + path_start;
     let body_start = header_end + 4;
     let content_length = parse_content_length(&buf[line_end + 2..header_end])?;
-    if content_length > MAX_BODY_BYTES {
+    if content_length >= MAX_BODY_BYTES {
         return Err(HttpError::BodyTooLarge);
     }
     while filled < body_start + content_length {

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -53,7 +53,7 @@ use embassy_sync::pubsub::WaitResult;
 use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
-use stackchan_core::RemoteCommand;
+use stackchan_core::{Emotion, RemoteCommand};
 
 use super::json::{self, JsonError};
 use super::snapshot::{self, AvatarSnapshot};
@@ -485,17 +485,34 @@ fn state_body(s: AvatarSnapshot) -> String {
         .map_or_else(|| String::from("null"), |a| format!("\"{a}\""));
     format!(
         "{{\
-\"emotion\":\"{emotion:?}\",\
+\"emotion\":\"{emotion}\",\
 \"head_pose\":{{\"pan_deg\":{pan:.2},\"tilt_deg\":{tilt:.2}}},\
 \"head_actual\":{actual},\
 \"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\
 \"wifi\":{{\"connected\":{connected},\"ip\":{ip}}}\
 }}\n",
-        emotion = s.emotion,
+        emotion = emotion_str(s.emotion),
         pan = s.head_pose.pan_deg,
         tilt = s.head_pose.tilt_deg,
         connected = s.wifi.connected,
     )
+}
+
+/// Render an [`Emotion`] as its lowercase wire name. The vocabulary
+/// is mirrored by [`super::json::parse_emotion`] — so a consumer can
+/// take an emotion from `GET /state` and `POST /emotion` it back
+/// without any case translation. Pinning the mapping here also
+/// guards against a future non-unit `Emotion` variant whose `Debug`
+/// representation would otherwise inject `{` into the JSON string.
+const fn emotion_str(e: Emotion) -> &'static str {
+    match e {
+        Emotion::Neutral => "neutral",
+        Emotion::Happy => "happy",
+        Emotion::Sad => "sad",
+        Emotion::Sleepy => "sleepy",
+        Emotion::Surprised => "surprised",
+        Emotion::Angry => "angry",
+    }
 }
 
 /// Write `status` + `body` as `application/json`.
@@ -582,4 +599,39 @@ async fn write_status_for_error(socket: &mut TcpSocket<'_>, err: &HttpError) {
         HttpError::Read | HttpError::Write => return,
     };
     let _ = write_text(socket, status, body).await;
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: panic-on-mismatch for variant extraction"
+)]
+mod tests {
+    use super::*;
+    use stackchan_core::RemoteCommand;
+
+    /// Every `Emotion` variant must round-trip through `emotion_str`
+    /// and `parse_set_emotion` so a `GET /state` consumer can post
+    /// the value back without case translation, and so a future
+    /// non-unit `Emotion` variant can't silently inject `{` into the
+    /// JSON output.
+    #[test]
+    fn emotion_str_round_trips_through_parser() {
+        for variant in [
+            Emotion::Neutral,
+            Emotion::Happy,
+            Emotion::Sad,
+            Emotion::Sleepy,
+            Emotion::Surprised,
+            Emotion::Angry,
+        ] {
+            let wire = emotion_str(variant);
+            let body = alloc::format!(r#"{{"emotion":"{wire}"}}"#);
+            match super::json::parse_set_emotion(&body).unwrap() {
+                RemoteCommand::SetEmotion { emotion, .. } => assert_eq!(emotion, variant),
+                other => panic!("expected SetEmotion for `{wire}`, got {other:?}"),
+            }
+        }
+    }
 }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -135,6 +135,11 @@ pub async fn http_worker(stack: Stack<'static>) -> ! {
         }
 
         if let Err(e) = serve_one(&mut socket).await {
+            // Best-effort status reply for parse-side failures so
+            // operators see `400`/`413`/`431` from curl instead of a
+            // bare connection reset. `Read`/`Write` skip — the socket
+            // is already broken.
+            write_status_for_error(&mut socket, &e).await;
             defmt::warn!("http: serve error ({})", defmt::Debug2Format(&e));
         }
 
@@ -555,6 +560,8 @@ const fn status_reason(status: u16) -> &'static str {
         400 => "Bad Request",
         404 => "Not Found",
         405 => "Method Not Allowed",
+        413 => "Payload Too Large",
+        431 => "Request Header Fields Too Large",
         500 => "Internal Server Error",
         503 => "Service Unavailable",
         // 200 + everything else fall through; the server only emits
@@ -562,4 +569,17 @@ const fn status_reason(status: u16) -> &'static str {
         // programming bug.
         _ => "OK",
     }
+}
+
+/// Best-effort: write a status response for a parse-side failure.
+/// `Read`/`Write` skip — the socket is already broken so any further
+/// write would just produce another `Write` error.
+async fn write_status_for_error(socket: &mut TcpSocket<'_>, err: &HttpError) {
+    let (status, body) = match err {
+        HttpError::Malformed => (400, "bad request\n"),
+        HttpError::BodyTooLarge => (413, "payload too large\n"),
+        HttpError::HeadersTooLarge => (431, "request header fields too large\n"),
+        HttpError::Read | HttpError::Write => return,
+    };
+    let _ = write_text(socket, status, body).await;
 }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -649,4 +649,111 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn content_length_missing_defaults_to_zero() {
+        let headers = b"Host: stackchan.local\r\nUser-Agent: curl/8\r\n";
+        assert!(matches!(parse_content_length(headers), Ok(0)));
+    }
+
+    #[test]
+    fn content_length_is_case_insensitive() {
+        for raw in [
+            "Content-Length: 42\r\n",
+            "content-length: 42\r\n",
+            "CONTENT-LENGTH: 42\r\n",
+            "cOnTeNt-LeNgTh: 42\r\n",
+        ] {
+            assert!(
+                matches!(parse_content_length(raw.as_bytes()), Ok(42)),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn content_length_trims_value_whitespace() {
+        let headers = b"Content-Length:    99\r\n";
+        assert!(matches!(parse_content_length(headers), Ok(99)));
+    }
+
+    #[test]
+    fn content_length_rejects_non_numeric() {
+        let headers = b"Content-Length: forty-two\r\n";
+        assert!(matches!(
+            parse_content_length(headers),
+            Err(HttpError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn content_length_rejects_signed_value() {
+        // `usize::from_str` doesn't accept a leading '+' or '-'; pin
+        // that the parser surfaces it as Malformed rather than 0.
+        for raw in ["Content-Length: +5\r\n", "Content-Length: -5\r\n"] {
+            assert!(
+                matches!(
+                    parse_content_length(raw.as_bytes()),
+                    Err(HttpError::Malformed)
+                ),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn content_length_rejects_overflow() {
+        // 2^64-ish — never fits in usize on 32- or 64-bit targets.
+        let headers = b"Content-Length: 99999999999999999999\r\n";
+        assert!(matches!(
+            parse_content_length(headers),
+            Err(HttpError::Malformed)
+        ));
+    }
+
+    #[test]
+    fn content_length_first_match_wins_on_duplicates() {
+        // RFC 7230 forbids multiple Content-Length headers with
+        // different values; this server takes the first match. Pin
+        // the behavior so a future change is conscious.
+        let headers = b"Content-Length: 7\r\nContent-Length: 99\r\n";
+        assert!(matches!(parse_content_length(headers), Ok(7)));
+    }
+
+    #[test]
+    fn find_subsequence_locates_or_misses() {
+        assert_eq!(find_subsequence(b"abcdef", b"cd"), Some(2));
+        assert_eq!(find_subsequence(b"abcdef", b"xy"), None);
+        assert_eq!(find_subsequence(b"abc", b"abcd"), None);
+        // Zero-length needle is a documented `windows(0)` quirk —
+        // the parser only ever passes the four-byte CRLF CRLF
+        // sentinel, so no caller exercises this. Recording the
+        // behaviour rather than relying on it.
+        assert_eq!(find_subsequence(b"abc", b""), Some(0));
+    }
+
+    #[test]
+    fn split_once_partitions_on_first_delim() {
+        assert_eq!(
+            split_once(b"key: value", b':'),
+            Some((b"key".as_slice(), b" value".as_slice()))
+        );
+        assert_eq!(
+            split_once(b"a:b:c", b':'),
+            Some((b"a".as_slice(), b"b:c".as_slice()))
+        );
+        assert_eq!(
+            split_once(b":empty", b':'),
+            Some((b"".as_slice(), b"empty".as_slice()))
+        );
+        assert_eq!(split_once(b"none", b':'), None);
+    }
+
+    #[test]
+    fn trim_ascii_strips_both_sides() {
+        assert_eq!(trim_ascii(b"  hello  "), b"hello");
+        assert_eq!(trim_ascii(b"\t\rkey\n "), b"key");
+        assert_eq!(trim_ascii(b"   "), b"");
+        assert_eq!(trim_ascii(b"clean"), b"clean");
+    }
 }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -551,12 +551,13 @@ async fn write_text(socket: &mut TcpSocket<'_>, status: u16, body: &str) -> Resu
     socket.flush().await.map_err(|_| HttpError::Write)
 }
 
-/// Serve [`DASHBOARD_HTML`] with `Content-Type: text/html` plus a
-/// short cache hint so reloads during development don't pile bytes
-/// through the LAN.
+/// Serve [`DASHBOARD_HTML`] with `Content-Type: text/html`. Cache is
+/// disabled so a freshly flashed firmware's dashboard JS shows up on
+/// the next reload — the payload is 10 KiB over LAN, so the saving
+/// from a longer max-age was never worth the staleness it caused.
 async fn write_dashboard(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     let header = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {len}\r\nCache-Control: max-age=60\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {len}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
         len = DASHBOARD_HTML.len(),
     );
     socket

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -518,6 +518,10 @@ fn state_body(s: AvatarSnapshot) -> String {
 /// without any case translation. Pinning the mapping here also
 /// guards against a future non-unit `Emotion` variant whose `Debug`
 /// representation would otherwise inject `{` into the JSON string.
+///
+/// `Emotion` is `#[non_exhaustive]`; the wildcard returns `"unknown"`
+/// so a newly added variant surfaces on the dashboard as a missing
+/// mapping rather than silently aliasing to neutral.
 const fn emotion_str(e: Emotion) -> &'static str {
     match e {
         Emotion::Neutral => "neutral",
@@ -526,6 +530,7 @@ const fn emotion_str(e: Emotion) -> &'static str {
         Emotion::Sleepy => "sleepy",
         Emotion::Surprised => "surprised",
         Emotion::Angry => "angry",
+        _ => "unknown",
     }
 }
 

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -68,9 +68,13 @@ const HTTP_PORT: u16 = 80;
 const REQUEST_BUF_BYTES: usize = 1024;
 
 /// Cap on the `Content-Length` header. Anything larger is rejected
-/// before any body bytes are read — the write surface only accepts
-/// short JSON object bodies.
-const MAX_BODY_BYTES: usize = 256;
+/// before any body bytes are read.
+///
+/// Sized for `PUT /settings`: the full schema-v1 body with a 32-char
+/// SSID, 63-char WPA2 PSK, an `America/…` IANA tz label, and a few
+/// SNTP servers lands around 320 bytes; 1024 leaves room for future
+/// fields without forcing every operator update through a re-cap.
+const MAX_BODY_BYTES: usize = 1024;
 
 /// Self-contained operator dashboard, embedded at compile time.
 /// Loaded by `GET /` at the device root; uses the existing

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -391,7 +391,7 @@ async fn handle_remote(
         Ok(cmd) => {
             defmt::info!("http: remote command {}", defmt::Debug2Format(&cmd));
             REMOTE_COMMAND_SIGNAL.signal(cmd);
-            write_text(socket, 204, "").await
+            write_no_content(socket).await
         }
         Err(e) => {
             defmt::warn!("http: bad request body ({})", e);
@@ -399,6 +399,20 @@ async fn handle_remote(
             write_text(socket, 400, &body).await
         }
     }
+}
+
+/// Write `204 No Content`. RFC 7230 says a 204 response "is always
+/// terminated by the first empty line after the header fields"; the
+/// general `write_text` helper would still emit `Content-Type` +
+/// `Content-Length: 0`, which is pedantically allowed but unusual.
+/// This helper omits both so the response is just headers + CRLF.
+async fn write_no_content(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let header = "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n";
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
 }
 
 /// Parse the `Content-Length` header value out of a header block.

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -730,11 +730,9 @@ mod tests {
         assert_eq!(find_subsequence(b"abcdef", b"cd"), Some(2));
         assert_eq!(find_subsequence(b"abcdef", b"xy"), None);
         assert_eq!(find_subsequence(b"abc", b"abcd"), None);
-        // Zero-length needle is a documented `windows(0)` quirk —
-        // the parser only ever passes the four-byte CRLF CRLF
-        // sentinel, so no caller exercises this. Recording the
-        // behaviour rather than relying on it.
-        assert_eq!(find_subsequence(b"abc", b""), Some(0));
+        // Zero-length needles aren't tested: `slice::windows(0)`
+        // panics, and the only caller passes the four-byte CRLF
+        // CRLF sentinel, so the case is unreachable.
     }
 
     #[test]

--- a/crates/stackchan-firmware/src/net/json.rs
+++ b/crates/stackchan-firmware/src/net/json.rs
@@ -32,6 +32,10 @@ pub enum JsonError {
     MissingKey(&'static str),
     /// Unknown key — schemas are closed.
     UnknownKey,
+    /// Same key appeared twice. RFC 8259 leaves duplicates
+    /// implementation-defined; this server rejects rather than
+    /// silently choosing last-wins, so a typo doesn't pass.
+    DuplicateKey(&'static str),
     /// Value type doesn't match the schema (e.g. number where a
     /// string was expected).
     BadValue,
@@ -53,8 +57,18 @@ pub fn parse_set_emotion(body: &str) -> Result<RemoteCommand, JsonError> {
     let mut hold_ms: Option<u32> = None;
     visit_object(body, |key, scanner| {
         match key {
-            "emotion" => emotion = Some(parse_emotion(scanner)?),
-            "hold_ms" => hold_ms = Some(parse_u32(scanner)?),
+            "emotion" => {
+                if emotion.is_some() {
+                    return Err(JsonError::DuplicateKey("emotion"));
+                }
+                emotion = Some(parse_emotion(scanner)?);
+            }
+            "hold_ms" => {
+                if hold_ms.is_some() {
+                    return Err(JsonError::DuplicateKey("hold_ms"));
+                }
+                hold_ms = Some(parse_u32(scanner)?);
+            }
             _ => return Err(JsonError::UnknownKey),
         }
         Ok(())
@@ -80,9 +94,24 @@ pub fn parse_look_at(body: &str) -> Result<RemoteCommand, JsonError> {
     let mut hold_ms: Option<u32> = None;
     visit_object(body, |key, scanner| {
         match key {
-            "pan_deg" => pan_deg = Some(parse_f32(scanner)?),
-            "tilt_deg" => tilt_deg = Some(parse_f32(scanner)?),
-            "hold_ms" => hold_ms = Some(parse_u32(scanner)?),
+            "pan_deg" => {
+                if pan_deg.is_some() {
+                    return Err(JsonError::DuplicateKey("pan_deg"));
+                }
+                pan_deg = Some(parse_f32(scanner)?);
+            }
+            "tilt_deg" => {
+                if tilt_deg.is_some() {
+                    return Err(JsonError::DuplicateKey("tilt_deg"));
+                }
+                tilt_deg = Some(parse_f32(scanner)?);
+            }
+            "hold_ms" => {
+                if hold_ms.is_some() {
+                    return Err(JsonError::DuplicateKey("hold_ms"));
+                }
+                hold_ms = Some(parse_u32(scanner)?);
+            }
             _ => return Err(JsonError::UnknownKey),
         }
         Ok(())
@@ -373,6 +402,24 @@ mod tests {
         assert!(matches!(
             parse_set_emotion(body),
             Err(JsonError::Unterminated)
+        ));
+    }
+
+    #[test]
+    fn set_emotion_rejects_duplicate_key() {
+        let body = r#"{"emotion":"happy","emotion":"sad"}"#;
+        assert!(matches!(
+            parse_set_emotion(body),
+            Err(JsonError::DuplicateKey("emotion"))
+        ));
+    }
+
+    #[test]
+    fn look_at_rejects_duplicate_key() {
+        let body = r#"{"pan_deg":1.0,"tilt_deg":0.0,"pan_deg":2.0}"#;
+        assert!(matches!(
+            parse_look_at(body),
+            Err(JsonError::DuplicateKey("pan_deg"))
         ));
     }
 

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -176,10 +176,10 @@ pub static SNAPSHOT_PUBSUB: PubSubChannel<
 const PUBLISH_MIN_INTERVAL_MS: u64 = 100;
 
 /// Last-published-at instant, in `embassy_time::Instant` ticks.
-/// `0` is the sentinel for "never published"; the first call always
-/// publishes.
-static LAST_PUBLISH_MS: Mutex<CriticalSectionRawMutex, core::cell::Cell<u64>> =
-    Mutex::new(core::cell::Cell::new(0));
+/// `None` until the first publish; `Some(ms)` thereafter so the
+/// throttle gate doesn't have to reserve a magic value.
+static LAST_PUBLISH_MS: Mutex<CriticalSectionRawMutex, core::cell::Cell<Option<u64>>> =
+    Mutex::new(core::cell::Cell::new(None));
 
 /// Last-published snapshot value, used to suppress duplicate
 /// publishes when nothing visible changed between ticks.
@@ -199,7 +199,9 @@ static LAST_PUBLISHED: Mutex<CriticalSectionRawMutex, core::cell::Cell<Option<Av
 pub fn publish_if_changed() {
     let now_ms = EmbassyInstant::now().as_millis();
     let last_ms = LAST_PUBLISH_MS.lock(core::cell::Cell::get);
-    if last_ms != 0 && now_ms.saturating_sub(last_ms) < PUBLISH_MIN_INTERVAL_MS {
+    if let Some(last) = last_ms
+        && now_ms.saturating_sub(last) < PUBLISH_MIN_INTERVAL_MS
+    {
         return;
     }
     let current = read();
@@ -209,7 +211,7 @@ pub fn publish_if_changed() {
     if !changed {
         return;
     }
-    LAST_PUBLISH_MS.lock(|cell| cell.set(now_ms));
+    LAST_PUBLISH_MS.lock(|cell| cell.set(Some(now_ms)));
     LAST_PUBLISHED.lock(|cell| cell.set(Some(current)));
     let publisher = SNAPSHOT_PUBSUB.immediate_publisher();
     publisher.publish_immediate(current);

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -521,6 +521,47 @@ mod tests {
     }
 
     #[test]
+    fn maximal_payload_fits_under_http_body_cap() {
+        // Pin the upper bound on `PUT /settings` payloads. Numbers
+        // mirror real-world maxima:
+        //   - SSID: 32 chars (IEEE 802.11 limit)
+        //   - PSK: 63 chars (WPA2/3 PSK upper bound)
+        //   - hostname: 63 chars (RFC-952 / firmware validator)
+        //   - tz: long IANA label
+        //   - sntp_servers: 4 servers, 16 chars each (typical FQDN)
+        // Firmware caps the body at 1024 bytes; this test fails if a
+        // schema addition pushes legitimate payloads past that cap so
+        // we notice before users do.
+        let config = Config {
+            wifi: WifiConfig {
+                ssid: "x".repeat(32),
+                psk: "x".repeat(63),
+                country: "US".to_string(),
+            },
+            mdns: MdnsConfig {
+                hostname: "x".repeat(63),
+            },
+            time: TimeConfig {
+                tz: "America/Argentina/Buenos_Aires".to_string(),
+                sntp_servers: vec![
+                    "time1.google.com".to_string(),
+                    "time2.google.com".to_string(),
+                    "time3.google.com".to_string(),
+                    "time4.google.com".to_string(),
+                ],
+            },
+        };
+        let rendered = render_settings_json(&config, false).unwrap();
+        assert!(
+            rendered.len() < 1024,
+            "maximal payload exceeded firmware MAX_BODY_BYTES: {} bytes",
+            rendered.len()
+        );
+        let parsed = parse_settings_json(&rendered).unwrap();
+        assert_eq!(parsed, config);
+    }
+
+    #[test]
     fn ron_parsed_config_round_trips_to_json() {
         // Pin: the bare RON parser and the bare JSON parser produce
         // structurally identical Config values for the same logical

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -155,9 +155,24 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws();
             match key.as_str() {
-                "wifi" => wifi = Some(self.parse_wifi()?),
-                "mdns" => mdns = Some(self.parse_mdns()?),
-                "time" => time = Some(self.parse_time()?),
+                "wifi" => {
+                    if wifi.is_some() {
+                        return Err(bare_err("duplicate top-level field", "wifi"));
+                    }
+                    wifi = Some(self.parse_wifi()?);
+                }
+                "mdns" => {
+                    if mdns.is_some() {
+                        return Err(bare_err("duplicate top-level field", "mdns"));
+                    }
+                    mdns = Some(self.parse_mdns()?);
+                }
+                "time" => {
+                    if time.is_some() {
+                        return Err(bare_err("duplicate top-level field", "time"));
+                    }
+                    time = Some(self.parse_time()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -189,9 +204,24 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let value = self.parse_string()?;
             match key.as_str() {
-                "ssid" => ssid = Some(value),
-                "psk" => psk = Some(value),
-                "country" => country = Some(value),
+                "ssid" => {
+                    if ssid.is_some() {
+                        return Err(bare_err("duplicate wifi field", "ssid"));
+                    }
+                    ssid = Some(value);
+                }
+                "psk" => {
+                    if psk.is_some() {
+                        return Err(bare_err("duplicate wifi field", "psk"));
+                    }
+                    psk = Some(value);
+                }
+                "country" => {
+                    if country.is_some() {
+                        return Err(bare_err("duplicate wifi field", "country"));
+                    }
+                    country = Some(value);
+                }
                 other => return Err(bare_err("unknown wifi field", other)),
             }
             self.skip_ws();
@@ -228,7 +258,12 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let value = self.parse_string()?;
             match key.as_str() {
-                "hostname" => hostname = Some(value),
+                "hostname" => {
+                    if hostname.is_some() {
+                        return Err(bare_err("duplicate mdns field", "hostname"));
+                    }
+                    hostname = Some(value);
+                }
                 other => return Err(bare_err("unknown mdns field", other)),
             }
             self.skip_ws();
@@ -256,8 +291,18 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws();
             match key.as_str() {
-                "tz" => tz = Some(self.parse_string()?),
-                "sntp_servers" => sntp_servers = Some(self.parse_string_list()?),
+                "tz" => {
+                    if tz.is_some() {
+                        return Err(bare_err("duplicate time field", "tz"));
+                    }
+                    tz = Some(self.parse_string()?);
+                }
+                "sntp_servers" => {
+                    if sntp_servers.is_some() {
+                        return Err(bare_err("duplicate time field", "sntp_servers"));
+                    }
+                    sntp_servers = Some(self.parse_string_list()?);
+                }
                 other => return Err(bare_err("unknown time field", other)),
             }
             self.skip_ws();
@@ -510,6 +555,32 @@ mod tests {
         // string parse rejects.
         let body = render_settings_json(&full_config(), true).unwrap();
         assert!(body.contains(&format!("\"psk\":\"{PSK_REDACTED}\"")));
+    }
+
+    #[test]
+    fn rejects_duplicate_top_level_field() {
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"wifi":{"ssid":"x","psk":"y","country":"JP"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let err = parse_settings_json(input).unwrap_err();
+        match err {
+            ConfigError::BareParse(msg) => assert!(
+                msg.contains("duplicate top-level field"),
+                "expected duplicate-field message, got `{msg}`"
+            ),
+            other => panic!("expected BareParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_nested_field() {
+        let input = r#"{"wifi":{"ssid":"a","ssid":"b","psk":"p","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let err = parse_settings_json(input).unwrap_err();
+        match err {
+            ConfigError::BareParse(msg) => assert!(
+                msg.contains("duplicate wifi field"),
+                "expected duplicate-wifi-field message, got `{msg}`"
+            ),
+            other => panic!("expected BareParse, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Post-arc audit of the HTTP control-plane PRs (#148, #152, #154, #156, #157, #158). The two named-risk patterns from prior reviews were already correctly defended — `PSK_REDACTED = "***"` blocks the `GET → PUT` clobber, and SSE fan-out uses `PubSubChannel` rather than a single-waker `Signal`. This PR ships the residual findings.

### Bug fixes
- **`MAX_BODY_BYTES` raised 256 → 1024.** A maximal `PUT /settings` payload (32-char SSID + 63-char WPA2 PSK + IANA tz label + 4 SNTP servers) is ~335 bytes — the old cap silently dropped real updates. Pin the boundary with a host test.
- **HTTP status replies on parse failures.** `Malformed`/`BodyTooLarge`/`HeadersTooLarge` previously closed the socket with no response body. `serve_one`'s caller now writes a best-effort `400`/`413`/`431` before close.
- **Explicit emotion wire mapping in `/state`.** Replaced `{:?}` Debug formatting with a const `emotion_str` mirroring the parser's lowercase vocabulary. The old form was case-asymmetric with `parse_set_emotion` and would inject `{` into the JSON if `Emotion` ever gains a non-unit variant.
- **Dashboard `Cache-Control: no-cache`.** `max-age=60` made freshly flashed dashboards look like the flash didn't take.

### Clarity / robustness
- **`LAST_PUBLISH_MS: Option<u64>`** instead of a `0` sentinel — removes a hidden invariant in `publish_if_changed`.
- **Duplicate JSON keys rejected** in both the firmware POST parser (`JsonError::DuplicateKey`) and `stackchan-net::bare_json` (`BareParse "duplicate <block> field"`). Closed schemas should fail loudly when a typo overlaps a real key.
- **Dedicated `write_no_content` helper** for `204` responses (no `Content-Type`, no `Content-Length`) — RFC 7230 §3.3.3.

### Tests
- Maximal-payload round-trip in `bare_json.rs`.
- Duplicate-key cases for both parsers.
- Round-trip of every `Emotion` variant through `emotion_str → parse_set_emotion`.
- Coverage for the byte helpers in `net/http.rs` (`parse_content_length` edges, `find_subsequence`, `split_once`, `trim_ascii`).

> **Heads-up:** the firmware crate's `#[cfg(test)]` blocks are not currently exercised by CI — `just check` excludes the firmware crate and `just clippy-firmware` runs without `--all-targets`. The new tests follow the existing in-firmware pattern; reviving them into CI is a separate cleanup (lift helpers to `stackchan-net`, or add `--tests` to the firmware clippy job).

Considered but not included: a TODO follow-up about `Debug2Format` on the rare-path log line — left as-is since the cost is negligible.

## Test plan
- [x] `just check` clean (host gate)
- [x] `just clippy-firmware` clean
- [x] `just build-firmware` clean (release)
- [ ] Manual `curl` smoke after flashing: `GET /state`, `POST /emotion {"emotion":"happy"}`, `PUT /settings` with maximal payload, parse-error case (`PUT /settings` with `{`)