### PR TITLE
feat(firmware): bearer-token auth on PUT/POST routes

### DIFF
--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -82,8 +82,12 @@ runs three networked services on the LAN:
 
 - **HTTP** on port 80 — operator dashboard at `GET /`, live state +
   control plane on `/state`, `/state/stream`, `/emotion`, `/look-at`,
-  `/reset`, `/settings`. See [docs/http.md](../../docs/http.md) for
-  the full route table, body shapes, and error codes.
+  `/reset`, `/settings`. Write routes (`PUT`, `POST`) are gated on
+  `auth.token` from the boot config — empty token (default) leaves
+  the LAN open; non-empty token requires
+  `Authorization: Bearer <token>`. See
+  [docs/http.md](../../docs/http.md) for the full route table, body
+  shapes, error codes, and the auth section with `curl` examples.
 - **mDNS** — advertises `<hostname>.local` from
   `mdns.hostname` in the boot config (default `stackchan`).
 - **SNTP** — on link-up, queries the SNTP servers from

--- a/crates/stackchan-firmware/src/net/dashboard.html
+++ b/crates/stackchan-firmware/src/net/dashboard.html
@@ -100,11 +100,12 @@ small { color: var(--muted); }
       <label>Country <input type="text" name="country" id="set-country" maxlength="2"></label>
       <label>mDNS hostname <input type="text" name="hostname" id="set-hostname"></label>
       <label>SNTP servers (comma-separated) <input type="text" name="sntp" id="set-sntp"></label>
+      <label>Auth token <input type="password" name="token" id="set-token" autocomplete="off" placeholder="(empty = auth disabled — type real token to overwrite)"></label>
       <div class="btn-row">
         <button type="submit">Save (reboot to apply)</button>
         <button type="button" id="settings-reload">Reload</button>
       </div>
-      <small>PSK shows as <code>***</code> in GET; submit blank to keep current PSK only by re-typing the real key. The server rejects <code>***</code>.</small>
+      <small>PSK and token show as <code>***</code> in GET; submit blank to clear, type the real value to overwrite. The server rejects <code>***</code> on PUT.</small>
     </form>
   </section>
 </main>
@@ -162,9 +163,32 @@ function connectStream() {
 }
 connectStream();
 
