### PR TITLE
feat(firmware): preserve-current sentinel for PSK + token on PUT /settings

### DIFF
--- a/crates/stackchan-firmware/src/net/dashboard.html
+++ b/crates/stackchan-firmware/src/net/dashboard.html
@@ -96,7 +96,7 @@ small { color: var(--muted); }
     <h2>Settings</h2>
     <form id="settings-form" class="grid">
       <label>SSID <input type="text" name="ssid" id="set-ssid" autocomplete="off"></label>
-      <label>PSK <input type="password" name="psk" id="set-psk" autocomplete="off" placeholder="(unchanged — supply real key to overwrite)"></label>
+      <label>PSK <input type="password" name="psk" id="set-psk" autocomplete="off" placeholder="(cleared = open AP)"></label>
       <label>Country <input type="text" name="country" id="set-country" maxlength="2"></label>
       <label>mDNS hostname <input type="text" name="hostname" id="set-hostname"></label>
       <label>SNTP servers (comma-separated) <input type="text" name="sntp" id="set-sntp"></label>
@@ -258,7 +258,7 @@ async function loadSettings() {
     $("set-country").value = c.wifi.country;
     $("set-hostname").value = c.mdns.hostname;
     $("set-sntp").value = c.time.sntp_servers.join(", ");
-    $("set-token").value = (c.auth && c.auth.token) || "";
+    $("set-token").value = c.auth.token;
     loadedTz = c.time.tz;
   } catch (e) { toast(e.message, true); }
 }

--- a/crates/stackchan-firmware/src/net/dashboard.html
+++ b/crates/stackchan-firmware/src/net/dashboard.html
@@ -100,12 +100,12 @@ small { color: var(--muted); }
       <label>Country <input type="text" name="country" id="set-country" maxlength="2"></label>
       <label>mDNS hostname <input type="text" name="hostname" id="set-hostname"></label>
       <label>SNTP servers (comma-separated) <input type="text" name="sntp" id="set-sntp"></label>
-      <label>Auth token <input type="password" name="token" id="set-token" autocomplete="off" placeholder="(empty = auth disabled — type real token to overwrite)"></label>
+      <label>Auth token <input type="password" name="token" id="set-token" autocomplete="off"></label>
       <div class="btn-row">
         <button type="submit">Save (reboot to apply)</button>
         <button type="button" id="settings-reload">Reload</button>
       </div>
-      <small>PSK and token show as <code>***</code> in GET; submit blank to clear, type the real value to overwrite. The server rejects <code>***</code> on PUT.</small>
+      <small>PSK and token show as <code>***</code> in GET and pre-fill into the form. Submit unchanged to keep the current value, clear the field to disable (open AP / auth off), or type a new value to overwrite.</small>
     </form>
   </section>
 </main>
@@ -249,15 +249,16 @@ async function loadSettings() {
     }
     const c = await res.json();
     $("set-ssid").value = c.wifi.ssid;
-    $("set-psk").value = "";
-    $("set-psk").placeholder = c.wifi.psk === "***" ? "(redacted — type real key to overwrite)" : "(empty = open AP — type real key to set)";
+    // Pre-fill the secret fields with whatever the server returned —
+    // either the `"***"` redaction sentinel (which the server now
+    // treats as "preserve current value" on PUT) or an empty string
+    // (open AP / auth disabled). The user clears to disable, types
+    // a new value to overwrite, or leaves untouched to preserve.
+    $("set-psk").value = c.wifi.psk;
     $("set-country").value = c.wifi.country;
     $("set-hostname").value = c.mdns.hostname;
     $("set-sntp").value = c.time.sntp_servers.join(", ");
