### PR TITLE
feat(firmware): POST /volume + POST /mute (persisted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ and the firmware exposes a LAN-only HTTP control plane:
 - `GET /` — operator dashboard, single-page HTML embedded in the binary
 - `GET /state/stream` — live state via Server-Sent Events
 - `POST /emotion`, `/look-at`, `/reset`, `/speak` — manual override
+- `POST /volume`, `/mute` — persistent audio control (atomic SD writeback)
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback
 - Bearer-token auth on writes; constant-time compare; LAN-scoped (no TLS)
 

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -116,10 +116,45 @@ const FULL_SCALE_SQ: f32 = 32768.0 * 32768.0;
 /// plenty of headroom for the embassy scheduler's worst-case latency.
 const TX_DMA_BYTES: usize = 4 * 1024;
 
-/// AW88298 attenuation, in dB, applied at TX bring-up. -18 dB is
-/// audible-but-not-startling for a 1 W desktop speaker; combined with
-/// a -12 dBFS digital tone the boot greeting plays at ≈ -30 dB.
-const BOOT_VOLUME_DB: i8 = -18;
+/// Wire-side minimum dB for the percentile mapping. `volume_pct = 0`
+/// lands here; the mute path (`audio.muted = true` / `POST /mute`)
+/// is the actual-silence channel.
+const VOLUME_PCT_MIN_DB: i8 = -36;
+/// Wire-side maximum dB for the percentile mapping. `volume_pct =
+/// 100` lands here (full-scale, no attenuation).
+const VOLUME_PCT_MAX_DB: i8 = 0;
+
+/// Linear-in-dB mapping of the wire-format `volume_pct` (0..=100) to
+/// AW88298 attenuation.
+///
+/// dB is already logarithmic in amplitude, so linear interpolation
+/// across the dB range gives the perceptual taper without a curve
+/// table. Values above 100 saturate at the max — the parser rejects
+/// them, but the firmware-side helper stays robust if a future
+/// caller bypasses the gate.
+#[must_use]
+pub fn volume_pct_to_db(pct: u8) -> i8 {
+    let pct = i32::from(pct.min(100));
+    let span = i32::from(VOLUME_PCT_MAX_DB) - i32::from(VOLUME_PCT_MIN_DB);
+    let scaled = i32::from(VOLUME_PCT_MIN_DB) + (span * pct / 100);
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        scaled as i8
+    }
+}
+
+/// Latest-wins request to apply a new volume to the AW88298.
+///
+/// Driven by the HTTP `POST /volume` route after the persisted
+/// update succeeds, and by the boot path once the SD config snapshot
+/// is loaded. The amp-control half of [`run_audio_task`] drains this
+/// and calls `Aw88298::set_volume_db` with the mapped dB value.
+pub static AUDIO_VOLUME_SIGNAL: Signal<CriticalSectionRawMutex, u8> = Signal::new();
+
+/// Latest-wins request to mute / un-mute the AW88298. Symmetric with
+/// [`AUDIO_VOLUME_SIGNAL`]: HTTP `POST /mute` writes after
+/// persistence, the amp-control loop applies via `set_muted`.
+pub static AUDIO_MUTE_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
 /// AW88298 settle delay between starting TX DMA (with a buffer of
 /// zeros = digital silence) and lifting `HMUTE`. Lets the codec lock
@@ -545,19 +580,29 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
 
     // AW88298 output-stage bring-up. With TX DMA not yet started, the
     // TX line carries no clocked data — the codec is on standby. We
