### PR TITLE
refactor: lift Emotion::wire_str to stackchan-core

### DIFF
--- a/crates/stackchan-core/src/emotion.rs
+++ b/crates/stackchan-core/src/emotion.rs
@@ -21,3 +21,33 @@ pub enum Emotion {
     /// of the autonomous `EmotionCycle` or touch-cycle order.
     Angry,
 }
+
+impl Emotion {
+    /// Lowercase wire name for the HTTP control plane.
+    ///
+    /// Mirrors the vocabulary that `stackchan_net::http_command`'s
+    /// emotion parser accepts on `POST /emotion`, so a consumer can
+    /// take an emotion off `GET /state` and post it back without any
+    /// case translation. Pinning the mapping here also guards
+    /// against a future non-unit `Emotion` variant whose `Debug`
+    /// representation would otherwise inject `{` into the JSON
+    /// string when the firmware renders the snapshot.
+    ///
+    /// The match is intentionally exhaustive without a wildcard:
+    /// `Emotion` is `#[non_exhaustive]` to downstream crates, but
+    /// here in `stackchan-core` the compiler can prove every variant
+    /// is covered. Adding a new variant forces this match to be
+    /// updated, which is what we want — silent fallback to
+    /// `"unknown"` would leak past the dashboard's redaction.
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Neutral => "neutral",
+            Self::Happy => "happy",
+            Self::Sad => "sad",
+            Self::Sleepy => "sleepy",
+            Self::Surprised => "surprised",
+            Self::Angry => "angry",
+        }
+    }
+}

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -64,7 +64,7 @@ use embassy_sync::pubsub::WaitResult;
 use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
-use stackchan_core::{Emotion, RemoteCommand};
+use stackchan_core::RemoteCommand;
 use stackchan_net::http_command::{self as json, JsonError};
 use stackchan_net::http_parse::{
     ct_eq, find_subsequence, parse_bearer_token, parse_content_length,
@@ -514,34 +514,11 @@ fn state_body(s: AvatarSnapshot) -> String {
 \"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\
 \"wifi\":{{\"connected\":{connected},\"ip\":{ip}}}\
 }}\n",
-        emotion = emotion_str(s.emotion),
+        emotion = s.emotion.wire_str(),
         pan = s.head_pose.pan_deg,
         tilt = s.head_pose.tilt_deg,
         connected = s.wifi.connected,
     )
-}
-
-/// Render an [`Emotion`] as its lowercase wire name. The vocabulary
-/// is mirrored by [`stackchan_net::http_command`]'s emotion parser —
-/// so a consumer can
-/// take an emotion from `GET /state` and `POST /emotion` it back
-/// without any case translation. Pinning the mapping here also
-/// guards against a future non-unit `Emotion` variant whose `Debug`
-/// representation would otherwise inject `{` into the JSON string.
-///
-/// `Emotion` is `#[non_exhaustive]`; the wildcard returns `"unknown"`
-/// so a newly added variant surfaces on the dashboard as a missing
-/// mapping rather than silently aliasing to neutral.
-const fn emotion_str(e: Emotion) -> &'static str {
-    match e {
-        Emotion::Neutral => "neutral",
-        Emotion::Happy => "happy",
-        Emotion::Sad => "sad",
-        Emotion::Sleepy => "sleepy",
-        Emotion::Surprised => "surprised",
-        Emotion::Angry => "angry",
-        _ => "unknown",
-    }
 }
 
 /// Write `status` + `body` as `application/json`.