-    $("set-token").value = "";
-    $("set-token").placeholder = (c.auth && c.auth.token === "***")
-      ? "(redacted — type real token to overwrite, or leave blank to disable)"
-      : "(empty = auth disabled — type a token to enable)";
+    $("set-token").value = (c.auth && c.auth.token) || "";
     loadedTz = c.time.tz;
   } catch (e) { toast(e.message, true); }
 }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -389,7 +389,7 @@ async fn handle_get_settings(socket: &mut TcpSocket<'_>) -> Result<(), HttpError
 /// re-bring-up Wi-Fi mid-flight (avoids dropping the operator's
 /// session when the SSID changes).
 async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
-    let new_config = match stackchan_net::parse_settings_json(body) {
+    let parsed_config = match stackchan_net::parse_settings_json(body) {
         Ok(c) => c,
         Err(e) => {
             defmt::warn!(
@@ -400,6 +400,17 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
             return write_text(socket, 400, &body).await;
         }
     };
+    // Substitute the `***` redaction sentinel for the persisted PSK
+    // and token so a dashboard form that submits unchanged secrets
+    // doesn't clobber them. With no current snapshot (the brief
+    // pre-storage-mount window), preserving against the default
+    // empty values is a no-op — the parsed body wins.
+    let snapshot_for_merge = crate::storage::CONFIG_SNAPSHOT
+        .lock()
+        .await
+        .clone()
+        .unwrap_or_default();
+    let new_config = stackchan_net::merge_settings_with_current(parsed_config, &snapshot_for_merge);
     let write_result =
         crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
     match write_result {

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -21,18 +21,19 @@ use alloc::vec::Vec;
 use crate::config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 use crate::error::ConfigError;
 
-/// Sentinel emitted by [`render_settings_json`] when `redact_psk = true`.
+/// Sentinel emitted by [`render_settings_json`] when `redact_secrets = true`.
 ///
-/// Rejected as a PSK value by [`parse_settings_json`] so a `GET → PUT`
-/// round trip can't accidentally persist the redacted placeholder as
-/// the real key (which would silently break Wi-Fi on next reboot).
+/// Doubles as a "preserve current value" marker on the input side:
+/// a `PUT /settings` body that echoes `"***"` back for the PSK
+/// keeps whatever's currently persisted instead of overwriting with
+/// the placeholder. Callers merge via [`merge_settings_with_current`]
+/// before writing back to disk.
 pub const PSK_REDACTED: &str = "***";
 
 /// Sentinel emitted in place of a non-empty `auth.token` on render.
 ///
-/// Keeps the secret out of `GET /settings` responses, and rejected
-/// as an input value by [`parse_settings_json`] for the same
-/// `GET → PUT` clobber reason as [`PSK_REDACTED`].
+/// Same `"preserve current value"` semantics on the input side as
+/// [`PSK_REDACTED`] — see [`merge_settings_with_current`].
 pub const TOKEN_REDACTED: &str = "***";
 
 /// Parse a schema-v1 JSON object into a [`Config`].
@@ -58,6 +59,47 @@ pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
     }
     validate(&config)?;
     Ok(config)
+}
+
+/// Substitute the redacted PSK / token sentinels in a parsed body
+/// with the values from `current`.
+///
+/// `PUT /settings` bodies may echo `"***"` back for [`PSK_REDACTED`]
+/// or [`TOKEN_REDACTED`]; this helper means "keep current value"
+/// rather than "overwrite with literal `***`."
+///
+/// Without this step, an operator who edits the hostname in the
+/// dashboard form (or via curl with the JSON returned by
+/// `GET /settings`) would unintentionally clobber the real PSK or
+/// token with the placeholder string. Anything other than the
+/// sentinel is taken at face value: an empty PSK clears the key
+/// (open-AP), an empty token disables auth, an explicit value
+/// overwrites.
+///
+/// Fields the wire format doesn't redact (`ssid`, `country`,
+/// `mdns.hostname`, `time.*`) pass through from `new` unchanged.
+#[must_use]
+pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
+    Config {
+        wifi: WifiConfig {
+            ssid: new.wifi.ssid,
+            psk: if new.wifi.psk == PSK_REDACTED {
+                current.wifi.psk.clone()
+            } else {
+                new.wifi.psk
+            },
+            country: new.wifi.country,
+        },
+        mdns: new.mdns,
+        time: new.time,
+        auth: AuthConfig {
+            token: if new.auth.token == TOKEN_REDACTED {
+                current.auth.token.clone()
+            } else {
+                new.auth.token
+            },
+        },
+    }
 }
 
 /// Render a [`Config`] to a compact JSON string.
@@ -258,12 +300,10 @@ impl<'a> Parser<'a> {
             }
         }
         let psk = psk.ok_or_else(|| bare_err("missing wifi.psk", ""))?;