-    // pre-configure volume so the un-mute step doesn't go straight to
-    // the chip's reset default, then start TX (silent zeros from the
-    // freshly-allocated DMA buffer), settle, and finally lift HMUTE.
-    if let Err(e) = amp.set_volume_db(BOOT_VOLUME_DB).await {
+    // pre-configure volume from the persisted config (or the audio
+    // default if no SD card / snapshot isn't loaded yet) so the
+    // un-mute step doesn't go straight to the chip's reset default,
+    // then start TX (silent zeros from the freshly-allocated DMA
+    // buffer), settle, and finally lift HMUTE — unless the persisted
+    // state asks the device to stay muted.
+    let boot_audio = crate::storage::CONFIG_SNAPSHOT
+        .lock()
+        .await
+        .as_ref()
+        .map_or_else(stackchan_net::config::AudioConfig::default, |cfg| cfg.audio);
+    let boot_volume_db = volume_pct_to_db(boot_audio.volume_pct);
+    if let Err(e) = amp.set_volume_db(boot_volume_db).await {
         defmt::warn!(
             "audio: AW88298 set_volume_db({=i8}) failed ({:?}); continuing at init default",
-            BOOT_VOLUME_DB,
+            boot_volume_db,
             defmt::Debug2Format(&e)
         );
     } else {
         defmt::debug!(
-            "audio: AW88298 volume set to {=i8} dB (boot default)",
-            BOOT_VOLUME_DB
+            "audio: AW88298 volume set to {=i8} dB (boot, from persisted volume_pct={=u8})",
+            boot_volume_db,
+            boot_audio.volume_pct
         );
     }
 
@@ -577,11 +622,18 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
 
     Timer::after(Duration::from_millis(u64::from(TX_SETTLE_MS))).await;
 
-    if let Err(e) = amp.set_muted(false).await {
+    // Honour the persisted mute state at boot. The default-config
+    // path keeps the prior shipping behaviour (`muted = false` →
+    // un-mute on boot); operators who set `audio.muted = true` get
+    // a silent boot until they un-mute over HTTP.
+    if let Err(e) = amp.set_muted(boot_audio.muted).await {
         defmt::warn!(
-            "audio: AW88298 un-mute failed ({:?}); speaker stays muted",
+            "audio: AW88298 set_muted({=bool}) failed ({:?}); speaker stays at chip-reset state",
+            boot_audio.muted,
             defmt::Debug2Format(&e)
         );
+    } else if boot_audio.muted {
+        defmt::info!("audio: AW88298 muted at boot (persisted audio.muted = true)");
     } else {
         defmt::info!("audio: AW88298 un-muted — speaker live");
     }
@@ -594,12 +646,49 @@ pub async fn run_audio_task(mut p: AudioPeripherals) -> ! {
         RMS_WINDOW_SAMPLES,
     );
 
-    // Both halves are `-> !`, so `join` itself never resolves; the
-    // trailing `park_forever` is unreachable but keeps the function
-    // body trivially `-> !` without leaning on never-type coercion.
-    embassy_futures::join::join(
+    // All three halves are `-> !`, so `join3` itself never resolves;
+    // the trailing `park_forever` is unreachable but keeps the
+    // function body trivially `-> !` without leaning on never-type
+    // coercion. The amp-control half stays in this function so the
+    // `amp` binding lives past init — moving it to a separate
+    // embassy task would require an alternate I²C bus path.
+    embassy_futures::join::join3(
         run_rms_loop(&mut rx_transfer),
         run_tx_loop(&mut tx_transfer),
+        async {
+            loop {
+                use embassy_futures::select::{Either, select};
+                match select(AUDIO_VOLUME_SIGNAL.wait(), AUDIO_MUTE_SIGNAL.wait()).await {
+                    Either::First(pct) => {
+                        let db = volume_pct_to_db(pct);
+                        if let Err(e) = amp.set_volume_db(db).await {
+                            defmt::warn!(
+                                "audio: runtime set_volume_db({=i8}) failed ({:?})",
+                                db,
+                                defmt::Debug2Format(&e)
+                            );
+                        } else {
+                            defmt::info!(
+                                "audio: volume → {=u8}% ({=i8} dB) via runtime signal",
+                                pct,
+                                db
+                            );
+                        }
+                    }
+                    Either::Second(muted) => {
+                        if let Err(e) = amp.set_muted(muted).await {
+                            defmt::warn!(
+                                "audio: runtime set_muted({=bool}) failed ({:?})",
+                                muted,
+                                defmt::Debug2Format(&e)
+                            );
+                        } else {
+                            defmt::info!("audio: muted → {=bool} via runtime signal", muted);
+                        }
+                    }
+                }
+            }
+        },
     )
     .await;
     park_forever().await

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -878,6 +878,11 @@ async fn main(spawner: Spawner) -> ! {
             // sees what's actually persisted.
             storage::install_storage(sd).await;
             *storage::CONFIG_SNAPSHOT.lock().await = Some(cfg.clone());
+            // Mirror persisted audio settings into the live snapshot
+            // so `GET /state` shows the right volume / mute on the
+            // first request — and so the SSE stream stays consistent
+            // with what the amp actually applies at boot.
+            net::snapshot::update_audio(cfg.audio);
             cfg
         }
         Err(e) => {

--- a/crates/stackchan-firmware/src/net/dashboard.html
+++ b/crates/stackchan-firmware/src/net/dashboard.html
@@ -93,6 +93,17 @@ small { color: var(--muted); }
   </section>
 
   <section>
+    <h2>Audio</h2>
+    <label>Volume: <span id="volume-label">—</span>
+      <input type="range" id="volume" min="0" max="100" value="50" step="1">
+    </label>
+    <div class="btn-row">
+      <button type="button" id="mute-btn">Mute</button>
+    </div>
+    <small>Slider POSTs /volume after a brief debounce. Mute is independent of volume so unmuting restores the prior level. Both persist to STACKCHAN.RON.</small>
+  </section>
+
+  <section>
     <h2>Settings</h2>
     <form id="settings-form" class="grid">
       <label>SSID <input type="text" name="ssid" id="set-ssid" autocomplete="off"></label>
@@ -146,6 +157,7 @@ function renderState(s) {
   $("state-battery").textContent = (b.percent != null ? `${b.percent}%` : "—") + (b.voltage_mv != null ? ` (${b.voltage_mv} mV)` : "");
   const w = s.wifi;
   $("state-wifi").textContent = w.connected ? `up @ ${w.ip || "—"}` : "down";
+  if (s.audio) syncAudioUi(s.audio);
 }
 
 // --- SSE live state ---
@@ -235,6 +247,55 @@ async function postLookAt() {
   el.addEventListener("change", postLookAt);
 });
 
+// --- Audio (volume + mute) ---
+// Track whether the slider is mid-drag so SSE-driven updates don't
+// fight the operator's input. Without this, a snapshot from the
+// device would jerk the slider back to the persisted value while
+// the user is still dragging it.
+const volumeEl = $("volume");
+const volumeLabel = $("volume-label");
+const muteBtn = $("mute-btn");
+let volumeDragging = false;
+let lastKnownMuted = false;
+function syncAudioUi(audio) {
+  if (!volumeDragging) {
+    volumeEl.value = String(audio.volume_pct);
+    volumeLabel.textContent = `${audio.volume_pct}%`;
+  }
+  lastKnownMuted = !!audio.muted;
+  muteBtn.textContent = audio.muted ? "Unmute" : "Mute";
+  muteBtn.classList.toggle("active", audio.muted);
+}
+// Debounce the slider POST so dragging doesn't burn an SD write per
+// pointer move. 250 ms matches the dashboard's general latency feel
+// — the operator stops moving briefly, the persist + amp apply lands
+// well inside the next visible state-stream tick.
+let volumeDebounceTimer = null;
+function scheduleVolumePost() {
+  if (volumeDebounceTimer != null) clearTimeout(volumeDebounceTimer);
+  volumeDebounceTimer = setTimeout(async () => {
+    volumeDebounceTimer = null;
+    const level = Number(volumeEl.value);
+    try {
+      await postJson("/volume", { level });
+      toast(`volume → ${level}%`);
+    } catch (e) { toast(e.message, true); }
+  }, 250);
+}
+volumeEl.addEventListener("pointerdown", () => { volumeDragging = true; });
+volumeEl.addEventListener("pointerup", () => { volumeDragging = false; });
+volumeEl.addEventListener("input", () => {
+  volumeLabel.textContent = `${volumeEl.value}%`;
+  scheduleVolumePost();
+});
+muteBtn.addEventListener("click", async () => {
+  const next = !lastKnownMuted;
+  try {
+    await postJson("/mute", { muted: next });
+    toast(next ? "muted" : "unmuted");
+  } catch (e) { toast(e.message, true); }
+});
+
 // --- Settings form ---
 // Hold non-editable fields loaded from GET /settings so they round-trip
 // on PUT instead of being clobbered by hard-coded defaults.
@@ -277,6 +338,13 @@ $("settings-form").addEventListener("submit", async (ev) => {
       sntp_servers: $("set-sntp").value.split(",").map((s) => s.trim()).filter(Boolean),
     },
     auth: { token: $("set-token").value },
+    // Echo the current audio block back so a settings save doesn't
+    // reset volume/mute to defaults. The slider + mute button are
+    // the operator-facing control for those.
+    audio: {
+      volume_pct: Number(volumeEl.value),
+      muted: lastKnownMuted,
+    },
   };
   // After a successful save, mirror the new token into localStorage
   // so the dashboard's next write request authenticates against the

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -445,7 +445,11 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
 ///
 /// Persist-then-signal ordering: a failed SD write leaves the amp
 /// at its current level rather than partially applying. Mirrors the
-/// shape of [`handle_put_settings`] but for a single field.
+/// shape of [`handle_put_settings`], including the clone-and-drop of
+/// the `CONFIG_SNAPSHOT` mutex before the SD write — the mutex is
+/// also taken by the auth gate, `GET /settings`, and the boot
+/// audio-init path, so holding it across an SD write would stall
+/// every concurrent request for the full write duration.
 async fn handle_post_volume(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let level = match json::parse_volume(body) {
         Ok(p) => p,
@@ -458,8 +462,7 @@ async fn handle_post_volume(socket: &mut TcpSocket<'_>, body: &str) -> Result<()
             return write_text(socket, 400, &body).await;
         }
     };
-    let mut snapshot_guard = crate::storage::CONFIG_SNAPSHOT.lock().await;
-    let Some(current) = snapshot_guard.clone() else {
+    let Some(current) = crate::storage::CONFIG_SNAPSHOT.lock().await.clone() else {
         return write_text(socket, 503, "config snapshot unavailable\n").await;
     };
     let mut new_config = current;
@@ -470,8 +473,7 @@ async fn handle_post_volume(socket: &mut TcpSocket<'_>, body: &str) -> Result<()
         Some(Ok(())) => {
             defmt::info!("http: POST /volume persisted (level={=u8})", level);
             snapshot::update_audio(new_config.audio);
-            *snapshot_guard = Some(new_config);
-            drop(snapshot_guard);
+            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
             crate::audio::AUDIO_VOLUME_SIGNAL.signal(level);
             write_no_content(socket).await
         }
@@ -490,7 +492,9 @@ async fn handle_post_volume(socket: &mut TcpSocket<'_>, body: &str) -> Result<()
 /// `STACKCHAN.RON`, signal the audio task to apply via the AW88298.
 ///
 /// Symmetric with [`handle_post_volume`]; mute is a separate boolean
-/// (not `volume = 0`) so unmuting restores the prior level.
+/// (not `volume = 0`) so unmuting restores the prior level. Same
+/// snapshot-mutex hygiene applies — clone the current snapshot, drop
+/// the lock, then re-acquire only to install the new value.
 async fn handle_post_mute(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let muted = match json::parse_mute(body) {
         Ok(m) => m,
@@ -503,8 +507,7 @@ async fn handle_post_mute(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), 
             return write_text(socket, 400, &body).await;
         }
     };
-    let mut snapshot_guard = crate::storage::CONFIG_SNAPSHOT.lock().await;
-    let Some(current) = snapshot_guard.clone() else {
+    let Some(current) = crate::storage::CONFIG_SNAPSHOT.lock().await.clone() else {
         return write_text(socket, 503, "config snapshot unavailable\n").await;
     };
     let mut new_config = current;
@@ -515,8 +518,7 @@ async fn handle_post_mute(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), 
         Some(Ok(())) => {
             defmt::info!("http: POST /mute persisted (muted={=bool})", muted);
             snapshot::update_audio(new_config.audio);
-            *snapshot_guard = Some(new_config);
-            drop(snapshot_guard);
+            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
             crate::audio::AUDIO_MUTE_SIGNAL.signal(muted);
             write_no_content(socket).await
         }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -280,6 +280,8 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/look-at") => handle_remote(socket, json::parse_look_at(body)).await,
         ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
         ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,
+        ("POST", "/volume") => handle_post_volume(socket, body).await,
+        ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
     }
@@ -420,6 +422,10 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
                 new_config.wifi.ssid.as_str(),
                 new_config.mdns.hostname.as_str()
             );
+            // Mirror the audio block into the live snapshot so the
+            // SSE stream picks up volume / mute changes from a full
+            // settings PUT without waiting for a reboot.
+            snapshot::update_audio(new_config.audio);
             *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
             write_json(socket, 200, "{\"reboot_required\":true}\n").await
         }
@@ -429,6 +435,97 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
         }
         None => {
             defmt::warn!("http: PUT /settings rejected (no SD mounted)");
+            write_text(socket, 503, "no SD card mounted\n").await
+        }
+    }
+}
+
+/// `POST /volume` — parse `{"level": 0..=100}`, persist to
+/// `STACKCHAN.RON`, signal the audio task to apply via the AW88298.
+///
+/// Persist-then-signal ordering: a failed SD write leaves the amp
+/// at its current level rather than partially applying. Mirrors the
+/// shape of [`handle_put_settings`] but for a single field.
+async fn handle_post_volume(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let level = match json::parse_volume(body) {
+        Ok(p) => p,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /volume parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    let mut snapshot_guard = crate::storage::CONFIG_SNAPSHOT.lock().await;
+    let Some(current) = snapshot_guard.clone() else {
+        return write_text(socket, 503, "config snapshot unavailable\n").await;
+    };
+    let mut new_config = current;
+    new_config.audio.volume_pct = level;
+    let write_result =
+        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
+    match write_result {
+        Some(Ok(())) => {
+            defmt::info!("http: POST /volume persisted (level={=u8})", level);
+            snapshot::update_audio(new_config.audio);
+            *snapshot_guard = Some(new_config);
+            drop(snapshot_guard);
+            crate::audio::AUDIO_VOLUME_SIGNAL.signal(level);
+            write_no_content(socket).await
+        }
+        Some(Err(e)) => {
+            defmt::warn!("http: POST /volume write failed ({})", e);
+            write_text(socket, 500, "config write failed\n").await
+        }
+        None => {
+            defmt::warn!("http: POST /volume rejected (no SD mounted)");
+            write_text(socket, 503, "no SD card mounted\n").await
+        }
+    }
+}
+
+/// `POST /mute` — parse `{"muted": <bool>}`, persist to
+/// `STACKCHAN.RON`, signal the audio task to apply via the AW88298.
+///
+/// Symmetric with [`handle_post_volume`]; mute is a separate boolean
+/// (not `volume = 0`) so unmuting restores the prior level.
+async fn handle_post_mute(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let muted = match json::parse_mute(body) {
+        Ok(m) => m,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /mute parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    let mut snapshot_guard = crate::storage::CONFIG_SNAPSHOT.lock().await;
+    let Some(current) = snapshot_guard.clone() else {
+        return write_text(socket, 503, "config snapshot unavailable\n").await;
+    };
+    let mut new_config = current;
+    new_config.audio.muted = muted;
+    let write_result =
+        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
+    match write_result {
+        Some(Ok(())) => {
+            defmt::info!("http: POST /mute persisted (muted={=bool})", muted);
+            snapshot::update_audio(new_config.audio);
+            *snapshot_guard = Some(new_config);
+            drop(snapshot_guard);
+            crate::audio::AUDIO_MUTE_SIGNAL.signal(muted);
+            write_no_content(socket).await
+        }
+        Some(Err(e)) => {
+            defmt::warn!("http: POST /mute write failed ({})", e);
+            write_text(socket, 500, "config write failed\n").await
+        }
+        None => {
+            defmt::warn!("http: POST /mute rejected (no SD mounted)");
             write_text(socket, 503, "no SD card mounted\n").await
         }
     }
@@ -512,12 +609,15 @@ fn state_body(s: AvatarSnapshot) -> String {
 \"head_pose\":{{\"pan_deg\":{pan:.2},\"tilt_deg\":{tilt:.2}}},\
 \"head_actual\":{actual},\
 \"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\
-\"wifi\":{{\"connected\":{connected},\"ip\":{ip}}}\
+\"wifi\":{{\"connected\":{connected},\"ip\":{ip}}},\
+\"audio\":{{\"volume_pct\":{volume_pct},\"muted\":{muted}}}\
 }}\n",
         emotion = s.emotion.wire_str(),
         pan = s.head_pose.pan_deg,
         tilt = s.head_pose.tilt_deg,
         connected = s.wifi.connected,
+        volume_pct = s.audio.volume_pct,
+        muted = s.audio.muted,
     )
 }
 

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -15,6 +15,7 @@ use embassy_sync::pubsub::PubSubChannel;
 use embassy_time::Instant as EmbassyInstant;
 use stackchan_core::Emotion;
 use stackchan_core::head::Pose;
+use stackchan_net::config::AudioConfig;
 
 /// Battery snapshot — published by the power task.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -52,6 +53,11 @@ pub struct AvatarSnapshot {
     pub battery: BatterySnapshot,
     /// Wi-Fi link state.
     pub wifi: WifiSnapshot,
+    /// Persisted audio settings (volume + mute) currently applied to
+    /// the AW88298. Mirrored from `CONFIG_SNAPSHOT.audio` on every
+    /// successful `POST /volume` / `POST /mute` so the dashboard's
+    /// SSE stream picks up the change without a full settings re-fetch.
+    pub audio: AudioConfig,
 }
 
 impl AvatarSnapshot {
@@ -77,6 +83,7 @@ impl AvatarSnapshot {
             && actual_eq
             && self.battery == other.battery
             && self.wifi == other.wifi
+            && self.audio == other.audio
     }
 }
 
@@ -88,6 +95,10 @@ impl Default for AvatarSnapshot {
             head_actual: None,
             battery: BatterySnapshot::default(),
             wifi: WifiSnapshot::default(),
+            audio: AudioConfig {
+                volume_pct: 50,
+                muted: false,
+            },
         }
     }
 }
@@ -109,6 +120,10 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
         wifi: WifiSnapshot {
             connected: false,
             ip: None,
+        },
+        audio: AudioConfig {
+            volume_pct: 50,
+            muted: false,
         },
     }));
 
