### PR TITLE
refactor: lift HTTP byte helpers to stackchan-net::http_parse

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -61,6 +61,9 @@ use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
 use stackchan_core::{Emotion, RemoteCommand};
+use stackchan_net::http_parse::{
+    ct_eq, find_subsequence, parse_bearer_token, parse_content_length,
+};
 
 use super::json::{self, JsonError};
 use super::snapshot::{self, AvatarSnapshot};
@@ -222,7 +225,8 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         .ok_or(HttpError::Malformed)?
         + path_start;
     let body_start = header_end + 4;
-    let content_length = parse_content_length(&buf[line_end + 2..header_end])?;
+    let content_length =
+        parse_content_length(&buf[line_end + 2..header_end]).map_err(|_| HttpError::Malformed)?;
     if content_length >= MAX_BODY_BYTES {
         return Err(HttpError::BodyTooLarge);
     }
@@ -448,102 +452,6 @@ async fn write_no_content(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         .await
         .map_err(|_| HttpError::Write)?;
     socket.flush().await.map_err(|_| HttpError::Write)
-}
-
-/// Parse the `Authorization: Bearer <token>` header value out of a
-/// header block. Returns `Some(token)` if a Bearer credential is
-/// present, `None` otherwise.
-///
-/// Header name compare is case-insensitive (RFC 9110 §5.1). Scheme
-/// compare is also case-insensitive — RFC 6750 says the
-/// `Authorization` field uses the standard `auth-scheme` token
-/// production, which is case-insensitive.
-///
-/// Whitespace between scheme and token is collapsed; leading and
-/// trailing whitespace on the token are stripped. Tokens are not
-/// further validated here — the caller compares against the
-/// configured value with [`ct_eq`].
-fn parse_bearer_token(headers: &[u8]) -> Option<&str> {
-    for line in headers.split(|&b| b == b'\n') {
-        let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let Some((name, value)) = split_once(line, b':') else {
-            continue;
-        };
-        if !name.eq_ignore_ascii_case(b"authorization") {
-            continue;
-        }
-        let value = trim_ascii(value);
-        let scheme_end = value.iter().position(|&b| b == b' ')?;
-        let (scheme, rest) = value.split_at(scheme_end);
-        if !scheme.eq_ignore_ascii_case(b"bearer") {
-            return None;
-        }
-        let token = trim_ascii(rest);
-        return core::str::from_utf8(token).ok();
-    }
-    None
-}
-
-/// Constant-time byte comparison. Folds every byte difference into
-/// a single accumulator before testing equality so timing leaks
-/// from an early-exit-on-mismatch loop can't reveal a prefix of the
-/// expected token. Length mismatch returns immediately — leaking
-/// the token *length* is acceptable; the operator chose it.
-fn ct_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (&x, &y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
-/// Parse the `Content-Length` header value out of a header block.
-/// Returns `0` when absent (correct for GET / 0-body POST). Returns
-/// [`HttpError::Malformed`] if the header is present but not a valid
-/// non-negative integer.
-fn parse_content_length(headers: &[u8]) -> Result<usize, HttpError> {
-    for line in headers.split(|&b| b == b'\n') {
-        // Trim trailing CR.
-        let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let Some((name, value)) = split_once(line, b':') else {
-            continue;
-        };
-        if !name.eq_ignore_ascii_case(b"content-length") {
-            continue;
-        }
-        let value = trim_ascii(value);
-        let s = core::str::from_utf8(value).map_err(|_| HttpError::Malformed)?;
-        return s.parse::<usize>().map_err(|_| HttpError::Malformed);
-    }
-    Ok(0)
-}
-
-/// Index of the first occurrence of `needle` in `haystack`, or `None`.
-fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack.windows(needle.len()).position(|w| w == needle)
-}
-
-/// Split `slice` at the first occurrence of `delim`. Returns `None`
-/// if the delimiter is absent.
-fn split_once(slice: &[u8], delim: u8) -> Option<(&[u8], &[u8])> {
-    let idx = slice.iter().position(|&b| b == delim)?;
-    Some((&slice[..idx], &slice[idx + 1..]))
-}
-
-/// Strip ASCII whitespace from both ends of `slice`.
-fn trim_ascii(slice: &[u8]) -> &[u8] {
-    let start = slice
-        .iter()
-        .position(|b| !b.is_ascii_whitespace())
-        .unwrap_or(slice.len());
-    let end = slice
-        .iter()
-        .rposition(|b| !b.is_ascii_whitespace())
-        .map_or(start, |i| i + 1);
-    &slice[start..end]
 }
 
 /// Serialise the `/health` body. Schema is a flat object — no nested
