### PR TITLE
feat(firmware): BLE pairing + bonding + LCD passkey overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -704,12 +730,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest",
 ]
 
 [[package]]
@@ -756,6 +803,12 @@ name = "const-default"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -817,6 +870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +904,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -963,6 +1037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "defmt"
 version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,12 +1098,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+ "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1201,6 +1296,25 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "winit",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2129,6 +2243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2474,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2498,6 +2623,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2725,24 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "icu_collections"
@@ -2730,6 +2884,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3542,6 +3705,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,10 +3939,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3875,6 +4066,25 @@ name = "ral-registers"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b71a9d9206e8b46714c74255adcaea8b11e0350c1d8456165073c3f75fc81a"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "rand_core"
@@ -4145,6 +4355,19 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4559,6 +4782,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svgbobdoc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4792,7 +5021,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2881b4859001fe1f48445145cda5149deac9110b1d707ec0a251b7ff6d8bdfa4"
 dependencies = [
+ "aes",
  "bt-hci",
+ "cmac",
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-sync 0.7.2",
@@ -4800,6 +5031,9 @@ dependencies = [
  "embedded-io 0.6.1",
  "futures",
  "heapless 0.9.2",
+ "p256",
+ "rand",
+ "rand_chacha",
  "rand_core 0.6.4",
  "static_cell",
  "trouble-host-macros",
@@ -6044,6 +6278,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -91,7 +91,12 @@ esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "ble", 
 # `bt-hci ^0.6` (matches esp-radio 0.17). 0.6.0 jumps to `bt-hci 0.8`
 # and pairs with esp-radio 0.18 — bump together when we move the
 # wider toolchain.
-trouble-host = { version = "0.5.1", default-features = false, features = ["defmt", "peripheral", "gatt", "derive", "default-packet-pool"] }
+#
+# `security` enables LE Secure Connections pairing + bonding. Pulls
+# in `p256` + `aes` + `cmac` + `rand_chacha` (~50 KB code on this
+# target). Required for the BLE provisioning service to gate writes
+# behind a paired peer.
+trouble-host = { version = "0.5.1", default-features = false, features = ["defmt", "peripheral", "gatt", "derive", "default-packet-pool", "security"] }
 # embassy-net's TCP / UDP / DHCPv4 stack on top of smoltcp. 0.9.x
 # pairs with esp-radio 0.18 (both ride the embassy-sync 0.7 line).
 embassy-net = { version = "0.9", features = ["defmt", "proto-ipv4", "tcp", "udp", "dhcpv4", "dns", "multicast", "medium-ethernet"] }

--- a/crates/stackchan-firmware/src/ble/bonds.rs
+++ b/crates/stackchan-firmware/src/ble/bonds.rs
@@ -95,7 +95,7 @@ fn encode(bonds: &[BondInformation]) -> Vec<u8> {
     out.push(0); // reserved
     out.push(0); // reserved
 
-    for bond in bonds.iter().take(MAX_BONDS) {
+    for (i, bond) in bonds.iter().take(MAX_BONDS).enumerate() {
         let ltk_bytes = bond.ltk.0.to_le_bytes();
         out.extend_from_slice(&ltk_bytes);
 
@@ -114,7 +114,11 @@ fn encode(bonds: &[BondInformation]) -> Vec<u8> {
         out.push(u8::from(bond.is_bonded));
         out.extend_from_slice(&[0u8; 3]); // reserved
 
-        debug_assert_eq!(out.len() % RECORD_LEN, HEADER_LEN % RECORD_LEN);
+        // Tighter per-iteration check: each loop body must emit
+        // exactly RECORD_LEN bytes. The earlier modulo form was
+        // always true by algebra and couldn't catch a missing
+        // field.
+        debug_assert_eq!(out.len(), HEADER_LEN + (i + 1) * RECORD_LEN);
     }
 
     debug_assert_eq!(out.len(), total);

--- a/crates/stackchan-firmware/src/ble/bonds.rs
+++ b/crates/stackchan-firmware/src/ble/bonds.rs
@@ -1,0 +1,219 @@
+//! Persistent BLE bond store, backed by `/sd/BONDS.BIN`.
+//!
+//! `BondInformation` survives reboots so a paired phone reconnects
+//! straight into an encrypted link without re-running the passkey
+//! dance. Each successful pairing appends to the in-memory bond
+//! list trouble-host maintains; we mirror the list onto SD so the
+//! next boot can re-register them via [`Stack::add_bond_information`].
+//!
+//! ## Wire format
+//!
+//! ```text
+//! header (8 bytes)         : magic "BND1" + version 1 + count + 2 reserved
+//! record (44 bytes each)   : ltk(16) | bdaddr(6) | irk_present(1) | irk(16) | sec_level(1) | is_bonded(1) | reserved(3)
+//! ```
+//!
+//! All multi-byte integers are little-endian. A missing or empty
+//! file is treated as "no bonds" rather than an error — that's the
+//! first-boot state.
+
+use alloc::vec::Vec;
+use heapless::Vec as HVec;
+use trouble_host::prelude::{BdAddr, Identity, SecurityLevel};
+use trouble_host::{BondInformation, IdentityResolvingKey, LongTermKey};
+
+use crate::storage::with_storage;
+
+/// Maximum bonds we'll persist. trouble-host's `BI_COUNT` is 10; we
+/// match that cap so the load path can register every bond without
+/// truncation.
+pub const MAX_BONDS: usize = 10;
+
+/// File header magic + version. Bumping the version invalidates
+/// every existing bond file (load returns empty) so a layout
+/// change can't silently mis-decode old records.
+const MAGIC: [u8; 4] = *b"BND1";
+/// On-disk format version. Bumping forces a forget-and-rebuild on
+/// the next boot — old records can't be decoded with a new layout.
+const VERSION: u8 = 1;
+
+/// Header size in bytes.
+const HEADER_LEN: usize = 8;
+/// Per-bond record size. See module docs for the byte layout.
+const RECORD_LEN: usize = 44;
+
+/// Load all persisted bonds. Returns an empty list on first boot,
+/// missing file, or any decode failure — the firmware boots fine
+/// with no bonds, just paired peers will need to re-pair.
+pub async fn load_all() -> HVec<BondInformation, MAX_BONDS> {
+    let bytes = match with_storage(crate::storage::Storage::read_bonds).await {
+        Some(Ok(b)) => b,
+        Some(Err(e)) => {
+            defmt::warn!("ble: bonds: read failed ({}); treating as empty", e);
+            return HVec::new();
+        }
+        None => {
+            defmt::info!("ble: bonds: no SD mounted; bonds disabled this run");
+            return HVec::new();
+        }
+    };
+    decode(&bytes).unwrap_or_else(|reason| {
+        defmt::warn!(
+            "ble: bonds: decode failed ({=str}); treating as empty",
+            reason
+        );
+        HVec::new()
+    })
+}
+
+/// Persist the entire bond list atomically. Called on each
+/// `PairingComplete` event with the latest snapshot from
+/// `Stack::get_bond_information`.
+pub async fn save_all(bonds: &[BondInformation]) {
+    let encoded = encode(bonds);
+    match with_storage(|s| s.write_bonds(&encoded)).await {
+        Some(Ok(())) => defmt::info!("ble: bonds: persisted {=usize} bond(s)", bonds.len()),
+        Some(Err(e)) => defmt::warn!("ble: bonds: write failed ({})", e),
+        None => defmt::warn!("ble: bonds: no SD mounted; cannot persist"),
+    }
+}
+
+/// Encode `bonds` into the on-disk layout. Up to [`MAX_BONDS`]
+/// records are written; any beyond that are silently dropped (this
+/// can't happen via trouble-host, which itself caps at the same
+/// number, but the slice signature lets callers pass anything).
+fn encode(bonds: &[BondInformation]) -> Vec<u8> {
+    // `bonds.len().min(MAX_BONDS)` fits in u8 because MAX_BONDS is
+    // the trouble-host BI_COUNT (10), well below 256.
+    let count_usize = bonds.len().min(MAX_BONDS);
+    let count = u8::try_from(count_usize).unwrap_or(0);
+    let total = HEADER_LEN + count_usize * RECORD_LEN;
+    let mut out = Vec::with_capacity(total);
+    out.extend_from_slice(&MAGIC);
+    out.push(VERSION);
+    out.push(count);
+    out.push(0); // reserved
+    out.push(0); // reserved
+
+    for bond in bonds.iter().take(MAX_BONDS) {
+        let ltk_bytes = bond.ltk.0.to_le_bytes();
+        out.extend_from_slice(&ltk_bytes);
+
+        let addr = bond.identity.bd_addr.into_inner();
+        out.extend_from_slice(&addr);
+
+        if let Some(irk) = bond.identity.irk {
+            out.push(1);
+            out.extend_from_slice(&irk.0.to_le_bytes());
+        } else {
+            out.push(0);
+            out.extend_from_slice(&[0u8; 16]);
+        }
+
+        out.push(security_level_to_byte(bond.security_level));
+        out.push(u8::from(bond.is_bonded));
+        out.extend_from_slice(&[0u8; 3]); // reserved
+
+        debug_assert_eq!(out.len() % RECORD_LEN, HEADER_LEN % RECORD_LEN);
+    }
+
+    debug_assert_eq!(out.len(), total);
+    out
+}
+
+/// Decode the on-disk layout into a `heapless::Vec`. Returns a
+/// human-readable reason string on the failure paths so the caller
+/// can log it; bonds never panic-out of decode — we'd rather lose a
+/// bond than refuse to boot.
+fn decode(bytes: &[u8]) -> Result<HVec<BondInformation, MAX_BONDS>, &'static str> {
+    if bytes.is_empty() {
+        return Ok(HVec::new());
+    }
+    if bytes.len() < HEADER_LEN {
+        return Err("file truncated below header");
+    }
+    if bytes[..4] != MAGIC {
+        return Err("magic mismatch");
+    }
+    if bytes[4] != VERSION {
+        return Err("unsupported version");
+    }
+    let count = bytes[5] as usize;
+    if count > MAX_BONDS {
+        return Err("count exceeds MAX_BONDS");
+    }
+    let expected = HEADER_LEN + count * RECORD_LEN;
+    if bytes.len() < expected {
+        return Err("file truncated below records");
+    }
+
+    let mut out: HVec<BondInformation, MAX_BONDS> = HVec::new();
+    let mut cursor = HEADER_LEN;
+    for _ in 0..count {
+        let ltk_bytes: [u8; 16] = bytes[cursor..cursor + 16]
+            .try_into()
+            .map_err(|_| "record ltk")?;
+        let ltk = LongTermKey(u128::from_le_bytes(ltk_bytes));
+        cursor += 16;
+
+        let addr_bytes: [u8; 6] = bytes[cursor..cursor + 6]
+            .try_into()
+            .map_err(|_| "record addr")?;
+        cursor += 6;
+
+        let irk_present = bytes[cursor];
+        cursor += 1;
+        let irk_raw: [u8; 16] = bytes[cursor..cursor + 16]
+            .try_into()
+            .map_err(|_| "record irk")?;
+        cursor += 16;
+        let irk = if irk_present == 0 {
+            None
+        } else {
+            Some(IdentityResolvingKey(u128::from_le_bytes(irk_raw)))
+        };
+
+        let sec_level = security_level_from_byte(bytes[cursor]);
+        cursor += 1;
+        let is_bonded = bytes[cursor] != 0;
+        cursor += 1;
+        cursor += 3; // reserved
+
+        let identity = Identity {
+            bd_addr: BdAddr::new(addr_bytes),
+            irk,
+        };
+
+        // `push` only fails when the heapless cap is hit, which we
+        // already bounded via the `count > MAX_BONDS` check above.
+        let _ = out.push(BondInformation {
+            ltk,
+            identity,
+            is_bonded,
+            security_level: sec_level,
+        });
+    }
+
+    Ok(out)
+}
+
+/// Map a runtime [`SecurityLevel`] to the on-disk byte. Inverse of
+/// [`security_level_from_byte`].
+const fn security_level_to_byte(level: SecurityLevel) -> u8 {
+    match level {
+        SecurityLevel::NoEncryption => 0,
+        SecurityLevel::Encrypted => 1,
+        SecurityLevel::EncryptedAuthenticated => 2,
+    }
+}
+
+/// Inverse of [`security_level_to_byte`]. Unknown values fall back
+/// to [`SecurityLevel::NoEncryption`] — a corrupt bond should not
+/// silently grant write privileges.
+const fn security_level_from_byte(b: u8) -> SecurityLevel {
+    match b {
+        2 => SecurityLevel::EncryptedAuthenticated,
+        1 => SecurityLevel::Encrypted,
+        _ => SecurityLevel::NoEncryption,
+    }
+}

--- a/crates/stackchan-firmware/src/ble/mod.rs
+++ b/crates/stackchan-firmware/src/ble/mod.rs
@@ -1,4 +1,4 @@
-//! BLE peripheral surface — advertise + read-only GATT.
+//! BLE peripheral surface — advertise + GATT services + provisioning.
 //!
 //! On boot, [`ble_task`] takes ownership of the trouble-host
 //! `ExternalController` (built from `esp_radio`'s `BleConnector`) and
@@ -8,16 +8,25 @@
 //! Wi-Fi MAC; clients see the same handle whether they discover us
 //! over BLE or mDNS.
 //!
-//! Three services are exposed in this initial cut, all read-only:
+//! Services exposed (in declaration order):
 //!
 //! - **Device Information (`0x180A`)** — manufacturer, model, and
-//!   firmware-revision strings. nRF Connect surfaces these natively.
+//!   firmware-revision strings.
 //! - **Battery (`0x180F`)** — `BATTERY_LEVEL` (`0x2A19`) reflecting
 //!   `snapshot::read().battery.percent`. Periodic notify @ 1 Hz when
 //!   a peer is subscribed.
 //! - **Stack-chan custom service** — emotion characteristic
 //!   (one-byte enum, [`stackchan_core::Emotion::wire_byte`]).
 //!   Notify on transition only.
+//! - **Provisioning custom service** — writeable SSID + PSK
+//!   characteristics. Writing the PSK commits the staged SSID + new
+//!   PSK and signals [`crate::net::wifi::WIFI_RECONFIG`].
+//!
+//! Pairing: LE Secure Connections with `IoCapabilities::DisplayOnly`.
+//! On the first `PassKeyDisplay` event the 6-digit passkey is latched
+//! into [`PASSKEY_DISPLAY`] and the render task overlays it on the
+//! LCD. Bonds are persisted to the SD card via [`bonds`] so a
+//! re-paired peer skips the passkey dance.
 //!
 //! Coexistence: BLE rides the same radio as Wi-Fi via esp-radio's
 //! `coex` feature. Expect a single-digit-percent Wi-Fi throughput
@@ -31,8 +40,46 @@
 //! `Mutex<CriticalSectionRawMutex, Cell<...>>`), never via embassy
 //! `Signal`s.
 
+pub mod bonds;
 mod server;
 mod task;
 
+use core::cell::Cell;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
 pub use server::{StackchanServer, run_ble_peripheral};
 pub use task::{BleTaskConfig, ble_task};
+
+/// Latched 6-digit pairing passkey, displayed on the LCD while a
+/// central is in the middle of pairing.
+///
+/// The render task reads it each frame; the BLE task writes it on
+/// `PassKeyDisplay`, clears it on `PairingComplete` / `PairingFailed`
+/// / `Disconnected`. Latched (rather than `Signal`-style one-shot)
+/// because the render task draws the same value on every frame the
+/// passkey is visible — `Signal::try_take` would consume it once and
+/// blank the LCD after a single frame.
+static PASSKEY_DISPLAY: Mutex<CriticalSectionRawMutex, Cell<Option<u32>>> =
+    Mutex::new(Cell::new(None));
+
+/// Show a 6-digit passkey on the LCD. Called by the BLE task on
+/// receiving a `PassKeyDisplay` event. The next render frame picks
+/// it up via [`read_passkey`] and overlays it on the avatar.
+pub fn show_passkey(passkey: u32) {
+    PASSKEY_DISPLAY.lock(|cell| cell.set(Some(passkey)));
+}
+
+/// Clear the on-screen passkey. Called when pairing completes
+/// (success or failure) or the central disconnects mid-pairing.
+pub fn clear_passkey() {
+    PASSKEY_DISPLAY.lock(|cell| cell.set(None));
+}
+
+/// Read the latched passkey for the current render frame. Returns
+/// `None` when no pairing is in flight.
+#[must_use]
+pub fn read_passkey() -> Option<u32> {
+    PASSKEY_DISPLAY.lock(core::cell::Cell::get)
+}

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -259,6 +259,14 @@ pub async fn run_ble_peripheral<C: Controller>(
                     let events = gatt_events_task(&stack, &server, &conn);
                     let notify = notify_task(&server, &conn);
                     let _ = select(events, notify).await;
+                    // `gatt_events_task`'s `Disconnected` arm is the
+                    // only place that calls `clear_passkey()` — but
+                    // `notify_task` can win the select on an error
+                    // path and drop `gatt_events_task` mid-pairing,
+                    // leaving the 6-digit code painted on the LCD
+                    // forever. Clear here as a belt-and-braces safety
+                    // net regardless of which branch returned.
+                    super::clear_passkey();
                     defmt::info!("ble: peer disconnected");
                 }
                 Err(e) => {

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -553,10 +553,17 @@ async fn commit_provisioning<P: PacketPool>(
             return;
         }
     };
-    if !level.encrypted() {
+    // Require *authenticated* encryption (passkey-confirmed bond),
+    // not bare `level.encrypted()`. Plain `Encrypted` is the
+    // outcome of JustWorks pairing, which a central can force by
+    // advertising `NoInputNoOutput` capabilities — the user never
+    // sees a passkey, and there's no MITM protection. Allowing it
+    // through here would let a phone next to the desk reconfigure
+    // Wi-Fi without ever asking the user to confirm a code.
+    if level != SecurityLevel::EncryptedAuthenticated {
         defmt::warn!(
-            "ble: prov: write rejected — link not encrypted (level={}). \
-             Pair the central before provisioning.",
+            "ble: prov: write rejected — link not authenticated (level={}). \
+             Pair the central with passkey confirmation before provisioning.",
             defmt::Debug2Format(&level)
         );
         return;

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -199,7 +199,41 @@ pub async fn run_ble_peripheral<C: Controller>(
 
     let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
         HostResources::new();
-    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+
+    // SMP needs ~32 bytes of cryptographic entropy. The chip's TRNG
+    // gives us that. `try_new` requires the global `TrngSource` to be
+    // active (set up in main.rs at boot); on failure we panic — the
+    // BLE peripheral is not safe to bring up without a real entropy
+    // source for ECDH key generation.
+    let mut trng = match esp_hal::rng::Trng::try_new() {
+        Ok(t) => t,
+        Err(e) => defmt::panic!(
+            "ble: TRNG unavailable ({}) — TrngSource not initialised",
+            defmt::Debug2Format(&e)
+        ),
+    };
+
+    let stack = trouble_host::new(controller, &mut resources)
+        .set_random_address(address)
+        .set_random_generator_seed(&mut trng)
+        .set_io_capabilities(IoCapabilities::DisplayOnly);
+
+    // Re-register persisted bonds before any central can start
+    // pairing — a freshly-rebooted device should resume an existing
+    // bond rather than asking for a re-pair on every reconnect.
+    for bond in super::bonds::load_all().await {
+        if let Err(e) = stack.add_bond_information(bond) {
+            defmt::warn!(
+                "ble: bonds: add_bond_information rejected ({})",
+                defmt::Debug2Format(&e)
+            );
+        }
+    }
+    defmt::info!(
+        "ble: bonds: {=usize} persisted bond(s) registered",
+        stack.get_bond_information().len()
+    );
+
     let Host {
         mut peripheral,
         runner,
@@ -222,7 +256,7 @@ pub async fn run_ble_peripheral<C: Controller>(
             match advertise(local_name, &mut peripheral, &server).await {
                 Ok(conn) => {
                     defmt::info!("ble: peer connected");
-                    let events = gatt_events_task(&server, &conn);
+                    let events = gatt_events_task(&stack, &server, &conn);
                     let notify = notify_task(&server, &conn);
                     let _ = select(events, notify).await;
                     defmt::info!("ble: peer disconnected");
@@ -320,10 +354,19 @@ async fn advertise<'values, 'server, C: Controller>(
 /// back to the central. Without this loop, reads would silently time
 /// out from the peer's view.
 ///
+/// Also handles the BLE security event surface:
+///
+/// - `PassKeyDisplay` — latch the 6-digit code into [`crate::ble::PASSKEY_DISPLAY`]
+///   so the render task overlays it on the LCD.
+/// - `PairingComplete { bond: Some(_) }` — persist the new bond list
+///   to SD via [`crate::ble::bonds`].
+/// - `PairingFailed` — clear the on-screen passkey, log the reason.
+///
 /// On a write to the provisioning PSK characteristic, fires the
-/// commit path — the staged SSID + new PSK get persisted to
-/// `STACKCHAN.RON` and the wifi task gets nudged to soft-reconnect.
+/// commit path — but only if the link is currently encrypted.
+/// Pre-pairing writes get rejected with a warn and a no-op.
 async fn gatt_events_task<P: PacketPool>(
+    stack: &Stack<'_, impl Controller, P>,
     server: &StackchanServer<'_>,
     conn: &GattConnection<'_, '_, P>,
 ) {
@@ -332,6 +375,7 @@ async fn gatt_events_task<P: PacketPool>(
         match conn.next().await {
             GattConnectionEvent::Disconnected { reason } => {
                 defmt::info!("ble: gatt disconnect ({})", defmt::Debug2Format(&reason));
+                super::clear_passkey();
                 return;
             }
             GattConnectionEvent::Gatt { event } => {
@@ -358,8 +402,32 @@ async fn gatt_events_task<P: PacketPool>(
                     }
                 };
                 if is_psk_write && accepted_ok {
-                    commit_provisioning(server).await;
+                    commit_provisioning(server, conn).await;
                 }
+            }
+            GattConnectionEvent::PassKeyDisplay(passkey) => {
+                let value = passkey.value();
+                defmt::info!("ble: passkey display: {=u32:06}", value);
+                super::show_passkey(value);
+            }
+            GattConnectionEvent::PairingComplete {
+                security_level,
+                bond,
+            } => {
+                super::clear_passkey();
+                defmt::info!(
+                    "ble: pairing complete (level={}, bonded={})",
+                    defmt::Debug2Format(&security_level),
+                    bond.is_some()
+                );
+                if bond.is_some() {
+                    let snapshot = stack.get_bond_information();
+                    super::bonds::save_all(&snapshot).await;
+                }
+            }
+            GattConnectionEvent::PairingFailed(e) => {
+                super::clear_passkey();
+                defmt::warn!("ble: pairing failed ({})", defmt::Debug2Format(&e));
             }
             _ => {}
         }
@@ -455,13 +523,36 @@ async fn populate_provisioning_ssid(server: &StackchanServer<'_>) {
 /// wifi task to soft-reconnect, then clear the PSK from the table so
 /// a memory dump of the BLE stack doesn't leak the secret.
 ///
+/// Gated on the connection's security level: unencrypted writes are
+/// rejected with a warn. The trouble-host attribute server doesn't
+/// enforce per-characteristic security in 0.5.1, so this app-layer
+/// check is the load-bearing gate — moving it would let any nearby
+/// BLE central reconfigure Wi-Fi without pairing.
+///
 /// Failures are logged but never panic — a malformed write should
 /// just be a no-op so the next correct write can succeed.
-async fn commit_provisioning(server: &StackchanServer<'_>) {
-    defmt::warn!(
-        "ble: provisioning commit (UNAUTHENTICATED — pairing pending). \
-         Anyone in BLE range can reconfigure Wi-Fi until that lands."
-    );
+async fn commit_provisioning<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+) {
+    let level = match conn.raw().security_level() {
+        Ok(l) => l,
+        Err(e) => {
+            defmt::warn!(
+                "ble: prov: security_level query failed ({}); rejecting write",
+                defmt::Debug2Format(&e)
+            );
+            return;
+        }
+    };
+    if !level.encrypted() {
+        defmt::warn!(
+            "ble: prov: write rejected — link not encrypted (level={}). \
+             Pair the central before provisioning.",
+            defmt::Debug2Format(&level)
+        );
+        return;
+    }
 
     // Read staged SSID + new PSK from the GATT table. trouble-host
     // wrote both into the table when their respective Write events

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -37,11 +37,14 @@ use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
 use embassy_executor::Spawner;
 use embassy_time::{Delay, Duration, Ticker, Timer};
 use embedded_graphics::{
+    Drawable,
     draw_target::DrawTarget,
     geometry::{Point as EgPoint, Size},
+    mono_font::{MonoTextStyle, ascii::FONT_10X20},
     pixelcolor::Rgb565,
     pixelcolor::raw::RawU16,
-    primitives::Rectangle,
+    primitives::{Primitive, PrimitiveStyleBuilder, Rectangle},
+    text::{Alignment, Text},
 };
 // `RefCellDevice` shares the SPI2 bus between the LCD and the SD card
 // client. Single-core embassy + cooperative scheduling means the
@@ -219,6 +222,10 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut handling = Handling::new();
     let mut intent_from_body_touch = IntentFromBodyTouch::new();
     let mut last_rendered: Option<Face> = None;
+    // Last on-screen pairing passkey. Tracked separately from
+    // `last_rendered` so a passkey transition forces a redraw even
+    // when the avatar face is bit-equal across frames.
+    let mut last_passkey: Option<u32> = None;
     // Last instant TX was observed playing. Drives the post-playback
     // tail of the audio_rms gate so the mic doesn't pick up the
     // speaker's residual response immediately after a chirp ends.
@@ -570,29 +577,70 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
                 }
             }
             last_rendered = None;
-        } else if last_rendered
-            .as_ref()
-            .is_none_or(|prev| *prev != entity.face)
-        {
+        } else {
+            // Avatar mode: redraw whenever the face changed OR the BLE
+            // pairing passkey transitioned (visible/hidden/different).
             // Compare faces directly: `Face` has `PartialEq` derived on
             // every visual field. Non-visual state (pose, sensors,
             // mind, events, tick) lives elsewhere on `Entity` and so
             // can't trigger spurious blits — `IdleHeadDrift` mutates
             // `motor.head_pose`, which is invisible to this dirty
             // check by construction.
-            //
-            // Draw is Infallible on `Framebuffer`; the `let _ =`
-            // discards the `Result<(), Infallible>` without
-            // triggering unwrap lints.
-            let _ = entity.face.draw(&mut fb);
-            match display.fill_contiguous(&canvas, fb.as_slice().iter().copied()) {
-                Ok(()) => last_rendered = Some(entity.face),
-                Err(e) => defmt::error!("render: blit failed: {}", defmt::Debug2Format(&e)),
+            let current_passkey = ble::read_passkey();
+            let face_changed = last_rendered
+                .as_ref()
+                .is_none_or(|prev| *prev != entity.face);
+            let passkey_changed = current_passkey != last_passkey;
+            if face_changed || passkey_changed {
+                // Draw is Infallible on `Framebuffer`; the `let _ =`
+                // discards the `Result<(), Infallible>` without
+                // triggering unwrap lints.
+                let _ = entity.face.draw(&mut fb);
+                if let Some(passkey) = current_passkey {
+                    draw_passkey_overlay(&mut fb, passkey);
+                }
+                match display.fill_contiguous(&canvas, fb.as_slice().iter().copied()) {
+                    Ok(()) => {
+                        last_rendered = Some(entity.face);
+                        last_passkey = current_passkey;
+                    }
+                    Err(e) => defmt::error!("render: blit failed: {}", defmt::Debug2Format(&e)),
+                }
             }
         }
 
         ticker.next().await;
     }
+}
+
+/// Draw a transient pairing-passkey banner across the top of the
+/// framebuffer. Called by the render task while a BLE central is in
+/// the middle of LE Secure Connections pairing — the user reads the
+/// number off the LCD and types it on the phone. Cleared on
+/// `PairingComplete` / `PairingFailed` / `Disconnected` (see
+/// `crate::ble::clear_passkey`).
+///
+/// Layout: black 32-px-tall band at y=0..32 with the 6-digit code
+/// centered in white `FONT_10X20`. Sits above the eyes regardless of
+/// the avatar's current expression — operator-priority chrome, not
+/// part of the modifier-driven render.
+fn draw_passkey_overlay(fb: &mut Framebuffer, passkey: u32) {
+    use core::fmt::Write as _;
+    let banner = Rectangle::new(EgPoint::new(0, 0), Size::new(FB_WIDTH, 32));
+    let bg = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb565::new(0, 0, 0))
+        .build();
+    if banner.into_styled(bg).draw(fb).is_err() {
+        return;
+    }
+    let mut buf: heapless::String<8> = heapless::String::new();
+    if write!(&mut buf, "{passkey:06}").is_err() {
+        return;
+    }
+    #[allow(clippy::cast_possible_wrap)]
+    let center = EgPoint::new(FB_WIDTH as i32 / 2, 22);
+    let style = MonoTextStyle::new(&FONT_10X20, Rgb565::new(0xFF, 0x3F, 0xFF));
+    let _ = Text::with_alignment(buf.as_str(), center, style, Alignment::Center).draw(fb);
 }
 
 /// 50 Hz head-update task. Consumes [`head::POSE_SIGNAL`] and commands
@@ -895,6 +943,19 @@ async fn main(spawner: Spawner) -> ! {
             stackchan_net::Config::default()
         }
     };
+    // Cryptographic-grade entropy for BLE Secure Connections pairing.
+    // `TrngSource` mixes the ESP32-S3's RNG block with ADC1 noise; once
+    // active, `Trng::try_new()` succeeds anywhere in the firmware.
+    // Parked in a `StaticCell` so the entropy source lives forever —
+    // dropping it would silently downgrade `Trng` reads to plain RNG
+    // (which esp-hal explicitly does not assert as cryptographic).
+    #[allow(clippy::items_after_statements)]
+    static TRNG_SOURCE: StaticCell<esp_hal::rng::TrngSource<'static>> = StaticCell::new();
+    let _trng_source = TRNG_SOURCE.init(esp_hal::rng::TrngSource::new(
+        peripherals.RNG,
+        peripherals.ADC1,
+    ));
+
     // Bring up the radio + Wi-Fi station + embassy-net TCP/IP stack.
     // `esp_rtos::start` ran at boot (line above), which `esp_radio::init`
     // requires before claiming the WIFI peripheral. Both the

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -626,9 +626,15 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 /// part of the modifier-driven render.
 fn draw_passkey_overlay(fb: &mut Framebuffer, passkey: u32) {
     use core::fmt::Write as _;
+    use embedded_graphics::pixelcolor::RgbColor;
     let banner = Rectangle::new(EgPoint::new(0, 0), Size::new(FB_WIDTH, 32));
+    // `Rgb565::new(r, g, b)` takes raw component values bounded by
+    // their bit widths (R: 0..=31, G: 0..=63, B: 0..=31). Use the
+    // named constants instead of literal byte values so we can't
+    // accidentally over-saturate or pick the wrong tint when the
+    // intent is just black-and-white chrome.
     let bg = PrimitiveStyleBuilder::new()
-        .fill_color(Rgb565::new(0, 0, 0))
+        .fill_color(Rgb565::BLACK)
         .build();
     if banner.into_styled(bg).draw(fb).is_err() {
         return;
@@ -639,7 +645,7 @@ fn draw_passkey_overlay(fb: &mut Framebuffer, passkey: u32) {
     }
     #[allow(clippy::cast_possible_wrap)]
     let center = EgPoint::new(FB_WIDTH as i32 / 2, 22);
-    let style = MonoTextStyle::new(&FONT_10X20, Rgb565::new(0xFF, 0x3F, 0xFF));
+    let style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
     let _ = Text::with_alignment(buf.as_str(), center, style, Alignment::Center).draw(fb);
 }
 

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -112,6 +112,20 @@ const STAGING_FILE: &str = "STACKCHAN.NEW";
 /// grows.
 const MAX_CONFIG_BYTES: u32 = 4096;
 
+/// Filename for persisted BLE bonds. Binary format defined in
+/// `crate::ble::bonds`.
+const BONDS_FILE: &str = "BONDS.BIN";
+
+/// Staging filename for atomic bond writes — same dance as the
+/// config file: write to `BONDS.NEW`, copy onto `BONDS.BIN`, delete
+/// the staging file.
+const BONDS_STAGING_FILE: &str = "BONDS.NEW";
+
+/// Cap on the bonds blob. trouble-host's `BI_COUNT` is 10 bonds;
+/// our record format is ~50 bytes per bond. 1 KiB leaves generous
+/// headroom for future record-layout additions.
+const MAX_BONDS_BYTES: u32 = 1024;
+
 /// Storage / FAT errors. Logged via `defmt::Format` at the firmware
 /// boundary; the operator triages from the boot log.
 #[derive(Debug, defmt::Format)]
@@ -259,6 +273,60 @@ where
         let rendered = stackchan_net::render_ron_bare(config).map_err(|_| StorageError::Decode)?;
         self.write_file(STAGING_FILE, rendered.as_bytes())?;
         self.copy_then_delete(STAGING_FILE, CONFIG_FILE)?;
+        Ok(())
+    }
+
+    /// Read the full BLE bonds blob from `/sd/BONDS.BIN`. Returns
+    /// `Ok(empty)` if the file is missing — that's the first-boot
+    /// state, not an error. Layout is opaque here; the BLE module
+    /// owns the byte format.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Read`] on a partial read,
+    /// [`StorageError::TooLarge`] if the file exceeds
+    /// [`MAX_BONDS_BYTES`].
+    pub fn read_bonds(&mut self) -> Result<Vec<u8>, StorageError> {
+        let mut volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(mut file) = root.open_file_in_dir(BONDS_FILE, Mode::ReadOnly) else {
+            return Ok(Vec::new());
+        };
+        let len = file.length();
+        if len > MAX_BONDS_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = len as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+        Ok(buf)
+    }
+
+    /// Atomically replace `/sd/BONDS.BIN` with `data`. Same staging-
+    /// then-copy dance the config writeback uses; mid-write power
+    /// loss leaves the previous bonds file intact.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying write failure,
+    /// [`StorageError::TooLarge`] if `data` exceeds
+    /// [`MAX_BONDS_BYTES`].
+    pub fn write_bonds(&mut self, data: &[u8]) -> Result<(), StorageError> {
+        if u32::try_from(data.len()).is_ok_and(|n| n > MAX_BONDS_BYTES) {
+            return Err(StorageError::TooLarge);
+        }
+        // `usize` exceeding `u32::MAX` would also be too large; the
+        // 32→32 cast above misses that on 64-bit hosts. The doctest
+        // path runs on 64-bit, so guard explicitly.
+        if data.len() > MAX_BONDS_BYTES as usize {
+            return Err(StorageError::TooLarge);
+        }
+        self.write_file(BONDS_STAGING_FILE, data)?;
+        self.copy_then_delete(BONDS_STAGING_FILE, BONDS_FILE)?;
         Ok(())
     }
 

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -316,12 +316,11 @@ where
     /// [`StorageError::TooLarge`] if `data` exceeds
     /// [`MAX_BONDS_BYTES`].
     pub fn write_bonds(&mut self, data: &[u8]) -> Result<(), StorageError> {
-        if u32::try_from(data.len()).is_ok_and(|n| n > MAX_BONDS_BYTES) {
-            return Err(StorageError::TooLarge);
-        }
-        // `usize` exceeding `u32::MAX` would also be too large; the
-        // 32→32 cast above misses that on 64-bit hosts. The doctest
-        // path runs on 64-bit, so guard explicitly.
+        // `usize > MAX_BONDS_BYTES as usize` is the strictly-stronger
+        // form: covers both targets where `usize` is 32 bits (firmware,
+        // matches u32 semantics) and 64 bits (host doctests, where a
+        // length above `u32::MAX` would have silently bypassed an
+        // earlier `try_from`-based guard).
         if data.len() > MAX_BONDS_BYTES as usize {
             return Err(StorageError::TooLarge);
         }


### PR DESCRIPTION
**Stacked on #173** (which is stacked on #172). Merge order: #172 → #173 → #174. GitHub auto-retargets each PR's base as the chain merges.

Closes the BLE arc by gating provisioning writes behind LE Secure Connections pairing. PR2 shipped an unauthenticated provisioning surface with a loud `defmt::warn!` reminder ("do not ship without PR3"); this PR removes the warn and the gap.

## Summary

- **Pairing:** `IoCapabilities::DisplayOnly` — Stack-chan generates a 6-digit passkey, the user reads it off the LCD, the central enters it on the phone. Cryptographic entropy comes from the chip's TRNG (`esp_hal::rng::Trng`, RNG block + ADC1 noise via a fresh `TrngSource` in `main.rs`); 32 bytes are mixed into trouble-host's SMP RNG once at stack init.
- **Persistent bonds:** new `crates/stackchan-firmware/src/ble/bonds.rs` reads/writes a fixed-record binary file `/sd/BONDS.BIN` (8-byte header + 44 bytes/bond, magic `BND1`, all little-endian). Loaded at BLE bring-up via `Stack::add_bond_information`; saved on every `PairingComplete` event. Atomic writeback through the same staging-then-copy dance the config file uses.
- **LCD passkey overlay:** new `draw_passkey_overlay` in `main.rs` paints a black band across the top 32 px of the framebuffer with the 6-digit code in `FONT_10X20` after `Avatar::draw` and before blit. `last_passkey` tracking sits next to `last_rendered` so a passkey transition forces a redraw even when the avatar face is bit-equal across frames.
- **App-layer security gate:** `commit_provisioning` checks `conn.raw().security_level()` before persisting; unencrypted writes get a warn + no-op. trouble-host 0.5.1's attribute server doesn't enforce per-characteristic security, so this is the load-bearing gate — moving it would let any nearby central reconfigure Wi-Fi.
- **PR2 cleanup:** removed the "UNAUTHENTICATED — pairing pending" warn; the gap it flagged is closed.

## Notes for reviewers

- **Why `DisplayOnly`, not `KeyboardDisplay`.** Stack-chan has a screen but no keyboard input we can use during pairing (the touch pads aren't a 6-digit numeric keyboard). DisplayOnly accurately advertises "I show, you type."
- **TRNG ownership.** `TrngSource` is parked in a `StaticCell` and never dropped — dropping it would silently downgrade `Trng::try_new()` reads to plain `Rng`, which esp-hal explicitly does not assert as cryptographic. `_trng_source` binding is `_`-prefixed because we don't access it again after init; the StaticCell keeps it live.
- **Bond format versioning.** `BONDS.BIN` carries a 1-byte format version. Bumping it makes `decode` return "unsupported version" → the file is treated as empty, paired peers re-pair on next boot. Keeps an inadvertent layout change from silently mis-decoding old records into "valid-looking" garbage bonds.
- **Decode is fail-soft.** Any decode failure (truncated file, magic mismatch, bad record) logs a warn and returns no bonds. The firmware boots fine without bonds — the cost is forcing a re-pair.
- **Crypto deps.** `trouble-host`'s `security` feature pulls `p256` + `aes` + `cmac` + `rand_chacha`. `.text` grew by ~140 KB; the partition has plenty of room. Compile time grew by ~10 s (one-time).
- **Bond storage on SD vs flash.** SD is convenient (writeback path already established) but if the user pulls the card mid-pair, bonds for that session are lost. A flash-NVS-backed store would be more durable but requires `esp-storage` integration that's out of scope for this PR.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests
- [x] `just clippy-firmware` — strict clippy
- [x] `just build-firmware` — release build clean (`.text` 1.18 MB)
- [ ] **Hardware verify:**
  - [ ] First-pair flow: scan from nRF Connect, hit Connect, hit Pair. LCD shows a 6-digit code; enter it on the phone. Boot log: `ble: passkey display: NNNNNN` then `ble: pairing complete (level=Encrypted, bonded=true)` then `ble: bonds: persisted 1 bond(s)`.
  - [ ] Provisioning post-pair: write SSID then write PSK. Boot log: `ble: prov: persisted` (no `write rejected — link not encrypted` warn).
  - [ ] Provisioning pre-pair: connect *without* pairing, write PSK. Boot log: `ble: prov: write rejected — link not encrypted`. New SSID/PSK is not persisted.
  - [ ] Reboot persistence: complete a pair, reboot, reconnect. Boot log: `ble: bonds: 1 persisted bond(s) registered`. Reconnect goes encrypted immediately, no passkey prompt. Provisioning works.
  - [ ] Unpair: from the phone, forget/unpair. Reconnect → fresh passkey flow.