### PR TITLE
refactor: lift HTTP body parsers to stackchan-net::http_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,6 +4452,7 @@ version = "0.2.0"
 dependencies = [
  "ron",
  "serde",
+ "stackchan-core",
  "thiserror 2.0.18",
 ]
 

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -16,7 +16,7 @@
 //! - `POST /emotion` — JSON `{"emotion": "...", "hold_ms": ...}`.
 //!   Sets affect + holds `mind.autonomy` against the autonomous
 //!   emotion drivers for `hold_ms` (default
-//!   [`super::json::DEFAULT_HOLD_MS`]).
+//!   [`stackchan_net::http_command::DEFAULT_HOLD_MS`]).
 //! - `POST /look-at` — JSON `{"pan_deg": f32, "tilt_deg": f32, "hold_ms": ...}`.
 //!   Sets `mind.attention = Tracking { target }` for `hold_ms`,
 //!   asserting the operator's target against camera tracking.
@@ -65,11 +65,11 @@ use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
 use stackchan_core::{Emotion, RemoteCommand};
+use stackchan_net::http_command::{self as json, JsonError};
 use stackchan_net::http_parse::{
     ct_eq, find_subsequence, parse_bearer_token, parse_content_length,
 };
 
-use super::json::{self, JsonError};
 use super::snapshot::{self, AvatarSnapshot};
 use super::wifi::LINK_READY;
 
@@ -449,7 +449,7 @@ async fn handle_remote(
             write_no_content(socket).await
         }
         Err(e) => {
-            defmt::warn!("http: bad request body ({})", e);
+            defmt::warn!("http: bad request body ({})", defmt::Debug2Format(&e));
             let body = format!("invalid request body: {e:?}\n");
             write_text(socket, 400, &body).await
         }
@@ -522,7 +522,8 @@ fn state_body(s: AvatarSnapshot) -> String {
 }
 
 /// Render an [`Emotion`] as its lowercase wire name. The vocabulary
-/// is mirrored by [`super::json::parse_emotion`] — so a consumer can
+/// is mirrored by [`stackchan_net::http_command`]'s emotion parser —
+/// so a consumer can
 /// take an emotion from `GET /state` and `POST /emotion` it back
 /// without any case translation. Pinning the mapping here also
 /// guards against a future non-unit `Emotion` variant whose `Debug`
