### PR TITLE
docs: post-network-arc reality reset across README + agent docs + handbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ human+agent guide; this file is agent-specific.
 ## At a glance
 
 - **Stack:** `no_std` + `alloc` Rust on ESP32-S3 (CoreS3), embassy executor, defmt logging over USB-Serial-JTAG.
-- **Domain model:** `Avatar` + `Modifier` trait in `stackchan-core` (pure, host-testable). Firmware composes a fixed modifier stack at 30 FPS in `render_task`.
+- **Domain model:** `Entity` + `Director` + `Modifier` / `Skill` traits in `stackchan-core` (pure, host-testable). Firmware composes a fixed modifier stack at 30 FPS in `render_task`.
 - **Cross-task communication:** typed `Signal<RawMutex, T>` channels. Sensors publish via `signal()`; consumers drain via `try_take()`. Latest-wins semantics throughout.
 - **Tests:** `stackchan-sim` runs modifiers against `FakeClock` for deterministic golden assertions. Firmware-side tests use on-device benches (`examples/*_bench.rs`).
 
@@ -47,27 +47,35 @@ translate that into face / motor.
 ### Shape 3: firmware integration
 1. Identify the `Signal<…, T>` channel(s) the new feature needs.
 2. Producer goes in a per-peripheral task (`src/<chip>.rs`); consumer reads in `render_task`.
-3. Update `Avatar` if the feature surfaces persistent state; remember to extend `frame_eq` only if it's pixel-affecting.
+3. Update `Entity` (or a sub-component like `Face` / `Motor` / `Perception`) if the feature surfaces persistent state; remember to extend `Face::frame_eq` only if it's pixel-affecting.
 4. `cargo +esp clippy --release -- -D warnings` from the firmware crate.
 5. Hardware-verify boot and runtime via `just fmr`.
 
 ### Shape 4: docs / tooling
-1. CLAUDE.md is shared (humans + agents). AGENTS.md is agent-only. `docs/` is for cross-cutting reference (e.g., `docs/errors.md`).
+1. CLAUDE.md is shared (humans + agents). AGENTS.md is agent-only. `docs/` is for cross-cutting reference (e.g., `docs/errors.md`, `docs/http.md`).
 2. Per-crate READMEs document API + gotchas — the pre-commit hook reminds you to review them when source changes.
 3. justfile recipes are the project's idiomatic invocation surface — prefer adding a recipe to documenting a long invocation in prose.
+
+### Shape 5: HTTP route or network feature
+1. Wire format: parsers + validators in `crates/stackchan-net/src/{config,http_command,http_parse,bare_json}.rs`. Host-testable; unit tests live beside the parser.
+2. Handler: `crates/stackchan-firmware/src/net/http.rs` matches requests by `(method, path)`; each route is a handler function.
+3. Persisted state rides the RON schema (`stackchan_net::config::Config`) through `PUT /settings`'s atomic writeback — no parallel persistence paths.
+4. Operator-driven routes update the dashboard at `crates/stackchan-firmware/src/net/dashboard.html` (embedded via `include_bytes!`).
+5. `just check-firmware && just clippy-firmware && just build-firmware`, then curl smoke after flashing.
+6. Document the route in `docs/http.md` (the canonical reference).
 
 ## Decision frameworks
 
 - **Ask vs assume:** ask when the change spans multiple PRs, when a public API surface changes, or when a doc rewrite is implied. Otherwise assume and proceed; the user can course-correct.