+// --- Auth (bearer token, stored in localStorage) ---
+const TOKEN_KEY = "stackchan-auth-token";
+const getAuthToken = () => localStorage.getItem(TOKEN_KEY) || "";
+const setAuthToken = (t) => { if (t) localStorage.setItem(TOKEN_KEY, t); else localStorage.removeItem(TOKEN_KEY); };
+function authHeaders(headers = {}) {
+  const t = getAuthToken();
+  return t ? { ...headers, "Authorization": `Bearer ${t}` } : headers;
+}
+// Wrapper around fetch that retries once with a freshly prompted token
+// when the server returns 401. Reads (GET /settings, /state, SSE) skip
+// this and go through plain `fetch` — the server only gates writes.
+async function authedFetch(path, init = {}) {
+  let res = await fetch(path, { ...init, headers: authHeaders(init.headers) });
+  if (res.status === 401) {
+    const tok = prompt("Auth token required. Enter Bearer token:", getAuthToken());
+    if (tok != null) {
+      setAuthToken(tok);
+      res = await fetch(path, { ...init, headers: authHeaders(init.headers) });
+    }
+  }
+  return res;
+}
+
 // --- Emotion buttons ---
 async function postJson(path, body) {
-  const res = await fetch(path, {
+  const res = await authedFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: body == null ? "" : JSON.stringify(body),
@@ -226,10 +250,14 @@ async function loadSettings() {
     const c = await res.json();
     $("set-ssid").value = c.wifi.ssid;
     $("set-psk").value = "";
-    $("set-psk").placeholder = c.wifi.psk === "***" ? "(redacted — type real key to overwrite)" : "";
+    $("set-psk").placeholder = c.wifi.psk === "***" ? "(redacted — type real key to overwrite)" : "(empty = open AP — type real key to set)";
     $("set-country").value = c.wifi.country;
     $("set-hostname").value = c.mdns.hostname;
     $("set-sntp").value = c.time.sntp_servers.join(", ");
+    $("set-token").value = "";
+    $("set-token").placeholder = (c.auth && c.auth.token === "***")
+      ? "(redacted — type real token to overwrite, or leave blank to disable)"
+      : "(empty = auth disabled — type a token to enable)";
     loadedTz = c.time.tz;
   } catch (e) { toast(e.message, true); }
 }
@@ -247,9 +275,15 @@ $("settings-form").addEventListener("submit", async (ev) => {
       tz: loadedTz,
       sntp_servers: $("set-sntp").value.split(",").map((s) => s.trim()).filter(Boolean),
     },
+    auth: { token: $("set-token").value },
   };
+  // After a successful save, mirror the new token into localStorage
+  // so the dashboard's next write request authenticates against the
+  // freshly configured value (until the device reboots and re-applies
+  // it from SD).
+  const newToken = body.auth.token;
   try {
-    const res = await fetch("/settings", {
+    const res = await authedFetch("/settings", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -258,6 +292,7 @@ $("settings-form").addEventListener("submit", async (ev) => {
       const text = await res.text().catch(() => "");
       throw new Error(`${res.status}: ${text || res.statusText}`);
     }
+    setAuthToken(newToken);
     toast("settings saved — reboot to apply");
   } catch (e) { toast(e.message, true); }
 });

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -697,15 +697,47 @@ const fn status_reason(status: u16) -> &'static str {
 /// Best-effort: write a status response for a parse-side failure.
 /// `Read`/`Write` skip — the socket is already broken so any further
 /// write would just produce another `Write` error.
+///
+/// `Unauthorized` takes a slightly different path so the response
+/// carries the `WWW-Authenticate: Bearer` challenge required by RFC
+/// 6750 §3 on `401`.
 async fn write_status_for_error(socket: &mut TcpSocket<'_>, err: &HttpError) {
+    if matches!(err, HttpError::Unauthorized) {
+        let _ = write_unauthorized(socket).await;
+        return;
+    }
     let (status, body) = match err {
         HttpError::Malformed => (400, "bad request\n"),
         HttpError::BodyTooLarge => (413, "payload too large\n"),
         HttpError::HeadersTooLarge => (431, "request header fields too large\n"),
-        HttpError::Unauthorized => (401, "unauthorized\n"),
-        HttpError::Read | HttpError::Write => return,
+        HttpError::Read | HttpError::Write | HttpError::Unauthorized => return,
     };
     let _ = write_text(socket, status, body).await;
+}
+
+/// Write `401 Unauthorized` with the `WWW-Authenticate: Bearer`
+/// challenge header (RFC 6750 §3). Strict HTTP clients use the
+/// challenge to know which auth scheme to negotiate; without it
+/// they may treat the response as a hard failure.
+async fn write_unauthorized(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let body = "unauthorized\n";
+    let header = format!(
+        "HTTP/1.1 401 Unauthorized\r\n\
+         WWW-Authenticate: Bearer\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\r\n",
+        len = body.len(),
+    );
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket
+        .write_all(body.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
 }
 
 #[cfg(test)]

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -23,11 +23,18 @@
 //! - `POST /reset` — empty body. Clears any active emotion or
 //!   look-at hold and returns the avatar to autonomous behaviour.
 //! - `GET /settings` — current persisted [`stackchan_net::Config`]
-//!   as JSON, with `wifi.psk` redacted.
+//!   as JSON, with `wifi.psk` and `auth.token` redacted.
 //! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
 //!   Validates, writes back atomically to `/sd/STACKCHAN.RON`, and
 //!   responds `{"reboot_required": true}`. Wi-Fi keeps using the
 //!   boot-time config; reboot to apply.
+//!
+//! ## Auth
+//!
+//! `PUT` and `POST` routes are gated by `auth.token` from the
+//! persisted config. Empty token (default) leaves the LAN open;
+//! a non-empty token requires `Authorization: Bearer <token>` and
+//! returns `401` on mismatch. Read routes stay unauthenticated.
 //!
 //! Avatar-state writes (POST /emotion, /look-at, /reset) funnel
 //! through [`REMOTE_COMMAND_SIGNAL`]; the render task drains it
@@ -59,7 +66,8 @@ use super::json::{self, JsonError};
 use super::snapshot::{self, AvatarSnapshot};
 use super::wifi::LINK_READY;
 
-/// Listening port. LAN-only; no auth.
+/// Listening port. LAN-only; write routes are gated on the
+/// configured `auth.token` (empty = no auth).
 const HTTP_PORT: u16 = 80;
 
 /// Maximum request line + headers + body size we'll buffer before
@@ -126,7 +134,7 @@ pub async fn http_worker(stack: Stack<'static>) -> ! {
     }
 
     defmt::info!(
-        "http: worker listening on 0.0.0.0:{=u16} (LAN-only, no auth)",
+        "http: worker listening on 0.0.0.0:{=u16} (LAN-only; auth gate: token-driven)",
         HTTP_PORT
     );
 
@@ -171,6 +179,9 @@ enum HttpError {
     BodyTooLarge,
     /// Method + path didn't parse as a valid HTTP request line.
     Malformed,
+    /// Write route required a bearer token; the request didn't carry
+    /// one or it didn't match the configured value.
+    Unauthorized,
 }
 
 /// Serve a single HTTP/1.1 exchange against an accepted socket.
@@ -230,6 +241,25 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         core::str::from_utf8(&buf[path_start..second_sp]).map_err(|_| HttpError::Malformed)?;
     let body = core::str::from_utf8(&buf[body_start..body_start + content_length])
         .map_err(|_| HttpError::Malformed)?;
+
+    // Gate write routes on the configured bearer token. An empty
+    // token (or missing config snapshot during the brief boot
+    // window) is treated as "auth disabled" — preserves the LAN-
+    // open behaviour for operators who haven't opted in.
+    if matches!(method, "PUT" | "POST") {
+        let provided = parse_bearer_token(&buf[line_end + 2..header_end]);
+        let snapshot = crate::storage::CONFIG_SNAPSHOT.lock().await;
+        let authorized = match snapshot.as_ref() {
+            Some(cfg) if !cfg.auth.token.is_empty() => {
+                provided.is_some_and(|t| ct_eq(t.as_bytes(), cfg.auth.token.as_bytes()))
+            }
+            _ => true,
+        };
+        drop(snapshot);
+        if !authorized {
+            return Err(HttpError::Unauthorized);
+        }
+    }
 
     match (method, path) {
         ("GET", "/" | "/index.html") => write_dashboard(socket).await,
@@ -420,6 +450,56 @@ async fn write_no_content(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     socket.flush().await.map_err(|_| HttpError::Write)
 }
 
+/// Parse the `Authorization: Bearer <token>` header value out of a
+/// header block. Returns `Some(token)` if a Bearer credential is
+/// present, `None` otherwise.
+///
+/// Header name compare is case-insensitive (RFC 9110 §5.1). Scheme
+/// compare is also case-insensitive — RFC 6750 says the
+/// `Authorization` field uses the standard `auth-scheme` token
+/// production, which is case-insensitive.
+///
+/// Whitespace between scheme and token is collapsed; leading and
+/// trailing whitespace on the token are stripped. Tokens are not
+/// further validated here — the caller compares against the
+/// configured value with [`ct_eq`].
+fn parse_bearer_token(headers: &[u8]) -> Option<&str> {
+    for line in headers.split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some((name, value)) = split_once(line, b':') else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case(b"authorization") {
+            continue;
+        }
+        let value = trim_ascii(value);
+        let scheme_end = value.iter().position(|&b| b == b' ')?;
+        let (scheme, rest) = value.split_at(scheme_end);
+        if !scheme.eq_ignore_ascii_case(b"bearer") {
+            return None;
+        }
+        let token = trim_ascii(rest);
+        return core::str::from_utf8(token).ok();
+    }
+    None
+}
+
+/// Constant-time byte comparison. Folds every byte difference into
+/// a single accumulator before testing equality so timing leaks
+/// from an early-exit-on-mismatch loop can't reveal a prefix of the
+/// expected token. Length mismatch returns immediately — leaking
+/// the token *length* is acceptable; the operator chose it.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// Parse the `Content-Length` header value out of a header block.
 /// Returns `0` when absent (correct for GET / 0-body POST). Returns
 /// [`HttpError::Malformed`] if the header is present but not a valid
@@ -600,6 +680,7 @@ const fn status_reason(status: u16) -> &'static str {
     match status {
         204 => "No Content",
         400 => "Bad Request",
+        401 => "Unauthorized",
         404 => "Not Found",
         405 => "Method Not Allowed",
         413 => "Payload Too Large",
@@ -621,6 +702,7 @@ async fn write_status_for_error(socket: &mut TcpSocket<'_>, err: &HttpError) {
         HttpError::Malformed => (400, "bad request\n"),
         HttpError::BodyTooLarge => (413, "payload too large\n"),
         HttpError::HeadersTooLarge => (431, "request header fields too large\n"),
+        HttpError::Unauthorized => (401, "unauthorized\n"),
         HttpError::Read | HttpError::Write => return,
     };
     let _ = write_text(socket, status, body).await;
@@ -755,6 +837,55 @@ mod tests {
             Some((b"".as_slice(), b"empty".as_slice()))
         );
         assert_eq!(split_once(b"none", b':'), None);
+    }
+
+    #[test]
+    fn bearer_token_extracts_value() {
+        let headers = b"Host: stackchan.local\r\nAuthorization: Bearer abc123\r\n";
+        assert_eq!(parse_bearer_token(headers), Some("abc123"));
+    }
+
+    #[test]
+    fn bearer_scheme_and_header_are_case_insensitive() {
+        for raw in [
+            "authorization: Bearer xyz\r\n",
+            "AUTHORIZATION: BEARER xyz\r\n",
+            "Authorization: bearer xyz\r\n",
+        ] {
+            assert_eq!(parse_bearer_token(raw.as_bytes()), Some("xyz"), "{raw}");
+        }
+    }
+
+    #[test]
+    fn bearer_token_absent_returns_none() {
+        let headers = b"Host: stackchan.local\r\nUser-Agent: curl/8\r\n";
+        assert_eq!(parse_bearer_token(headers), None);
+    }
+
+    #[test]
+    fn bearer_token_rejects_other_schemes() {
+        // `Basic` and unknown schemes return `None`, not a bogus token.
+        for raw in [
+            "Authorization: Basic dXNlcjpwYXNz\r\n",
+            "Authorization: Digest realm=test\r\n",
+        ] {
+            assert_eq!(parse_bearer_token(raw.as_bytes()), None, "{raw}");
+        }
+    }
+
+    #[test]
+    fn bearer_token_handles_extra_whitespace() {
+        let headers = b"Authorization:    Bearer    spaced-token   \r\n";
+        assert_eq!(parse_bearer_token(headers), Some("spaced-token"));
+    }
+
+    #[test]
+    fn ct_eq_reports_equality_and_diff() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"ab"));
+        assert!(!ct_eq(b"", b"a"));
+        assert!(ct_eq(b"", b""));
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -19,6 +19,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 use crate::error::ConfigError;
 
@@ -276,9 +277,18 @@ impl<'a> Parser<'a> {
                 return Err(bare_err("expected ',' or ')' in auth", ""));
             }
         }
-        Ok(AuthConfig {
-            token: token.unwrap_or_default(),
-        })
+        let token = token.unwrap_or_default();
+        // Symmetric with the JSON parser: a literal `***` on disk is
+        // almost certainly a copy-paste from `GET /settings`, not an
+        // intentional value. Catch it here so the operator gets a
+        // clear error instead of a silently-locked-out device.
+        if token == TOKEN_REDACTED {
+            return Err(bare_err(
+                "auth.token is the redacted sentinel — supply the real token",
+                "",
+            ));
+        }
+        Ok(AuthConfig { token })
     }
 
     /// Parse `[ "...", "...", ]` into a `Vec<String>`.

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -19,7 +19,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use crate::config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+use crate::config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 use crate::error::ConfigError;
 
 /// Parse a schema-v1 RON document into a [`Config`] without using `serde` or `ron`.
@@ -73,6 +73,10 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     out.push_str("        ],\n");
     out.push_str("    ),\n");
 
+    out.push_str("    auth: (\n");
+    push_field(&mut out, "        token", &config.auth.token);
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -119,6 +123,7 @@ impl<'a> Parser<'a> {
         let mut wifi: Option<WifiConfig> = None;
         let mut mdns: Option<MdnsConfig> = None;
         let mut time: Option<TimeConfig> = None;
+        let mut auth: Option<AuthConfig> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -133,6 +138,7 @@ impl<'a> Parser<'a> {
                 "wifi" => wifi = Some(self.parse_wifi()?),
                 "mdns" => mdns = Some(self.parse_mdns()?),
                 "time" => time = Some(self.parse_time()?),
+                "auth" => auth = Some(self.parse_auth()?),
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -146,6 +152,10 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
+            // `auth` is optional for migration: SD cards written before
+            // schema v1.1 don't have it, and an empty token means
+            // "auth disabled," matching the offline-first stance.
+            auth: auth.unwrap_or_default(),
         })
     }
 
