### PR TITLE
feat(firmware): BLE peripheral with read-only GATT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5f48f1e9b0aad0a4f05d17bdeae0fa20ff798e272a03a6940ca27ad9c5a6ae7"
 dependencies = [
  "defmt 0.3.100",
+ "uuid",
 ]
 
 [[package]]
@@ -755,6 +756,15 @@ name = "const-default"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2224,6 +2234,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2323,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -4432,6 +4467,7 @@ dependencies = [
  "ft6336u",
  "gc0308",
  "heapless 0.8.0",
+ "heapless 0.9.2",
  "ir-nec",
  "ltr553",
  "micromath",
@@ -4444,6 +4480,7 @@ dependencies = [
  "stackchan-tts",
  "static_cell",
  "tracker",
+ "trouble-host",
 ]
 
 [[package]]
@@ -4747,6 +4784,40 @@ dependencies = [
  "heapless 0.8.0",
  "libm",
  "stackchan-core",
+]
+
+[[package]]
+name = "trouble-host"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881b4859001fe1f48445145cda5149deac9110b1d707ec0a251b7ff6d8bdfa4"
+dependencies = [
+ "bt-hci",
+ "defmt 1.0.1",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "embedded-io 0.6.1",
+ "futures",
+ "heapless 0.9.2",
+ "rand_core 0.6.4",
+ "static_cell",
+ "trouble-host-macros",
+ "zerocopy",
+]
+
+[[package]]
+name = "trouble-host-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb85bec3a8393c22ca1a7c25c82c2d33689ab412f3487c492fd01a033ede7c2"
+dependencies = [
+ "convert_case",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/stackchan-core/src/emotion.rs
+++ b/crates/stackchan-core/src/emotion.rs
@@ -50,4 +50,45 @@ impl Emotion {
             Self::Angry => "angry",
         }
     }
+
+    /// Single-byte wire encoding for the BLE GATT surface.
+    ///
+    /// The stack-chan custom service exposes the current emotion as a
+    /// one-byte read+notify characteristic. The mapping below is the
+    /// stable wire format: variant indices may not be reordered, and
+    /// new variants must be appended at the next free index. Clients
+    /// that decode a value not listed here should fall back to
+    /// [`Self::Neutral`] (forward-compatible decoding).
+    ///
+    /// As with [`Self::wire_str`], the match is intentionally
+    /// exhaustive without a wildcard — adding a new variant forces a
+    /// conscious choice of byte index here.
+    #[must_use]
+    pub const fn wire_byte(self) -> u8 {
+        match self {
+            Self::Neutral => 0,
+            Self::Happy => 1,
+            Self::Sad => 2,
+            Self::Sleepy => 3,
+            Self::Surprised => 4,
+            Self::Angry => 5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Emotion;
+
+    /// Lock the BLE wire-byte mapping. Reordering breaks every paired
+    /// client; renaming a variant doesn't.
+    #[test]
+    fn wire_byte_mapping_is_stable() {
+        assert_eq!(Emotion::Neutral.wire_byte(), 0);
+        assert_eq!(Emotion::Happy.wire_byte(), 1);
+        assert_eq!(Emotion::Sad.wire_byte(), 2);
+        assert_eq!(Emotion::Sleepy.wire_byte(), 3);
+        assert_eq!(Emotion::Surprised.wire_byte(), 4);
+        assert_eq!(Emotion::Angry.wire_byte(), 5);
+    }
 }

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -46,6 +46,12 @@ embedded-sdmmc = { version = "0.8", default-features = false, features = ["defmt
 # translated from `tracker::Outcome.candidates` into the engine's
 # `TrackingObservation`. Matches the cap (`MAX_CANDIDATES`).
 heapless = "0.8"
+# trouble-host 0.5 implements `AsGatt` on `heapless::String<N>` from
+# the 0.9 line; the rest of the firmware still rides 0.8 (transitive
+# pin via `embassy-net`'s smoltcp). Aliased so the two versions can
+# coexist in the dep graph without resolver-time conflict — only the
+# BLE module reaches for `heapless_09`.
+heapless_09 = { package = "heapless", version = "0.9" }
 embedded-graphics = { workspace = true }
 # `embedded_hal::spi::SpiDevice` (sync) is what `embedded-sdmmc 0.8`
 # wants from the SD client wrapper. The async equivalent is also
@@ -72,12 +78,20 @@ esp-hal = { version = "~1.0", features = ["defmt", "esp32s3", "psram", "unstable
 esp-rtos = { version = "0.2.0", features = ["defmt", "embassy", "esp-alloc", "esp-radio", "esp32s3"] }
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["defmt", "esp32s3"] }
 esp-alloc = { version = "0.9.0", features = ["defmt"] }
-# Wi-Fi station-mode driver. `esp-radio` replaces `esp-wifi` on the
+# Wi-Fi + BLE radio driver. `esp-radio` replaces `esp-wifi` on the
 # esp-hal 1.0 release line. Pinned to 0.17.x because 0.18 requires
 # esp-hal ~1.1.0-rc.0 which would force a wider toolchain bump.
 # `unstable` is required because esp-hal itself runs with `unstable`
-# enabled here.
-esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "unstable"] }
+# enabled here. `ble` enables the on-chip BLE controller (HCI behind
+# the `BleConnector` Transport); `coex` lets Wi-Fi STA and BLE share
+# the radio at the cost of ~10–15% Wi-Fi throughput. The bt-hci
+# version pin (^0.6) cascades into the trouble-host 0.5.x line.
+esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "ble", "coex", "unstable"] }
+# BLE host stack. 0.5.1 is the trouble-host release pinned to
+# `bt-hci ^0.6` (matches esp-radio 0.17). 0.6.0 jumps to `bt-hci 0.8`
+# and pairs with esp-radio 0.18 — bump together when we move the
+# wider toolchain.
+trouble-host = { version = "0.5.1", default-features = false, features = ["defmt", "peripheral", "gatt", "derive", "default-packet-pool"] }
 # embassy-net's TCP / UDP / DHCPv4 stack on top of smoltcp. 0.9.x
 # pairs with esp-radio 0.18 (both ride the embassy-sync 0.7 line).
 embassy-net = { version = "0.9", features = ["defmt", "proto-ipv4", "tcp", "udp", "dhcpv4", "dns", "multicast", "medium-ethernet"] }

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -27,6 +27,7 @@ modifier pipeline at ~30 FPS.
 - `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
 - `src/imu.rs` — BMI270 task publishing accel/gyro samples on `IMU_SIGNAL`
 - `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` / `src/power.rs` — per-peripheral tasks
+- `src/ble/` — BLE peripheral. `mod.rs` re-exports the task entry point; `server.rs` declares the GATT server (Device Information / Battery / Stack-chan custom emotion service) via the `trouble-host` macros and runs the advertise / accept / serve loop; `task.rs` pins the controller type for `embassy_executor::task` spawn
 - `src/audio.rs` — I²S0 + codec bring-up, then RX RMS loop (publishing on `AUDIO_RMS_SIGNAL`) + TX feeder (silence between trigger-driven clips) running concurrently via `embassy_futures::join`. Exposes `AUDIO_TX_PLAYING` so the render loop can gate `audio_rms` against speaker self-trigger
 - `src/camera.rs` — `LCD_CAM` + DMA bring-up + always-on capture loop. Each frame is published on `CAMERA_FRAME_SIGNAL` for the LCD preview AND fed through `tracker::Tracker::step`, with the result on `CAMERA_TRACKING_SIGNAL`. `CAMERA_MODE_SIGNAL` is now display-only (preview vs avatar)
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
@@ -98,6 +99,16 @@ The boot config schema (Wi-Fi credentials, mDNS hostname, SNTP
 servers) lives in [`stackchan-net`](../stackchan-net/README.md) and
 round-trips between the SD-card RON file and the HTTP `/settings`
 JSON.
+
+In parallel, the device advertises a BLE peripheral named
+`stackchan-XXXXXX` (last three MAC bytes) so a phone or laptop on the
+same physical radio can read battery percent and current emotion
+without joining the LAN. Services exposed: Device Information
+(`0x180A` — manufacturer / model / firmware revision), Battery
+(`0x180F`), and a custom Stack-chan service whose emotion
+characteristic notifies on transition. Wi-Fi and BLE share the radio
+via `esp-radio`'s coex scheduler; expect a small Wi-Fi airtime tax
+when a BLE central is connected.
 
 ## I²C Bus Sharing
 

--- a/crates/stackchan-firmware/src/ble/mod.rs
+++ b/crates/stackchan-firmware/src/ble/mod.rs
@@ -1,0 +1,38 @@
+//! BLE peripheral surface — advertise + read-only GATT.
+//!
+//! On boot, [`ble_task`] takes ownership of the trouble-host
+//! `ExternalController` (built from `esp_radio`'s `BleConnector`) and
+//! drives an advertise → accept-connection → serve-GATT loop for the
+//! firmware lifetime. The advertised local name is
+//! `stackchan-XXXXXX`, where `XXXXXX` is the last three bytes of the
+//! Wi-Fi MAC; clients see the same handle whether they discover us
+//! over BLE or mDNS.
+//!
+//! Three services are exposed in this initial cut, all read-only:
+//!
+//! - **Device Information (`0x180A`)** — manufacturer, model, and
+//!   firmware-revision strings. nRF Connect surfaces these natively.
+//! - **Battery (`0x180F`)** — `BATTERY_LEVEL` (`0x2A19`) reflecting
+//!   `snapshot::read().battery.percent`. Periodic notify @ 1 Hz when
+//!   a peer is subscribed.
+//! - **Stack-chan custom service** — emotion characteristic
+//!   (one-byte enum, [`stackchan_core::Emotion::wire_byte`]).
+//!   Notify on transition only.
+//!
+//! Coexistence: BLE rides the same radio as Wi-Fi via esp-radio's
+//! `coex` feature. Expect a single-digit-percent Wi-Fi throughput
+//! cost — invisible for the dashboard / SSE / settings round-trips
+//! the firmware does today.
+//!
+//! Sync-version note: trouble-host 0.5.x pulls
+//! `embassy-sync = 0.6` while the rest of the firmware uses 0.7.
+//! Both compile side-by-side because nothing crosses the boundary —
+//! shared state goes through `snapshot::read()` (a
+//! `Mutex<CriticalSectionRawMutex, Cell<...>>`), never via embassy
+//! `Signal`s.
+
+mod server;
+mod task;
+
+pub use server::{StackchanServer, run_ble_peripheral};
+pub use task::{BleTaskConfig, ble_task};

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -131,6 +131,14 @@ pub async fn run_ble_peripheral<C: Controller>(
     address_bytes: [u8; 6],
     local_name: &'static str,
 ) -> ! {
+    // BLE static random address requires bits 47:46 == 0b11 (Core
+    // Spec Vol 6, Part B, §1.3.2.1). `Address::random` doesn't
+    // enforce this, and a typical ESP32 OUI starts with `0x24`
+    // which clears those bits — the controller silently rejects
+    // the address on most units. `bt-hci` stores the address
+    // little-endian, so the MSB lives at index 5.
+    let mut address_bytes = address_bytes;
+    address_bytes[5] |= 0xC0;
     let address = Address::random(address_bytes);
     defmt::info!(
         "ble: address={=[u8; 6]:02x} name={=str}",
@@ -302,9 +310,21 @@ async fn notify_task<P: PacketPool>(
                 defmt::Debug2Format(&e)
             );
         }
+        // Notify failures here cover two cases: (1) the central
+        // hasn't subscribed via CCCD yet (common in the first few
+        // seconds after connect; trouble-host returns an error
+        // because there's no notify destination), and (2) the
+        // connection actually dropped. We don't try to distinguish:
+        // a real disconnect surfaces in `gatt_events_task`'s
+        // `Disconnected` arm, which terminates the outer
+        // `select(events, notify)`. Returning here on every error
+        // would race that path and end the connection on the first
+        // pre-subscription tick — the Greptile P2.
         if let Err(e) = battery_handle.notify(conn, &battery_pct).await {
-            defmt::info!("ble: battery notify ended ({})", defmt::Debug2Format(&e));
-            return;
+            defmt::trace!(
+                "ble: battery notify skipped ({}) — peer not subscribed?",
+                defmt::Debug2Format(&e)
+            );
         }
 
         let emotion_byte = snap.emotion.wire_byte();
@@ -317,8 +337,10 @@ async fn notify_task<P: PacketPool>(
         if last_emotion != Some(snap.emotion) {
             last_emotion = Some(snap.emotion);
             if let Err(e) = emotion_handle.notify(conn, &emotion_byte).await {
-                defmt::info!("ble: emotion notify ended ({})", defmt::Debug2Format(&e));
-                return;
+                defmt::trace!(
+                    "ble: emotion notify skipped ({}) — peer not subscribed?",
+                    defmt::Debug2Format(&e)
+                );
             }
         }
 

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -1,0 +1,327 @@
+//! GATT server declaration + per-connection serve loop.
+//!
+//! ## Lints
+//!
+//! `missing_docs` is silenced for the whole module because the
+//! `#[gatt_server]` and `#[gatt_service]` proc-macros emit public
+//! support items (auxiliary `handle: u16` fields, `new` /
+//! `new_with_config` constructors, `get` / `set` methods) without
+//! doc comments. Our own struct/field doc comments below stay
+//! authoritative for the human-facing surface.
+//!
+//! The server exposes three services beyond the auto-built GAP:
+//!
+//! 1. **Device Information `0x180A`** — manufacturer / model /
+//!    firmware-revision strings. Populated at boot and never mutated.
+//! 2. **Battery `0x180F`** — battery level (`0x2A19`), `read + notify`.
+//! 3. **Stack-chan custom service** (128-bit UUID
+//!    `8a1c0001-7b3f-4d52-9c6e-5f5ba1e5cf01`) — emotion characteristic
+//!    (`8a1c0002-…`), `read + notify`, one byte using
+//!    [`stackchan_core::Emotion::wire_byte`].
+//!
+//! DIS characteristic types are `heapless::String<N>` rather than
+//! `&'static str` because trouble-host's `AsGatt for &'static str`
+//! sets `MAX_SIZE = usize::MAX`, which the gatt-service macro tries
+//! to allocate as a static byte buffer — it doesn't fit.
+//! `heapless::String<N>` caps the storage at N bytes and is set at
+//! runtime via [`StackchanServer::set`].
+
+#![allow(missing_docs)]
+
+use embassy_futures::join::join;
+use embassy_futures::select::select;
+use embassy_time::{Duration, Timer};
+// trouble-host 0.5 implements `AsGatt` on `heapless::String<N>` from
+// the 0.9 line; the firmware's other uses of `heapless` still ride
+// 0.8. Reach explicitly for the alias so the right impl is picked.
+use heapless_09::String as HString;
+use stackchan_core::Emotion;
+use trouble_host::Address;
+use trouble_host::prelude::*;
+
+use crate::net::snapshot;
+
+/// Manufacturer string for DIS. Stack-chan rides the M5Stack CoreS3.
+const DIS_MANUFACTURER: &str = "M5Stack";
+
+/// Model string for DIS — the human-readable product identity.
+const DIS_MODEL: &str = "Stack-chan CoreS3";
+
+/// Firmware revision shown over BLE. Wired from cargo metadata so the
+/// value tracks release-please bumps without manual sync.
+const DIS_FIRMWARE_REVISION: &str = env!("CARGO_PKG_VERSION");
+
+/// Storage cap for each DIS string characteristic. 32 bytes is more
+/// than enough for `M5Stack`, `Stack-chan CoreS3`, and any
+/// foreseeable cargo version string.
+const DIS_FIELD_CAP: usize = 32;
+
+/// Maximum simultaneous BLE centrals. One phone at a time is plenty.
+const CONNECTIONS_MAX: usize = 1;
+
+/// L2CAP channels: ATT + signaling. We don't open L2CAP `CoC`, so two
+/// is enough.
+const L2CAP_CHANNELS_MAX: usize = 2;
+
+/// Notify cadence for the battery characteristic. Battery state moves
+/// slowly; 1 Hz is generous and stays well below the BLE radio's
+/// busy threshold.
+const BATTERY_NOTIFY_PERIOD: Duration = Duration::from_secs(1);
+
+/// Top-level GATT server. The `#[gatt_server]` macro emits a struct
+/// with a `'values` lifetime parameter that ties the GAP name + any
+/// `&'static str` characteristic defaults to a single anchor.
+///
+/// The `#[allow(missing_docs)]` covers macro-generated internals
+/// (the auxiliary `handle` fields + `new` methods that the
+/// `gatt_server` / `gatt_service` macros emit alongside our own
+/// fields) — those are public so the macro-emitted constructors can
+/// see them, but they're not part of our intentional surface.
+#[allow(missing_docs)]
+#[gatt_server]
+pub struct StackchanServer {
+    /// Device Information Service (`0x180A`) — manufacturer / model /
+    /// firmware-revision strings, populated at boot.
+    pub dis: DeviceInformationService,
+    /// Battery Service (`0x180F`) — battery level percent, notified
+    /// at 1 Hz when subscribed.
+    pub battery: BatteryService,
+    /// Stack-chan custom service — emotion characteristic, notified
+    /// on transition.
+    pub stackchan: StackchanService,
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = service::DEVICE_INFORMATION)]
+pub struct DeviceInformationService {
+    #[characteristic(uuid = characteristic::MANUFACTURER_NAME_STRING, read)]
+    pub manufacturer: HString<DIS_FIELD_CAP>,
+    #[characteristic(uuid = characteristic::MODEL_NUMBER_STRING, read)]
+    pub model: HString<DIS_FIELD_CAP>,
+    #[characteristic(uuid = characteristic::FIRMWARE_REVISION_STRING, read)]
+    pub firmware_revision: HString<DIS_FIELD_CAP>,
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = service::BATTERY)]
+pub struct BatteryService {
+    /// Battery state of charge, percent 0..=100.
+    #[characteristic(uuid = characteristic::BATTERY_LEVEL, read, notify, value = 0)]
+    pub level: u8,
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = "8a1c0001-7b3f-4d52-9c6e-5f5ba1e5cf01")]
+pub struct StackchanService {
+    /// Current emotion, encoded by [`Emotion::wire_byte`]. Notified on
+    /// transition.
+    #[characteristic(uuid = "8a1c0002-7b3f-4d52-9c6e-5f5ba1e5cf01", read, notify, value = 0)]
+    pub emotion: u8,
+}
+
+/// Run the BLE peripheral for the firmware lifetime.
+///
+/// Owns the trouble-host stack and loops `advertise → accept → serve`.
+/// Returns only on unrecoverable controller failure (in which case the
+/// caller should park rather than restart, since esp-radio's BLE
+/// transport can't be safely re-initialized while the controller is
+/// still alive).
+pub async fn run_ble_peripheral<C: Controller>(
+    controller: C,
+    address_bytes: [u8; 6],
+    local_name: &'static str,
+) -> ! {
+    let address = Address::random(address_bytes);
+    defmt::info!(
+        "ble: address={=[u8; 6]:02x} name={=str}",
+        address_bytes,
+        local_name
+    );
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let Host {
+        mut peripheral,
+        runner,
+        ..
+    } = stack.build();
+
+    let server = match StackchanServer::new_with_config(GapConfig::Peripheral(PeripheralConfig {
+        name: local_name,
+        appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
+    })) {
+        Ok(s) => s,
+        Err(e) => defmt::panic!("ble: server build failed ({=str})", e),
+    };
+
+    populate_dis(&server);
+
+    let advertise_serve = async {
+        loop {
+            match advertise(local_name, &mut peripheral, &server).await {
+                Ok(conn) => {
+                    defmt::info!("ble: peer connected");
+                    let events = gatt_events_task(&conn);
+                    let notify = notify_task(&server, &conn);
+                    let _ = select(events, notify).await;
+                    defmt::info!("ble: peer disconnected");
+                }
+                Err(e) => {
+                    defmt::warn!("ble: advertise failed ({})", defmt::Debug2Format(&e));
+                    Timer::after(Duration::from_millis(500)).await;
+                }
+            }
+        }
+    };
+
+    join(ble_runner(runner), advertise_serve).await;
+    defmt::panic!("ble: stack exited (unrecoverable)");
+}
+
+/// Populate the static DIS characteristic values at boot. Failures
+/// here are degraded-but-not-fatal: a phone reading DIS would see an
+/// empty string instead of the friendly value, but the device still
+/// advertises and the battery / emotion services remain usable.
+fn populate_dis(server: &StackchanServer<'_>) {
+    let mut s: HString<DIS_FIELD_CAP> = HString::new();
+    if s.push_str(DIS_MANUFACTURER).is_err() {
+        defmt::warn!("ble: manufacturer string overflow");
+    }
+    if let Err(e) = server.set(&server.dis.manufacturer, &s) {
+        defmt::warn!("ble: dis manufacturer set ({})", defmt::Debug2Format(&e));
+    }
+
+    s.clear();
+    if s.push_str(DIS_MODEL).is_err() {
+        defmt::warn!("ble: model string overflow");
+    }
+    if let Err(e) = server.set(&server.dis.model, &s) {
+        defmt::warn!("ble: dis model set ({})", defmt::Debug2Format(&e));
+    }
+
+    s.clear();
+    if s.push_str(DIS_FIRMWARE_REVISION).is_err() {
+        defmt::warn!("ble: firmware-revision string overflow");
+    }
+    if let Err(e) = server.set(&server.dis.firmware_revision, &s) {
+        defmt::warn!(
+            "ble: dis firmware-revision set ({})",
+            defmt::Debug2Format(&e)
+        );
+    }
+}
+
+/// Background task: drives the trouble-host runner. Required to stay
+/// alive alongside any other BLE task — the runner pumps HCI events
+/// and timer ticks for the host stack.
+async fn ble_runner<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
+    loop {
+        if let Err(e) = runner.run().await {
+            defmt::warn!("ble: runner error ({})", defmt::Debug2Format(&e));
+            // Brief pause to avoid spinning on a transient HCI error.
+            Timer::after(Duration::from_millis(500)).await;
+        }
+    }
+}
+
+/// Advertise as `<local_name>` with a connectable, scannable, undirected
+/// payload. Includes the Battery service UUID in the AD so iOS battery
+/// widgets can find us at scan-time.
+async fn advertise<'values, 'server, C: Controller>(
+    local_name: &str,
+    peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    server: &'server StackchanServer<'values>,
+) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
+    let mut adv_data = [0u8; 31];
+    let len = AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ServiceUuids16(&[[0x0f, 0x18]]), // 0x180F battery service, little-endian.
+            AdStructure::CompleteLocalName(local_name.as_bytes()),
+        ],
+        &mut adv_data[..],
+    )?;
+    let advertiser = peripheral
+        .advertise(
+            &AdvertisementParameters::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &adv_data[..len],
+                scan_data: &[],
+            },
+        )
+        .await?;
+    let conn = advertiser.accept().await?.with_attribute_server(server)?;
+    Ok(conn)
+}
+
+/// Drains GATT events for one connection. trouble-host requires every
+/// event to be `accept()`ed — the reply path runs the ATT response
+/// back to the central. Without this loop, reads would silently time
+/// out from the peer's view.
+async fn gatt_events_task<P: PacketPool>(conn: &GattConnection<'_, '_, P>) {
+    loop {
+        match conn.next().await {
+            GattConnectionEvent::Disconnected { reason } => {
+                defmt::info!("ble: gatt disconnect ({})", defmt::Debug2Format(&reason));
+                return;
+            }
+            GattConnectionEvent::Gatt { event } => match event.accept() {
+                Ok(reply) => reply.send().await,
+                Err(e) => defmt::warn!(
+                    "ble: gatt event accept failed ({})",
+                    defmt::Debug2Format(&e)
+                ),
+            },
+            _ => {}
+        }
+    }
+}
+
+/// Periodic battery notify (1 Hz) + change-driven emotion notify.
+///
+/// Reads the snapshot every tick. Battery percent always notifies so
+/// first-time subscribers see a value within a second. Emotion notifies
+/// only on transition — the value barely changes at steady state, so
+/// notifying every tick would waste airtime and flicker in nRF Connect.
+async fn notify_task<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+) {
+    let battery_handle = server.battery.level;
+    let emotion_handle = server.stackchan.emotion;
+    let mut last_emotion: Option<Emotion> = None;
+
+    loop {
+        let snap = snapshot::read();
+        let battery_pct = snap.battery.percent.unwrap_or(0);
+
+        if let Err(e) = server.set(&battery_handle, &battery_pct) {
+            defmt::warn!(
+                "ble: battery table set failed ({})",
+                defmt::Debug2Format(&e)
+            );
+        }
+        if let Err(e) = battery_handle.notify(conn, &battery_pct).await {
+            defmt::info!("ble: battery notify ended ({})", defmt::Debug2Format(&e));
+            return;
+        }
+
+        let emotion_byte = snap.emotion.wire_byte();
+        if let Err(e) = server.set(&emotion_handle, &emotion_byte) {
+            defmt::warn!(
+                "ble: emotion table set failed ({})",
+                defmt::Debug2Format(&e)
+            );
+        }
+        if last_emotion != Some(snap.emotion) {
+            last_emotion = Some(snap.emotion);
+            if let Err(e) = emotion_handle.notify(conn, &emotion_byte).await {
+                defmt::info!("ble: emotion notify ended ({})", defmt::Debug2Format(&e));
+                return;
+            }
+        }
+
+        Timer::after(BATTERY_NOTIFY_PERIOD).await;
+    }
+}