-- **One PR per feature:** the recent v1.0 polish bundle (#77–#80) shows the cadence. Greptile reviews are tighter on small PRs.
+- **One PR per feature:** the recent network arc (#134–#168) shows the cadence — a large new surface broken into thematically tight PRs, capped with a self-audit (#159) and a string of refactor lifts that pull duplicated firmware helpers up into `stackchan-net`. Greptile reviews are tighter on small PRs.
 - **Hardware verification:** required for any firmware-touching PR. Skip only for pure host-side changes (sim tests, doc updates, host crate refactors).
 - **Memory writes:** save hardware quirks, gotchas, and corrections — but never current task state. Use the `feedback` type for behavioral preferences and `project` for unit-specific or repo-specific facts.
 
 ## Patterns + idioms
 
-- **Signal drain pattern:** `if let Some(x) = SOME_SIGNAL.try_take() { avatar.x = Some(x); }` — non-blocking, drops misses (the producer's next signal overwrites), runs once per render tick.
-- **`frame_eq` gate:** the render task short-circuits LCD blits when no pixel-affecting field changed. New `Avatar` fields default to *excluded* from `frame_eq` unless they affect drawing.
-- **Per-modifier state:** modifiers own their state (timers, RNG, pending transitions). `update(&mut self, &mut Avatar, now)` is the only mutation surface.
+- **Signal drain pattern:** `if let Some(x) = SOME_SIGNAL.try_take() { entity.perception.x = Some(x); }` — non-blocking, drops misses (the producer's next signal overwrites), runs once per render tick. SSE fan-out is the exception: it uses `embassy_sync::pubsub::PubSubChannel` because it has multiple consumers.
+- **`frame_eq` gate:** the render task short-circuits LCD blits when no pixel-affecting field changed. New `Face` fields default to *excluded* from `frame_eq` unless they affect drawing.
+- **Per-modifier state:** modifiers own their state (timers, RNG, pending transitions). `update(&mut self, &mut Entity)` is the only mutation surface; time flows in via `entity.tick.now`.
 - **Errors:** typed across the workspace via `thiserror` (host) or `defmt::Format` derives (firmware). See `docs/errors.md`.
 
 ## Debugging recipes
@@ -118,6 +126,7 @@ Highlights to know at session start:
 
 - USB-Serial-JTAG wedges on rapid back-to-back `espflash` invocations — prefer `just fmr`, use `just reattach` to pick up without reset.
 - ES7210 has no documented chip-ID register and needs MCLK to answer I²C. AW88298 uses 16-bit big-endian registers.
+- HTTP control plane lives in `crates/stackchan-firmware/src/net/`; wire formats + RON config schema are in `stackchan-net`. Auth is bearer-token, LAN-only by design — no TLS / CSRF / rate limit in v0.x (see `docs/http.md` security section). The firmware boots offline if the SD card is absent.
 - The user opts out of proactive `/schedule` offers — don't end replies with "want me to schedule a follow-up?" pitches.
 - Forward-looking PRDs and v2.x vision content go to the user's Obsidian vault, not the public repo. Repo docs stay tactical and present-tense.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@
 
 ## Project Structure
 
-Cargo workspace with 19 crates, grouped by purpose:
+Cargo workspace, organized by purpose:
 
 **Domain + sim (host)**
-- `crates/stackchan-core` — `no_std` domain library: `Avatar`, `Eye`, `Mouth`, `Modifier` trait, `Clock` trait, `Emotion`, `Pose`. Pure Rust, no hardware deps.
+- `crates/stackchan-core` — `no_std` domain library: `Entity`, `Director`, `Modifier` + `Skill` traits, `Clock`, `Emotion`, `Intent`, `Phase`. Pure Rust, no hardware deps.
 - `crates/stackchan-sim` — Headless integration tests that drive `stackchan-core` with a fake clock.
 - `crates/tracker` — Block-grid motion tracker for the camera path. Pure algorithm; host-testable.
 
@@ -28,6 +28,10 @@ Cargo workspace with 19 crates, grouped by purpose:
 - `crates/py32` — PY32 co-processor (servo-power gate, WS2812 LED ring).
 - `crates/scservo` — Feetech SCServo half-duplex serial driver (UART1).
 - `crates/si12t` — `Si12T` 3-zone capacitive touch (back-of-head body pads), I²C, polled at 50 ms.
+
+**Networking + voice** (`no_std`)
+- `crates/stackchan-net` — Shared wire formats: RON config schema for `STACKCHAN.RON`, HTTP request/body parsers, validators. Used by both the firmware HTTP plane and SD config bring-up.
+- `crates/stackchan-tts` — Speech surface: `SpeechBackend` trait + a `BakedBackend` of compile-time PCM phrases. `no_std` + `alloc`.
 
 **Firmware**
 - `crates/stackchan-firmware` — Binary crate. `no_std` + `alloc`. Embassy executor on CoreS3.
@@ -82,9 +86,9 @@ Conventional-commit check at `.githooks/commit-msg`.
 
 ## Architecture
 
-- `stackchan-core` models the avatar as data: `Avatar { left_eye, right_eye, mouth, emotion, … }` plus a `Modifier` trait with `update(&mut Avatar, now: Instant)`. Time comes from the `Clock` trait so core is deterministic and host-testable.
-- `stackchan-sim` constructs an `Avatar` + `FakeClock` and runs `Modifier`s through hand-crafted time sequences. Golden assertions on `Eye::weight`, `Mouth::rotation`, etc.
-- `stackchan-firmware` initializes AXP2101 → AW9523 (releases LCD reset + enables backlight-boost) → SPI LCD via `mipidsi` → SCServo head driver on UART1 → spawns embassy tasks for: render (~30 FPS), head (~50 Hz), touch, IR, IMU, ambient, button, LEDs, power, audio (RX RMS + TX queue), camera. Cross-task communication runs through typed `Signal<RawMutex, T>` channels — `try_take` for sensor input (latest-wins), `signal()` for output sinks.
+- `stackchan-core` models the desk toy as data: an `Entity { face, motor, perception, voice, mind, events, input, tick }` plus a `Director` that sorts `Modifier`s by phase + priority and ticks them each frame against the entity. Time flows in via `entity.tick.now`, stamped from the `Clock` trait so core is deterministic and host-testable.
+- `stackchan-sim` constructs an `Entity` + `FakeClock` and runs the same `Director` through hand-crafted time sequences. Golden assertions on `Eye::weight`, `Mouth::mouth_open`, etc.
+- `stackchan-firmware` initializes AXP2101 → AW9523 (releases LCD reset + enables backlight-boost) → SPI LCD via `mipidsi` → SCServo head driver on UART1 → spawns embassy tasks for: render (~30 FPS), head (~50 Hz), touch, IR, IMU, ambient, button, LEDs, power, audio (RX RMS + TX queue), camera, plus optional Wi-Fi + HTTP control plane when `STACKCHAN.RON` is on the SD card. Cross-task communication runs through typed `Signal<RawMutex, T>` channels — `try_take` for sensor input (latest-wins), `signal()` for output sinks. SSE fan-out uses `embassy_sync::pubsub::PubSubChannel` instead of `Signal` to support multiple subscribers.
 
 ## Conventions
 
@@ -96,10 +100,7 @@ Conventional-commit check at `.githooks/commit-msg`.
 
 **Parallel work:** `git worktree add .worktrees/<dirname> <branch>` — `.worktrees/` is gitignored. Always run `gh pr merge` from the main repo path, not from inside a worktree (the `--delete-branch` flag pulls cwd out from under bash).
 
-**Type naming** — domain-first, no redundant suffixes:
-- `Avatar`, `Eye`, `Mouth`, `Emotion` (not `AvatarData`, `EyeState`)
-- `EyePhase::{Open, Closed}` (not `EyeState`); fields use `.phase`
-- `Modifier`, `BlinkModifier`, `BreathModifier` (not `IModifier`, `ModifierImpl`)
+**Type naming** — domain-first, no redundant suffixes. See [docs/naming.md](docs/naming.md) for the full ruleset (Intent / Modifier / Skill / ChirpKind / OverrideSource) with citations and inventory.
 
 **Unsafe code:** denied at the workspace level. The firmware crate explicitly allows unsafe for linker-defined symbols and register-map pointers, gated behind per-module `#![allow(unsafe_code)]` with a comment explaining why.
 
@@ -117,4 +118,6 @@ Conventional-commit check at `.githooks/commit-msg`.
 
 ## Config + assets
 
-None yet. Avatar geometry is hardcoded in `stackchan-core::avatar`. Later releases may add RON-configurable appearance.
+Boot-time network + auth config lives at `/sd/STACKCHAN.RON` — schema in [`stackchan-net::config`](crates/stackchan-net/src/config.rs), atomic writeback via `PUT /settings`. The firmware boots offline if the SD card is absent.
+
+Face geometry is hardcoded in `stackchan-core::face`. Later releases may add RON-configurable appearance.

--- a/README.md
+++ b/README.md
@@ -70,20 +70,35 @@ for the details.
 
 ## Features
 
-- **Animated face** — five emotions, 300 ms eased transitions, blink / breath / idle-drift at double-buffered 30 FPS
+- **Animated face** — eased transitions across the m5stack-avatar emotion palette, blink / breath / idle-drift at double-buffered 30 FPS
 - **Head motion** — Feetech SCServo pan/tilt with a calibration bench (`just bench`)
 - **9-axis sensing** — BMI270 accel + gyro, BMM150 magnetometer (compensated µT, live bench via `just mag-bench`)
-- **Local inputs** — FT6336U touch, LTR-553 ambient + proximity, NEC IR decoder
+- **Local inputs** — FT6336U touch, Si12T body-touch strip, LTR-553 ambient + proximity, NEC IR decoder
 - **Timekeeping + peripherals** — BM8563 RTC, PY32 co-processor, WS2812 neck LED ring (`just leds-bench`)
+- **Camera tracking** — GC0308 capture into a block-grid motion tracker, engagement-driven gaze with microsaccades and lost-target search
 - **Host-side sim** — runs the full modifier stack on the host with pixel-golden tests + an `egui` visualiser (`cargo run -p stackchan-sim --bin viz --features viz`); cuts behaviour iteration from ~30 s build cycles to under a second
 - **Safe by default** — no `unwrap` in library code, typed errors throughout, `unsafe` denied workspace-wide
+
+## Networking
+
+`STACKCHAN.RON` on an SD card brings up Wi-Fi station, mDNS, and SNTP-on-link-up,
+and the firmware exposes a LAN-only HTTP control plane:
+
+- `GET /` — operator dashboard, single-page HTML embedded in the binary
+- `GET /state/stream` — live state via Server-Sent Events
+- `POST /emotion`, `/look-at`, `/reset`, `/speak` — manual override
+- `GET` / `PUT /settings` — persistent config with atomic SD writeback
+- Bearer-token auth on writes; constant-time compare; LAN-scoped (no TLS)
+
+Without an SD card the firmware boots offline and the desk-toy surface works
+the same. See [HTTP control plane](https://andymai.github.io/stackchan-kai/http)
+for the full reference.
 
 ## Non-goals
 
 - No voice agent or LLM. This is not a xiaozhi replacement.
-- No cloud or telemetry. Zero outbound network calls.
+- No cloud APIs or telemetry.
 - No C/C++ in the firmware binary. Drivers are written directly against datasheets.
-- No Wi-Fi or BLE.
 - Not an M5Unified port. Only the desk-toy surface area is covered.
 
 ## License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,12 +87,14 @@ and exposes static `ModifierMeta`. [`Director`] owns a fixed-capacity
 heapless registry of modifier and skill references, sorts them once
 on first `run()`, and ticks them each frame.
 
-[`Skill`] is a longer-running NPC capability with a `name` and a
-`description` consumable by a dispatcher. Trait surface only — no
-shipped implementations yet.
+[`Skill`] is a longer-running predicate-fired capability — a recognizer
+that watches percepts and writes `mind.intent` / `mind.attention`.
+Later-phase modifiers translate that intent into face / motor. The
+current population lives at `crates/stackchan-core/src/skills/`.
 
-`reads` / `writes` are documentation; debug-mode enforcement after each
-`update` is planned.
+`reads` / `writes` are documentation, and `cfg(debug_assertions)` builds
+assert that each modifier only writes its declared `Field`s after every
+`update` — see `Director::run`.
 
 ## Phase ordering
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -101,6 +101,16 @@ Half-duplex serial servo bus.
 ### `ir-nec`
 No `Error` enum — decoder returns `Option<NecCommand>` and treats noise as "no decode" rather than an error.
 
+### `stackchan_net::ConfigError`
+RON config parse + validation. Host crate; firmware wraps with `Debug2Format` for `defmt` logging. Validators only fire through `parse_ron` — the firmware's `Config::default()` fallback path never trips them.
+- `Parse(SpannedError)` — RON syntax error / missing field / type mismatch. Inner value carries `(line, col)`.
+- `Serialize(ron::Error)` — RON round-trip failure on `render_ron`. Should not happen with well-formed `Config`; treat as a bug.
+- `EmptySsid` — `wifi.ssid` empty / whitespace-only on disk. Default `WifiConfig` has an empty SSID by design (the offline-first sentinel), but explicit blanks in a written file are almost always mistakes.
+- `InvalidCountry(String)` — `wifi.country` not exactly two **uppercase** ASCII letters. esp-wifi expects ISO-3166 alpha-2 in canonical case (`"US"`, `"JP"`); lowercase silently mis-applies the regulatory mask at the driver layer, so the validator pins the case here.
+- `InvalidHostname(String)` — `mdns.hostname` failed RFC-952 subset (alphanumerics + hyphen, must start with letter, no trailing hyphen, length 1-63).
+- `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
+- `EmptySntpServer(usize)` — a `time.sntp_servers` entry was empty / whitespace-only. The `usize` carries the offending index. Caught at parse time so the firmware's "try in order" loop doesn't burn its full per-server timeout on an unresolvable hostname before falling back.
+
 ### `stackchan_tts::RenderError`
 Speech-backend rendering. Returned from `SpeechBackend::render` when a
 backend that answered `can_handle == true` can't produce audio for the
@@ -114,16 +124,6 @@ specific utterance, or is currently degraded. `#[non_exhaustive]`.
 - `BackendUnavailable` — the backend is in a degraded state (Wi-Fi
   down for a cloud backend, decoder failed to initialize). Caller may
   retry later.
-
-### `stackchan_net::ConfigError`
-RON config parse + validation. Host crate; firmware wraps with `Debug2Format` for `defmt` logging. Validators only fire through `parse_ron` — the firmware's `Config::default()` fallback path never trips them.
-- `Parse(SpannedError)` — RON syntax error / missing field / type mismatch. Inner value carries `(line, col)`.
-- `Serialize(ron::Error)` — RON round-trip failure on `render_ron`. Should not happen with well-formed `Config`; treat as a bug.
-- `EmptySsid` — `wifi.ssid` empty / whitespace-only on disk. Default `WifiConfig` has an empty SSID by design (the offline-first sentinel), but explicit blanks in a written file are almost always mistakes.
-- `InvalidCountry(String)` — `wifi.country` not exactly two **uppercase** ASCII letters. esp-wifi expects ISO-3166 alpha-2 in canonical case (`"US"`, `"JP"`); lowercase silently mis-applies the regulatory mask at the driver layer, so the validator pins the case here.
-- `InvalidHostname(String)` — `mdns.hostname` failed RFC-952 subset (alphanumerics + hyphen, must start with letter, no trailing hyphen, length 1-63).
-- `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
-- `EmptySntpServer(usize)` — a `time.sntp_servers` entry was empty / whitespace-only. The `usize` carries the offending index. Caught at parse time so the firmware's "try in order" loop doesn't burn its full per-server timeout on an unresolvable hostname before falling back.
 
 ## Firmware-side error wrapping
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -101,6 +101,20 @@ Half-duplex serial servo bus.
 ### `ir-nec`
 No `Error` enum — decoder returns `Option<NecCommand>` and treats noise as "no decode" rather than an error.
 
+### `stackchan_tts::RenderError`
+Speech-backend rendering. Returned from `SpeechBackend::render` when a
+backend that answered `can_handle == true` can't produce audio for the
+specific utterance, or is currently degraded. `#[non_exhaustive]`.
+- `UnsupportedContent` — content kind is supported but the specific
+  `PhraseId` / dynamic handle isn't baked into this backend yet.
+  Caller should fall through to the next backend in registration order.
+- `AssetMissing` — a required asset (PCM file, cached response) is
+  unavailable. Distinct from `UnsupportedContent` because the content
+  kind itself is supported in principle.
+- `BackendUnavailable` — the backend is in a degraded state (Wi-Fi
+  down for a cloud backend, decoder failed to initialize). Caller may
+  retry later.
+
 ### `stackchan_net::ConfigError`
 RON config parse + validation. Host crate; firmware wraps with `Debug2Format` for `defmt` logging. Validators only fire through `parse_ron` — the firmware's `Config::default()` fallback path never trips them.
 - `Parse(SpannedError)` — RON syntax error / missing field / type mismatch. Inner value carries `(line, col)`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,8 @@ title: stackchan-kai engineering handbook
 
 Reference docs for [stackchan-kai](https://github.com/andymai/stackchan-kai)
 — `no_std` Rust firmware for the M5Stack CoreS3 Stack-chan, plus the
-host simulator and 14 driver crates.
+host simulator, networking + voice crates, and a stack of `embedded-hal-async`
+driver crates.
 
 ## Pages
 
@@ -21,13 +22,15 @@ host simulator and 14 driver crates.
 
 ```
 crates/
-├── stackchan-core   # no_std engine (Entity, Director, Modifier, Skill, Phase, Clock)
-├── stackchan-sim    # host simulator (FakeClock, Framebuffer, viz binary)
+├── stackchan-core      # no_std engine (Entity, Director, Modifier, Skill, Phase, Clock)
+├── stackchan-sim       # host simulator (FakeClock, Framebuffer, viz binary)
+├── stackchan-net       # no_std wire formats: RON config, HTTP parsers, validators
+├── stackchan-tts       # no_std + alloc speech surface: SpeechBackend trait + BakedBackend
 ├── stackchan-firmware  # CoreS3 firmware binary (embassy + esp-rtos)
-├── tracker          # block-grid motion tracker for the camera path
-└── driver crates    # axp2101, aw9523, aw88298, bm8563, bmi270, bmm150,
-                    # es7210, ft6336u, gc0308, ir-nec, ltr553, py32,
-                    # scservo, si12t
+├── tracker             # block-grid motion tracker for the camera path
+└── driver crates       # axp2101, aw9523, aw88298, bm8563, bmi270, bmm150,
+                        # es7210, ft6336u, gc0308, ir-nec, ltr553, py32,
+                        # scservo, si12t
 ```
 
 See [STABILITY.md](https://github.com/andymai/stackchan-kai/blob/main/STABILITY.md)

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -94,8 +94,9 @@ Entity fields fall into a few buckets:
 - Output requests (`voice.chirp_request`): modifiers write; firmware
   reads + clears after `Director::run`.
 
-The `reads` / `writes` slices on `ModifierMeta` are documentation;
-debug-mode enforcement after each `update` is planned.
+The `reads` / `writes` slices on `ModifierMeta` are documentation, and
+`cfg(debug_assertions)` builds assert that each modifier only writes its
+declared `Field`s after every `update` — see `Director::run`.
 
 ## Field granularity
 
@@ -130,7 +131,8 @@ A `Skill` has `should_fire(&Entity) -> bool` and
 `invoke(&mut Entity) -> SkillStatus`, plus richer metadata than a
 modifier. Use it when the behavior is discoverable — selected from a
 menu rather than always-on. Skills don't write `face` or `motor`
-directly; they go through `mind` / `voice` / `events` and modifiers
-translate. The trait ships; no implementations have landed.
+directly; they go through `mind` / `voice` / `events` and modifiers in
+later phases translate that into rendered face and physical motion.
+The current population lives at `crates/stackchan-core/src/skills/`.
 
 [`Director`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/director.rs

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -119,33 +119,21 @@ grammatical forms of the same concept, so the pair reads naturally
 in context (`source = Pickup, intent = PickedUp`) without colliding
 on identifier.
 
-## Current inventory
+## Source-of-truth
 
-All names on `main` conform to the rules above. The inventory below
-is a quick cross-reference; the canonical lists live in the source
-(`crates/stackchan-core/src/{mind,voice,emotion}.rs` and
-`crates/stackchan-core/src/{modifiers,skills}/mod.rs`).
+All names on `main` conform to the rules above. Canonical lists live
+in the source — read these instead of trying to keep an inline
+inventory in sync:
 
-- **Intent** (rule A): `Idle`, `Listening`, `Startled`, `Petted`,
-  `PickedUp`, `Shaken`, `Tilted`.
-- **Emotion** (single-word adjectives, matches the
+- `crates/stackchan-core/src/mind.rs` — `Intent`, `Attention`, `Autonomy`.
+- `crates/stackchan-core/src/emotion.rs` — `Emotion` (matches the
   [m5stack-avatar `Expression`][m5stack-expression] enum this project
-  descends from): `Neutral`, `Happy`, `Sad`, `Sleepy`, `Surprised`,
-  `Angry`.
-- **Skills** (rule C, all gerund recognizers today): `Listening`,
-  `Petting`, `Handling`.
-- **ChirpKind** (rule D): `Pickup`, `Wake`, `Startle`,
-  `LowBatteryAlert`, `CameraModeEntered`, `CameraModeExited`.
-- **OverrideSource** (rule E): `FaceTouch`, `BodyTouch`, `Remote`,
-  `Pickup`, `Shake`, `Voice`, `Startle`, `Ambient`, `LowBattery`.
-- **Modifiers — autonomous** (rule B, bare noun): `Blink`, `Breath`,
-  `IdleHeadDrift`, `IdleDrift`, `EmotionCycle`.
-- **Modifiers — translators** (rule B, `<Output>From<Source>`):
-  `EmotionFromTouch`, `EmotionFromRemote`, `EmotionFromIntent`,
-  `EmotionFromVoice`, `EmotionFromAmbient`, `EmotionFromBattery`,
-  `IntentFromBodyTouch`, `IntentFromLoud`, `StyleFromEmotion`,
-  `StyleFromIntent`, `HeadFromEmotion`, `HeadFromAttention`,
-  `HeadFromIntent`, `MouthFromAudio`.
+  descends from).
+- `crates/stackchan-core/src/voice.rs` — `ChirpKind`, `PhraseId`,
+  `Locale`.
+- `crates/stackchan-core/src/modifiers/mod.rs` — every shipped
+  `Modifier` (autonomous + translator).
+- `crates/stackchan-core/src/skills/mod.rs` — every shipped `Skill`.
 
 [m5stack-expression]: https://github.com/stack-chan/m5stack-avatar/blob/master/src/Expression.h
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -7,7 +7,10 @@ title: Signal channels
 Cross-task communication runs through typed `Signal<RawMutex, T>`
 channels — `embassy_sync::signal::Signal`. Each channel has exactly
 one producer and one consumer, latest-wins semantics, and never
-blocks.
+blocks. SSE fan-out is the deliberate exception: it uses
+`embassy_sync::pubsub::PubSubChannel` because `/state/stream` has
+multiple concurrent subscribers; see [HTTP control plane](http) for
+how that channel is sized and exhausted.
 
 ## The pattern
 
@@ -24,7 +27,7 @@ SOMETHING_SIGNAL.signal(my_value);
 
 // Consumer side (render task):
 if let Some(value) = SOMETHING_SIGNAL.try_take() {
-    avatar.something = Some(value);
+    entity.perception.something = Some(value);
 }
 ```
 
@@ -51,11 +54,11 @@ task's 33 ms tick virtually never coincides with the signal write.
 | `audio::AUDIO_RMS_SIGNAL` | audio task RX RMS loop | render → `MouthFromAudio` + `EmotionFromVoice` | ~33 ms |
 | `touch::TAP_SIGNAL` | touch task / button task | render → `EmotionFromTouch` | event |
 | `ir::REMOTE_SIGNAL` | IR RMT task | render → `EmotionFromRemote` | event |
-| `imu::IMU_SIGNAL` | IMU polling | render → `avatar.accel_g`, `gyro_dps` | 10 ms |
-| `ambient::AMBIENT_LUX_SIGNAL` | LTR-553 polling | render → `avatar.ambient_lux` | 500 ms |
-| `power::POWER_STATUS_SIGNAL` | AXP2101 polling | render → `avatar.battery_percent` | 1000 ms |
+| `imu::IMU_SIGNAL` | IMU polling | render → `entity.perception.accel_g`, `.gyro_dps` | 10 ms |
+| `ambient::AMBIENT_LUX_SIGNAL` | LTR-553 polling | render → `entity.perception.ambient_lux` | 500 ms |
+| `power::POWER_STATUS_SIGNAL` | AXP2101 polling | render → `entity.perception.battery_percent` | 1000 ms |
 | `head::POSE_SIGNAL` | render task | head task → SCServo | 33 ms |
-| `head::HEAD_POSE_ACTUAL_SIGNAL` | head task readback | render → `avatar.head_pose_actual` | 1000 ms |
+| `head::HEAD_POSE_ACTUAL_SIGNAL` | head task readback | render → `entity.motor.head_pose_actual` | 1000 ms |
 | `leds::LED_FRAME_SIGNAL` | render task | led task → PY32 | 33 ms |
 | `camera::CAMERA_FRAME_SIGNAL` | camera DMA task | render task → blit | gated |
 | `camera::CAMERA_MODE_SIGNAL` | button task | render + camera tasks | event |


### PR DESCRIPTION
## Summary

Reconcile the public-facing docs with what shipped in the #134–#168 networking arc. None of these are new claims — every change either drops a now-false statement, fills in a missing one, or reframes a count-rotting list to point at source.

- **README** — drop the `No Wi-Fi or BLE` non-goal (Wi-Fi shipped); add a Networking section pointing at the operator dashboard, SSE, atomic SD writeback, and bearer-token auth; fix the count-rotting "five emotions" (six ship; reframed to "the m5stack-avatar emotion palette" per the saved no-counts-in-docs convention); add Si12T body-touch + camera-tracking bullets that were never added during their respective arcs.
- **CLAUDE.md** — add `stackchan-net` + `stackchan-tts` to the crate inventory under a new `Networking + voice` group, replace the stale `Avatar` references with `Entity` (the rename predates the network arc but the doc never caught up), drop the redundant 3-bullet type-naming rules (defer to `docs/naming.md` where the full ruleset lives).
- **AGENTS.md** — add Shape 5 for HTTP / network feature work, freshen the highlights with a network-arc bullet, point the "one PR per feature" cadence example at #134–#168 (the `v1.0 polish bundle (#77–#80)` reference was never quite right post-v0.1).
- **docs/architecture.md** / **docs/modifiers.md** — Skill paragraph claimed "Trait surface only — no shipped implementations yet"; `Listening`, `Petting`, `Handling` ship. `reads / writes` paragraph claimed "debug-mode enforcement after each `update` is planned"; it ships via `#[cfg(debug_assertions)]` in `Director::run` (#95).
- **docs/index.md** — source layout block now lists `stackchan-net` and `stackchan-tts`.
- **docs/signals.md** — `avatar.x` → `entity.perception.x` reflecting the rename + per-component nesting; one-line callout that SSE fan-out uses `PubSubChannel` instead of `Signal` (since the doc opens by saying "exactly one producer and one consumer").
- **docs/naming.md** — `Current inventory` was a 26-line bullet list that already named 19 modifiers when 26 ship; deleted in favor of a source-of-truth pointer (which the section's own preamble was already telling readers to use).
- **docs/errors.md** — adds `stackchan_tts::RenderError` (UnsupportedContent / AssetMissing / BackendUnavailable).

No code changes. README's "The engine" example block already used `Entity` correctly.

## Test plan

- [x] `just check` clean (host gate: fmt + workspace clippy + host tests + doctests)
- [x] No `\bAvatar\b` *type* references remaining in the doc set (the conceptual / m5stack-avatar lineage references stay)
- [x] Pre-commit hook clean