@@ -238,6 +248,36 @@ impl<'a> Parser<'a> {
         Ok(TimeConfig {
             tz: tz.ok_or_else(|| bare_err("missing time.tz", ""))?,
             sntp_servers: sntp_servers.ok_or_else(|| bare_err("missing time.sntp_servers", ""))?,
+        })
+    }
+
+    /// Parse the `auth: (token)` block. An empty block is permitted
+    /// and yields [`AuthConfig::default`] — operators who haven't
+    /// configured auth keep the LAN-open behaviour.
+    fn parse_auth(&mut self) -> Result<AuthConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut token: Option<String> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            let value = self.parse_string()?;
+            match key {
+                "token" => token = Some(value),
+                other => return Err(bare_err("unknown auth field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in auth", ""));
+            }
+        }
+        Ok(AuthConfig {
+            token: token.unwrap_or_default(),
         })
     }
 
@@ -481,6 +521,49 @@ mod tests {
     fn rejects_missing_field() {
         let err = parse_ron_bare("(wifi: (ssid: \"x\", psk: \"y\", country: \"US\"))").unwrap_err();
         assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn missing_auth_block_defaults_to_empty_token() {
+        // Schema-v1 SD cards (written before the auth block landed)
+        // omit `auth:` entirely. The parser must accept that and fall
+        // back to the default empty token so a firmware bump doesn't
+        // brick existing kits.
+        let cfg = parse_ron_bare(FIXTURE).unwrap();
+        assert_eq!(cfg.auth.token, "");
+    }
+
+    #[test]
+    fn parses_auth_block_with_token() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                auth: ( token: "shared-secret" ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        assert_eq!(cfg.auth.token, "shared-secret");
+    }
+
+    #[test]
+    fn round_trips_with_token() {
+        // The renderer always emits an auth block; pin that a token
+        // round-trips losslessly through render → re-parse.
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                auth: ( token: "abc-123" ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        let rendered = render_ron_bare(&cfg).unwrap();
+        let reparsed = parse_ron_bare(&rendered).unwrap();
+        assert_eq!(cfg, reparsed);
+        assert_eq!(reparsed.auth.token, "abc-123");
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -18,7 +18,7 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use crate::config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+use crate::config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 use crate::error::ConfigError;
 
 /// Sentinel emitted by [`render_settings_json`] when `redact_psk = true`.
@@ -27,6 +27,13 @@ use crate::error::ConfigError;
 /// round trip can't accidentally persist the redacted placeholder as
 /// the real key (which would silently break Wi-Fi on next reboot).
 pub const PSK_REDACTED: &str = "***";
+
+/// Sentinel emitted in place of a non-empty `auth.token` on render.
+///
+/// Keeps the secret out of `GET /settings` responses, and rejected
+/// as an input value by [`parse_settings_json`] for the same
+/// `GET → PUT` clobber reason as [`PSK_REDACTED`].
+pub const TOKEN_REDACTED: &str = "***";
 
 /// Parse a schema-v1 JSON object into a [`Config`].
 ///
@@ -55,16 +62,19 @@ pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
 
 /// Render a [`Config`] to a compact JSON string.
 ///
-/// `redact_psk = true` replaces `wifi.psk` with `"***"` so the
-/// output is safe to expose to unauthed callers (HTTP `GET /settings`
-/// passes `true`). `redact_psk = false` round-trips losslessly with
+/// `redact_secrets = true` replaces `wifi.psk` and any non-empty
+/// `auth.token` with `"***"` so the output is safe to expose to
+/// unauthed callers (HTTP `GET /settings` passes `true`). An empty
+/// token renders as `""` regardless — there's nothing to redact and
+/// the empty string is its own meaningful value (= auth disabled).
+/// `redact_secrets = false` round-trips losslessly with
 /// [`parse_settings_json`].
 ///
 /// # Errors
 ///
 /// Currently infallible — kept as `Result` for symmetry with
 /// [`crate::render_ron`].
-pub fn render_settings_json(config: &Config, redact_psk: bool) -> Result<String, ConfigError> {
+pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<String, ConfigError> {
     let mut out = String::new();
     out.push('{');
     out.push_str("\"wifi\":{");
@@ -73,7 +83,7 @@ pub fn render_settings_json(config: &Config, redact_psk: bool) -> Result<String,
     push_string_field(
         &mut out,
         "psk",
-        if redact_psk {
+        if redact_secrets {
             PSK_REDACTED
         } else {
             &config.wifi.psk
@@ -92,7 +102,14 @@ pub fn render_settings_json(config: &Config, redact_psk: bool) -> Result<String,
         }
         push_string_literal(&mut out, s);
     }
-    out.push_str("]}}");
+    out.push_str("]},\"auth\":{");
+    let token_view: &str = if redact_secrets && !config.auth.token.is_empty() {
+        TOKEN_REDACTED
+    } else {
+        &config.auth.token
+    };
+    push_string_field(&mut out, "token", token_view);
+    out.push_str("}}");
     Ok(out)
 }
 
@@ -145,6 +162,7 @@ impl<'a> Parser<'a> {
         let mut wifi: Option<WifiConfig> = None;
         let mut mdns: Option<MdnsConfig> = None;
         let mut time: Option<TimeConfig> = None;
+        let mut auth: Option<AuthConfig> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -173,6 +191,12 @@ impl<'a> Parser<'a> {
                     }
                     time = Some(self.parse_time()?);
                 }
+                "auth" => {
+                    if auth.is_some() {
+                        return Err(bare_err("duplicate top-level field", "auth"));
+                    }
+                    auth = Some(self.parse_auth()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -184,6 +208,10 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
+            // `auth` is optional for migration: bodies emitted before
+            // schema v1.1 don't have it, and the default empty token
+            // means "auth disabled."
+            auth: auth.unwrap_or_default(),
         })
     }
 
@@ -314,6 +342,44 @@ impl<'a> Parser<'a> {
             tz: tz.ok_or_else(|| bare_err("missing time.tz", ""))?,
             sntp_servers: sntp_servers.ok_or_else(|| bare_err("missing time.sntp_servers", ""))?,
         })
+    }
+
+    /// Parse the `"auth": { "token": ... }` block.
+    fn parse_auth(&mut self) -> Result<AuthConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut token: Option<String> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            let value = self.parse_string()?;
+            match key.as_str() {
+                "token" => {
+                    if token.is_some() {
+                        return Err(bare_err("duplicate auth field", "token"));
+                    }
+                    token = Some(value);
+                }
+                other => return Err(bare_err("unknown auth field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in auth", ""));
+            }
+        }
+        let token = token.unwrap_or_default();
+        if token == TOKEN_REDACTED {
+            return Err(bare_err(
+                "auth.token is the redacted sentinel — supply the real token",
+                "",
+            ));
+        }
+        Ok(AuthConfig { token })
     }
 
     /// Parse `[ "...", "...", ... ]` into a `Vec<String>`.
@@ -452,6 +518,9 @@ mod tests {
                 tz: "UTC".to_string(),
                 sntp_servers: vec!["pool.ntp.org".to_string(), "time.google.com".to_string()],
             },
+            auth: AuthConfig {
+                token: "shared-secret".to_string(),
+            },
         }
     }
 
