### PR TITLE
feat(firmware): POST /speak + audio queue eviction policy

### DIFF
--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -14,6 +14,7 @@
 
 use crate::emotion::Emotion;
 use crate::head::Pose;
+use crate::voice::{Locale, PhraseId, Priority};
 
 /// External command delivered through the firmware control plane.
 ///
@@ -51,6 +52,21 @@ pub enum RemoteCommand {
     /// Clear any active emotion or look-at hold and return to
     /// autonomous behavior.
     Reset,
+    /// Play a [`PhraseId`] from the baked TTS catalog through the
+    /// firmware's TX path. Fire-and-forget — no avatar-state hold,
+    /// no autonomy gate. The firmware drains this slot before
+    /// `Director::run` and dispatches via the audio queue;
+    /// [`crate::modifiers::RemoteCommandModifier`] sees this variant
+    /// only as a defensive no-op.
+    Speak {
+        /// Catalog entry to render (chirp, beep, or verbal phrase).
+        phrase: PhraseId,
+        /// Locale for verbal phrases. Ignored for non-verbal chirps.
+        locale: Locale,
+        /// Queue priority. Higher priorities preempt currently-
+        /// playing audio; the default is [`Priority::Normal`].
+        priority: Priority,
+    },
 }
 
 /// Pending inputs the modifier graph consumes.

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -87,6 +87,13 @@ impl RemoteCommandModifier {
                 self.emotion_hold = None;
                 self.lookat_hold = None;
             }
+            RemoteCommand::Speak { .. } => {
+                // Audio dispatch is firmware-only; the producer drains
+                // this variant from `entity.input.remote_command` before
+                // `Director::run`. If a `Speak` slot survives that
+                // intercept, treat it as a no-op rather than panic so
+                // the modifier stays resilient under reordering.
+            }
         }
     }
 }
@@ -407,6 +414,30 @@ mod tests {
             Emotion::Sleepy,
             "reset must drop the emotion hold"
         );
+    }
+
+    #[test]
+    fn speak_is_a_no_op_at_the_modifier() {
+        // Speak is dispatched to the audio queue by the firmware
+        // before Director::run. If a Speak slot reaches the modifier,
+        // it must consume harmlessly without touching mind state.
+        use crate::voice::{Locale, PhraseId, Priority};
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        let baseline_emotion = entity.mind.affect.emotion;
+        let baseline_attention = entity.mind.attention;
+        entity.input.remote_command = Some(RemoteCommand::Speak {
+            phrase: PhraseId::WakeChirp,
+            locale: Locale::En,
+            priority: Priority::Normal,
+        });
+
+        step(&mut m, &mut entity, 0);
+
+        assert_eq!(entity.mind.affect.emotion, baseline_emotion);
+        assert_eq!(entity.mind.attention, baseline_attention);
+        assert!(entity.input.remote_command.is_none(), "slot must drain");
+        assert!(entity.mind.autonomy.manual_until.is_none());
     }
 
     #[test]

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -82,10 +82,11 @@ runs three networked services on the LAN:
 
 - **HTTP** on port 80 — operator dashboard at `GET /`, live state +
   control plane on `/state`, `/state/stream`, `/emotion`, `/look-at`,
-  `/reset`, `/settings`. Write routes (`PUT`, `POST`) are gated on
-  `auth.token` from the boot config — empty token (default) leaves
-  the LAN open; non-empty token requires
-  `Authorization: Bearer <token>`. See
+  `/reset`, `/speak`, `/settings`. Write routes (`PUT`, `POST`) are
+  gated on `auth.token` from the boot config — empty token (default)
+  leaves the LAN open; non-empty token requires
+  `Authorization: Bearer <token>`. `POST /speak` queues a baked
+  phrase or chirp on the AW88298 TX path. See
   [docs/http.md](../../docs/http.md) for the full route table, body
   shapes, error codes, and the auth section with `curl` examples.
 - **mDNS** — advertises `<hostname>.local` from

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -153,11 +153,19 @@ pub struct SpeechSlot {
 /// [`SpeechSlot`]s; the TX feeder pops them and pulls samples through
 /// [`AudioSource::fill`].
 ///
-/// Capacity 4. Eviction policy when full is "drop incoming non-Critical;
-/// log Critical drops" — full-priority eviction (drop oldest non-Critical
-/// to make room for Critical) is a TODO once the v1 catalog grows past
-/// the no-overlap regime.
+/// Capacity 4. Eviction policy when full:
+/// - Incoming non-Critical → drop the incoming slot.
+/// - Incoming Critical → drain the queue, drop the oldest
+///   non-Critical to make room, re-enqueue the rest plus the
+///   incoming. If every queued slot is also Critical, drop the
+///   incoming with a warn log — there's nothing of lower priority
+///   to evict without losing equivalent urgency.
 pub static AUDIO_TX_QUEUE: Channel<CriticalSectionRawMutex, SpeechSlot, 4> = Channel::new();
+
+/// Hard cap on the eviction-buffer size — matches [`AUDIO_TX_QUEUE`]
+/// capacity. A `heapless::Vec` typed at this length lets the
+/// eviction path drain the queue without a heap alloc.
+const AUDIO_TX_QUEUE_CAPACITY: usize = 4;
 
 /// Discriminant of the [`Priority`] of the source currently playing —
 /// `0` (Background) when nothing is playing.
@@ -242,20 +250,68 @@ pub fn try_dispatch_utterance(utterance: &Utterance) -> Result<(), DispatchError
         priority: utterance.priority,
     };
 