@@ -141,6 +156,18 @@ pub fn update_wifi(connected: bool, ip: Option<Ipv4Addr>) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
         s.wifi = WifiSnapshot { connected, ip };
+        cell.set(s);
+    });
+}
+
+/// Replace the audio (volume / mute) fields. Called once at boot
+/// from the persisted config, and again after each successful
+/// `POST /volume` or `POST /mute` so the SSE stream surfaces the
+/// change.
+pub fn update_audio(audio: AudioConfig) {
+    AVATAR_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.audio = audio;
         cell.set(s);
     });
 }

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -95,10 +95,7 @@ impl Default for AvatarSnapshot {
             head_actual: None,
             battery: BatterySnapshot::default(),
             wifi: WifiSnapshot::default(),
-            audio: AudioConfig {
-                volume_pct: 50,
-                muted: false,
-            },
+            audio: AudioConfig::DEFAULT,
         }
     }
 }
@@ -121,10 +118,7 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
             connected: false,
             ip: None,
         },
-        audio: AudioConfig {
-            volume_pct: 50,
-            muted: false,
-        },
+        audio: AudioConfig::DEFAULT,
     }));
 
 /// Replace the avatar/head fields. Called per render tick.

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -18,9 +18,12 @@
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::fmt::Write as _;
 
 use crate::bare_json::TOKEN_REDACTED;