@@ -691,7 +692,7 @@ mod tests {
         ] {
             let wire = emotion_str(variant);
             let body = alloc::format!(r#"{{"emotion":"{wire}"}}"#);
-            match super::json::parse_set_emotion(&body).unwrap() {
+            match stackchan_net::http_command::parse_set_emotion(&body).unwrap() {
                 RemoteCommand::SetEmotion { emotion, .. } => assert_eq!(emotion, variant),
                 other => panic!("expected SetEmotion for `{wire}`, got {other:?}"),
             }

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -7,7 +7,6 @@
 //! unreachable.
 
 pub mod http;
-pub mod json;
 pub mod mdns;
 pub mod snapshot;
 pub mod sntp;

--- a/crates/stackchan-net/Cargo.toml
+++ b/crates/stackchan-net/Cargo.toml
@@ -22,6 +22,11 @@ default = ["parse"]
 parse = ["dep:serde", "dep:ron"]
 
 [dependencies]
+# Domain types for the HTTP control plane (`Emotion`, `Pose`,
+# `Locale`, `PhraseId`, `Priority`, `RemoteCommand`). Pulled
+# unconditionally — the JSON body parsers in `http_command` map
+# directly onto these types.
+stackchan-core = { path = "../stackchan-core" }
 # `no_std` serde with derive macros. Optional; only pulled when the
 # `parse` feature is active. Firmware target avoids it because of the
 # transitive `serde/std` requirement upstream of ron.

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -143,7 +143,7 @@ pub fn parse_look_at(body: &str) -> Result<RemoteCommand, JsonError> {
 /// Priority is not on the wire — the firmware fills
 /// [`Priority::Normal`] for every operator-driven request. Modifier-
 /// internal call sites that need elevated priority go through
-/// [`crate::audio::try_dispatch_utterance`] directly.
+/// the firmware's `audio::try_dispatch_utterance` directly.
 ///
 /// # Errors
 ///
@@ -250,13 +250,22 @@ impl<'a> Scanner<'a> {
     }
 
     /// Read a contiguous run of number-shaped bytes (`-`, digits,
-    /// `.`, `e`, `E`, `+`). The slice is parsed by the typed
-    /// `parse_*` helpers via [`core::str::FromStr`].
+    /// `.`, `e`, `E`). The slice is parsed by the typed `parse_*`
+    /// helpers via [`core::str::FromStr`].
+    ///
+    /// Rejects a leading `+`. `f32::from_str` would accept it but
+    /// RFC 8259 §6 (the JSON number production) doesn't allow one
+    /// — `u32::from_str` already rejects it, so without this gate
+    /// the wire surface would be inconsistent across the integer
+    /// and float fields.
     fn read_number(&mut self) -> Result<&'a str, JsonError> {
         self.skip_ws();
+        if self.peek() == Some(b'+') {
+            return Err(JsonError::BadValue);
+        }
         let start = self.pos;
         while let Some(b) = self.peek() {
-            let is_num = matches!(b, b'-' | b'+' | b'.' | b'0'..=b'9' | b'e' | b'E');
+            let is_num = matches!(b, b'-' | b'.' | b'0'..=b'9' | b'e' | b'E');
             if !is_num {
                 break;
             }
@@ -501,6 +510,17 @@ mod tests {
             parse_look_at(body),
             Err(JsonError::DuplicateKey("pan_deg"))
         ));
+    }
+
+    #[test]
+    fn look_at_rejects_leading_plus_on_floats() {
+        // RFC 8259 §6: JSON numbers don't allow a leading `+`.
+        // `f32::from_str` accepts `"+3.5"` whereas `u32::from_str`
+        // rejects `"+5"`, so the parser tightens the gate to keep
+        // the wire surface consistent across integer and float
+        // fields.
+        let body = r#"{"pan_deg":+3.5,"tilt_deg":0.0}"#;
+        assert!(matches!(parse_look_at(body), Err(JsonError::BadValue)));
     }
 
     #[test]

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -1,5 +1,9 @@
-//! Hand-rolled JSON-ish parser for the HTTP control plane's POST
-//! bodies.
+//! Hand-rolled JSON-ish parser for the HTTP control plane's POST bodies.
+//!
+//! Lives in `stackchan-net` (not `stackchan-firmware`) so the parser
+//! tests run on host — the firmware crate is
+//! `xtensa-esp32s3-none-elf`-only and its `cfg(test)` modules are
+//! never executed by `just check`.
 //!
 //! The HTTP server only accepts a handful of body shapes:
 //!
@@ -22,8 +26,9 @@ use stackchan_core::{Emotion, Pose, RemoteCommand};
 pub const DEFAULT_HOLD_MS: u32 = 30_000;
 
 /// Parser error surface — kept small; routes turn these into
-/// `400 Bad Request` plain-text responses.
-#[derive(Debug, defmt::Format)]
+/// `400 Bad Request` plain-text responses. The firmware logs these
+/// via `defmt::Debug2Format` so this crate doesn't pull `defmt`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JsonError {
     /// Body did not start with `{` after optional whitespace.
     NotAnObject,

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -52,6 +52,7 @@ pub mod bare;
 pub mod bare_json;
 pub mod config;
 pub mod error;
+pub mod http_command;
 pub mod http_parse;
 
 pub use bare::{parse_ron_bare, render_ron_bare};


### PR DESCRIPTION
## Summary

Closes the orphan-test gap on the largest remaining target: the 21 `cfg(test)` cases in `firmware/net/json.rs` that covered the `POST /emotion` / `/look-at` / `/speak` parsers but never ran (firmware crate is `xtensa-esp32s3-none-elf`-only, excluded from `just check`).

Move the entire parser surface — `JsonError`, the `Scanner`, `visit_object`, per-route parsers, and the closed-vocabulary lookups for `Emotion`, `PhraseId`, `Locale` — into a new `stackchan-net::http_command` module. Tests now run on host in CI.

## Why now

Three PRs in this session piled new orphaned tests onto the firmware crate (#159 audit, #160 auth, #163 speak). [#162 lifted the byte helpers](https://github.com/andymai/stackchan-kai/pull/162) and surfaced an actual bug (the orphaned test asserted `Content-Length: +5` was rejected when the parser accepted it). This PR closes the rest of the json-side gap.

## Dependency direction

`stackchan-net` now declares a path dependency on `stackchan-core`. That's a clean direction — `stackchan-core` doesn't depend on `stackchan-net`, so no cycle. The parsers map JSON onto domain types that `stackchan-core` already owns; this is where they should live.

## defmt removed from JsonError

`JsonError` dropped its `defmt::Format` derive — pulling `defmt` into `stackchan-net` for one log line isn't worth it. The single firmware log site (`handle_remote`'s 400 branch) wraps with `defmt::Debug2Format`, matching the pattern already used for `ConfigError`.

## Remaining orphans

After this PR, 6 firmware `cfg(test)` cases remain:

- 1 in `net/http.rs` — the `emotion_str` round-trip, trapped on `parse_emotion` having moved out (still trivially correct, low value to lift further)
- 3 in `net/sntp.rs` — SNTP packet helpers, would need their own lift
- 2 in `net/mdns.rs` — same shape

Those are smaller targets and not in scope here.

## Test plan

- [x] `cargo test -p stackchan-net` — 21 newly-exercised tests pass on host
- [x] `just check` — host gate
- [x] `just clippy-firmware`
- [x] `just build-firmware`
- Equivalent runtime behaviour (no functional change to wire protocol)