+    // Fast path: queue had room.
+    let slot = match AUDIO_TX_QUEUE.try_send(slot) {
+        Ok(()) => {
+            update_preempt_after_enqueue(utterance.priority);
+            return Ok(());
+        }
+        Err(embassy_sync::channel::TrySendError::Full(rejected)) => rejected,
+    };
+
+    // Slow path: queue is full. Only `Critical` incoming attempts to
+    // evict; lower priorities preserve in-flight audio.
+    if slot.priority != Priority::Critical {
+        return Err(DispatchError::QueueFull);
+    }
+
+    // Drain FIFO — `try_receive` gives the oldest first — so we can
+    // pick the *oldest* non-Critical to drop. Capacity is bounded by
+    // [`AUDIO_TX_QUEUE_CAPACITY`]; the buffer never overflows.
+    let mut buffer: heapless::Vec<SpeechSlot, AUDIO_TX_QUEUE_CAPACITY> = heapless::Vec::new();
+    while let Ok(s) = AUDIO_TX_QUEUE.try_receive() {
+        // Push can't fail: queue cap == buffer cap.
+        let _ = buffer.push(s);
+    }
+    let Some(evict_idx) = buffer.iter().position(|s| s.priority != Priority::Critical) else {
+        // Every queued slot is Critical too — can't evict without
+        // losing equivalent urgency. Restore the queue and drop the
+        // incoming with a log line so the operator notices.
+        defmt::warn!("audio: queue saturated with Critical; incoming Critical dropped");
+        for s in buffer {
+            let _ = AUDIO_TX_QUEUE.try_send(s);
+        }
+        return Err(DispatchError::QueueFull);
+    };
+    let evicted = buffer.remove(evict_idx);
+    defmt::warn!(
+        "audio: evicting non-Critical (priority={=u8}) to make room for Critical",
+        evicted.priority as u8,
+    );
+    drop(evicted);
+    // Re-enqueue survivors in their original FIFO order, then the
+    // new Critical at the tail.
+    for s in buffer {
+        let _ = AUDIO_TX_QUEUE.try_send(s);
+    }
     AUDIO_TX_QUEUE
         .try_send(slot)
         .map_err(|_| DispatchError::QueueFull)?;
+    update_preempt_after_enqueue(Priority::Critical);
+    Ok(())
+}
 