--- a/crates/stackchan-firmware/src/ble/task.rs
+++ b/crates/stackchan-firmware/src/ble/task.rs
@@ -1,0 +1,43 @@
+//! Embassy task entry point for the BLE peripheral.
+//!
+//! This file pins the otherwise-generic [`run_ble_peripheral`] to the
+//! concrete controller type (`ExternalController<BleConnector<'static>,
+//! 20>`) so it can be spawned with `embassy_executor::task`. The 20 is
+//! the depth of the HCI command queue between trouble-host and the
+//! esp-radio controller — matches the trouble-host esp32 example and
+//! is plenty for our single-peer peripheral surface.
+
+use esp_radio::ble::controller::BleConnector;
+use trouble_host::prelude::ExternalController;
+
+use super::server::run_ble_peripheral;
+
+/// Boot-time inputs to the BLE task.
+///
+/// The controller is built in `main.rs` so it can borrow the same
+/// `&'static esp_radio::Controller` the Wi-Fi side uses; the
+/// leftover bookkeeping (advertised name, random address bytes) is
+/// plumbed through this struct.
+pub struct BleTaskConfig {
+    /// Connector handed off from `BleConnector::new(&radio, BT, _)`.
+    pub controller: ExternalController<BleConnector<'static>, 20>,
+    /// Random LE address advertised by the device. Derived from the
+    /// MAC at boot; see [`crate::ble::ble_task`]'s caller in
+    /// `main.rs`.
+    pub address_bytes: [u8; 6],
+    /// Local name shown in scans (`stackchan-XXXXXX`). Held for
+    /// the firmware lifetime via `StaticCell` in `main.rs`.
+    pub local_name: &'static str,
+}
+
+/// Spawnable BLE task. Owns the controller and runs the trouble-host
+/// stack forever.
+#[embassy_executor::task]
+pub async fn ble_task(config: BleTaskConfig) -> ! {
+    let BleTaskConfig {
+        controller,
+        address_bytes,
+        local_name,
+    } = config;
+    run_ble_peripheral(controller, address_bytes, local_name).await
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -19,6 +19,7 @@ extern crate alloc;
 
 pub mod ambient;
 pub mod audio;
+pub mod ble;
 pub mod board;
 pub mod body_touch;
 pub mod button;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -25,8 +25,8 @@
 extern crate alloc;
 
 use stackchan_firmware::{
-    ambient, audio, board, body_touch, button, camera, clock, framebuffer, head, imu, ir, leds,
-    net, power, storage, touch, tracking_trace, wallclock, watchdog,
+    ambient, audio, ble, board, body_touch, button, camera, clock, framebuffer, head, imu, ir,
+    leds, net, power, storage, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -950,6 +950,49 @@ async fn main(spawner: Spawner) -> ! {
         net_config.mdns.hostname.clone(),
     )) {
         defmt::panic!("spawn(mdns_task) failed: {}", defmt::Debug2Format(&e));
+    }
+
+    // BLE peripheral. Shares the same `&'static esp_radio::Controller`
+    // as Wi-Fi — coex (enabled via the `coex` feature on `esp-radio`)
+    // schedules airtime between the two stacks. The BLE address +
+    // local name are derived from the chip's eFuse MAC so a single
+    // device shows up consistently across reboots, and matches the
+    // discovery handle visible on the LAN over mDNS.
+    #[allow(clippy::items_after_statements)]
+    static BLE_NAME: StaticCell<heapless::String<32>> = StaticCell::new();
+    let ble_mac = esp_hal::efuse::Efuse::mac_address();
+    let ble_name: &'static str = {
+        use core::fmt::Write as _;
+        let mut s: heapless::String<32> = heapless::String::new();
+        // 16 bytes total — well under the 22-byte BLE GAP-name cap.
+        if let Err(e) = write!(
+            &mut s,
+            "stackchan-{:02x}{:02x}{:02x}",
+            ble_mac[3], ble_mac[4], ble_mac[5]
+        ) {
+            defmt::panic!("ble: name format failed: {}", defmt::Debug2Format(&e));
+        }
+        BLE_NAME.init(s).as_str()
+    };
+    let ble_connector = match esp_radio::ble::controller::BleConnector::new(
+        radio,
+        peripherals.BT,
+        esp_radio::ble::Config::default(),
+    ) {
+        Ok(c) => c,
+        Err(e) => defmt::panic!(
+            "ble: BleConnector::new failed ({})",
+            defmt::Debug2Format(&e)
+        ),
+    };
+    let ble_controller: trouble_host::prelude::ExternalController<_, 20> =
+        trouble_host::prelude::ExternalController::new(ble_connector);
+    if let Err(e) = spawner.spawn(ble::ble_task(ble::BleTaskConfig {
+        controller: ble_controller,
+        address_bytes: ble_mac,
+        local_name: ble_name,
+    })) {
+        defmt::panic!("spawn(ble_task) failed: {}", defmt::Debug2Format(&e));
     }
 
     // Sample the chip's hardware RNG twice — once for IdleDrift