-        if psk == PSK_REDACTED {
-            return Err(bare_err(
-                "wifi.psk is the redacted sentinel — supply the real key",
-                "",
-            ));
-        }
+        // Note: a literal `"***"` here is *not* an error — it's the
+        // "preserve current PSK" sentinel. The HTTP handler merges
+        // it against the current snapshot via
+        // [`merge_settings_with_current`] before writing back.
         Ok(WifiConfig {
             ssid: ssid.ok_or_else(|| bare_err("missing wifi.ssid", ""))?,
             psk,
@@ -373,12 +413,9 @@ impl<'a> Parser<'a> {
             }
         }
         let token = token.unwrap_or_default();
-        if token == TOKEN_REDACTED {
-            return Err(bare_err(
-                "auth.token is the redacted sentinel — supply the real token",
-                "",
-            ));
-        }
+        // `"***"` is the "preserve current token" sentinel; the
+        // HTTP handler merges via [`merge_settings_with_current`]
+        // before persisting.
         Ok(AuthConfig { token })
     }
 
@@ -635,27 +672,19 @@ mod tests {
     }
 
     #[test]
-    fn rejects_redacted_token_sentinel() {
-        // Same `GET → PUT` clobber pattern as PSK: a body that
-        // round-trips a real PSK but the redacted token must trip
-        // the auth.token guard. Hand-roll the JSON so we can pin the
-        // token-only redaction case — `render_settings_json(_, true)`
-        // would redact the PSK first and the parser would surface
-        // that error instead of reaching the token check.
+    fn parser_accepts_redacted_token_for_preserve_round_trip() {
+        // GET /settings emits `"token":"***"` for a configured token;
+        // a dashboard form that submits unchanged should send the same
+        // sentinel back, and the parser must accept it. Merge happens
+        // downstream via [`merge_settings_with_current`].
         let body = r#"{
             "wifi":{"ssid":"a","psk":"realkey","country":"US"},
             "mdns":{"hostname":"x"},
             "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
             "auth":{"token":"***"}
         }"#;
-        let err = parse_settings_json(body).unwrap_err();
-        match err {
-            ConfigError::BareParse(msg) => assert!(
-                msg.contains("auth.token") && msg.contains("redacted"),
-                "expected token-sentinel message, got `{msg}`"
-            ),
-            other => panic!("expected BareParse, got {other:?}"),
-        }
+        let parsed = parse_settings_json(body).unwrap();
+        assert_eq!(parsed.auth.token, TOKEN_REDACTED);
     }
 
     #[test]
@@ -670,20 +699,88 @@ mod tests {
     }
 
     #[test]