-use crate::config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+use crate::config::{
+    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate,
+};
 use crate::error::ConfigError;
 
 /// Parse a schema-v1 RON document into a [`Config`] without using `serde` or `ron`.
@@ -78,6 +81,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     push_field(&mut out, "        token", &config.auth.token);
     out.push_str("    ),\n");
 
+    out.push_str("    audio: (\n");
+    let _ = writeln!(out, "        volume_pct: {},", config.audio.volume_pct);
+    let _ = writeln!(out, "        muted: {},", config.audio.muted);
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -125,6 +133,7 @@ impl<'a> Parser<'a> {
         let mut mdns: Option<MdnsConfig> = None;
         let mut time: Option<TimeConfig> = None;
         let mut auth: Option<AuthConfig> = None;
+        let mut audio: Option<AudioConfig> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -140,6 +149,7 @@ impl<'a> Parser<'a> {
                 "mdns" => mdns = Some(self.parse_mdns()?),
                 "time" => time = Some(self.parse_time()?),
                 "auth" => auth = Some(self.parse_auth()?),
+                "audio" => audio = Some(self.parse_audio()?),
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -153,10 +163,12 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
-            // `auth` is optional for migration: SD cards written before
-            // schema v1.1 don't have it, and an empty token means
-            // "auth disabled," matching the offline-first stance.
+            // `auth` and `audio` are optional for migration: SD cards
+            // written before each block landed lack them, and the
+            // defaults (empty token = auth disabled; volume_pct = 50,
+            // muted = false) match the firmware's prior behaviour.
             auth: auth.unwrap_or_default(),
+            audio: audio.unwrap_or_default(),
         })
     }
 
@@ -289,6 +301,79 @@ impl<'a> Parser<'a> {
             ));
         }
         Ok(AuthConfig { token })
+    }
+
+    /// Parse the `audio: (volume_pct, muted)` block. Volume is an
+    /// integer literal (RON `u8`), mute is a bare `true` / `false`.
+    fn parse_audio(&mut self) -> Result<AudioConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut volume_pct: Option<u8> = None;
+        let mut muted: Option<bool> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "volume_pct" => volume_pct = Some(self.parse_u8()?),
+                "muted" => muted = Some(self.parse_bool()?),
+                other => return Err(bare_err("unknown audio field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in audio", ""));
+            }
+        }
+        let defaults = AudioConfig::default();
+        Ok(AudioConfig {
+            volume_pct: volume_pct.unwrap_or(defaults.volume_pct),
+            muted: muted.unwrap_or(defaults.muted),
+        })
+    }
+
+    /// Parse a contiguous run of decimal digits as a `u8`. Used for
+    /// `audio.volume_pct`. Range gating is left to [`validate`] so the
+    /// out-of-range surface lands on `ConfigError::InvalidVolumePct`
+    /// (with the offending value) rather than a generic `BareParse`.
+    fn parse_u8(&mut self) -> Result<u8, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected unsigned integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        // Parse as u16 first so 0..=255 + a few extra digits land on
+        // BareParse cleanly rather than wrapping silently. Then cast
+        // down — the validator catches > 100 on the audio path.
+        let parsed: u16 = digits
+            .parse()
+            .map_err(|_| bare_err("not a u8 literal", digits))?;
+        if parsed > u16::from(u8::MAX) {
+            return Err(bare_err("u8 literal out of range", digits));
+        }
+        self.input = rest;
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(parsed as u8)
+    }
+
+    /// Parse a bare `true` or `false` literal.
+    fn parse_bool(&mut self) -> Result<bool, ConfigError> {
+        if self.input.starts_with("true") {
+            self.advance("true".len());
+            Ok(true)
+        } else if self.input.starts_with("false") {
+            self.advance("false".len());
+            Ok(false)
+        } else {
+            Err(bare_err("expected boolean literal", ""))
+        }
     }
 
     /// Parse `[ "...", "...", ]` into a `Vec<String>`.
@@ -574,6 +659,63 @@ mod tests {
         let reparsed = parse_ron_bare(&rendered).unwrap();
         assert_eq!(cfg, reparsed);
         assert_eq!(reparsed.auth.token, "abc-123");
+    }
+
+    #[test]
+    fn missing_audio_block_defaults_to_50_unmuted() {
+        let cfg = parse_ron_bare(FIXTURE).unwrap();
+        assert_eq!(cfg.audio.volume_pct, 50);
+        assert!(!cfg.audio.muted);
+    }
+
+    #[test]
+    fn parses_audio_block_with_explicit_values() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                audio: ( volume_pct: 75, muted: true ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        assert_eq!(cfg.audio.volume_pct, 75);
+        assert!(cfg.audio.muted);
+    }
+
+    #[test]
+    fn round_trips_with_audio_block() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                audio: ( volume_pct: 33, muted: true ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        let rendered = render_ron_bare(&cfg).unwrap();
+        let reparsed = parse_ron_bare(&rendered).unwrap();
+        assert_eq!(cfg, reparsed);
+        assert_eq!(reparsed.audio.volume_pct, 33);
+        assert!(reparsed.audio.muted);
+    }
+
+    #[test]
+    fn audio_volume_above_100_fails_validate() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                audio: ( volume_pct: 200, muted: false ),
+            )
+        "#;
+        let err = parse_ron_bare(s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidVolumePct(200)),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -17,8 +17,11 @@
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::fmt::Write as _;
 
