### PR TITLE
feat(firmware): BLE Wi-Fi provisioning + soft reconnect

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -9,7 +9,7 @@
   "crates/ir-nec": "0.8.0",
   "crates/ltr553": "0.8.0",
   "crates/scservo": "0.6.0",
-  "crates/stackchan-firmware": "0.27.0",
+  "crates/stackchan-firmware": "0.28.0",
   "crates/aw88298": "0.4.0",
   "crates/es7210": "0.4.0",
   "crates/gc0308": "0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "stackchan-firmware"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "aw88298",
  "aw9523",

--- a/crates/stackchan-firmware/CHANGELOG.md
+++ b/crates/stackchan-firmware/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.28.0](https://github.com/andymai/stackchan-kai/compare/stackchan-firmware-v0.27.0...stackchan-firmware-v0.28.0) (2026-04-28)
+
+
+### Features
+
+* **firmware:** POST /volume + POST /mute (persisted) ([#170](https://github.com/andymai/stackchan-kai/issues/170)) ([f27d2e1](https://github.com/andymai/stackchan-kai/commit/f27d2e1e047371a382386562a14df76540945b09))
+
 ## [0.27.0](https://github.com/andymai/stackchan-kai/compare/stackchan-firmware-v0.26.0...stackchan-firmware-v0.27.0) (2026-04-27)
 
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stackchan-firmware"
-version = "0.27.0"
+version = "0.28.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -9,7 +9,7 @@
 //! doc comments. Our own struct/field doc comments below stay
 //! authoritative for the human-facing surface.
 //!
-//! The server exposes three services beyond the auto-built GAP:
+//! The server exposes four services beyond the auto-built GAP:
 //!
 //! 1. **Device Information `0x180A`** — manufacturer / model /
 //!    firmware-revision strings. Populated at boot and never mutated.
@@ -18,6 +18,21 @@
 //!    `8a1c0001-7b3f-4d52-9c6e-5f5ba1e5cf01`) — emotion characteristic
 //!    (`8a1c0002-…`), `read + notify`, one byte using
 //!    [`stackchan_core::Emotion::wire_byte`].
+//! 4. **Provisioning custom service** (`8a1c0010-…`) — writeable SSID
+//!    + PSK characteristics. Writing the PSK commits the staged SSID
+//!    + new PSK through the same atomic SD-writeback path that `PUT
+//!      /settings` uses, then signals
+//!      [`crate::net::wifi::WIFI_RECONFIG`] so the wifi task soft-
+//!      reconnects without a reboot.
+//!
+//! ## Security
+//!
+//! The provisioning service is **unauthenticated** in this PR — any
+//! BLE central in radio range can write SSID/PSK and reconfigure the
+//! device. PR3 adds passkey display + LE Secure Connections bonding
+//! and gates these writes to bonded peers only. Until then, the
+//! `defmt::warn!` on every PSK commit is the loud reminder that this
+//! is provisional.
 //!
 //! DIS characteristic types are `heapless::String<N>` rather than
 //! `&'static str` because trouble-host's `AsGatt for &'static str`
@@ -28,6 +43,7 @@
 
 #![allow(missing_docs)]
 
+use alloc::string::String as AString;
 use embassy_futures::join::join;
 use embassy_futures::select::select;
 use embassy_time::{Duration, Timer};
@@ -40,6 +56,8 @@ use trouble_host::Address;
 use trouble_host::prelude::*;
 
 use crate::net::snapshot;
+use crate::net::wifi::{WIFI_RECONFIG, WifiCreds};
+use crate::storage::{CONFIG_SNAPSHOT, with_storage};
 
 /// Manufacturer string for DIS. Stack-chan rides the M5Stack CoreS3.
 const DIS_MANUFACTURER: &str = "M5Stack";
@@ -55,6 +73,13 @@ const DIS_FIRMWARE_REVISION: &str = env!("CARGO_PKG_VERSION");
 /// than enough for `M5Stack`, `Stack-chan CoreS3`, and any
 /// foreseeable cargo version string.
 const DIS_FIELD_CAP: usize = 32;
+
+/// SSID storage cap. The 802.11 spec caps SSIDs at 32 bytes.
+const PROV_SSID_CAP: usize = 32;
+
+/// PSK storage cap. WPA2-PSK ASCII is 8–63 chars; 64 bytes leaves a
+/// byte of slack for an opaque trailing byte.
+const PROV_PSK_CAP: usize = 64;
 
 /// Maximum simultaneous BLE centrals. One phone at a time is plenty.
 const CONNECTIONS_MAX: usize = 1;
@@ -89,6 +114,9 @@ pub struct StackchanServer {
     /// Stack-chan custom service — emotion characteristic, notified
     /// on transition.
     pub stackchan: StackchanService,
+    /// Wi-Fi provisioning service — writeable SSID + PSK. Commits +
+    /// soft-reconnects on PSK write.
+    pub provisioning: ProvisioningService,
 }
 
 #[allow(missing_docs)]
@@ -117,6 +145,24 @@ pub struct StackchanService {
     /// transition.
     #[characteristic(uuid = "8a1c0002-7b3f-4d52-9c6e-5f5ba1e5cf01", read, notify, value = 0)]
     pub emotion: u8,
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = "8a1c0010-7b3f-4d52-9c6e-5f5ba1e5cf01")]
+pub struct ProvisioningService {
+    /// Staged SSID. `read + write`: a phone app can pre-fill the
+    /// current value, replace it, and the new bytes are held in the
+    /// GATT table until the PSK characteristic write triggers commit.
+    /// 32-byte cap matches the 802.11 SSID limit.
+    #[characteristic(uuid = "8a1c0011-7b3f-4d52-9c6e-5f5ba1e5cf01", read, write)]
+    pub ssid: HString<PROV_SSID_CAP>,
+    /// Pre-shared key. `write`-only — read access would let any
+    /// scanner exfiltrate the network secret. Writing this character-
+    /// istic triggers commit: the staged SSID + new PSK are persisted
+    /// to `STACKCHAN.RON`, then `WIFI_RECONFIG` is signaled so the
+    /// wifi task soft-reconnects without a reboot.
+    #[characteristic(uuid = "8a1c0012-7b3f-4d52-9c6e-5f5ba1e5cf01", write)]
+    pub psk: HString<PROV_PSK_CAP>,
 }
 
 /// Run the BLE peripheral for the firmware lifetime.
@@ -164,13 +210,14 @@ pub async fn run_ble_peripheral<C: Controller>(
     };
 
     populate_dis(&server);
+    populate_provisioning_ssid(&server).await;
 
     let advertise_serve = async {
         loop {
             match advertise(local_name, &mut peripheral, &server).await {
                 Ok(conn) => {
                     defmt::info!("ble: peer connected");
-                    let events = gatt_events_task(&conn);
+                    let events = gatt_events_task(&server, &conn);
                     let notify = notify_task(&server, &conn);
                     let _ = select(events, notify).await;
                     defmt::info!("ble: peer disconnected");
@@ -267,20 +314,35 @@ async fn advertise<'values, 'server, C: Controller>(
 /// event to be `accept()`ed — the reply path runs the ATT response
 /// back to the central. Without this loop, reads would silently time
 /// out from the peer's view.
-async fn gatt_events_task<P: PacketPool>(conn: &GattConnection<'_, '_, P>) {
+///
+/// On a write to the provisioning PSK characteristic, fires the
+/// commit path — the staged SSID + new PSK get persisted to
+/// `STACKCHAN.RON` and the wifi task gets nudged to soft-reconnect.
+async fn gatt_events_task<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+) {
+    let psk_handle = server.provisioning.psk.handle;
     loop {
         match conn.next().await {
             GattConnectionEvent::Disconnected { reason } => {
                 defmt::info!("ble: gatt disconnect ({})", defmt::Debug2Format(&reason));
                 return;
             }
-            GattConnectionEvent::Gatt { event } => match event.accept() {
-                Ok(reply) => reply.send().await,
-                Err(e) => defmt::warn!(
-                    "ble: gatt event accept failed ({})",
-                    defmt::Debug2Format(&e)
-                ),
-            },
+            GattConnectionEvent::Gatt { event } => {
+                let is_psk_write =
+                    matches!(&event, GattEvent::Write(w) if w.handle() == psk_handle);
+                match event.accept() {
+                    Ok(reply) => reply.send().await,
+                    Err(e) => defmt::warn!(
+                        "ble: gatt event accept failed ({})",
+                        defmt::Debug2Format(&e)
+                    ),
+                }
+                if is_psk_write {
+                    commit_provisioning(server).await;
+                }
+            }
             _ => {}
         }
     }
@@ -345,5 +407,115 @@ async fn notify_task<P: PacketPool>(
         }
 
         Timer::after(BATTERY_NOTIFY_PERIOD).await;
+    }
+}
+
+/// Pre-fill the SSID characteristic value with the currently-persisted
+/// network name so a phone reading it sees the active config rather
+/// than an empty string. The PSK is intentionally not pre-filled —
+/// the characteristic is write-only.
+async fn populate_provisioning_ssid(server: &StackchanServer<'_>) {
+    let snap_ssid = match CONFIG_SNAPSHOT.lock().await.as_ref() {
+        Some(cfg) => cfg.wifi.ssid.clone(),
+        None => return,
+    };
+    let mut s: HString<PROV_SSID_CAP> = HString::new();
+    if s.push_str(snap_ssid.as_str()).is_err() {
+        defmt::warn!(
+            "ble: persisted SSID exceeds {=usize} bytes; not pre-filling",
+            PROV_SSID_CAP
+        );
+        return;
+    }
+    if let Err(e) = server.set(&server.provisioning.ssid, &s) {
+        defmt::warn!("ble: provisioning SSID set ({})", defmt::Debug2Format(&e));
+    }
+}
+
+/// Commit a provisioning write: take the staged SSID + just-written
+/// PSK from the GATT table, validate, persist atomically, signal the
+/// wifi task to soft-reconnect, then clear the PSK from the table so
+/// a memory dump of the BLE stack doesn't leak the secret.
+///
+/// Failures are logged but never panic — a malformed write should
+/// just be a no-op so the next correct write can succeed.
+async fn commit_provisioning(server: &StackchanServer<'_>) {
+    defmt::warn!(
+        "ble: provisioning commit (UNAUTHENTICATED — pairing pending). \
+         Anyone in BLE range can reconfigure Wi-Fi until that lands."
+    );
+
+    // Read staged SSID + new PSK from the GATT table. trouble-host
+    // wrote both into the table when their respective Write events
+    // were accepted.
+    let staged_ssid: HString<PROV_SSID_CAP> = match server.get(&server.provisioning.ssid) {
+        Ok(v) => v,
+        Err(e) => {
+            defmt::warn!("ble: prov: ssid get failed ({})", defmt::Debug2Format(&e));
+            return;
+        }
+    };
+    let new_psk: HString<PROV_PSK_CAP> = match server.get(&server.provisioning.psk) {
+        Ok(v) => v,
+        Err(e) => {
+            defmt::warn!("ble: prov: psk get failed ({})", defmt::Debug2Format(&e));
+            return;
+        }
+    };
+
+    if staged_ssid.trim().is_empty() {
+        defmt::warn!("ble: prov: empty SSID — write SSID before PSK to commit");
+        return;
+    }
+
+    // Build a new Config from the persisted snapshot, mutating only
+    // the wifi block. Any other settings (mDNS hostname, SNTP, audio)
+    // stay untouched, mirroring the conservative-update shape of
+    // PUT /settings's merge step.
+    //
+    // Snapshot is cloned out-of-line so the mutex guard drops before
+    // the subsequent `with_storage` call (also under a mutex) — both
+    // mutexes touch the SD via the boot path, so holding both at once
+    // would risk a re-entrant deadlock if storage internals ever grew
+    // a CONFIG_SNAPSHOT touch.
+    let snapshot_value = CONFIG_SNAPSHOT.lock().await.clone();
+    let Some(mut new_config) = snapshot_value else {
+        defmt::warn!("ble: prov: no config snapshot — boot config not yet read");
+        return;
+    };
+    new_config.wifi.ssid = AString::from(staged_ssid.as_str());
+    new_config.wifi.psk = AString::from(new_psk.as_str());
+
+    let write_result = with_storage(|storage| storage.write_config(&new_config)).await;
+    match write_result {
+        Some(Ok(())) => {
+            defmt::info!(
+                "ble: prov: persisted (ssid={=str})",
+                new_config.wifi.ssid.as_str()
+            );
+            *CONFIG_SNAPSHOT.lock().await = Some(new_config.clone());
+            WIFI_RECONFIG.signal(WifiCreds {
+                ssid: new_config.wifi.ssid,
+                psk: new_config.wifi.psk,
+            });
+        }
+        Some(Err(e)) => {
+            defmt::warn!("ble: prov: write_config failed ({})", e);
+        }
+        None => {
+            defmt::warn!("ble: prov: no SD mounted — cannot persist");
+        }
+    }
+
+    // Clear the PSK from the GATT table. The central just wrote it
+    // and could theoretically read it back if `read` were enabled
+    // (it isn't), but a future maintenance change to the macro
+    // attributes shouldn't accidentally start leaking secrets.
+    let empty: HString<PROV_PSK_CAP> = HString::new();
+    if let Err(e) = server.set(&server.provisioning.psk, &empty) {
+        defmt::warn!(
+            "ble: prov: psk-clear table set ({})",
+            defmt::Debug2Format(&e)
+        );
     }
 }

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -81,6 +81,11 @@ const PROV_SSID_CAP: usize = 32;
 /// byte of slack for an opaque trailing byte.
 const PROV_PSK_CAP: usize = 64;
 
+/// Minimum WPA2-PSK length in characters. The 802.11 spec rejects
+/// passphrases shorter than this — committing one would just stick
+/// the wifi task in a retry-backoff loop.
+const PROV_PSK_MIN: usize = 8;
+
 /// Maximum simultaneous BLE centrals. One phone at a time is plenty.
 const CONNECTIONS_MAX: usize = 1;
 
@@ -332,14 +337,27 @@ async fn gatt_events_task<P: PacketPool>(
             GattConnectionEvent::Gatt { event } => {
                 let is_psk_write =
                     matches!(&event, GattEvent::Write(w) if w.handle() == psk_handle);
-                match event.accept() {
-                    Ok(reply) => reply.send().await,
-                    Err(e) => defmt::warn!(
-                        "ble: gatt event accept failed ({})",
-                        defmt::Debug2Format(&e)
-                    ),
-                }
-                if is_psk_write {
+                // Only fire commit when the write was actually
+                // applied to the GATT table. A failed `accept()`
+                // means trouble-host did not store the new bytes,
+                // and `server.get(&psk)` would return stale or
+                // empty data — committing on that path would
+                // persist the wrong PSK (or treat an empty PSK as
+                // an open-AP credential).
+                let accepted_ok = match event.accept() {
+                    Ok(reply) => {
+                        reply.send().await;
+                        true
+                    }
+                    Err(e) => {
+                        defmt::warn!(
+                            "ble: gatt event accept failed ({})",
+                            defmt::Debug2Format(&e)
+                        );
+                        false
+                    }
+                };
+                if is_psk_write && accepted_ok {
                     commit_provisioning(server).await;
                 }
             }
@@ -465,6 +483,19 @@ async fn commit_provisioning(server: &StackchanServer<'_>) {
 
     if staged_ssid.trim().is_empty() {
         defmt::warn!("ble: prov: empty SSID — write SSID before PSK to commit");
+        return;
+    }
+    // Reject below-spec PSKs at the BLE boundary so they never reach
+    // the SD card or the wifi task. Committing a 1–7 char PSK would
+    // just thrash the radio on a retry loop. Empty PSK is allowed
+    // for provisioning an open AP (which the 802.11 driver will
+    // accept).
+    if !new_psk.is_empty() && new_psk.len() < PROV_PSK_MIN {
+        defmt::warn!(
+            "ble: prov: PSK too short ({=usize} bytes; need {=usize}+)",
+            new_psk.len(),
+            PROV_PSK_MIN
+        );
         return;
     }
 

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -30,8 +30,12 @@
 //!   as JSON, with `wifi.psk` and `auth.token` redacted.
 //! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
 //!   Validates, writes back atomically to `/sd/STACKCHAN.RON`, and
-//!   responds `{"reboot_required": true}`. Wi-Fi keeps using the
-//!   boot-time config; reboot to apply.
+//!   responds `{"reboot_required": false}`. On any change to the
+//!   `wifi` block, signals [`super::wifi::WIFI_RECONFIG`] so the
+//!   wifi task drops the current link and reconnects with the new
+//!   credentials — no reboot needed. Other persisted blocks
+//!   (mDNS hostname, SNTP servers, audio) only take effect on the
+//!   next boot.
 //!
 //! ## Auth
 //!
@@ -71,7 +75,7 @@ use stackchan_net::http_parse::{
 };
 
 use super::snapshot::{self, AvatarSnapshot};
-use super::wifi::LINK_READY;
+use super::wifi::{LINK_READY, WIFI_RECONFIG, WifiCreds};
 
 /// Listening port. LAN-only; write routes are gated on the
 /// configured `auth.token` (empty = no auth).
@@ -387,9 +391,13 @@ async fn handle_get_settings(socket: &mut TcpSocket<'_>) -> Result<(), HttpError
 }
 
 /// `PUT /settings` — full replace, atomic SD writeback. Returns
-/// `{"reboot_required": true}` on success; the firmware doesn't
-/// re-bring-up Wi-Fi mid-flight (avoids dropping the operator's
-/// session when the SSID changes).
+/// `{"reboot_required": false}` on success.
+///
+/// On a change to `wifi.ssid` or `wifi.psk` (compared against the
+/// current `CONFIG_SNAPSHOT`), signals [`WIFI_RECONFIG`] so the
+/// wifi task drops the link and reconnects with the new creds.
+/// Operators changing the AP from the dashboard now see a brief
+/// link blip rather than needing to power-cycle the device.
 async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let parsed_config = match stackchan_net::parse_settings_json(body) {
         Ok(c) => c,
@@ -422,12 +430,26 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
                 new_config.wifi.ssid.as_str(),
                 new_config.mdns.hostname.as_str()
             );
+            // Soft-reconnect Wi-Fi only when the credentials actually
+            // changed. Comparing against the pre-merge snapshot avoids
+            // a needless link drop when the dashboard re-PUTs the
+            // same body (e.g. the user only changed mDNS hostname,
+            // which can't be applied without a reboot anyway).
+            let wifi_changed = new_config.wifi.ssid != snapshot_for_merge.wifi.ssid
+                || new_config.wifi.psk != snapshot_for_merge.wifi.psk;
+            if wifi_changed {
+                defmt::info!("http: PUT /settings triggered Wi-Fi soft reconnect");
+                WIFI_RECONFIG.signal(WifiCreds {
+                    ssid: new_config.wifi.ssid.clone(),
+                    psk: new_config.wifi.psk.clone(),
+                });
+            }
             // Mirror the audio block into the live snapshot so the
             // SSE stream picks up volume / mute changes from a full
             // settings PUT without waiting for a reboot.
             snapshot::update_audio(new_config.audio);
             *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
-            write_json(socket, 200, "{\"reboot_required\":true}\n").await
+            write_json(socket, 200, "{\"reboot_required\":false}\n").await
         }
         Some(Err(e)) => {
             defmt::warn!("http: PUT /settings write failed ({})", e);

--- a/crates/stackchan-firmware/src/net/wifi.rs
+++ b/crates/stackchan-firmware/src/net/wifi.rs
@@ -1,15 +1,24 @@
-//! Wi-Fi station-mode task with offline-first retry.
+//! Wi-Fi station-mode task with offline-first retry + soft reconfig.
 //!
 //! Owns the [`WifiController`] for the duration of the firmware run.
 //! On boot, checks the SSID from [`stackchan_net::WifiConfig`] — an
-//! empty value means "no Wi-Fi configured", and the task parks
-//! silently so the avatar runs offline-first without any retry storm.
-//! With a non-empty SSID it configures station mode, attempts to
-//! connect, and on disconnection retries with exponential backoff.
+//! empty value means "no Wi-Fi configured", and the task parks on
+//! [`WIFI_RECONFIG`] so a later BLE provisioning write or HTTP `PUT
+//! /settings` can hand it credentials without a reboot. With a
+//! non-empty SSID it configures station mode, attempts to connect,
+//! and on disconnection retries with exponential backoff.
+//!
+//! Soft reconfig: when [`WIFI_RECONFIG`] fires (from the BLE
+//! provisioning service or `PUT /settings`), the task drops the
+//! current link, swaps creds, and re-enters the connect loop. The
+//! HTTP server's settings handler used to return
+//! `{"reboot_required": true}` for a Wi-Fi change; with this signal
+//! wired up the user-visible recovery is just a brief link blip.
 
 use alloc::string::String;
 use core::sync::atomic::{AtomicBool, Ordering};
 
+use embassy_futures::select::{Either, select};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Timer};
@@ -34,6 +43,25 @@ pub static WIFI_LINK_SIGNAL: Signal<CriticalSectionRawMutex, WifiLinkState> = Si
 /// each worker's first accept call.
 pub static LINK_READY: AtomicBool = AtomicBool::new(false);
 
+/// Soft-reconfig signal — replace the active Wi-Fi credentials.
+///
+/// Producers: HTTP `PUT /settings` (after a successful SD writeback)
+/// and the BLE provisioning service (after a writable SSID/PSK
+/// characteristic write). The wifi task is the single consumer; new
+/// values overwrite older pending ones (latest-wins) before the task
+/// actually picks them up, which is the right semantics if a user
+/// retries provisioning rapidly.
+pub static WIFI_RECONFIG: Signal<CriticalSectionRawMutex, WifiCreds> = Signal::new();
+
+/// Credentials handed to [`WIFI_RECONFIG`].
+#[derive(Clone, Debug)]
+pub struct WifiCreds {
+    /// SSID. Empty string means "park; wait for a non-empty value".
+    pub ssid: String,
+    /// Pre-shared key. Empty for an open AP.
+    pub psk: String,
+}
+
 /// Coarse-grained Wi-Fi link state. Published on every transition.
 #[derive(Clone, Copy, Debug, defmt::Format)]
 pub enum WifiLinkState {
@@ -51,73 +79,118 @@ pub enum WifiLinkState {
 const RETRY_BACKOFF_MS: [u64; 5] = [1_000, 2_000, 5_000, 10_000, 30_000];
 
 /// Wi-Fi station task entry point. Owns the [`WifiController`] for
-/// the firmware lifetime. Empty SSID parks silently — the avatar
-/// runs offline-first and downstream `WIFI_LINK_SIGNAL` consumers
-/// see `Disconnected` and `wait()` indefinitely.
+/// the firmware lifetime. Empty SSID parks on [`WIFI_RECONFIG`] —
+/// the avatar runs offline-first; a later BLE provisioning write or
+/// `PUT /settings` wakes the task without a reboot.
 ///
 /// The task never returns: the embassy-net runner shares a
 /// `WifiDevice` borrowed from the same controller, and dropping the
 /// controller would null its backing radio state. On any setup
 /// error we log and park rather than `return`.
 #[embassy_executor::task]
-pub async fn wifi_task(mut controller: WifiController<'static>, ssid: String, psk: String) -> ! {
-    if ssid.trim().is_empty() {
-        defmt::info!("wifi: no SSID configured, idle");
-        WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
-        park_forever().await;
-    }
+pub async fn wifi_task(
+    mut controller: WifiController<'static>,
+    initial_ssid: String,
+    initial_psk: String,
+) -> ! {
+    let mut creds = WifiCreds {
+        ssid: initial_ssid,
+        psk: initial_psk,
+    };
+    // `controller.start_async()` is one-shot per radio lifetime. Track
+    // whether we've called it so a fresh boot with an empty SSID
+    // doesn't start the radio until the first valid creds arrive
+    // (saving idle airtime), and a re-provisioning doesn't try to
+    // start it twice.
+    let mut started = false;
 
-    let client_cfg = ClientConfig::default()
-        .with_ssid(ssid.clone())
-        .with_password(psk);
-    if let Err(e) = controller.set_config(&ModeConfig::Client(client_cfg)) {
-        defmt::error!(
-            "wifi: set_config rejected ({}); parking",
-            defmt::Debug2Format(&e)
-        );
-        park_forever().await;
-    }
-    if let Err(e) = controller.start_async().await {
-        defmt::error!(
-            "wifi: start_async failed ({}); parking",
-            defmt::Debug2Format(&e)
-        );
-        park_forever().await;
-    }
+    loop {
+        if creds.ssid.trim().is_empty() {
+            defmt::info!("wifi: no SSID configured, idle");
+            WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+            creds = WIFI_RECONFIG.wait().await;
+            continue;
+        }
 
-    connect_loop(controller, ssid).await
+        let client_cfg = ClientConfig::default()
+            .with_ssid(creds.ssid.clone())
+            .with_password(creds.psk.clone());
+        if let Err(e) = controller.set_config(&ModeConfig::Client(client_cfg)) {
+            defmt::error!(
+                "wifi: set_config rejected ({}); waiting for next provisioning",
+                defmt::Debug2Format(&e)
+            );
+            WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+            creds = WIFI_RECONFIG.wait().await;
+            continue;
+        }
+        if !started {
+            if let Err(e) = controller.start_async().await {
+                defmt::error!(
+                    "wifi: start_async failed ({}); parking",
+                    defmt::Debug2Format(&e)
+                );
+                park_forever().await;
+            }
+            started = true;
+        }
+
+        let next_creds = run_connect_loop(&mut controller, creds.ssid.as_str()).await;
+        creds = next_creds;
+    }
 }
 
 /// Sleeps forever without dropping the caller's stack — used by
-/// `wifi_task`'s error / no-SSID paths. The embassy-net runner
-/// borrows the `WifiDevice` from the controller this task owns, so
-/// returning would null the runner's backing state and trip a
-/// `LoadProhibited` exception.
+/// `wifi_task`'s unrecoverable error paths (where `start_async`
+/// itself failed). The embassy-net runner borrows the `WifiDevice`
+/// from the controller this task owns, so returning would null the
+/// runner's backing state and trip a `LoadProhibited` exception.
 async fn park_forever() -> ! {
     loop {
         Timer::after(Duration::from_secs(3600)).await;
     }
 }
 
-/// Connect / reconnect loop with exponential backoff. Owns the
-/// controller for the firmware lifetime.
-async fn connect_loop(mut controller: WifiController<'static>, ssid: String) -> ! {
+/// Connect / reconnect loop with exponential backoff *and* reconfig
+/// handling. Returns the new credentials when [`WIFI_RECONFIG`] fires;
+/// the caller (`wifi_task`) re-applies them via `set_config` and
+/// re-enters this loop.
+async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) -> WifiCreds {
     let mut backoff_idx: usize = 0;
     loop {
-        defmt::info!("wifi: connecting to ssid={=str}", ssid.as_str());
+        defmt::info!("wifi: connecting to ssid={=str}", ssid);
         WIFI_LINK_SIGNAL.signal(WifiLinkState::Connecting);
-        match controller.connect_async().await {
-            Ok(()) => {
+
+        let connect_outcome = select(controller.connect_async(), WIFI_RECONFIG.wait()).await;
+        match connect_outcome {
+            Either::First(Ok(())) => {
                 defmt::info!("wifi: connected");
                 WIFI_LINK_SIGNAL.signal(WifiLinkState::Connected);
                 LINK_READY.store(true, Ordering::Release);
                 backoff_idx = 0;
-                // Park until the controller reports a disconnect.
-                controller.wait_for_event(WifiEvent::StaDisconnected).await;
-                defmt::warn!("wifi: link dropped; reconnecting");
-                WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+
+                let live_outcome = select(
+                    controller.wait_for_event(WifiEvent::StaDisconnected),
+                    WIFI_RECONFIG.wait(),
+                )
+                .await;
+                match live_outcome {
+                    Either::First(()) => {
+                        defmt::warn!("wifi: link dropped; reconnecting");
+                        WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+                    }
+                    Either::Second(new_creds) => {
+                        defmt::info!(
+                            "wifi: reconfig while connected (new ssid={=str})",
+                            new_creds.ssid.as_str()
+                        );
+                        let _ = controller.disconnect_async().await;
+                        WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+                        return new_creds;
+                    }
+                }
             }
-            Err(e) => {
+            Either::First(Err(e)) => {
                 let backoff_ms = RETRY_BACKOFF_MS[backoff_idx];
                 defmt::warn!(
                     "wifi: connect failed ({}); retry in {=u64} ms",
@@ -125,10 +198,38 @@ async fn connect_loop(mut controller: WifiController<'static>, ssid: String) -> 
                     backoff_ms
                 );
                 WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
-                Timer::after(Duration::from_millis(backoff_ms)).await;
-                if backoff_idx + 1 < RETRY_BACKOFF_MS.len() {
-                    backoff_idx += 1;
+
+                let wait_outcome = select(
+                    Timer::after(Duration::from_millis(backoff_ms)),
+                    WIFI_RECONFIG.wait(),
+                )
+                .await;
+                match wait_outcome {
+                    Either::First(()) => {
+                        if backoff_idx + 1 < RETRY_BACKOFF_MS.len() {
+                            backoff_idx += 1;
+                        }
+                    }
+                    Either::Second(new_creds) => {
+                        defmt::info!(
+                            "wifi: reconfig during backoff (new ssid={=str})",
+                            new_creds.ssid.as_str()
+                        );
+                        return new_creds;
+                    }
                 }
+            }
+            Either::Second(new_creds) => {
+                defmt::info!(
+                    "wifi: reconfig during connect attempt (new ssid={=str})",
+                    new_creds.ssid.as_str()
+                );
+                // The connect attempt may still be in flight in the
+                // radio; the outer loop's `set_config` + `connect_async`
+                // supersede it. A speculative `disconnect_async` here
+                // would block on a `StaDisconnected` event the radio
+                // may never emit (we never reached `Connected`).
+                return new_creds;
             }
         }
     }


### PR DESCRIPTION
**Stacked on #172** — base branch is `feat/ble-peripheral-readonly`. Merge order: #172 first, then GitHub will retarget this PR to `main` automatically.

## Summary

- Adds a writeable **Provisioning** GATT service to the BLE peripheral (`8a1c0010-…`) with two characteristics:
  - **SSID** (`8a1c0011-…`, `read + write`, `heapless::String<32>`) — pre-filled at boot from `CONFIG_SNAPSHOT.wifi.ssid` so a phone reading it sees the active network. 32-byte cap matches the 802.11 SSID limit.
  - **PSK** (`8a1c0012-…`, `write` only, `heapless::String<64>`) — `read` deliberately omitted so a scanner can't exfiltrate the secret. Writing this characteristic is the *commit* trigger.
- New shared signal `WIFI_RECONFIG: Signal<CriticalSectionRawMutex, WifiCreds>` driven by **both** the BLE PSK-write commit path **and** the HTTP `PUT /settings` handler (when `wifi.ssid` or `wifi.psk` actually changed). Single source of truth for "config changed, reload Wi-Fi"; closes today's PUT-doesn't-reconnect UX hole as a side effect.
- `wifi_task` reshaped around `select(connect/event, WIFI_RECONFIG.wait())` at every blocking step — connect, post-connect wait, backoff timer. Reconfig pre-empts whatever the task is doing, drops the link, and re-enters the connect attempt with new creds. The empty-SSID idle path now parks on `WIFI_RECONFIG` instead of `park_forever()`, so a fresh out-of-the-box unit can be brought up over BLE without an SD card insert.
- `PUT /settings` now responds `{"reboot_required": false}` and the docs/comment block updated to match.

## Security note (read me)

**Provisioning writes are unauthenticated in this PR.** Anyone in BLE radio range can write SSID/PSK and reconfigure the device's network. The `defmt::warn!` on every commit makes this loud in the boot log, and after each commit the PSK is cleared from the GATT table so it doesn't stick around in memory.

PR3 will add LE Secure Connections passkey display + bond storage in flash, and gate provisioning writes to bonded peers only. **Do not ship this PR alone to a release; merge it to a feature branch awaiting PR3, or merge with PR3 directly.**

## Notes for reviewers

- **Cancel-safety of `connect_async`.** esp-radio 0.17's `connect_async` calls `connect_impl()` synchronously before awaiting the result event — dropping the future leaves the connect attempt running in the radio, but the next outer-loop `set_config(...) + connect_async()` cycle replaces it. The `wifi.rs` reconfig branch deliberately does *not* call `disconnect_async` here because there's no pending `StaDisconnected` event to wait on (we never reached `Connected`).
- **PSK clear after commit.** `server.set(&psk_handle, &empty)` is called post-commit even though the characteristic is write-only — defense-in-depth against a future maintainer flipping the `read` permission and accidentally exposing whatever was last written.
- **Wifi-changed gate in `PUT /settings`.** Compares the new config's wifi block against `snapshot_for_merge` (the pre-merge persisted state) so a re-PUT of the same body — a common dashboard pattern — doesn't trigger a needless link drop. Only ssid/psk changes trip reconnect; mDNS hostname / SNTP changes still need a reboot to take effect.
- **No new tests.** The reconfig flow is fundamentally an embassy task interacting with the radio driver — host-mockable only via heavy fakes that wouldn't catch the real behavior. Hardware verify is the test (see plan below).

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests
- [x] `just clippy-firmware` — strict clippy
- [x] `just build-firmware` — release build clean
- [ ] **Hardware verify:**
  - [ ] Boot with valid SSID in `STACKCHAN.RON` → Wi-Fi connects normally; `ble: address=…` and `boot complete` both emit.
  - [ ] Connect from nRF Connect, write to `8a1c0011-…` (SSID), then write to `8a1c0012-…` (PSK). Watch log for `ble: prov: persisted (ssid=…)` and `wifi: reconfig while connected (new ssid=…)`. Confirm new link comes up with the new creds within ~10 s.
  - [ ] Boot with empty SSID in `STACKCHAN.RON` (rename or delete the file) → `wifi: no SSID configured, idle` then BLE provision → `wifi: connecting…` and `wifi: connected`.
  - [ ] `PUT /settings` with a changed `wifi.ssid` → `http: PUT /settings triggered Wi-Fi soft reconnect` then `wifi: reconfig while connected`. Same payload re-PUT → no reconnect log line.