-    fn rejects_redacted_psk_sentinel() {
-        // GET /settings emits "psk":"***"; if an operator round-trips
-        // that through PUT /settings unchanged, the firmware would
-        // persist "***" as the real key and break Wi-Fi at next
-        // boot. parse_settings_json must catch it.
+    fn parser_accepts_redacted_psk_for_preserve_round_trip() {
+        // The redacted body emitted by `GET /settings` round-trips
+        // through the parser; the literal sentinel value flows
+        // through to the downstream merge step rather than tripping
+        // a 400.
         let body = render_settings_json(&full_config(), true).unwrap();
-        let err = parse_settings_json(&body).unwrap_err();
-        match err {
-            ConfigError::BareParse(msg) => assert!(
-                msg.contains("redacted"),
-                "expected redacted-sentinel message, got `{msg}`"
-            ),
-            other => panic!("expected BareParse, got {other:?}"),
-        }
+        let parsed = parse_settings_json(&body).unwrap();
+        assert_eq!(parsed.wifi.psk, PSK_REDACTED);
+        assert_eq!(parsed.auth.token, TOKEN_REDACTED);
+    }
+
+    #[test]
+    fn merge_substitutes_redacted_psk_with_current() {
+        let current = full_config(); // psk = "secret", token = "shared-secret"
+        let new = Config {
+            wifi: WifiConfig {
+                ssid: "newssid".to_string(),
+                psk: PSK_REDACTED.to_string(),
+                country: "JP".to_string(),
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert_eq!(merged.wifi.psk, "secret", "psk preserved from current");
+        assert_eq!(
+            merged.wifi.ssid, "newssid",
+            "non-secret fields pass through"
+        );
+        assert_eq!(merged.wifi.country, "JP");
+    }
+
+    #[test]
+    fn merge_substitutes_redacted_token_with_current() {
+        let current = full_config(); // token = "shared-secret"
+        let new = Config {
+            auth: AuthConfig {
+                token: TOKEN_REDACTED.to_string(),
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert_eq!(merged.auth.token, "shared-secret");
+    }
+
+    #[test]
+    fn merge_overwrites_explicit_value() {
+        let current = full_config();
+        let new = Config {
+            wifi: WifiConfig {
+                ssid: current.wifi.ssid.clone(),
+                psk: "new-psk".to_string(),
+                country: current.wifi.country.clone(),
+            },
+            auth: AuthConfig {
+                token: "new-token".to_string(),
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert_eq!(merged.wifi.psk, "new-psk");
+        assert_eq!(merged.auth.token, "new-token");
+    }
+
+    #[test]
+    fn merge_clears_to_empty_when_explicitly_empty() {
+        // An empty-string PSK or token isn't the redaction sentinel;
+        // it's a meaningful value (open AP / auth disabled) and must
+        // pass through.
+        let current = full_config();
+        let new = Config {
+            wifi: WifiConfig {
+                psk: String::new(),
+                ..current.wifi.clone()
+            },
+            auth: AuthConfig {
+                token: String::new(),
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert!(merged.wifi.psk.is_empty(), "empty PSK clears to empty");
+        assert!(merged.auth.token.is_empty(), "empty token disables auth");
     }
 
     #[test]

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -55,7 +55,7 @@ pub mod error;
 pub mod http_parse;
 
 pub use bare::{parse_ron_bare, render_ron_bare};
-pub use bare_json::{parse_settings_json, render_settings_json};
+pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
 pub use config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};

--- a/docs/http.md
+++ b/docs/http.md
@@ -170,11 +170,13 @@ $ curl http://stackchan.local/settings
  "auth":{"token":"***"}}
 ```
 
-`wifi.psk` and a non-empty `auth.token` are redacted to `***`. The
-server rejects PUT bodies that contain `***` for either field so a
-copy-paste round trip can't silently overwrite the real value with
-the redaction sentinel. An empty `auth.token` (= auth disabled)
-renders as `""` and round-trips losslessly.
+`wifi.psk` and a non-empty `auth.token` are redacted to `***`.
+On `PUT /settings`, the server treats either sentinel as **"keep
+current value"** rather than overwriting with the literal
+placeholder — so a `GET → mutate hostname → PUT` round trip
+preserves the secrets. An empty `""` value still means "clear"
+(open AP / auth disabled); only the literal `"***"` triggers the
+preserve substitution.
 
 ### `PUT /settings`
 
@@ -189,8 +191,14 @@ $ curl -X PUT http://stackchan.local/settings \
 {"reboot_required":true}
 ```
 
-Drop the `Authorization` header (and replace `auth.token` with `""`)
-to disable auth on a device that previously had it enabled.
+To disable auth on a device that previously had it enabled, send
+`auth.token = ""` (the explicit empty string, not the `***`
+sentinel) and drop the `Authorization` header on the PUT itself.
+
+Operators using curl who only want to update one field can echo
+the rest of the body back from `GET /settings` unchanged — the
+`***` sentinels for `wifi.psk` and `auth.token` will be merged
+against the persisted values rather than clobbering them.
 
 Full-replace. The server validates the body via
 `stackchan_net::validate` (rejects empty SSID, invalid country code,
@@ -208,7 +216,7 @@ the operator's HTTP session if the SSID changed. Reboot to apply.
 |------|---------------------------------------------------------------------|
 | 200  | GET responses, dashboard, successful PUT                            |
 | 204  | POST `/emotion` / `/look-at` / `/reset` on success                  |
-| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion / phrase / locale, redacted PSK or token sentinel, validation failure on PUT `/settings` |
+| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion / phrase / locale, validation failure on PUT `/settings` |
 | 401  | Write route called without a valid bearer token (when auth is enabled) |
 | 404  | Path not in the matcher                                             |
 | 405  | Method not allowed                                                  |


### PR DESCRIPTION
## Summary

Closes the dashboard data-loss UX flagged as future work in [#160](https://github.com/andymai/stackchan-kai/pull/160). Today, an operator who edits the hostname in the dashboard form (or curls a JSON body assembled from `GET /settings`) silently disables auth or wipes the Wi-Fi PSK because empty form fields sent `""` over the wire. This PR repurposes the existing `***` redaction sentinel from "rejected on PUT" to **"keep current value"**.

## Semantics

| `wifi.psk` / `auth.token` value on PUT | Result |
|---|---|
| `"***"` (the redaction sentinel) | Preserve the currently-persisted value |
| `""` (explicit empty string) | Clear (open AP / auth disabled) |
| `"x"` (any other string) | Overwrite with the new value |

Other fields (`ssid`, `country`, `mdns.hostname`, `time.*`) pass through unchanged from the parsed body. Migration: SD cards / clients that don't include the new fields keep working — the parser still defaults missing fields to safe values.

## Three pieces

1. **`stackchan_net::merge_settings_with_current`** — pure helper that swaps sentinels for current values. Host-tested (5 new cases). The parser no longer rejects the sentinel — the rejection-test suite is replaced with positive round-trip coverage.
2. **Firmware `handle_put_settings`** — calls `merge_settings_with_current` between `parse_settings_json` and SD writeback, against a clone of `CONFIG_SNAPSHOT`. Pre-mount window falls back to `Config::default()` (preserving against empty is a no-op).
3. **Dashboard** — pre-fills the PSK and token inputs with whatever `GET /settings` returned (the `***` sentinel for configured secrets, or empty for open AP / disabled auth). User clears to disable, types to overwrite, leaves untouched to preserve.

## Test plan

- [x] `cargo test -p stackchan-net` — 5 new merge tests, refactored sentinel-handling tests pass
- [x] `just check` — host gate
- [x] `just clippy-firmware`
- [x] `just build-firmware`
- Manual on hardware:
  - [ ] `curl http://stackchan.local/settings` returns body with `"psk":"***"` and `"auth":{"token":"***"}` when both are configured
  - [ ] `curl -X PUT ... -d '{<body with hostname change, secrets unchanged as ***>}'` — hostname changes, PSK + token preserved, reboot keeps Wi-Fi up and auth gating in place
  - [ ] `curl -X PUT ... -d '{<body with auth.token=""">}'` — disables auth on next boot
  - [ ] Dashboard: edit hostname, save, reboot — Wi-Fi still works, auth still required