@@ -772,159 +680,5 @@ mod tests {
                 other => panic!("expected SetEmotion for `{wire}`, got {other:?}"),
             }
         }
-    }
-
-    #[test]
-    fn content_length_missing_defaults_to_zero() {
-        let headers = b"Host: stackchan.local\r\nUser-Agent: curl/8\r\n";
-        assert!(matches!(parse_content_length(headers), Ok(0)));
-    }
-
-    #[test]
-    fn content_length_is_case_insensitive() {
-        for raw in [
-            "Content-Length: 42\r\n",
-            "content-length: 42\r\n",
-            "CONTENT-LENGTH: 42\r\n",
-            "cOnTeNt-LeNgTh: 42\r\n",
-        ] {
-            assert!(
-                matches!(parse_content_length(raw.as_bytes()), Ok(42)),
-                "{raw}"
-            );
-        }
-    }
-
-    #[test]
-    fn content_length_trims_value_whitespace() {
-        let headers = b"Content-Length:    99\r\n";
-        assert!(matches!(parse_content_length(headers), Ok(99)));
-    }
-
-    #[test]
-    fn content_length_rejects_non_numeric() {
-        let headers = b"Content-Length: forty-two\r\n";
-        assert!(matches!(
-            parse_content_length(headers),
-            Err(HttpError::Malformed)
-        ));
-    }
-
-    #[test]
-    fn content_length_rejects_signed_value() {
-        // `usize::from_str` doesn't accept a leading '+' or '-'; pin
-        // that the parser surfaces it as Malformed rather than 0.
-        for raw in ["Content-Length: +5\r\n", "Content-Length: -5\r\n"] {
-            assert!(
-                matches!(
-                    parse_content_length(raw.as_bytes()),
-                    Err(HttpError::Malformed)
-                ),
-                "{raw}"
-            );
-        }
-    }
-
-    #[test]
-    fn content_length_rejects_overflow() {
-        // 2^64-ish — never fits in usize on 32- or 64-bit targets.
-        let headers = b"Content-Length: 99999999999999999999\r\n";
-        assert!(matches!(
-            parse_content_length(headers),
-            Err(HttpError::Malformed)
-        ));
-    }
-
-    #[test]
-    fn content_length_first_match_wins_on_duplicates() {
-        // RFC 7230 forbids multiple Content-Length headers with
-        // different values; this server takes the first match. Pin
-        // the behavior so a future change is conscious.
-        let headers = b"Content-Length: 7\r\nContent-Length: 99\r\n";
-        assert!(matches!(parse_content_length(headers), Ok(7)));
-    }
-
-    #[test]
-    fn find_subsequence_locates_or_misses() {
-        assert_eq!(find_subsequence(b"abcdef", b"cd"), Some(2));
-        assert_eq!(find_subsequence(b"abcdef", b"xy"), None);
-        assert_eq!(find_subsequence(b"abc", b"abcd"), None);
-        // Zero-length needles aren't tested: `slice::windows(0)`
-        // panics, and the only caller passes the four-byte CRLF
-        // CRLF sentinel, so the case is unreachable.
-    }
-
-    #[test]
-    fn split_once_partitions_on_first_delim() {
-        assert_eq!(
-            split_once(b"key: value", b':'),
-            Some((b"key".as_slice(), b" value".as_slice()))
-        );
-        assert_eq!(
-            split_once(b"a:b:c", b':'),
-            Some((b"a".as_slice(), b"b:c".as_slice()))
-        );
-        assert_eq!(
-            split_once(b":empty", b':'),
-            Some((b"".as_slice(), b"empty".as_slice()))
-        );
-        assert_eq!(split_once(b"none", b':'), None);
-    }
-
-    #[test]
-    fn bearer_token_extracts_value() {
-        let headers = b"Host: stackchan.local\r\nAuthorization: Bearer abc123\r\n";
-        assert_eq!(parse_bearer_token(headers), Some("abc123"));
-    }
-
-    #[test]
-    fn bearer_scheme_and_header_are_case_insensitive() {
-        for raw in [
-            "authorization: Bearer xyz\r\n",
-            "AUTHORIZATION: BEARER xyz\r\n",
-            "Authorization: bearer xyz\r\n",
-        ] {
-            assert_eq!(parse_bearer_token(raw.as_bytes()), Some("xyz"), "{raw}");
-        }
-    }
-
-    #[test]
-    fn bearer_token_absent_returns_none() {
-        let headers = b"Host: stackchan.local\r\nUser-Agent: curl/8\r\n";
-        assert_eq!(parse_bearer_token(headers), None);
-    }
-
-    #[test]
-    fn bearer_token_rejects_other_schemes() {
-        // `Basic` and unknown schemes return `None`, not a bogus token.
-        for raw in [
-            "Authorization: Basic dXNlcjpwYXNz\r\n",
-            "Authorization: Digest realm=test\r\n",
-        ] {
-            assert_eq!(parse_bearer_token(raw.as_bytes()), None, "{raw}");
-        }
-    }
-
-    #[test]
-    fn bearer_token_handles_extra_whitespace() {
-        let headers = b"Authorization:    Bearer    spaced-token   \r\n";
-        assert_eq!(parse_bearer_token(headers), Some("spaced-token"));
-    }
-
-    #[test]
-    fn ct_eq_reports_equality_and_diff() {
-        assert!(ct_eq(b"abc", b"abc"));
-        assert!(!ct_eq(b"abc", b"abd"));
-        assert!(!ct_eq(b"abc", b"ab"));
-        assert!(!ct_eq(b"", b"a"));
-        assert!(ct_eq(b"", b""));
-    }
-
-    #[test]
-    fn trim_ascii_strips_both_sides() {
-        assert_eq!(trim_ascii(b"  hello  "), b"hello");
-        assert_eq!(trim_ascii(b"\t\rkey\n "), b"key");
-        assert_eq!(trim_ascii(b"   "), b"");
-        assert_eq!(trim_ascii(b"clean"), b"clean");
     }
 }