--- a/justfile
+++ b/justfile
@@ -298,3 +298,10 @@ si12t-bench:
 # <phrase>` args to bake one entry; no args bakes everything.
 bake-tts *args:
     bash scripts/bake-tts.sh {{args}}
+
+# BLE smoke: scan for an advertised stack-chan and verify the GATT
+# table can be read end-to-end. Optional first arg: device-name prefix
+# (default `stackchan-`). Falls back to a printed manual procedure
+# if BlueZ + a powered adapter aren't available — agent-friendly.
+ble-smoke *args:
+    bash scripts/ble-smoke.sh {{args}}

--- a/scripts/ble-smoke.sh
+++ b/scripts/ble-smoke.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# BLE smoke: scan for an advertised stack-chan, list its GATT services,
+# and read the SIG-standard battery level. Designed to be runnable from
+# the host without any phone or BLE-explorer GUI.
+#
+# Prereqs: BlueZ (bluetoothctl, gatttool) + a working Bluetooth adapter.
+# Falls back to a printed-procedure mode if either is missing — useful
+# in CI / agent shells where there's no radio to scan with.
+#
+# Usage:
+#   scripts/ble-smoke.sh                    # scan-only smoke
+#   scripts/ble-smoke.sh stackchan-abc123   # target a specific device
+
+set -u
+
+readonly TARGET_NAME_PREFIX="${1:-stackchan-}"
+readonly SCAN_SECS="${SCAN_SECS:-15}"
+
+print_manual_procedure() {
+    cat <<EOF
+
+Manual smoke procedure (phone — nRF Connect or LightBlue):
+
+    1. Power the CoreS3. Boot log should announce
+       "ble: address=… name=stackchan-XXXXXX".
+    2. In nRF Connect → Scanner, look for "stackchan-XXXXXX".
+       Signal strength varies; pull the device closer if it doesn't
+       appear within ~10 s.
+    3. Connect. Three services should be listed:
+        - Generic Access (auto)
+        - Device Information (0x180A)
+            • Manufacturer Name String → "M5Stack"
+            • Model Number String     → "Stack-chan CoreS3"
+            • Firmware Revision String → cargo version, e.g. "0.27.0"
+        - Battery (0x180F)
+            • Battery Level (0x2A19) → integer 0..=100
+              Subscribe (CCCD) to receive a value every ~1 s.
+        - Stack-chan custom (8a1c0001-7b3f-4d52-9c6e-5f5ba1e5cf01)
+            • Emotion (8a1c0002-…) → byte 0..=5
+              Subscribe; touch the head pads or watch the autonomous
+              EmotionCycle to see the value change.
+    4. Disconnect. The boot log should print "ble: peer disconnected"
+       and resume advertising. Reconnect should succeed.
+
+EOF
+}
+
+if ! command -v bluetoothctl >/dev/null 2>&1; then
+    print_manual_procedure
+    exit 0
+fi
+
+# `bluetoothctl show` blocks forever when no adapter is registered (or
+# the bluetoothd dbus path isn't responding). Bound it.
+adapter_status="$(timeout 3 bluetoothctl show 2>/dev/null || true)"
+if ! echo "$adapter_status" | grep -q "Powered: yes"; then
+    echo "ble-smoke: bluetoothctl present but no powered adapter — falling back to manual procedure."
+    print_manual_procedure
+    exit 0
+fi
+
+echo "ble-smoke: scanning for ${SCAN_SECS}s for advertisers matching '${TARGET_NAME_PREFIX}'..."
+
+# Run a timed scan and capture devices. The `--timeout` flag exists on
+# newer bluetoothctl; older versions need the wrapped scan-on / scan-off
+# pattern. Try both for portability.
+scan_output=$(
+    {
+        echo "scan on"
+        sleep "${SCAN_SECS}"
+        echo "scan off"
+        echo "devices"
+        echo "exit"
+    } | timeout "$((SCAN_SECS + 10))" bluetoothctl 2>&1 || true
+)
+
+# Print everything matching the target prefix; sort by MAC for stability.
+hits=$(echo "$scan_output" | grep -E "Device [0-9A-F:]{17} ${TARGET_NAME_PREFIX}" | sort -u)
+
+if [ -z "$hits" ]; then
+    echo "ble-smoke: no advertisers matching '${TARGET_NAME_PREFIX}' seen in ${SCAN_SECS}s."
+    echo "ble-smoke: confirm the firmware is flashed and the BT radio is up; re-run with longer SCAN_SECS=30 if RF is noisy."
+    exit 1
+fi
+
+echo "ble-smoke: found:"
+echo "$hits" | sed 's/^/  /'
+
+# Pick the first match for the deeper read.
+mac=$(echo "$hits" | head -n 1 | awk '{print $2}')
+echo
+echo "ble-smoke: connecting to ${mac} for a battery-level read..."
+
+# bluetoothctl GATT subcommands work with the active adapter and
+# require the device to be paired-or-trusted in some BlueZ builds. We
+# don't pair (provisioning will need that in PR3); just attempt a
+# direct connect + read.
+read_output=$(
+    {
+        echo "connect ${mac}"
+        sleep 4
+        echo "menu gatt"
+        echo "list-attributes ${mac}"
+        sleep 2
+        echo "back"
+        echo "disconnect ${mac}"
+        echo "exit"
+    } | timeout 15 bluetoothctl 2>&1 || true
+)
+
+# We can't reliably select the characteristic by path (the service / char
+# index varies per advertise cycle), but list-attributes alone confirms
+# the GATT table parsed end-to-end. A successful connect means the
+# trouble-host advertise loop accepted us.
+if echo "$read_output" | grep -q "Connected: yes\|new connection"; then
+    echo "ble-smoke: connected + GATT table enumerated."
+    echo "$read_output" | grep -E "Service /org|Characteristic /org" | head -20
+    exit 0
+else
+    echo "ble-smoke: connect failed."
+    echo "$read_output" | tail -20
+    exit 1
+fi