-use crate::config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+use crate::config::{
+    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate,
+};
 use crate::error::ConfigError;
 
 /// Sentinel emitted by [`render_settings_json`] when `redact_secrets = true`.
@@ -77,7 +80,8 @@ pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
 /// overwrites.
 ///
 /// Fields the wire format doesn't redact (`ssid`, `country`,
-/// `mdns.hostname`, `time.*`) pass through from `new` unchanged.
+/// `mdns.hostname`, `time.*`, `audio.*`) pass through from `new`
+/// unchanged.
 #[must_use]
 pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
     Config {
@@ -99,6 +103,7 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
                 new.auth.token
             },
         },
+        audio: new.audio,
     }
 }
 
@@ -151,6 +156,12 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         &config.auth.token
     };
     push_string_field(&mut out, "token", token_view);
+    out.push_str("},\"audio\":{");
+    let _ = write!(
+        out,
+        "\"volume_pct\":{},\"muted\":{}",
+        config.audio.volume_pct, config.audio.muted
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -205,6 +216,7 @@ impl<'a> Parser<'a> {
         let mut mdns: Option<MdnsConfig> = None;
         let mut time: Option<TimeConfig> = None;
         let mut auth: Option<AuthConfig> = None;
+        let mut audio: Option<AudioConfig> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -239,6 +251,12 @@ impl<'a> Parser<'a> {
                     }
                     auth = Some(self.parse_auth()?);
                 }
+                "audio" => {
+                    if audio.is_some() {
+                        return Err(bare_err("duplicate top-level field", "audio"));
+                    }
+                    audio = Some(self.parse_audio()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -250,10 +268,12 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
-            // `auth` is optional for migration: bodies emitted before
-            // schema v1.1 don't have it, and the default empty token
-            // means "auth disabled."
+            // `auth` and `audio` are optional for migration: bodies
+            // emitted before each block landed don't have them, and
+            // the defaults (empty token = auth disabled; volume_pct
+            // = 50, muted = false) match prior behaviour.
             auth: auth.unwrap_or_default(),
+            audio: audio.unwrap_or_default(),
         })
     }
 
@@ -419,6 +439,89 @@ impl<'a> Parser<'a> {
         Ok(AuthConfig { token })
     }
 
+    /// Parse the `"audio": { "volume_pct": <int>, "muted": <bool> }` block.
+    /// Both fields are optional on the wire for forward-compat — a
+    /// body that omits one keeps the default. The validator catches
+    /// out-of-range `volume_pct` after parse with
+    /// `ConfigError::InvalidVolumePct`.
+    fn parse_audio(&mut self) -> Result<AudioConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut volume_pct: Option<u8> = None;
+        let mut muted: Option<bool> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "volume_pct" => {
+                    if volume_pct.is_some() {
+                        return Err(bare_err("duplicate audio field", "volume_pct"));
+                    }
+                    volume_pct = Some(self.parse_u8()?);
+                }
+                "muted" => {
+                    if muted.is_some() {
+                        return Err(bare_err("duplicate audio field", "muted"));
+                    }
+                    muted = Some(self.parse_bool()?);
+                }
+                other => return Err(bare_err("unknown audio field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in audio", ""));
+            }
+        }
+        let defaults = AudioConfig::default();
+        Ok(AudioConfig {
+            volume_pct: volume_pct.unwrap_or(defaults.volume_pct),
+            muted: muted.unwrap_or(defaults.muted),
+        })
+    }
+
+    /// Parse a contiguous run of decimal digits as `u8`. Out-of-range
+    /// (>100) values pass parse but trip
+    /// `ConfigError::InvalidVolumePct` in `validate` so the operator
+    /// gets the exact offending value back.
+    fn parse_u8(&mut self) -> Result<u8, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected unsigned integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: u16 = digits
+            .parse()
+            .map_err(|_| bare_err("not a u8 literal", digits))?;
+        if parsed > u16::from(u8::MAX) {
+            return Err(bare_err("u8 literal out of range", digits));
+        }
+        self.input = rest;
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(parsed as u8)
+    }
+
+    /// Parse a bare JSON `true` / `false` literal.
+    fn parse_bool(&mut self) -> Result<bool, ConfigError> {
+        if self.input.starts_with("true") {
+            self.advance("true".len());
+            Ok(true)
+        } else if self.input.starts_with("false") {
+            self.advance("false".len());
+            Ok(false)
+        } else {
+            Err(bare_err("expected boolean literal", ""))
+        }
+    }
+
     /// Parse `[ "...", "...", ... ]` into a `Vec<String>`.
     fn parse_string_list(&mut self) -> Result<Vec<String>, ConfigError> {
         self.expect_char('[')?;
@@ -557,6 +660,10 @@ mod tests {
             },
             auth: AuthConfig {
                 token: "shared-secret".to_string(),
+            },
+            audio: AudioConfig {
+                volume_pct: 33,
+                muted: true,
             },
         }
     }