--- a/crates/stackchan-net/src/http_parse.rs
+++ b/crates/stackchan-net/src/http_parse.rs
@@ -81,10 +81,16 @@ pub fn parse_bearer_token(headers: &[u8]) -> Option<&str> {
             continue;
         }
         let value = trim_ascii(value);
-        let scheme_end = value.iter().position(|&b| b == b' ')?;
+        let Some(scheme_end) = value.iter().position(|&b| b == b' ') else {
+            // Header is malformed (no scheme/token split). Skip and
+            // see if a later `Authorization` line carries Bearer.
+            continue;
+        };
         let (scheme, rest) = value.split_at(scheme_end);
         if !scheme.eq_ignore_ascii_case(b"bearer") {
-            return None;
+            // Non-Bearer scheme (Basic, Digest, …). Don't bail —
+            // the request might also carry a Bearer line we'd miss.
+            continue;
         }
         let token = trim_ascii(rest);
         return core::str::from_utf8(token).ok();
@@ -99,6 +105,14 @@ pub fn parse_bearer_token(headers: &[u8]) -> Option<&str> {
 /// loop can't reveal a prefix of the expected token. Length mismatch
 /// returns immediately — leaking the token *length* is acceptable;
 /// the operator chose it.
+///
+/// The accumulator update is wrapped in [`core::hint::black_box`] on
+/// each iteration. Without it, LLVM can prove that `diff` doesn't
+/// escape the function and is free to short-circuit the loop on
+/// first non-zero XOR, defeating the constant-time property. This
+/// isn't as strong as the inline-assembly approach `subtle` takes,
+/// but the threat model is LAN-scoped jitter swamping any
+/// nanosecond-level timing window — a barrier suffices.
 #[must_use]
 pub fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
@@ -106,18 +120,22 @@ pub fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     }
     let mut diff: u8 = 0;
     for (&x, &y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
+        diff = core::hint::black_box(diff | (x ^ y));
     }