@@ -530,6 +599,65 @@ mod tests {
             matches!(err, ConfigError::NoSntpServers),
             "expected NoSntpServers, got {err:?}"
         );
+    }
+
+    #[test]
+    fn render_redacts_token_when_requested() {
+        let original = full_config();
+        let rendered = render_settings_json(&original, true).unwrap();
+        assert!(
+            rendered.contains("\"token\":\"***\""),
+            "expected redacted token in: {rendered}"
+        );
+        assert!(
+            !rendered.contains("shared-secret"),
+            "token leaked through redaction: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_does_not_redact_empty_token() {
+        // An empty token is meaningful (= auth disabled); it should
+        // render as `""` even when `redact_secrets = true`, because
+        // `***` is the rejected sentinel and a no-auth device must
+        // be able to round-trip its (empty) token through GET → PUT.
+        let mut cfg = full_config();
+        cfg.auth.token = String::new();
+        let redacted = render_settings_json(&cfg, true).unwrap();
+        assert!(
+            redacted.contains("\"token\":\"\""),
+            "empty token should render as empty string: {redacted}"
+        );
+        // Round-trip via the lossless render to confirm parser side.
+        let lossless = render_settings_json(&cfg, false).unwrap();
+        let parsed = parse_settings_json(&lossless).unwrap();
+        assert_eq!(parsed.auth.token, "");
+    }
+
+    #[test]
+    fn rejects_redacted_token_sentinel() {
+        // Same `GET → PUT` clobber pattern as PSK: render emits
+        // `"***"`, parse must reject it.
+        let body = render_settings_json(&full_config(), true).unwrap();
+        let err = parse_settings_json(&body).unwrap_err();
+        match err {
+            ConfigError::BareParse(msg) => assert!(
+                msg.contains("redacted") && (msg.contains("psk") || msg.contains("token")),
+                "expected a redacted-sentinel message, got `{msg}`"
+            ),
+            other => panic!("expected BareParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_auth_block_defaults_to_empty_token() {
+        // Schema-v1 bodies (rendered before auth was added) lack the
+        // `auth` field. The parser must fall back to the default empty
+        // token so existing operators don't get locked out on first
+        // boot of a firmware build that knows about auth.
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.auth.token, "");
     }
 
     #[test]
@@ -620,6 +748,9 @@ mod tests {
                     "time3.google.com".to_string(),
                     "time4.google.com".to_string(),
                 ],
+            },
+            auth: AuthConfig {
+                token: "x".repeat(64),
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -636,14 +636,23 @@ mod tests {
 
     #[test]
     fn rejects_redacted_token_sentinel() {
-        // Same `GET → PUT` clobber pattern as PSK: render emits
-        // `"***"`, parse must reject it.
-        let body = render_settings_json(&full_config(), true).unwrap();
-        let err = parse_settings_json(&body).unwrap_err();
+        // Same `GET → PUT` clobber pattern as PSK: a body that
+        // round-trips a real PSK but the redacted token must trip
+        // the auth.token guard. Hand-roll the JSON so we can pin the
+        // token-only redaction case — `render_settings_json(_, true)`
+        // would redact the PSK first and the parser would surface
+        // that error instead of reaching the token check.
+        let body = r#"{
+            "wifi":{"ssid":"a","psk":"realkey","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "auth":{"token":"***"}
+        }"#;
+        let err = parse_settings_json(body).unwrap_err();
         match err {
             ConfigError::BareParse(msg) => assert!(
-                msg.contains("redacted") && (msg.contains("psk") || msg.contains("token")),
-                "expected a redacted-sentinel message, got `{msg}`"
+                msg.contains("auth.token") && msg.contains("redacted"),
+                "expected token-sentinel message, got `{msg}`"
             ),
             other => panic!("expected BareParse, got {other:?}"),
         }

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -21,8 +21,9 @@ use crate::error::ConfigError;
 ///
 /// Defaults are tuned for offline-first boot: an empty SSID is a
 /// no-op at the Wi-Fi layer, hostname `"stackchan"` is the canonical
-/// mDNS label, and `time` points at `pool.ntp.org` so SNTP picks up
-/// once Wi-Fi is configured.
+/// mDNS label, `time` points at `pool.ntp.org` so SNTP picks up
+/// once Wi-Fi is configured, and `auth.token` is empty so the HTTP
+/// control plane stays LAN-open until the operator opts in.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct Config {
@@ -32,6 +33,11 @@ pub struct Config {
     pub mdns: MdnsConfig,
     /// Timezone label + SNTP server list.
     pub time: TimeConfig,
+    /// HTTP control-plane authentication. Empty token = auth
+    /// disabled (current LAN-open behaviour); non-empty token gates
+    /// `PUT`/`POST` routes behind `Authorization: Bearer <token>`.
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub auth: AuthConfig,
 }
 
 /// Wi-Fi station credentials.
@@ -73,6 +79,19 @@ impl Default for MdnsConfig {
             hostname: "stackchan".to_string(),
         }
     }
+}
+
+/// HTTP control-plane authentication.
+///
+/// Default `token` is the empty string, which leaves the HTTP plane
+/// LAN-open (matching the offline-first stance for Wi-Fi). Setting
+/// a non-empty token requires `Authorization: Bearer <token>` on
+/// `PUT`/`POST` routes; reads stay unauthenticated.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct AuthConfig {
+    /// Shared-secret bearer token. Empty = auth disabled.
+    pub token: String,
 }
 
 /// Time / SNTP configuration.

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -55,7 +55,7 @@ pub mod error;
 
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{parse_settings_json, render_settings_json};
-pub use config::{Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+pub use config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};
 pub use error::ConfigError;

--- a/docs/http.md
+++ b/docs/http.md
@@ -6,9 +6,11 @@ title: HTTP control plane
 
 A LAN-scoped HTTP/1.1 server runs on port 80 once Wi-Fi connects.
 It exposes a small, fixed set of routes for live state, manual
-override, persistent config, and an embedded operator dashboard. No
-auth; the security boundary is the LAN. See the [security note](#security)
-for what that means.
+override, persistent config, and an embedded operator dashboard.
+Write routes (`PUT`, `POST`) are gated on a configurable bearer
+token — empty token (default) leaves the LAN open, matching the
+offline-first stance for Wi-Fi. See [Auth](#auth) for how to enable
+it; [security](#security) covers what's still out of scope.
 
 The wire-format implementation is hand-rolled in
 [`crates/stackchan-firmware/src/net/http.rs`](https://github.com/andymai/stackchan-kai/tree/main/crates/stackchan-firmware/src/net/http.rs)
@@ -26,8 +28,11 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/emotion`       | Set affect with hold timer                          |
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |
-| GET    | `/settings`      | Persisted config (PSK redacted)                     |
+| GET    | `/settings`      | Persisted config (PSK + token redacted)             |
 | PUT    | `/settings`      | Replace persisted config; atomic SD writeback        |
+
+Write routes (`PUT`, all `POST`) require `Authorization: Bearer <token>`
+when `auth.token` is configured. Reads are always unauthenticated.
 
 ## Live state
 
@@ -124,23 +129,31 @@ The HTTP control plane round-trips it as JSON.
 $ curl http://stackchan.local/settings
 {"wifi":{"ssid":"my-net","psk":"***","country":"US"},
  "mdns":{"hostname":"stackchan"},
- "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}
+ "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+ "auth":{"token":"***"}}
 ```
 
-`wifi.psk` is always redacted to `***`. The server rejects PUT
-bodies that contain `***` for the PSK so a copy-paste round trip
-can't silently overwrite the real key with the redaction sentinel.
+`wifi.psk` and a non-empty `auth.token` are redacted to `***`. The
+server rejects PUT bodies that contain `***` for either field so a
+copy-paste round trip can't silently overwrite the real value with
+the redaction sentinel. An empty `auth.token` (= auth disabled)
+renders as `""` and round-trips losslessly.
 
 ### `PUT /settings`
 
 ```
 $ curl -X PUT http://stackchan.local/settings \
        -H 'Content-Type: application/json' \
+       -H 'Authorization: Bearer s3cret' \
        -d '{"wifi":{"ssid":"new-net","psk":"realkey","country":"US"},
             "mdns":{"hostname":"stackchan"},
-            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}'
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "auth":{"token":"s3cret"}}'
 {"reboot_required":true}
 ```
+
+Drop the `Authorization` header (and replace `auth.token` with `""`)
+to disable auth on a device that previously had it enabled.
 
 Full-replace. The server validates the body via
 `stackchan_net::validate` (rejects empty SSID, invalid country code,
@@ -158,9 +171,12 @@ the operator's HTTP session if the SSID changed. Reboot to apply.
 |------|---------------------------------------------------------------------|
 | 200  | GET responses, dashboard, successful PUT                            |
 | 204  | POST `/emotion` / `/look-at` / `/reset` on success                  |
-| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion, redacted PSK sentinel, validation failure on PUT `/settings` |
+| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion, redacted PSK or token sentinel, validation failure on PUT `/settings` |
+| 401  | Write route called without a valid bearer token (when auth is enabled) |
 | 404  | Path not in the matcher                                             |
 | 405  | Method not allowed                                                  |
+| 413  | Request body exceeds `MAX_BODY_BYTES` (1024)                        |
+| 431  | Headers exceed `REQUEST_BUF_BYTES` before `\r\n\r\n` is reached     |
 | 500  | SD write failed during PUT `/settings`                              |
 | 503  | PUT `/settings` with no SD; GET `/settings` before the config snapshot is loaded; no free SSE subscriber slot |
 
@@ -185,19 +201,71 @@ To customise it, edit the HTML in
 and re-flash. Embedding via `include_bytes!` instead of serving from
 SD is intentional: the dashboard works on a card-less device.
 
+## Auth
+
+Write routes (`PUT`, all `POST`) accept an optional bearer token.
+Token is stored in `auth.token` of the persisted config and read
+once at boot into a snapshot the HTTP handler consults on every
+write request. Empty token (default) disables the gate; non-empty
+token requires `Authorization: Bearer <token>` and returns `401` on
+mismatch.
+
+Compare is constant-time across the byte length so a co-located
+attacker can't leak the token byte by byte through timing — though
+on a LAN, network jitter dominates any sub-microsecond difference.
+
+```
+$ curl -X POST http://stackchan.local/emotion
+HTTP/1.1 401 Unauthorized
+unauthorized
+
+$ curl -X POST http://stackchan.local/emotion \
+       -H 'Authorization: Bearer s3cret' \
+       -H 'Content-Type: application/json' \
+       -d '{"emotion":"happy"}'
+HTTP/1.1 204 No Content
+```
+
+To enable auth on a fresh kit:
+
+```
+$ curl -X PUT http://stackchan.local/settings \
+       -H 'Content-Type: application/json' \
+       -d '{"wifi":{...},"mdns":{...},"time":{...},
+            "auth":{"token":"s3cret"}}'
+$ # reboot the device — Wi-Fi keeps the boot config until restart
+```
+
+The dashboard at `GET /` reads the configured token from
+`localStorage` and prompts the operator on its first `401`. The
+typed value is persisted to the device on `PUT /settings` *and* to
+`localStorage`, so a freshly configured browser keeps writing
+without re-prompting until the device reboots.
+
 ## Security
 
-There is no auth. Anyone on the same LAN can:
+What's covered:
 
-- Read the persisted config (with PSK redaction).
-- Overwrite the persisted config (without redaction — `PUT` accepts
-  the real PSK as plaintext on the wire).
-- Drive the avatar to arbitrary poses and emotions.
+- LAN scope (port 80 binds to `0.0.0.0`; reachable inside the
+  network the device joined).
+- Bearer-token gate on writes.
+- PSK and auth-token redaction on `GET /settings`.
+- Atomic SD writeback for `PUT /settings`.
 
-This is acceptable for a desktop toy on a trusted home LAN and
+What isn't:
+
+- **No TLS.** Tokens cross the wire in cleartext. A network
+  observer on the same broadcast domain can capture and replay.
+- **No rate limiting.** A misconfigured client can hammer `401`s
+  without throttling.
+- **No replay protection.** A captured request can be re-sent.
+- **No CSRF protection on the dashboard.** Any page on the same
+  LAN that can fetch the dashboard can also drive writes through
+  the operator's browser.
+
+These are acceptable for a desktop toy on a trusted home LAN and
 explicitly out of scope for v0.x. If you put Stack-chan on an
-untrusted network, fence it off — there's no TLS, no auth, no rate
-limiting on this server.
+untrusted network, fence it off.
 
 ## Worker pool sizing
 


### PR DESCRIPTION
## Summary

Adds an opt-in bearer-token gate to the HTTP control plane's write routes (`PUT /settings`, `POST /emotion`, `POST /look-at`, `POST /reset`). Reads stay open. Default empty token preserves the current LAN-open behaviour, so existing SD cards keep booting and existing scripts keep working until the operator opts in by setting a token.

## Schema bump

- New `AuthConfig { token: String }` block in `stackchan_net::Config`. Default = empty.
- Bare RON parser and JSON parser both treat the new `auth` block as **optional with default**, so SD cards and request bodies written before this change still parse.
- `render_settings_json` now redacts both `wifi.psk` and a non-empty `auth.token` to `***`. Empty token renders as `""`. New `TOKEN_REDACTED` constant mirrors `PSK_REDACTED`. Parsers reject either sentinel as input — same `GET → PUT` clobber defense as the PSK.

## Wire surface

- `Authorization: Bearer <token>` on `PUT`/`POST` when `auth.token` is set.
- `parse_bearer_token` (case-insensitive header + scheme, whitespace-tolerant) and `ct_eq` (constant-time byte compare) helpers in `net/http.rs`. New `HttpError::Unauthorized` → `401`.
- `serve_one` reads the configured token from `CONFIG_SNAPSHOT` and authorizes before dispatch. Snapshot lock is dropped before route handlers run (some of which take the same lock for SD writeback).

## Dashboard

- Token stored in `localStorage`. `authedFetch` wrapper prompts on `401` and retries once.
- Settings form gains a token field that mirrors the PSK pattern (redacted display, blank-on-submit clears, real value sets).
- Successful `PUT /settings` mirrors the typed token into `localStorage` so the same browser keeps writing without re-prompting.

## Docs

- New Auth section in `docs/http.md` with curl examples for both the unauthorized and authorized flow.
- Updated route table, GET/PUT settings examples, status codes (401/413/431).
- Security section rewritten to enumerate what's covered vs. what's still out of scope (no TLS, no rate limiting, no replay/CSRF protection).

## Test plan

- [x] `just check` — host gate
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `just build-firmware` — release binary builds
- Manual on hardware:
  - [ ] Empty token (default): all routes work without `Authorization` header
  - [ ] `PUT /settings` with `auth.token = "s3cret"`, reboot, verify subsequent writes need the header
  - [ ] `POST /emotion` without header → 401 with `unauthorized\n` body
  - [ ] `POST /emotion` with wrong token → 401
  - [ ] `POST /emotion` with correct token → 204
  - [ ] Dashboard prompts on first write after auth is enabled, persists the token, subsequent writes work
  - [ ] `GET /settings` shows `auth.token = "***"`; `PUT /settings` echoing `***` is rejected as the redacted sentinel
  - [ ] SD card with no `auth:` block still boots cleanly with auth disabled (migration path)