@@ -858,6 +965,10 @@ mod tests {
             auth: AuthConfig {
                 token: "x".repeat(64),
             },
+            audio: AudioConfig {
+                volume_pct: 100,
+                muted: false,
+            },
         };
         let rendered = render_settings_json(&config, false).unwrap();
         assert!(
@@ -867,6 +978,86 @@ mod tests {
         );
         let parsed = parse_settings_json(&rendered).unwrap();
         assert_eq!(parsed, config);
+    }
+
+    #[test]
+    fn missing_audio_block_defaults_to_50_unmuted() {
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.audio.volume_pct, 50);
+        assert!(!parsed.audio.muted);
+    }
+
+    #[test]
+    fn parses_audio_block_with_explicit_values() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "audio":{"volume_pct":75,"muted":true}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.audio.volume_pct, 75);
+        assert!(parsed.audio.muted);
+    }
+
+    #[test]
+    fn audio_block_round_trips() {
+        let original = full_config();
+        let rendered = render_settings_json(&original, false).unwrap();
+        let parsed = parse_settings_json(&rendered).unwrap();
+        assert_eq!(parsed.audio, original.audio);
+    }
+
+    #[test]
+    fn audio_volume_above_100_fails_validate() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "audio":{"volume_pct":200,"muted":false}
+        }"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidVolumePct(200)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn audio_rejects_duplicate_field() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "audio":{"volume_pct":50,"volume_pct":75,"muted":false}
+        }"#;
+        let err = parse_settings_json(input).unwrap_err();
+        match err {
+            ConfigError::BareParse(msg) => assert!(
+                msg.contains("duplicate audio field"),
+                "expected duplicate-audio-field, got `{msg}`"
+            ),
+            other => panic!("expected BareParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn merge_passes_audio_through_unchanged() {
+        // Audio has no redaction, so merge should always take the
+        // `new` value verbatim — operators who tweak hostname via PUT
+        // /settings should still get their volume/mute echo correctly.
+        let current = full_config(); // volume 33, muted true
+        let new = Config {
+            audio: AudioConfig {
+                volume_pct: 80,
+                muted: false,
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert_eq!(merged.audio.volume_pct, 80);
+        assert!(!merged.audio.muted);
     }
 
     #[test]

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -120,12 +120,20 @@ pub struct AudioConfig {
     pub muted: bool,
 }
 
+impl AudioConfig {
+    /// Const-evaluable default. Exposed so static initializers (e.g.
+    /// the firmware's `AvatarSnapshot` constant) can reference the
+    /// canonical defaults without duplicating the literals — `Default`
+    /// itself isn't `const`-evaluable.
+    pub const DEFAULT: Self = Self {
+        volume_pct: 50,
+        muted: false,
+    };
+}
+
 impl Default for AudioConfig {
     fn default() -> Self {
-        Self {
-            volume_pct: 50,
-            muted: false,
-        }
+        Self::DEFAULT
     }
 }
 

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -38,6 +38,11 @@ pub struct Config {
     /// `PUT`/`POST` routes behind `Authorization: Bearer <token>`.
     #[cfg_attr(feature = "parse", serde(default))]
     pub auth: AuthConfig,
+    /// Audio output: persistent volume + mute state. Mirrored to the
+    /// AW88298 amplifier on boot and on every `POST /volume` / `POST
+    /// /mute` write.
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub audio: AudioConfig,
 }
 
 /// Wi-Fi station credentials.
@@ -92,6 +97,36 @@ impl Default for MdnsConfig {
 pub struct AuthConfig {
     /// Shared-secret bearer token. Empty = auth disabled.
     pub token: String,
+}
+
+/// Audio output configuration — persistent volume + mute state.
+///
+/// `volume_pct` is on the wire as an integer 0..=100 to keep the
+/// operator-facing surface intuitive; the firmware maps it linearly
+/// across the AW88298's dB range when applying to the amp. `0` is
+/// audible-but-quiet, not silent — explicit `muted: true` is the
+/// actual-silence path. Default `volume_pct = 50` lands at roughly
+/// the chip's prior compile-time boot default; default `muted =
+/// false` matches the behaviour the firmware shipped with before
+/// runtime audio control existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct AudioConfig {
+    /// Output volume as a percentile (0..=100). Mapped linearly over
+    /// dB by the firmware before being written to the amp.
+    pub volume_pct: u8,
+    /// Whether the output stage is muted. Independent of
+    /// `volume_pct` so unmuting restores the prior level.
+    pub muted: bool,
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Self {
+            volume_pct: 50,
+            muted: false,
+        }
+    }
 }
 
 /// Time / SNTP configuration.
@@ -190,6 +225,9 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
     {
         return Err(ConfigError::EmptySntpServer(idx));
     }
+    if config.audio.volume_pct > 100 {
+        return Err(ConfigError::InvalidVolumePct(config.audio.volume_pct));
+    }
     Ok(())
 }
 
@@ -233,6 +271,29 @@ mod tests {
         assert_eq!(c.mdns.hostname, "stackchan");
         assert_eq!(c.time.tz, "UTC");
         assert_eq!(c.time.sntp_servers, vec!["pool.ntp.org".to_string()]);
+        assert_eq!(c.audio.volume_pct, 50);
+        assert!(!c.audio.muted);
+    }
+
+    #[test]
+    fn validate_rejects_volume_above_100() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.audio.volume_pct = 101;
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidVolumePct(101))
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_volume_at_boundaries() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        for pct in [0u8, 1, 50, 99, 100] {
+            c.audio.volume_pct = pct;
+            assert!(validate(&c).is_ok(), "expected pct={pct} to pass");
+        }
     }
 
     #[test]

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -71,6 +71,12 @@ pub enum ConfigError {
     #[error("time.sntp_servers[{0}] is empty or whitespace-only")]
     EmptySntpServer(usize),
 
+    /// `audio.volume_pct` was outside `0..=100`. The wire format is
+    /// a percentile; the firmware maps it linearly across the AW88298
+    /// dB range. The `u8` carries the offending value.
+    #[error("audio.volume_pct must be 0..=100; got {0}")]
+    InvalidVolumePct(u8),
+
     /// Hand-rolled bare parser failure (firmware-side path that
     /// avoids `serde + ron`). Carries a short reason string in lieu
     /// of `ron`'s line/col `SpannedError` — the firmware logs this

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -51,6 +51,10 @@ pub enum JsonError {
     UnknownPhrase,
     /// Locale string didn't match any [`Locale`] variant.
     UnknownLocale,
+    /// `audio.volume_pct` value outside the documented `0..=100`
+    /// range. Carries the offending value so the firmware's `400`
+    /// response body is self-describing.
+    VolumeOutOfRange(u16),
 }
 
 /// Parse a `POST /emotion` body into a [`RemoteCommand::SetEmotion`].
@@ -175,6 +179,66 @@ pub fn parse_speak(body: &str) -> Result<RemoteCommand, JsonError> {
         locale: locale.unwrap_or(Locale::En),
         priority: Priority::Normal,
     })