-    diff == 0
+    core::hint::black_box(diff) == 0
 }
 
 /// Index of the first occurrence of `needle` in `haystack`, or `None`.
 ///
-/// `needle` must be non-empty — `slice::windows(0)` panics. The
-/// firmware's only caller passes the four-byte CRLF CRLF sentinel,
-/// so the constraint is upheld at every call site.
+/// Returns `None` for an empty `needle`. The underlying
+/// `slice::windows(0)` panics, and as a public crate API this would
+/// be a footgun for downstream callers — a vacuous "found at every
+/// position" result isn't useful, and a panic is worse than `None`.
 #[must_use]
 pub fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return None;
+    }
     haystack.windows(needle.len()).position(|w| w == needle)
 }
 
@@ -246,6 +264,24 @@ mod tests {
     }
 
     #[test]
+    fn bearer_token_skips_past_non_bearer_scheme() {
+        // RFC 9110 §11.6.2 lets a request carry multiple
+        // `Authorization`-like fields; if the first is `Basic` or
+        // `Digest`, the parser must keep scanning for a Bearer
+        // line rather than giving up.
+        let headers = b"Authorization: Basic dXNlcjpwYXNz\r\nAuthorization: Bearer real-token\r\n";
+        assert_eq!(parse_bearer_token(headers), Some("real-token"));
+    }
+
+    #[test]
+    fn bearer_token_skips_malformed_header_to_find_valid_one() {
+        // A first `Authorization` with no scheme/token split (no
+        // space) is malformed — keep scanning rather than bailing.
+        let headers = b"Authorization: malformed\r\nAuthorization: Bearer ok\r\n";
+        assert_eq!(parse_bearer_token(headers), Some("ok"));
+    }
+
+    #[test]
     fn ct_eq_reports_equality_and_diff() {
         assert!(ct_eq(b"abc", b"abc"));
         assert!(!ct_eq(b"abc", b"abd"));
@@ -259,6 +295,14 @@ mod tests {
         assert_eq!(find_subsequence(b"abcdef", b"cd"), Some(2));
         assert_eq!(find_subsequence(b"abcdef", b"xy"), None);
         assert_eq!(find_subsequence(b"abc", b"abcd"), None);
+    }
+
+    #[test]
+    fn find_subsequence_returns_none_for_empty_needle() {
+        // `slice::windows(0)` panics; the public API caps that off
+        // by returning `None` instead of letting the panic escape.
+        assert_eq!(find_subsequence(b"abc", b""), None);
+        assert_eq!(find_subsequence(b"", b""), None);
     }
 
     #[test]

--- a/crates/stackchan-net/src/http_parse.rs
+++ b/crates/stackchan-net/src/http_parse.rs
@@ -1,0 +1,288 @@
+//! Byte-level helpers for the firmware's HTTP request parser.
+//!
+//! These live here (not in `stackchan-firmware`) so they get host-side
+//! `cargo test` coverage. The firmware crate compiles only for
+//! `xtensa-esp32s3-none-elf` and its `cfg(test)` modules are not
+//! exercised by `just check` or by CI — keeping the parsing edges in
+//! a host-testable crate is the difference between "pinned" and
+//! "documented but never run."
+//!
+//! Functions here are deliberately small and protocol-specific
+//! (`parse_content_length`, `parse_bearer_token`, `ct_eq`) plus a few
+//! generic byte helpers the firmware currently uses
+//! (`find_subsequence`, `split_once`, `trim_ascii`). The firmware's
+//! `net::http` module owns the higher-level state machine and maps
+//! [`ParseError`] into its own [`HttpError`] surface.
+
+/// Generic parse failure for the helpers that can fail. Kept unit-
+/// shaped because the firmware only ever needs to know whether the
+/// input was malformed; the route handler maps to `400 Bad Request`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseError;
+
+/// Parse the `Content-Length` header value out of a header block.
+///
+/// Returns `Ok(0)` when the header is absent — correct for `GET`
+/// and 0-body `POST` requests. Returns [`ParseError`] when the
+/// header is present but not a valid non-negative integer.
+///
+/// Header name compare is case-insensitive (RFC 9110 §5.1). The
+/// first match wins on duplicate headers; the firmware's request
+/// surface is small enough that strict de-duplication isn't worth
+/// the bytes.
+///
+/// # Errors
+///
+/// [`ParseError`] when a `Content-Length` header is present but
+/// can't be parsed as `usize`.
+pub fn parse_content_length(headers: &[u8]) -> Result<usize, ParseError> {
+    for line in headers.split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some((name, value)) = split_once(line, b':') else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case(b"content-length") {
+            continue;
+        }
+        let value = trim_ascii(value);
+        // RFC 9110 §8.6: `Content-Length = 1*DIGIT`. `usize::from_str`
+        // accepts a leading `+`, which would otherwise leak through;
+        // enforce digits-only here so the wire shape is spec-tight.
+        if value.is_empty() || !value.iter().all(u8::is_ascii_digit) {
+            return Err(ParseError);
+        }
+        let s = core::str::from_utf8(value).map_err(|_| ParseError)?;
+        return s.parse::<usize>().map_err(|_| ParseError);
+    }
+    Ok(0)
+}
+
+/// Parse the `Authorization: Bearer <token>` header value out of a
+/// header block.
+///
+/// Returns `Some(token)` if a Bearer credential is present, `None`
+/// otherwise. Header name compare is case-insensitive (RFC 9110 §5.1).
+/// Scheme compare is also case-insensitive — RFC 6750 says the
+/// `Authorization` field uses the standard `auth-scheme` token
+/// production, which is case-insensitive.
+///
+/// Whitespace between scheme and token is collapsed; leading and
+/// trailing whitespace on the token are stripped. The token itself
+/// is not further validated; the caller compares against the
+/// configured value with [`ct_eq`].
+#[must_use]
+pub fn parse_bearer_token(headers: &[u8]) -> Option<&str> {
+    for line in headers.split(|&b| b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some((name, value)) = split_once(line, b':') else {
+            continue;
+        };
+        if !name.eq_ignore_ascii_case(b"authorization") {
+            continue;
+        }
+        let value = trim_ascii(value);
+        let scheme_end = value.iter().position(|&b| b == b' ')?;
+        let (scheme, rest) = value.split_at(scheme_end);
+        if !scheme.eq_ignore_ascii_case(b"bearer") {
+            return None;
+        }
+        let token = trim_ascii(rest);
+        return core::str::from_utf8(token).ok();
+    }
+    None
+}
+
+/// Constant-time byte comparison.
+///
+/// Folds every byte difference into a single accumulator before
+/// testing equality so timing leaks from an early-exit-on-mismatch
+/// loop can't reveal a prefix of the expected token. Length mismatch
+/// returns immediately — leaking the token *length* is acceptable;
+/// the operator chose it.
+#[must_use]
+pub fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Index of the first occurrence of `needle` in `haystack`, or `None`.
+///
+/// `needle` must be non-empty — `slice::windows(0)` panics. The
+/// firmware's only caller passes the four-byte CRLF CRLF sentinel,
+/// so the constraint is upheld at every call site.
+#[must_use]
+pub fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Split `slice` at the first occurrence of `delim`. Returns `None`
+/// if the delimiter is absent.
+#[must_use]
+pub fn split_once(slice: &[u8], delim: u8) -> Option<(&[u8], &[u8])> {
+    let idx = slice.iter().position(|&b| b == delim)?;
+    Some((&slice[..idx], &slice[idx + 1..]))
+}
+
+/// Strip ASCII whitespace from both ends of `slice`.
+#[must_use]
+pub fn trim_ascii(slice: &[u8]) -> &[u8] {
+    let start = slice
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(slice.len());
+    let end = slice
+        .iter()
+        .rposition(|b| !b.is_ascii_whitespace())
+        .map_or(start, |i| i + 1);
+    &slice[start..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_length_missing_defaults_to_zero() {
+        let headers = b"Host: stackchan.local\r\nUser-Agent: curl/8\r\n";
+        assert_eq!(parse_content_length(headers), Ok(0));
+    }
+
+    #[test]
+    fn content_length_is_case_insensitive() {
+        for raw in [
+            "Content-Length: 42\r\n",
+            "content-length: 42\r\n",
+            "CONTENT-LENGTH: 42\r\n",
+            "cOnTeNt-LeNgTh: 42\r\n",
+        ] {
+            assert_eq!(parse_content_length(raw.as_bytes()), Ok(42), "{raw}");
+        }
+    }
+
+    #[test]
+    fn content_length_trims_value_whitespace() {
+        let headers = b"Content-Length:    99\r\n";
+        assert_eq!(parse_content_length(headers), Ok(99));
+    }
+
+    #[test]
+    fn content_length_rejects_non_numeric() {
+        let headers = b"Content-Length: forty-two\r\n";
+        assert_eq!(parse_content_length(headers), Err(ParseError));
+    }
+
+    #[test]
+    fn content_length_rejects_signed_value() {
+        // `usize::from_str` doesn't accept a leading `+` or `-`; pin
+        // that the parser surfaces it as Malformed rather than 0.
+        for raw in ["Content-Length: +5\r\n", "Content-Length: -5\r\n"] {
+            assert_eq!(
+                parse_content_length(raw.as_bytes()),
+                Err(ParseError),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn content_length_rejects_overflow() {
+        // 2^64-ish — never fits in usize on 32- or 64-bit targets.
+        let headers = b"Content-Length: 99999999999999999999\r\n";
+        assert_eq!(parse_content_length(headers), Err(ParseError));
+    }
+
+    #[test]
+    fn content_length_first_match_wins_on_duplicates() {
+        // RFC 7230 forbids multiple Content-Length headers with
+        // different values; this server takes the first match. Pin
+        // the behaviour so a future change is conscious.
+        let headers = b"Content-Length: 7\r\nContent-Length: 99\r\n";
+        assert_eq!(parse_content_length(headers), Ok(7));
+    }
+
+    #[test]
+    fn bearer_token_extracts_value() {
+        let headers = b"Host: stackchan.local\r\nAuthorization: Bearer abc123\r\n";
+        assert_eq!(parse_bearer_token(headers), Some("abc123"));
+    }
+
+    #[test]
+    fn bearer_scheme_and_header_are_case_insensitive() {
+        for raw in [
+            "authorization: Bearer xyz\r\n",
+            "AUTHORIZATION: BEARER xyz\r\n",
+            "Authorization: bearer xyz\r\n",
+        ] {
+            assert_eq!(parse_bearer_token(raw.as_bytes()), Some("xyz"), "{raw}");
+        }
+    }
+
+    #[test]
+    fn bearer_token_absent_returns_none() {
+        let headers = b"Host: stackchan.local\r\nUser-Agent: curl/8\r\n";
+        assert_eq!(parse_bearer_token(headers), None);
+    }
+
+    #[test]
+    fn bearer_token_rejects_other_schemes() {
+        for raw in [
+            "Authorization: Basic dXNlcjpwYXNz\r\n",
+            "Authorization: Digest realm=test\r\n",
+        ] {
+            assert_eq!(parse_bearer_token(raw.as_bytes()), None, "{raw}");
+        }
+    }
+
+    #[test]
+    fn bearer_token_handles_extra_whitespace() {
+        let headers = b"Authorization:    Bearer    spaced-token   \r\n";
+        assert_eq!(parse_bearer_token(headers), Some("spaced-token"));
+    }
+
+    #[test]
+    fn ct_eq_reports_equality_and_diff() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"ab"));
+        assert!(!ct_eq(b"", b"a"));
+        assert!(ct_eq(b"", b""));
+    }
+
+    #[test]
+    fn find_subsequence_locates_or_misses() {
+        assert_eq!(find_subsequence(b"abcdef", b"cd"), Some(2));
+        assert_eq!(find_subsequence(b"abcdef", b"xy"), None);
+        assert_eq!(find_subsequence(b"abc", b"abcd"), None);
+    }
+
+    #[test]
+    fn split_once_partitions_on_first_delim() {
+        assert_eq!(
+            split_once(b"key: value", b':'),
+            Some((b"key".as_slice(), b" value".as_slice()))
+        );
+        assert_eq!(
+            split_once(b"a:b:c", b':'),
+            Some((b"a".as_slice(), b"b:c".as_slice()))
+        );
+        assert_eq!(
+            split_once(b":empty", b':'),
+            Some((b"".as_slice(), b"empty".as_slice()))
+        );
+        assert_eq!(split_once(b"none", b':'), None);
+    }
+
+    #[test]
+    fn trim_ascii_strips_both_sides() {
+        assert_eq!(trim_ascii(b"  hello  "), b"hello");
+        assert_eq!(trim_ascii(b"\t\rkey\n "), b"key");
+        assert_eq!(trim_ascii(b"   "), b"");
+        assert_eq!(trim_ascii(b"clean"), b"clean");
+    }
+}

--- a/crates/stackchan-net/src/http_parse.rs
+++ b/crates/stackchan-net/src/http_parse.rs
@@ -12,7 +12,7 @@
 //! generic byte helpers the firmware currently uses
 //! (`find_subsequence`, `split_once`, `trim_ascii`). The firmware's
 //! `net::http` module owns the higher-level state machine and maps
-//! [`ParseError`] into its own [`HttpError`] surface.
+//! [`ParseError`] into its own `HttpError` surface.
 
 /// Generic parse failure for the helpers that can fail. Kept unit-
 /// shaped because the firmware only ever needs to know whether the

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -52,6 +52,7 @@ pub mod bare;
 pub mod bare_json;
 pub mod config;
 pub mod error;
+pub mod http_parse;
 
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{parse_settings_json, render_settings_json};


### PR DESCRIPTION
## Summary

Closes a follow-up flagged in both [#159](https://github.com/andymai/stackchan-kai/pull/159) and [#160](https://github.com/andymai/stackchan-kai/pull/160): the firmware crate had `cfg(test)` blocks for the HTTP byte helpers (`parse_content_length`, `parse_bearer_token`, `ct_eq`, `find_subsequence`, `split_once`, `trim_ascii`) but those tests **never ran** — the firmware crate compiles only for `xtensa-esp32s3-none-elf` and `just check` explicitly excludes it.

Lifting the helpers into `stackchan-net::http_parse` gives them real host-side coverage in both `cargo test` and CI.

## What this caught

The orphaned firmware test asserted `Content-Length: +5` would be rejected as malformed. `usize::from_str("+5")` actually returns `Ok(5)`. RFC 9110 §8.6 specifies `Content-Length = 1*DIGIT`, so the parser now enforces digits-only before delegating to `from_str`:

```rust
if value.is_empty() || !value.iter().all(u8::is_ascii_digit) {
    return Err(ParseError);
}
```

Two PRs of CI never caught this because the test never ran — exactly the failure mode this refactor exists to prevent.

## API shape

`parse_content_length` returns `Result<usize, ParseError>` (a unit-shaped error type local to `stackchan-net::http_parse`) instead of the firmware's `Result<usize, HttpError>`. Callers map `ParseError → HttpError::Malformed` at the call site (one place, in `serve_one`).

The firmware's `net/http.rs` shrinks by ~150 lines: helper bodies and tests both move out, leaving only the imports and the `emotion_str_round_trips_through_parser` test (still orphaned because `Emotion` is firmware-domain, but documented as such).

## Test plan

- [x] `cargo test -p stackchan-net` — 16 new tests pass
- [x] `just check` — host gate
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `just build-firmware` — release binary builds
- Equivalent end-to-end behaviour on hardware (no functional change in the wire protocol):
  - [ ] `Content-Length: +5` now returns 400 (RFC tightening)
  - [ ] All other request shapes pass through unchanged