--- a/scripts/ble-smoke.sh
+++ b/scripts/ble-smoke.sh
@@ -75,7 +75,9 @@ scan_output=$(
 )
 
 # Print everything matching the target prefix; sort by MAC for stability.
-hits=$(echo "$scan_output" | grep -E "Device [0-9A-F:]{17} ${TARGET_NAME_PREFIX}" | sort -u)
+# Case-insensitive: BlueZ on Debian/Ubuntu/Pi OS sometimes emits lowercase
+# MACs (`aa:bb:cc:…`) where Fedora emits uppercase. `-i` covers both.
+hits=$(echo "$scan_output" | grep -Ei "Device [0-9A-F:]{17} ${TARGET_NAME_PREFIX}" | sort -u)
 
 if [ -z "$hits" ]; then
     echo "ble-smoke: no advertisers matching '${TARGET_NAME_PREFIX}' seen in ${SCAN_SECS}s."


### PR DESCRIPTION
## Summary

- Wires `esp-radio`'s `BleConnector` into `trouble-host 0.5.1`, sharing the same `&'static esp_radio::Controller` Wi-Fi already owns. Coex enabled via the new `coex` feature on `esp-radio`.
- Advertises as `stackchan-XXXXXX` (derived from the last three MAC bytes via `esp_hal::efuse::Efuse::mac_address()`), so the same handle that ends up on the LAN over mDNS shows up under the BLE scanner.
- Exposes three services beyond the auto-built GAP:
  - **Device Information (`0x180A`)** — `MANUFACTURER_NAME_STRING`, `MODEL_NUMBER_STRING`, `FIRMWARE_REVISION_STRING` (wired from `env!("CARGO_PKG_VERSION")`). Set once at boot via `server.set(...)`.
  - **Battery (`0x180F`)** — `BATTERY_LEVEL` (`0x2A19`), `read + notify` @ 1 Hz, source is `snapshot::read().battery.percent`.
  - **Stack-chan custom (`8a1c0001-7b3f-4d52-9c6e-5f5ba1e5cf01`)** — emotion characteristic (`8a1c0002-…`), one byte via the new `Emotion::wire_byte`. Notifies on transition only.
- `Emotion::wire_byte()` lands in `stackchan-core` next to `wire_str` with an exhaustive match (no wildcard, so a future variant forces a conscious byte choice). Locking unit-test pins the mapping.
- `just ble-smoke` recipe + `scripts/ble-smoke.sh` — scans for the advertiser and walks the GATT table when BlueZ + a powered adapter are available; falls back to printing the nRF Connect manual procedure otherwise (so the recipe is agent-runnable on hosts without BT hardware).
- README updated with the new module + BLE network-surface paragraph.

This is PR1 of a planned three-PR arc; PR2 will add writeable SSID/PSK characteristics with the same atomic SD writeback path `PUT /settings` uses, plus a soft-reconnect signal that both BLE and HTTP drive (closing the existing PUT-doesn't-reconnect UX hole). PR3 adds passkey display + LE Secure Connections bonding.

### Notes for reviewers

- **Version triple-pin.** `esp-radio 0.17` → `bt-hci 0.6` → `trouble-host 0.5.1`. Bumping any one of these requires moving the other two together. The next bump (`esp-radio 0.18` → `bt-hci 0.8` → `trouble-host 0.6`) also drags `esp-hal ~1.1.0-rc.0`, which is why we stayed on the 0.5.x line.
- **`heapless` rename.** `trouble-host`'s `AsGatt` impls live on `heapless::String<N>` from the 0.9 line; the rest of the firmware still uses 0.8 (transitively pinned via `embassy-net`'s `smoltcp`). Added under `heapless_09 = { package = "heapless", version = "0.9" }` so both versions can resolve. Only the BLE module reaches for the alias.
- **No embassy-sync version leak.** `trouble-host` pulls `embassy-sync 0.6` while the firmware uses 0.7. Compiles side-by-side because nothing crosses the boundary — shared state goes through `snapshot::read()` (a `Mutex<CriticalSectionRawMutex, Cell<...>>`), never via embassy `Signal`s.
- **Macro-generated `missing_docs`.** `#[gatt_server]` and `#[gatt_service]` emit public auxiliary items (`handle: u16` fields, `new` / `new_with_config` constructors) without doc comments. Silenced module-wide via `#![allow(missing_docs)]` in `ble/server.rs`; the human-facing surface still has explicit doc comments.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests
- [x] `just clippy-firmware` — strict clippy on the firmware crate
- [x] `just build-firmware` — release build clean
- [x] `just ci` — fmt + clippy + tests + cargo-deny + workspace doc-lint
- [x] `just ble-smoke` (no-adapter mode) — prints the manual procedure and exits 0
- [x] New `Emotion::wire_byte` mapping unit-tested
- [ ] **Hardware verify:** flash via `just fmr`, watch `/tmp/scfmr.log` for `ble: address=… name=stackchan-XXXXXX` after Wi-Fi spawn and `boot complete — idle heartbeat`. Connect from nRF Connect, confirm DIS / Battery / Stack-chan emotion services populate. Wi-Fi dashboard + SSE should still serve. _(Blocked at PR-author time on `/dev/ttyACM*` — AXP2101 had shut the chip; will verify post-merge or post-button-press.)_