+}
+
+/// Parse a `POST /volume` body into a percentile value (`0..=100`).
+///
+/// Required: `level` (integer 0..=100). No optional fields.
+///
+/// Returns the raw percentile so the firmware route handler can
+/// build the persisted `AudioConfig` against the current snapshot
+/// without taking a dependency on this crate's `Config` type.
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys,
+/// unknown keys, malformed JSON shape, or `level > 100`.
+pub fn parse_volume(body: &str) -> Result<u8, JsonError> {
+    let mut level: Option<u16> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "level" => {
+                if level.is_some() {
+                    return Err(JsonError::DuplicateKey("level"));
+                }
+                level = Some(parse_u16(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    let level = level.ok_or(JsonError::MissingKey("level"))?;
+    if level > 100 {
+        return Err(JsonError::VolumeOutOfRange(level));
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(level as u8)
+}
+
+/// Parse a `POST /mute` body into a `bool`.
+///
+/// Required: `muted` (boolean). No optional fields.
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys,
+/// unknown keys, malformed JSON shape, or non-boolean `muted`
+/// values.
+pub fn parse_mute(body: &str) -> Result<bool, JsonError> {
+    let mut muted: Option<bool> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "muted" => {
+                if muted.is_some() {
+                    return Err(JsonError::DuplicateKey("muted"));
+                }
+                muted = Some(parse_bool(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    muted.ok_or(JsonError::MissingKey("muted"))
 }
 
 /// Single-pass byte cursor over the body. Each parse helper advances
@@ -365,12 +429,41 @@ fn parse_u32(scanner: &mut Scanner<'_>) -> Result<u32, JsonError> {
         .map_err(|_| JsonError::BadValue)
 }
 
+/// Parse a contiguous number-shaped run as a `u16`. Used by the
+/// volume parser so a wildly out-of-range value (e.g. `5000`) flows
+/// through to [`JsonError::VolumeOutOfRange`] with the original
+/// value rather than collapsing to a generic `BadValue`.
+fn parse_u16(scanner: &mut Scanner<'_>) -> Result<u16, JsonError> {
+    scanner
+        .read_number()?
+        .parse::<u16>()
+        .map_err(|_| JsonError::BadValue)
+}
+
 /// Parse a contiguous number-shaped run as an `f32`.
 fn parse_f32(scanner: &mut Scanner<'_>) -> Result<f32, JsonError> {
     scanner
         .read_number()?
         .parse::<f32>()
         .map_err(|_| JsonError::BadValue)
+}
+
+/// Parse a bare JSON `true` / `false` literal at the current scanner
+/// position. The body parsers consume `true` / `false` directly —
+/// `read_string` would reject them and `read_number` would treat the
+/// leading `t` / `f` as garbage, so this helper covers the boolean
+/// shape explicitly.
+fn parse_bool(scanner: &mut Scanner<'_>) -> Result<bool, JsonError> {
+    scanner.skip_ws();
+    if scanner.bytes[scanner.pos..].starts_with(b"true") {
+        scanner.pos += 4;
+        Ok(true)
+    } else if scanner.bytes[scanner.pos..].starts_with(b"false") {
+        scanner.pos += 5;
+        Ok(false)
+    } else {
+        Err(JsonError::BadValue)
+    }
 }
 
 #[cfg(test)]
@@ -619,5 +712,99 @@ mod tests {
     fn speak_rejects_unknown_key() {
         let body = r#"{"phrase":"wake_chirp","priority":"normal"}"#;
         assert!(matches!(parse_speak(body), Err(JsonError::UnknownKey)));
+    }
+
+    #[test]
+    fn volume_accepts_in_range() {
+        for pct in [0u8, 1, 50, 99, 100] {
+            let body = alloc::format!(r#"{{"level":{pct}}}"#);
+            assert_eq!(parse_volume(&body).unwrap(), pct, "pct={pct}");
+        }
+    }
+
+    #[test]
+    fn volume_rejects_above_100() {
+        let body = r#"{"level":101}"#;
+        assert!(matches!(
+            parse_volume(body),
+            Err(JsonError::VolumeOutOfRange(101))
+        ));
+    }
+
+    #[test]
+    fn volume_rejects_far_above_range_with_original_value() {
+        // Pin: a wildly out-of-range value (e.g. fat-finger 5000)
+        // surfaces as VolumeOutOfRange(5000), not a generic BadValue.
+        let body = r#"{"level":5000}"#;
+        assert!(matches!(
+            parse_volume(body),
+            Err(JsonError::VolumeOutOfRange(5000))
+        ));
+    }
+
+    #[test]
+    fn volume_rejects_missing_level() {
+        let body = r"{}";
+        assert!(matches!(
+            parse_volume(body),
+            Err(JsonError::MissingKey("level"))
+        ));
+    }
+
+    #[test]
+    fn volume_rejects_unknown_key() {
+        let body = r#"{"level":50,"db":-12}"#;
+        assert!(matches!(parse_volume(body), Err(JsonError::UnknownKey)));
+    }
+
+    #[test]
+    fn volume_rejects_duplicate_level() {
+        let body = r#"{"level":50,"level":75}"#;
+        assert!(matches!(
+            parse_volume(body),
+            Err(JsonError::DuplicateKey("level"))
+        ));
+    }
+
+    #[test]
+    fn volume_rejects_string_value() {
+        let body = r#"{"level":"50"}"#;
+        assert!(matches!(parse_volume(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn mute_accepts_both_booleans() {
+        assert!(parse_mute(r#"{"muted":true}"#).unwrap());
+        assert!(!parse_mute(r#"{"muted":false}"#).unwrap());
+    }
+
+    #[test]
+    fn mute_rejects_missing_field() {
+        let body = r"{}";
+        assert!(matches!(
+            parse_mute(body),
+            Err(JsonError::MissingKey("muted"))
+        ));
+    }
+
+    #[test]
+    fn mute_rejects_non_boolean_value() {
+        let body = r#"{"muted":1}"#;
+        assert!(matches!(parse_mute(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn mute_rejects_duplicate_muted() {
+        let body = r#"{"muted":true,"muted":false}"#;
+        assert!(matches!(
+            parse_mute(body),
+            Err(JsonError::DuplicateKey("muted"))
+        ));
+    }
+
+    #[test]
+    fn mute_rejects_unknown_key() {
+        let body = r#"{"muted":true,"hold_ms":1000}"#;
+        assert!(matches!(parse_mute(body), Err(JsonError::UnknownKey)));
     }
 }

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -110,6 +110,7 @@ RON config parse + validation. Host crate; firmware wraps with `Debug2Format` fo
 - `InvalidHostname(String)` — `mdns.hostname` failed RFC-952 subset (alphanumerics + hyphen, must start with letter, no trailing hyphen, length 1-63).
 - `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
 - `EmptySntpServer(usize)` — a `time.sntp_servers` entry was empty / whitespace-only. The `usize` carries the offending index. Caught at parse time so the firmware's "try in order" loop doesn't burn its full per-server timeout on an unresolvable hostname before falling back.
+- `InvalidVolumePct(u8)` — `audio.volume_pct` was outside `0..=100`. The wire format is a percentile; the firmware maps it linearly across the AW88298 dB range. The `u8` carries the offending value.
 
 ### `stackchan_tts::RenderError`
 Speech-backend rendering. Returned from `SpeechBackend::render` when a

--- a/docs/http.md
+++ b/docs/http.md
@@ -256,7 +256,7 @@ the operator's HTTP session if the SSID changed. Reboot to apply.
 | Code | Where it shows up                                                  |
 |------|---------------------------------------------------------------------|
 | 200  | GET responses, dashboard, successful PUT                            |
-| 204  | POST `/emotion` / `/look-at` / `/reset` on success                  |
+| 204  | POST `/emotion` / `/look-at` / `/reset` / `/volume` / `/mute` on success |
 | 400  | Malformed JSON, missing required fields, unknown field, invalid emotion / phrase / locale, `volume.level > 100`, validation failure on PUT `/settings` |
 | 401  | Write route called without a valid bearer token (when auth is enabled) |
 | 404  | Path not in the matcher                                             |

--- a/docs/http.md
+++ b/docs/http.md
@@ -23,12 +23,14 @@ beats pulling a full HTTP framework into the firmware target.
 |--------|------------------|-----------------------------------------------------|
 | GET    | `/`              | Operator dashboard (HTML + JS, embedded in firmware) |
 | GET    | `/health`        | Uptime, firmware version, free heap                  |
-| GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi    |
+| GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi, audio |
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
 | POST   | `/emotion`       | Set affect with hold timer                          |
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |
 | POST   | `/speak`         | Play a baked phrase / chirp through the speaker      |
+| POST   | `/volume`        | Set output volume (0–100); persisted to SD           |
+| POST   | `/mute`          | Mute / un-mute output stage; persisted to SD         |
 | GET    | `/settings`      | Persisted config (PSK + token redacted)             |
 | PUT    | `/settings`      | Replace persisted config; atomic SD writeback        |
 
@@ -42,7 +44,8 @@ $ curl http://stackchan.local/state
 {"emotion":"Neutral","head_pose":{"pan_deg":0.00,"tilt_deg":0.00},
  "head_actual":{"pan_deg":0.10,"tilt_deg":-0.20},
  "battery":{"percent":78,"voltage_mv":3920},
- "wifi":{"connected":true,"ip":"192.168.1.42"}}
+ "wifi":{"connected":true,"ip":"192.168.1.42"},
+ "audio":{"volume_pct":50,"muted":false}}
 ```
 
 `GET /state/stream` opens a Server-Sent Events stream. The server
@@ -154,6 +157,42 @@ or evict an in-flight operator request.
 
 `POST /speak` is gated by [auth](#auth) when a token is configured.
 
+### `POST /volume`
+
+```
+$ curl -X POST http://stackchan.local/volume \
+       -H 'Content-Type: application/json' \
+       -d '{"level":75}'
+```
+
+| Field | Type | Required | Notes                                      |
+|-------|------|----------|--------------------------------------------|
+| level | u8   | yes      | Output volume as a percentile, `0..=100`.  |
+
+Persistent — the new value is written atomically to
+`/sd/STACKCHAN.RON` (same writeback path as `PUT /settings`) and
+mirrored into the live `audio.volume_pct` field surfaced on
+`GET /state`. The firmware then signals the audio task, which calls
+`Aw88298::set_volume_db` with the linear-in-dB mapping (`0% → -36
+dB`, `100% → 0 dB`). Persist-then-apply ordering: a failed SD write
+leaves the amp at its current level instead of partially applying.
+
+### `POST /mute`
+
+```
+$ curl -X POST http://stackchan.local/mute \
+       -H 'Content-Type: application/json' \
+       -d '{"muted":true}'
+```
+
+| Field | Type | Required | Notes                                                      |
+|-------|------|----------|------------------------------------------------------------|
+| muted | bool | yes      | `true` = mute output stage, `false` = un-mute.             |
+
+Persistent. Mute is independent of volume so unmuting restores the
+prior level — `volume = 0` is "audible but very quiet"; `muted =
+true` is the actual-silence path.
+
 ## Persistent config
 
 The boot config lives at `/sd/STACKCHAN.RON` in the schema described
@@ -167,7 +206,8 @@ $ curl http://stackchan.local/settings
 {"wifi":{"ssid":"my-net","psk":"***","country":"US"},
  "mdns":{"hostname":"stackchan"},
  "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
- "auth":{"token":"***"}}
+ "auth":{"token":"***"},
+ "audio":{"volume_pct":50,"muted":false}}
 ```
 
 `wifi.psk` and a non-empty `auth.token` are redacted to `***`.
@@ -187,7 +227,8 @@ $ curl -X PUT http://stackchan.local/settings \
        -d '{"wifi":{"ssid":"new-net","psk":"realkey","country":"US"},
             "mdns":{"hostname":"stackchan"},
             "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
-            "auth":{"token":"s3cret"}}'
+            "auth":{"token":"s3cret"},
+            "audio":{"volume_pct":50,"muted":false}}'
 {"reboot_required":true}
 ```
 
@@ -216,7 +257,7 @@ the operator's HTTP session if the SSID changed. Reboot to apply.
 |------|---------------------------------------------------------------------|
 | 200  | GET responses, dashboard, successful PUT                            |
 | 204  | POST `/emotion` / `/look-at` / `/reset` on success                  |
-| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion / phrase / locale, validation failure on PUT `/settings` |
+| 400  | Malformed JSON, missing required fields, unknown field, invalid emotion / phrase / locale, `volume.level > 100`, validation failure on PUT `/settings` |
 | 401  | Write route called without a valid bearer token (when auth is enabled) |
 | 404  | Path not in the matcher                                             |
 | 405  | Method not allowed                                                  |
@@ -238,6 +279,9 @@ no framework, no external CDN. The dashboard:
 - Subscribes to `/state/stream` for live state.
 - Has a button per emotion (POST `/emotion` with a 30 s hold).
 - Renders pan/tilt sliders that POST `/look-at` on release.
+- Volume slider (POST `/volume` with a 250 ms client-side debounce
+  so dragging doesn't burn an SD write per pointer move) and a mute
+  toggle (POST `/mute`).
 - Loads `/settings` into an editable form; submits PUT `/settings`
   on save and surfaces the `reboot_required` hint via toast.
 


### PR DESCRIPTION
## Summary

First step of the voice/TTS arc: HTTP control over speaker volume + mute, persisted to `STACKCHAN.RON` and applied to the AW88298 amp at runtime.

### Schema

`stackchan_net::AudioConfig { volume_pct: u8, muted: bool }` — defaults to `50` / `false`. Both blocks are `serde(default)` and the firmware-side bare RON / JSON parsers default the block when missing, so SD cards / clients written before this lands keep working.

### Routes

Both auth-gated (existing bearer-token convention on writes):

- `POST /volume {\"level\": 0..=100}` — persist to SD, signal audio task → `Aw88298::set_volume_db` with a linear-in-dB mapping (`0% → -36 dB`, `100% → 0 dB`). dB is already log in amplitude so linear-in-dB gives the perceptual taper without a curve table.
- `POST /mute {\"muted\": <bool>}` — persist + signal → `Aw88298::set_muted`. Mute is a separate boolean so unmuting restores the prior level.

Persist-then-apply ordering: a failed SD write leaves the amp at its current level rather than partially applying. Mirrors the shape of `handle_put_settings`.

### `/state` and SSE

`/state` (and the SSE stream) now includes `\"audio\":{\"volume_pct\":..., \"muted\":...}` so the dashboard surfaces live audio without a separate fetch. `bit_eq` includes audio so an audio-only change still triggers an SSE publish.

### Dashboard

Adds a volume slider + mute toggle to `dashboard.html`:
- Slider fires `POST /volume` with a 250 ms client-side debounce — dragging doesn't burn an SD write per pointer move, but the operator gets responsive feedback.
- `pointerdown` / `pointerup` track drag state so SSE-driven updates don't fight the slider mid-drag.
- Mute button toggles based on the latest known state from SSE.
- PUT /settings body now echoes the live audio block back so a settings save doesn't reset volume / mute to defaults.

### Audio init

Replaces the hard-coded `BOOT_VOLUME_DB` constant with a read from `CONFIG_SNAPSHOT.audio` (or `AudioConfig::default()` when the SD is missing). Storage init runs before the audio task spawns, so the snapshot is populated by the time the task reads it.

After init, an `embassy_futures::join3` third future drains `AUDIO_VOLUME_SIGNAL` / `AUDIO_MUTE_SIGNAL` and applies runtime changes via the same amp handle. The amp binding stays alive past init by living in the join's borrow scope — no separate task / no parallel I²C bus needed.

### Tests

102 host tests pass in `stackchan-net`:
- `AudioConfig` defaults + validator boundaries (0, 1, 50, 99, 100 pass; 101+ fails with `InvalidVolumePct(101)`).
- Bare RON + bare JSON parsers: missing block defaults, explicit values, round-trip, validation surfaces `InvalidVolumePct`, duplicate-field rejection.
- `parse_volume` / `parse_mute` happy paths + error paths (out-of-range, missing, unknown key, duplicate, string-instead-of-number, non-boolean).
- `merge_settings_with_current` passes audio through unchanged (no redaction).

## Test plan

- [x] `just check` — 102 stackchan-net tests pass; full host gate clean.
- [x] `just clippy-firmware` — strict warnings clean.
- [x] `just build-firmware` — release build clean.
- [ ] Manual `curl` smoke after flashing:
  - [ ] `curl http://stackchan.local/state` includes `\"audio\":{\"volume_pct\":50,\"muted\":false}`.
  - [ ] `curl -X POST http://stackchan.local/volume -d '{\"level\":80}' -H 'Content-Type: application/json'` → 204; \`/state\` reflects new value; \`STACKCHAN.RON\` on SD now contains \`audio: ( volume_pct: 80, ... )\`.
  - [ ] `curl -X POST http://stackchan.local/mute -d '{\"muted\":true}' -H 'Content-Type: application/json'` → 204; speaker silences immediately; \`/state\` reflects.
  - [ ] `curl -X POST http://stackchan.local/volume -d '{\"level\":150}'` → 400 with `VolumeOutOfRange(150)`.
- [ ] Manual dashboard smoke: drag slider — single SD write per pause, no thrash; mute button toggles correctly across SSE updates.