-    // Set preempt only after the slot is queued. If we set it first
-    // and the send fails, the flag stays high — on the next DMA
-    // batch the TX loop would drop the in-flight source and promote
-    // whatever was already at the head of the (full) queue, which
-    // may be lower priority than what was just dropped.
+/// Set `AUDIO_TX_PREEMPT` if `new_priority` is strictly higher than
+/// what's currently playing. Must run *after* the slot is in the
+/// queue: if the flag is set before the slot is enqueueable, the TX
+/// loop drops the in-flight source and promotes whatever's already
+/// at the head of the queue — possibly lower priority than what was
+/// dropped.
+fn update_preempt_after_enqueue(new_priority: Priority) {
     let current = AUDIO_TX_CURRENT_PRIORITY.load(Ordering::Relaxed);
-    if (utterance.priority as u8) > current {
+    if (new_priority as u8) > current {
         AUDIO_TX_PREEMPT.store(true, Ordering::Relaxed);
     }
-    Ok(())
 }
 
 /// Microphone RMS sample, published per render tick.

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -156,10 +156,13 @@ pub struct SpeechSlot {
 /// Capacity 4. Eviction policy when full:
 /// - Incoming non-Critical → drop the incoming slot.
 /// - Incoming Critical → drain the queue, drop the oldest
-///   non-Critical to make room, re-enqueue the rest plus the
-///   incoming. If every queued slot is also Critical, drop the
-///   incoming with a warn log — there's nothing of lower priority
-///   to evict without losing equivalent urgency.
+///   non-Critical to make room, then re-enqueue the new Critical
+///   *at the head* with the survivors behind it. The Critical
+///   then plays immediately when `AUDIO_TX_PREEMPT` fires rather
+///   than waiting through up to three survivor slots. If every
+///   queued slot is also Critical, drop the incoming with a warn
+///   log — there's nothing of lower priority to evict without
+///   losing equivalent urgency.
 pub static AUDIO_TX_QUEUE: Channel<CriticalSectionRawMutex, SpeechSlot, 4> = Channel::new();
 
 /// Hard cap on the eviction-buffer size — matches [`AUDIO_TX_QUEUE`]
@@ -289,14 +292,17 @@ pub fn try_dispatch_utterance(utterance: &Utterance) -> Result<(), DispatchError
         evicted.priority as u8,
     );
     drop(evicted);
-    // Re-enqueue survivors in their original FIFO order, then the
-    // new Critical at the tail.
-    for s in buffer {
-        let _ = AUDIO_TX_QUEUE.try_send(s);
-    }
+    // Enqueue the Critical at the head, then put the survivors
+    // back behind it. `update_preempt_after_enqueue` drops the
+    // in-flight source on the next TX fill, and the TX feeder
+    // promotes from the queue head — so the Critical plays
+    // immediately rather than after the survivor slots.
     AUDIO_TX_QUEUE
         .try_send(slot)
         .map_err(|_| DispatchError::QueueFull)?;
+    for s in buffer {
+        let _ = AUDIO_TX_QUEUE.try_send(s);
+    }
     update_preempt_after_enqueue(Priority::Critical);
     Ok(())
 }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -69,7 +69,7 @@ use mipidsi::{
     options::{ColorInversion, ColorOrder},
 };
 use stackchan_core::{
-    Clock, Director, Entity, Face, HeadDriver, LedFrame,
+    Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
     modifiers::{
         AttentionFromTracking, Blink, Breath, DormancyFromActivity, EmotionCycle,
         EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
@@ -380,8 +380,27 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // Drain HTTP control-plane commands, if any. RemoteCommandModifier
         // (Phase::Cognition) consumes the slot, asserts emotion or
         // attention, and re-asserts each tick until the hold expires.
+        //
+        // `Speak` short-circuits the modifier round-trip — audio
+        // dispatch is firmware-only and the modifier graph would
+        // see it only as a no-op. Render the utterance and queue
+        // it directly here.
         if let Some(cmd) = net::http::REMOTE_COMMAND_SIGNAL.try_take() {
-            entity.input.remote_command = Some(cmd);
+            match cmd {
+                RemoteCommand::Speak {
+                    phrase,
+                    locale,
+                    priority,
+                } => {
+                    let utterance = Utterance::phrase(phrase)
+                        .with_locale(locale)
+                        .with_priority(priority);
+                    if let Err(e) = audio::try_dispatch_utterance(&utterance) {
+                        defmt::warn!("speak: dispatch failed ({})", e);
+                    }
+                }
+                other => entity.input.remote_command = Some(other),
+            }
         }
         // Drain the latest IMU reading.
         if let Some(m) = imu::IMU_SIGNAL.try_take() {

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -22,6 +22,10 @@
 //!   asserting the operator's target against camera tracking.
 //! - `POST /reset` — empty body. Clears any active emotion or
 //!   look-at hold and returns the avatar to autonomous behaviour.
+//! - `POST /speak` — JSON `{"phrase": "...", "locale": "..."}`.
+//!   Renders a [`stackchan_core::voice::PhraseId`] from the baked
+//!   catalog and queues it on the audio TX path. Fire-and-forget;
+//!   no avatar-state hold timer.
 //! - `GET /settings` — current persisted [`stackchan_net::Config`]
 //!   as JSON, with `wifi.psk` and `auth.token` redacted.
 //! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
@@ -275,6 +279,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/emotion") => handle_remote(socket, json::parse_set_emotion(body)).await,
         ("POST", "/look-at") => handle_remote(socket, json::parse_look_at(body)).await,
         ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
+        ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,
         ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
     }

--- a/crates/stackchan-firmware/src/net/json.rs
+++ b/crates/stackchan-firmware/src/net/json.rs
@@ -15,6 +15,7 @@
 //! that handles full JSON belongs in a real crate. Numbers are
 //! parsed in their entirety with [`core::str::FromStr`].
 
+use stackchan_core::voice::{Locale, PhraseId, Priority};
 use stackchan_core::{Emotion, Pose, RemoteCommand};
 
 /// Default hold window when the request body omits `hold_ms`.
@@ -41,6 +42,10 @@ pub enum JsonError {
     BadValue,
     /// Emotion string didn't match any known variant.
     UnknownEmotion,
+    /// Phrase string didn't match any [`PhraseId`] variant.
+    UnknownPhrase,
+    /// Locale string didn't match any [`Locale`] variant.
+    UnknownLocale,
 }
 
 /// Parse a `POST /emotion` body into a [`RemoteCommand::SetEmotion`].
@@ -122,6 +127,48 @@ pub fn parse_look_at(body: &str) -> Result<RemoteCommand, JsonError> {
             tilt_deg: tilt_deg.ok_or(JsonError::MissingKey("tilt_deg"))?,
         },
         hold_ms: hold_ms.unwrap_or(DEFAULT_HOLD_MS),
+    })
+}
+
+/// Parse a `POST /speak` body into a [`RemoteCommand::Speak`].
+///
+/// Required: `phrase` (string, lowercase `snake_case`). Optional:
+/// `locale` (string, `"en"` / `"ja"`, defaults to `"en"`).
+///
+/// Priority is not on the wire — the firmware fills
+/// [`Priority::Normal`] for every operator-driven request. Modifier-
+/// internal call sites that need elevated priority go through
+/// [`crate::audio::try_dispatch_utterance`] directly.
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys, unknown
+/// keys, malformed JSON shape, or unrecognised phrase/locale strings.
+pub fn parse_speak(body: &str) -> Result<RemoteCommand, JsonError> {
+    let mut phrase: Option<PhraseId> = None;
+    let mut locale: Option<Locale> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "phrase" => {
+                if phrase.is_some() {
+                    return Err(JsonError::DuplicateKey("phrase"));
+                }
+                phrase = Some(parse_phrase(scanner)?);
+            }
+            "locale" => {
+                if locale.is_some() {
+                    return Err(JsonError::DuplicateKey("locale"));
+                }
+                locale = Some(parse_locale(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    Ok(RemoteCommand::Speak {
+        phrase: phrase.ok_or(JsonError::MissingKey("phrase"))?,
+        locale: locale.unwrap_or(Locale::En),
+        priority: Priority::Normal,
     })
 }
 
@@ -265,6 +312,34 @@ fn parse_emotion(scanner: &mut Scanner<'_>) -> Result<Emotion, JsonError> {
         "surprised" => Ok(Emotion::Surprised),
         "angry" => Ok(Emotion::Angry),
         _ => Err(JsonError::UnknownEmotion),
+    }
+}
+
+/// Parse a quoted phrase string into the corresponding [`PhraseId`].
+/// Vocabulary is the full baked catalog: SFX chirps + verbal phrases.
+fn parse_phrase(scanner: &mut Scanner<'_>) -> Result<PhraseId, JsonError> {
+    let raw = scanner.read_string()?;
+    match raw {
+        "wake_chirp" => Ok(PhraseId::WakeChirp),
+        "pickup_chirp" => Ok(PhraseId::PickupChirp),
+        "startle_chirp" => Ok(PhraseId::StartleChirp),
+        "low_battery_chirp" => Ok(PhraseId::LowBatteryChirp),
+        "camera_mode_entered_chirp" => Ok(PhraseId::CameraModeEnteredChirp),
+        "camera_mode_exited_chirp" => Ok(PhraseId::CameraModeExitedChirp),
+        "greeting" => Ok(PhraseId::Greeting),
+        "acknowledge_name" => Ok(PhraseId::AcknowledgeName),
+        "battery_low" => Ok(PhraseId::BatteryLow),
+        _ => Err(JsonError::UnknownPhrase),
+    }
+}
+
+/// Parse a quoted locale string into the corresponding [`Locale`].
+fn parse_locale(scanner: &mut Scanner<'_>) -> Result<Locale, JsonError> {
+    let raw = scanner.read_string()?;
+    match raw {
+        "en" => Ok(Locale::En),
+        "ja" => Ok(Locale::Ja),
+        _ => Err(JsonError::UnknownLocale),
     }
 }
 
@@ -430,5 +505,70 @@ mod tests {
             parse_set_emotion("{}"),
             Err(JsonError::MissingKey("emotion"))
         ));
+    }
+
+    #[test]
+    fn speak_with_phrase_only_defaults_locale_and_priority() {
+        let body = r#"{"phrase":"wake_chirp"}"#;
+        match parse_speak(body).unwrap() {
+            RemoteCommand::Speak {
+                phrase,
+                locale,
+                priority,
+            } => {
+                assert_eq!(phrase, PhraseId::WakeChirp);
+                assert_eq!(locale, Locale::En);
+                assert_eq!(priority, Priority::Normal);
+            }
+            other => panic!("expected Speak, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn speak_accepts_explicit_locale() {
+        let body = r#"{"phrase":"greeting","locale":"ja"}"#;
+        match parse_speak(body).unwrap() {
+            RemoteCommand::Speak { phrase, locale, .. } => {
+                assert_eq!(phrase, PhraseId::Greeting);
+                assert_eq!(locale, Locale::Ja);
+            }
+            other => panic!("expected Speak, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn speak_rejects_missing_phrase() {
+        let body = r#"{"locale":"en"}"#;
+        assert!(matches!(
+            parse_speak(body),
+            Err(JsonError::MissingKey("phrase"))
+        ));
+    }
+
+    #[test]
+    fn speak_rejects_unknown_phrase() {
+        let body = r#"{"phrase":"yodel"}"#;
+        assert!(matches!(parse_speak(body), Err(JsonError::UnknownPhrase)));
+    }
+
+    #[test]
+    fn speak_rejects_unknown_locale() {
+        let body = r#"{"phrase":"greeting","locale":"de"}"#;
+        assert!(matches!(parse_speak(body), Err(JsonError::UnknownLocale)));
+    }
+
+    #[test]
+    fn speak_rejects_duplicate_phrase() {
+        let body = r#"{"phrase":"wake_chirp","phrase":"pickup_chirp"}"#;
+        assert!(matches!(
+            parse_speak(body),
+            Err(JsonError::DuplicateKey("phrase"))
+        ));
+    }
+
+    #[test]
+    fn speak_rejects_unknown_key() {
+        let body = r#"{"phrase":"wake_chirp","priority":"normal"}"#;
+        assert!(matches!(parse_speak(body), Err(JsonError::UnknownKey)));
     }
 }

--- a/docs/http.md
+++ b/docs/http.md
@@ -28,6 +28,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/emotion`       | Set affect with hold timer                          |
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |
+| POST   | `/speak`         | Play a baked phrase / chirp through the speaker      |
 | GET    | `/settings`      | Persisted config (PSK + token redacted)             |
 | PUT    | `/settings`      | Replace persisted config; atomic SD writeback        |
 
@@ -117,6 +118,42 @@ $ curl -X POST http://stackchan.local/reset
 Empty body. Clears any active emotion or look-at hold; autonomous
 behaviours resume on the next render tick.
 
+### `POST /speak`
+
+```
+$ curl -X POST http://stackchan.local/speak \
+       -H 'Content-Type: application/json' \
+       -d '{"phrase":"wake_chirp"}'
+```
+
+| Field   | Type   | Required | Notes                                                  |
+|---------|--------|----------|--------------------------------------------------------|
+| phrase  | string | yes      | Catalog entry — see vocabulary below                   |
+| locale  | string | no       | `"en"` (default) / `"ja"` — only meaningful for verbal phrases |
+
+**Phrase vocabulary** (matches [`stackchan_core::voice::PhraseId`]):
+
+| Wire string                     | Kind           | Notes                                            |
+|---------------------------------|----------------|--------------------------------------------------|
+| `wake_chirp`                    | SFX            | 100 ms / 1 kHz                                   |
+| `pickup_chirp`                  | SFX            | Two-tone upward sweep                            |
+| `startle_chirp`                 | SFX            | Sharp 4 kHz tone                                 |
+| `low_battery_chirp`             | SFX            | Two-pulse 2 kHz alert                            |
+| `camera_mode_entered_chirp`     | SFX            | Upward "doot-DEE"                                |
+| `camera_mode_exited_chirp`      | SFX            | Downward "DEE-doot"                              |
+| `greeting`                      | Verbal phrase  | en + ja PCM assets                               |
+| `acknowledge_name`              | Verbal phrase  | en + ja PCM assets                               |
+| `battery_low`                   | Verbal phrase  | en + ja PCM assets                               |
+
+Fire-and-forget — the request returns `204 No Content` once the
+utterance is queued; playback completes asynchronously. Operator-
+driven calls land at `Priority::Normal`. Modifier-internal call
+sites (low-battery alert, etc.) use elevated priority via the
+firmware's `audio::try_dispatch_utterance` directly and can preempt
+or evict an in-flight operator request.
+
+`POST /speak` is gated by [auth](#auth) when a token is configured.
+
 ## Persistent config
 
 The boot config lives at `/sd/STACKCHAN.RON` in the schema described
@@ -171,7 +208,7 @@ the operator's HTTP session if the SSID changed. Reboot to apply.
 |------|---------------------------------------------------------------------|
 | 200  | GET responses, dashboard, successful PUT                            |
 | 204  | POST `/emotion` / `/look-at` / `/reset` on success                  |
-| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion, redacted PSK or token sentinel, validation failure on PUT `/settings` |
+| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion / phrase / locale, redacted PSK or token sentinel, validation failure on PUT `/settings` |
 | 401  | Write route called without a valid bearer token (when auth is enabled) |
 | 404  | Path not in the matcher                                             |
 | 405  | Method not allowed                                                  |


### PR DESCRIPTION
## Summary

Two pieces of the audio v1 catalog work, bundled because the eviction-policy fix de-risks the new operator-facing route:

- **`POST /speak`** queues a baked `PhraseId` (six chirps + three verbal phrases) onto the AW88298 TX path. Operator-facing addition; reads stay open, writes obey the existing bearer-token gate.
- **Eviction policy** in `audio::try_dispatch_utterance` (resolves the `audio.rs:158` TODO): when the queue is full and a `Critical` utterance arrives, drop the oldest non-Critical to make room instead of dropping the incoming.

## Routing

`Speak` is added to `RemoteCommand` for one-shape control-plane symmetry with `SetEmotion` / `LookAt` / `Reset`. The render task in `main.rs` short-circuits the `Speak` variant before it lands in `entity.input.remote_command` — audio dispatch is firmware-only and the modifier graph would see it as a pure no-op. `RemoteCommandModifier` carries a defensive no-op arm in case ordering changes ever route a `Speak` slot through the graph.

## Wire format

```
POST /speak
Content-Type: application/json
Authorization: Bearer <token>   # only when auth is enabled

{ "phrase": "wake_chirp", "locale": "en" }
```

| Field   | Required | Default | Notes                                              |
|---------|----------|---------|----------------------------------------------------|
| phrase  | yes      | —       | Lowercase snake_case mirroring `PhraseId` variants |
| locale  | no       | `"en"`  | Only meaningful for verbal phrases                 |

Priority is firmware-fixed at `Normal` for all operator calls. Modifier-internal call sites that need elevated priority continue to call `audio::try_dispatch_utterance` directly.

## Eviction policy

```
incoming != Critical && queue full → drop incoming (unchanged)
incoming == Critical && queue full → drain, evict oldest non-Critical, re-enqueue rest + new
                                     all queued are Critical → drop incoming, warn log
```

Drain uses a `heapless::Vec<_, 4>` matching the queue capacity so eviction is alloc-free.

## Test plan

- [x] `cargo test -p stackchan-core` — Speak no-op modifier test
- [x] `cargo test -p stackchan-firmware` — JSON parser tests (orphaned in CI but compile-checked locally)
- [x] `just check` — host gate
- [x] `just clippy-firmware`
- [x] `just build-firmware` — release binary builds
- Manual on hardware:
  - [ ] `curl -X POST http://stackchan.local/speak -d '{"phrase":"wake_chirp"}'` produces a 100 ms 1 kHz tone
  - [ ] Each phrase/locale combo plays the correct PCM (verbal en/ja)
  - [ ] Unknown phrase / locale returns 400 with a clear body
  - [ ] With `auth.token` set, a missing `Authorization` header returns 401
  - [ ] Saturate the queue with 4 Background utterances, send a Critical → oldest Background is evicted, Critical plays