@@ -663,39 +640,4 @@ async fn write_unauthorized(socket: &mut TcpSocket<'_>) -> Result<(), HttpError>
         .await
         .map_err(|_| HttpError::Write)?;
     socket.flush().await.map_err(|_| HttpError::Write)
-}
-
-#[cfg(test)]
-#[allow(
-    clippy::panic,
-    clippy::unwrap_used,
-    reason = "test-only: panic-on-mismatch for variant extraction"
-)]
-mod tests {
-    use super::*;
-    use stackchan_core::RemoteCommand;
-
-    /// Every `Emotion` variant must round-trip through `emotion_str`
-    /// and `parse_set_emotion` so a `GET /state` consumer can post
-    /// the value back without case translation, and so a future
-    /// non-unit `Emotion` variant can't silently inject `{` into the
-    /// JSON output.
-    #[test]
-    fn emotion_str_round_trips_through_parser() {
-        for variant in [
-            Emotion::Neutral,
-            Emotion::Happy,
-            Emotion::Sad,
-            Emotion::Sleepy,
-            Emotion::Surprised,
-            Emotion::Angry,
-        ] {
-            let wire = emotion_str(variant);
-            let body = alloc::format!(r#"{{"emotion":"{wire}"}}"#);
-            match stackchan_net::http_command::parse_set_emotion(&body).unwrap() {
-                RemoteCommand::SetEmotion { emotion, .. } => assert_eq!(emotion, variant),
-                other => panic!("expected SetEmotion for `{wire}`, got {other:?}"),
-            }
-        }
-    }
 }

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -513,6 +513,30 @@ mod tests {
     }
 
     #[test]
+    fn emotion_wire_str_round_trips_through_parser() {
+        // Every `Emotion` variant must round-trip through
+        // `Emotion::wire_str` and `parse_set_emotion` — a `GET /state`
+        // consumer should be able to post the emotion value back
+        // without case translation. A failure here would also surface
+        // an enum/parser mismatch from a newly added variant.
+        for variant in [
+            Emotion::Neutral,
+            Emotion::Happy,
+            Emotion::Sad,
+            Emotion::Sleepy,
+            Emotion::Surprised,
+            Emotion::Angry,
+        ] {
+            let wire = variant.wire_str();
+            let body = alloc::format!(r#"{{"emotion":"{wire}"}}"#);
+            match parse_set_emotion(&body).unwrap() {
+                RemoteCommand::SetEmotion { emotion, .. } => assert_eq!(emotion, variant),
+                other => panic!("expected SetEmotion for `{wire}`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn look_at_rejects_leading_plus_on_floats() {
         // RFC 8259 §6: JSON numbers don't allow a leading `+`.
         // `f32::from_str` accepts `"+3.5"` whereas `u32::from_str`


### PR DESCRIPTION
## Summary

The firmware's `emotion_str` const fn was the last orphan test trapped in `firmware/net/http.rs` — host-testing the round trip required both `emotion_str` (firmware) and `parse_emotion` (stackchan-net) to live in a host-runnable place.

Move `emotion_str` to `stackchan-core::emotion` as `Emotion::wire_str()`, where it sits next to the type it maps. Relocate the round-trip test to `stackchan-net::http_command` alongside the other parser cases that already cover the same vocabulary.

## Wildcard removed

The match in `wire_str` no longer carries a `_ => "unknown"` arm. `Emotion` is `#[non_exhaustive]` to downstream crates, but the compiler can prove inner-crate exhaustiveness, so a future variant forces this site to be updated rather than silently aliasing to `"unknown"`. Better to break the build than leak a missing variant past the dashboard's redaction.

## Counts

Firmware orphan-test count: 7 → 6.

Remaining orphans:

- 3 in `net/sntp.rs` — would need `bm8563::DateTime` to migrate
- 2 in `net/mdns.rs` — would need `embassy_net::Ipv4Address` swapped for `core::net::Ipv4Addr`

Both are smaller targets and not in scope here.

## Test plan

- [x] `cargo test -p stackchan-net` — `emotion_wire_str_round_trips_through_parser` passes on host
- [x] `cargo test -p stackchan-core` — match exhaustiveness verified at compile time
- [x] `just check`
- [x] `just clippy-firmware`
- [x] `just build-firmware`
- No runtime change: `state_body` still calls into the same const lookup, just via `s.emotion.wire_str()` now