### PR TITLE
feat(firmware): BLE control-plane writes for audio + avatar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,6 +4724,7 @@ dependencies = [
  "embedded-graphics",
  "heapless 0.8.0",
  "stackchan-core",
+ "stackchan-net",
 ]
 
 [[package]]

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -27,7 +27,7 @@ modifier pipeline at ~30 FPS.
 - `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
 - `src/imu.rs` — BMI270 task publishing accel/gyro samples on `IMU_SIGNAL`
 - `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` / `src/power.rs` — per-peripheral tasks
-- `src/ble/` — BLE peripheral. `mod.rs` re-exports the task entry point; `server.rs` declares the GATT server (Device Information / Battery / Stack-chan custom emotion service) via the `trouble-host` macros and runs the advertise / accept / serve loop; `task.rs` pins the controller type for `embassy_executor::task` spawn
+- `src/ble/` — BLE peripheral. `mod.rs` re-exports the task entry point; `server.rs` declares the GATT server (Device Information, Battery, Stack-chan emotion, Wi-Fi provisioning, audio control, avatar control) via the `trouble-host` macros and runs the advertise / accept / serve loop; `task.rs` pins the controller type for `embassy_executor::task` spawn; `bonds.rs` persists pairing keys to SD
 - `src/audio.rs` — I²S0 + codec bring-up, then RX RMS loop (publishing on `AUDIO_RMS_SIGNAL`) + TX feeder (silence between trigger-driven clips) running concurrently via `embassy_futures::join`. Exposes `AUDIO_TX_PLAYING` so the render loop can gate `audio_rms` against speaker self-trigger
 - `src/camera.rs` — `LCD_CAM` + DMA bring-up + always-on capture loop. Each frame is published on `CAMERA_FRAME_SIGNAL` for the LCD preview AND fed through `tracker::Tracker::step`, with the result on `CAMERA_TRACKING_SIGNAL`. `CAMERA_MODE_SIGNAL` is now display-only (preview vs avatar)
 - `examples/bench.rs` — calibration bench, flashed via `just bench`
@@ -102,13 +102,19 @@ JSON.
 
 In parallel, the device advertises a BLE peripheral named
 `stackchan-XXXXXX` (last three MAC bytes) so a phone or laptop on the
-same physical radio can read battery percent and current emotion
-without joining the LAN. Services exposed: Device Information
-(`0x180A` — manufacturer / model / firmware revision), Battery
-(`0x180F`), and a custom Stack-chan service whose emotion
-characteristic notifies on transition. Wi-Fi and BLE share the radio
-via `esp-radio`'s coex scheduler; expect a small Wi-Fi airtime tax
-when a BLE central is connected.
+same physical radio can read state and drive the firmware without
+joining the LAN. Services exposed: Device Information (`0x180A` —
+manufacturer / model / firmware revision), Battery (`0x180F`), a
+Stack-chan custom service for emotion read+notify, a Wi-Fi
+provisioning service for SSID + PSK writes, an audio service
+(`8a1c0020-...`) for volume + mute read+write+notify, and an avatar
+control service (`8a1c0030-...`) for emotion / look-at / reset /
+speak writes. Control writes require an authenticated bond
+(passkey-confirmed pairing). The notify task diffs the avatar
+snapshot every tick so subscribed centrals see HTTP-side changes
+without explicit polling. Wi-Fi and BLE share the radio via
+`esp-radio`'s coex scheduler; expect a small Wi-Fi airtime tax when
+a BLE central is connected.
 
 ## I²C Bus Sharing
 

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -166,14 +166,18 @@ pub enum AudioPersistOutcome {
     /// audio task signaled to apply the new value.
     Persisted,
     /// `CONFIG_SNAPSHOT` was empty — the boot config hasn't been
-    /// loaded yet. HTTP maps to `503`, BLE maps to
-    /// `WRITE_REQUEST_REJECTED`.
+    /// loaded yet. HTTP maps to `503`. BLE writes have already
+    /// completed their ATT `WRITE_RSP` by the time the persist runs,
+    /// so the central sees a successful write; the firmware logs
+    /// loudly via `defmt::warn!` so the failure is visible on the
+    /// monitor.
     NoSnapshot,
     /// No SD card mounted. Same status mapping as [`Self::NoSnapshot`].
     NoStorage,
-    /// SD write failed. HTTP maps to `500`, BLE maps to
-    /// `UNLIKELY_ERROR`. The error is logged via `defmt` at the
-    /// callsite that surfaced it.
+    /// SD write failed. HTTP maps to `500`. Same caveat as
+    /// [`Self::NoSnapshot`] for BLE — the ATT `WRITE_RSP` is already
+    /// out, so the central sees success while the firmware-side log
+    /// records the failure.
     WriteFailed,
 }
 

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -156,6 +156,85 @@ pub static AUDIO_VOLUME_SIGNAL: Signal<CriticalSectionRawMutex, u8> = Signal::ne
 /// persistence, the amp-control loop applies via `set_muted`.
 pub static AUDIO_MUTE_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
+/// Result of a persisted audio-setting change. Returned by
+/// [`persist_volume`] / [`persist_mute`] so the HTTP and BLE
+/// control planes can map the outcome onto their own protocol's
+/// success / error encoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, defmt::Format)]
+pub enum AudioPersistOutcome {
+    /// Config was written, [`crate::net::snapshot`] updated, and the
+    /// audio task signaled to apply the new value.
+    Persisted,
+    /// `CONFIG_SNAPSHOT` was empty — the boot config hasn't been
+    /// loaded yet. HTTP maps to `503`, BLE maps to
+    /// `WRITE_REQUEST_REJECTED`.
+    NoSnapshot,
+    /// No SD card mounted. Same status mapping as [`Self::NoSnapshot`].
+    NoStorage,
+    /// SD write failed. HTTP maps to `500`, BLE maps to
+    /// `UNLIKELY_ERROR`. The error is logged via `defmt` at the
+    /// callsite that surfaced it.
+    WriteFailed,
+}
+
+/// Persist a new volume percentile and signal the audio task.
+///
+/// Mirrors the snapshot-mutex hygiene of the HTTP `POST /volume`
+/// path: clone the current snapshot, drop the lock, write to SD,
+/// then re-acquire only to install the updated value. Holding the
+/// snapshot lock across the SD write would stall every concurrent
+/// request that touches `CONFIG_SNAPSHOT` (auth gate, `GET
+/// /settings`, BLE provisioning) for the full write duration.
+pub async fn persist_volume(level: u8) -> AudioPersistOutcome {
+    let Some(current) = crate::storage::CONFIG_SNAPSHOT.lock().await.clone() else {
+        return AudioPersistOutcome::NoSnapshot;
+    };
+    let mut new_config = current;
+    new_config.audio.volume_pct = level;
+    let write_result =
+        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
+    match write_result {
+        Some(Ok(())) => {
+            defmt::info!("audio: volume persisted (level={=u8})", level);
+            crate::net::snapshot::update_audio(new_config.audio);
+            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
+            AUDIO_VOLUME_SIGNAL.signal(level);
+            AudioPersistOutcome::Persisted
+        }
+        Some(Err(e)) => {
+            defmt::warn!("audio: volume write failed ({})", e);
+            AudioPersistOutcome::WriteFailed
+        }
+        None => AudioPersistOutcome::NoStorage,
+    }
+}
+
+/// Persist a new mute flag and signal the audio task. Symmetric with
+/// [`persist_volume`].
+pub async fn persist_mute(muted: bool) -> AudioPersistOutcome {
+    let Some(current) = crate::storage::CONFIG_SNAPSHOT.lock().await.clone() else {
+        return AudioPersistOutcome::NoSnapshot;
+    };
+    let mut new_config = current;
+    new_config.audio.muted = muted;
+    let write_result =
+        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
+    match write_result {
+        Some(Ok(())) => {
+            defmt::info!("audio: mute persisted (muted={=bool})", muted);
+            crate::net::snapshot::update_audio(new_config.audio);
+            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
+            AUDIO_MUTE_SIGNAL.signal(muted);
+            AudioPersistOutcome::Persisted
+        }
+        Some(Err(e)) => {
+            defmt::warn!("audio: mute write failed ({})", e);
+            AudioPersistOutcome::WriteFailed
+        }
+        None => AudioPersistOutcome::NoStorage,
+    }
+}
+
 /// AW88298 settle delay between starting TX DMA (with a buffer of
 /// zeros = digital silence) and lifting `HMUTE`. Lets the codec lock
 /// onto the I²S clock domain before the output stage goes live so the

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -9,7 +9,7 @@
 //! doc comments. Our own struct/field doc comments below stay
 //! authoritative for the human-facing surface.
 //!
-//! The server exposes four services beyond the auto-built GAP:
+//! The server exposes the following services beyond the auto-built GAP:
 //!
 //! 1. **Device Information `0x180A`** — manufacturer / model /
 //!    firmware-revision strings. Populated at boot and never mutated.
@@ -24,15 +24,27 @@
 //!      /settings` uses, then signals
 //!      [`crate::net::wifi::WIFI_RECONFIG`] so the wifi task soft-
 //!      reconnects without a reboot.
+//! 5. **Audio service** (`8a1c0020-…`) — volume + mute, both
+//!    `read + write + notify`. Writes route through
+//!    [`crate::audio::persist_volume`] / [`crate::audio::persist_mute`]
+//!    so HTTP `POST /volume` / `POST /mute` and the BLE write share
+//!    one persistence implementation.
+//! 6. **Avatar control service** (`8a1c0030-…`) — `write`-only
+//!    characteristics for emotion, look-at, reset, and speak. Each
+//!    write decodes a fixed-length payload via
+//!    [`stackchan_net::ble_command`] and signals
+//!    [`crate::net::http::REMOTE_COMMAND_SIGNAL`], the same channel
+//!    the HTTP control plane drives.
 //!
 //! ## Security
 //!
-//! The provisioning service is **unauthenticated** in this PR — any
-//! BLE central in radio range can write SSID/PSK and reconfigure the
-//! device. PR3 adds passkey display + LE Secure Connections bonding
-//! and gates these writes to bonded peers only. Until then, the
-//! `defmt::warn!` on every PSK commit is the loud reminder that this
-//! is provisional.
+//! Control writes (audio + avatar services) and provisioning writes
+//! both require an `EncryptedAuthenticated` link (passkey-confirmed
+//! bond). Centrals that haven't paired get an
+//! `INSUFFICIENT_AUTHENTICATION` reject for control writes; the
+//! provisioning path additionally validates payload contents at
+//! commit time and silently no-ops on auth failure (legacy from the
+//! initial provisioning PR).
 //!
 //! DIS characteristic types are `heapless::String<N>` rather than
 //! `&'static str` because trouble-host's `AsGatt for &'static str`
@@ -52,9 +64,12 @@ use embassy_time::{Duration, Timer};
 // 0.8. Reach explicitly for the alias so the right impl is picked.
 use heapless_09::String as HString;
 use stackchan_core::Emotion;
+use stackchan_net::ble_command::{self, BleError, EMOTION_WRITE_LEN, LOOK_AT_LEN, SPEAK_LEN};
 use trouble_host::Address;
 use trouble_host::prelude::*;
 
+use crate::audio::AudioPersistOutcome;
+use crate::net::http::REMOTE_COMMAND_SIGNAL;
 use crate::net::snapshot;
 use crate::net::wifi::{WIFI_RECONFIG, WifiCreds};
 use crate::storage::{CONFIG_SNAPSHOT, with_storage};
@@ -122,6 +137,13 @@ pub struct StackchanServer {
     /// Wi-Fi provisioning service — writeable SSID + PSK. Commits +
     /// soft-reconnects on PSK write.
     pub provisioning: ProvisioningService,
+    /// Audio service — volume + mute (read + write + notify). Mirrors
+    /// HTTP `POST /volume` / `POST /mute`.
+    pub audio: AudioService,
+    /// Avatar control service — emotion / look-at / reset / speak
+    /// (write only). Mirrors HTTP `POST /emotion`, `/look-at`,
+    /// `/reset`, `/speak`.
+    pub avatar: AvatarControlService,
 }
 
 #[allow(missing_docs)]
@@ -150,6 +172,54 @@ pub struct StackchanService {
     /// transition.
     #[characteristic(uuid = "8a1c0002-7b3f-4d52-9c6e-5f5ba1e5cf01", read, notify, value = 0)]
     pub emotion: u8,
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = "8a1c0020-7b3f-4d52-9c6e-5f5ba1e5cf01")]
+pub struct AudioService {
+    /// Volume percentile (`0..=100`). `read + write + notify`.
+    /// Decoded via [`stackchan_net::ble_command::decode_volume`];
+    /// writes route through [`crate::audio::persist_volume`].
+    #[characteristic(
+        uuid = "8a1c0021-7b3f-4d52-9c6e-5f5ba1e5cf01",
+        read,
+        write,
+        notify,
+        value = 0
+    )]
+    pub volume: u8,
+    /// Mute flag (`0 = un-muted`, `1 = muted`). `read + write + notify`.
+    /// Decoded via [`stackchan_net::ble_command::decode_mute`];
+    /// writes route through [`crate::audio::persist_mute`].
+    #[characteristic(
+        uuid = "8a1c0022-7b3f-4d52-9c6e-5f5ba1e5cf01",
+        read,
+        write,
+        notify,
+        value = 0
+    )]
+    pub mute: u8,
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = "8a1c0030-7b3f-4d52-9c6e-5f5ba1e5cf01")]
+pub struct AvatarControlService {
+    /// Emotion override. 3-byte payload (`u8` emotion + `u16 LE`
+    /// `hold_ms`). See [`stackchan_net::ble_command::decode_emotion_write`].
+    #[characteristic(uuid = "8a1c0031-7b3f-4d52-9c6e-5f5ba1e5cf01", write, value = [0u8; EMOTION_WRITE_LEN])]
+    pub emotion_write: [u8; EMOTION_WRITE_LEN],
+    /// Look-at override. 6-byte payload (two `i16 LE` centi-degrees +
+    /// `u16 LE` `hold_ms`). See [`stackchan_net::ble_command::decode_look_at`].
+    #[characteristic(uuid = "8a1c0032-7b3f-4d52-9c6e-5f5ba1e5cf01", write, value = [0u8; LOOK_AT_LEN])]
+    pub look_at: [u8; LOOK_AT_LEN],
+    /// Reset trigger. Any 1-byte write clears active emotion / look-at
+    /// holds. See [`stackchan_net::ble_command::decode_reset`].
+    #[characteristic(uuid = "8a1c0033-7b3f-4d52-9c6e-5f5ba1e5cf01", write, value = 0)]
+    pub reset: u8,
+    /// Speak trigger. 2-byte payload (`u8` phrase + `u8` locale). See
+    /// [`stackchan_net::ble_command::decode_speak`].
+    #[characteristic(uuid = "8a1c0034-7b3f-4d52-9c6e-5f5ba1e5cf01", write, value = [0u8; SPEAK_LEN])]
+    pub speak: [u8; SPEAK_LEN],
 }
 
 #[allow(missing_docs)]
@@ -250,6 +320,7 @@ pub async fn run_ble_peripheral<C: Controller>(
 
     populate_dis(&server);
     populate_provisioning_ssid(&server).await;
+    populate_audio_state(&server);
 
     let advertise_serve = async {
         loop {
@@ -357,10 +428,79 @@ async fn advertise<'values, 'server, C: Controller>(
     Ok(conn)
 }
 
+/// Cached write-characteristic handles, looked up once per connection
+/// so the per-event dispatch is a handful of integer compares.
+struct WriteHandles {
+    /// Provisioning PSK write — kept here so the dispatch routes
+    /// straight into [`commit_provisioning`] without a separate
+    /// pattern match.
+    psk: u16,
+    /// Audio volume write.
+    volume: u16,
+    /// Audio mute write.
+    mute: u16,
+    /// Avatar emotion-write characteristic.
+    emotion_write: u16,
+    /// Avatar look-at write.
+    look_at: u16,
+    /// Avatar reset trigger.
+    reset: u16,
+    /// Avatar speak trigger.
+    speak: u16,
+}
+
+impl WriteHandles {
+    /// Snapshot the write handles from the freshly-built server.
+    /// Cheap — each field is one `u16` copy from a fixed offset
+    /// inside the macro-emitted server struct.
+    const fn new(server: &StackchanServer<'_>) -> Self {
+        Self {
+            psk: server.provisioning.psk.handle,
+            volume: server.audio.volume.handle,
+            mute: server.audio.mute.handle,
+            emotion_write: server.avatar.emotion_write.handle,
+            look_at: server.avatar.look_at.handle,
+            reset: server.avatar.reset.handle,
+            speak: server.avatar.speak.handle,
+        }
+    }
+}
+
+/// Action performed after a write has been accepted at the ATT layer.
+/// Decoded from the wire payload up front so the post-accept handler
+/// is a straight signal/persist call without re-parsing.
+enum WriteAction {
+    /// Provisioning-PSK commit (existing flow): read SSID + PSK back
+    /// from the GATT table, validate, persist, signal Wi-Fi reconfig.
+    ProvisioningPsk,
+    /// Apply a new volume percentile via [`crate::audio::persist_volume`].
+    Volume(u8),
+    /// Apply a new mute flag via [`crate::audio::persist_mute`].
+    Mute(bool),
+    /// Forward a parsed [`stackchan_core::RemoteCommand`] onto
+    /// [`REMOTE_COMMAND_SIGNAL`] — handles emotion / look-at / reset / speak.
+    Remote(stackchan_core::RemoteCommand),
+    /// Forward a synthesised reset onto [`REMOTE_COMMAND_SIGNAL`].
+    /// Reset has no decoded payload but needs the same dispatch shape.
+    RemoteReset,
+}
+
+/// Decision the dispatcher takes for one Gatt event.
+enum WriteDecision {
+    /// Non-write event, or write to an unknown handle. Fall through
+    /// to default accept-and-discard semantics.
+    Default,
+    /// Accept the write, then perform [`WriteAction`].
+    Accept(WriteAction),
+    /// Reject the write with an ATT error code. The central sees the
+    /// error; the GATT table is not modified.
+    Reject(AttErrorCode),
+}
+
 /// Drains GATT events for one connection. trouble-host requires every
-/// event to be `accept()`ed — the reply path runs the ATT response
-/// back to the central. Without this loop, reads would silently time
-/// out from the peer's view.
+/// event to be `accept()` (or `reject()`)-ed — the reply path runs the
+/// ATT response back to the central. Without this loop, reads would
+/// silently time out from the peer's view.
 ///
 /// Also handles the BLE security event surface:
 ///
@@ -370,15 +510,18 @@ async fn advertise<'values, 'server, C: Controller>(
 ///   to SD via [`crate::ble::bonds`].
 /// - `PairingFailed` — clear the on-screen passkey, log the reason.
 ///
-/// On a write to the provisioning PSK characteristic, fires the
-/// commit path — but only if the link is currently encrypted.
-/// Pre-pairing writes get rejected with a warn and a no-op.
+/// Control writes (audio + avatar services) require an
+/// `EncryptedAuthenticated` link; unauthenticated writes are rejected
+/// with `INSUFFICIENT_AUTHENTICATION` so the GATT table never holds
+/// bytes from an unpaired peer. Provisioning-PSK writes use the
+/// pre-existing accept-then-commit flow; their security check lives
+/// in `commit_provisioning`.
 async fn gatt_events_task<P: PacketPool>(
     stack: &Stack<'_, impl Controller, P>,
     server: &StackchanServer<'_>,
     conn: &GattConnection<'_, '_, P>,
 ) {
-    let psk_handle = server.provisioning.psk.handle;
+    let handles = WriteHandles::new(server);
     loop {
         match conn.next().await {
             GattConnectionEvent::Disconnected { reason } => {
@@ -387,31 +530,7 @@ async fn gatt_events_task<P: PacketPool>(
                 return;
             }
             GattConnectionEvent::Gatt { event } => {
-                let is_psk_write =
-                    matches!(&event, GattEvent::Write(w) if w.handle() == psk_handle);
-                // Only fire commit when the write was actually
-                // applied to the GATT table. A failed `accept()`
-                // means trouble-host did not store the new bytes,
-                // and `server.get(&psk)` would return stale or
-                // empty data — committing on that path would
-                // persist the wrong PSK (or treat an empty PSK as
-                // an open-AP credential).
-                let accepted_ok = match event.accept() {
-                    Ok(reply) => {
-                        reply.send().await;
-                        true
-                    }
-                    Err(e) => {
-                        defmt::warn!(
-                            "ble: gatt event accept failed ({})",
-                            defmt::Debug2Format(&e)
-                        );
-                        false
-                    }
-                };
-                if is_psk_write && accepted_ok {
-                    commit_provisioning(server, conn).await;
-                }
+                dispatch_gatt_event(server, conn, &handles, event).await;
             }
             GattConnectionEvent::PassKeyDisplay(passkey) => {
                 let value = passkey.value();
@@ -442,19 +561,206 @@ async fn gatt_events_task<P: PacketPool>(
     }
 }
 
-/// Periodic battery notify (1 Hz) + change-driven emotion notify.
+/// Dispatch one Gatt event: decide accept/reject for known writes,
+/// fall through to default accept for everything else, then run any
+/// post-accept action (signal + persist).
+async fn dispatch_gatt_event<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    handles: &WriteHandles,
+    event: GattEvent<'_, '_, P>,
+) {
+    let decision = match &event {
+        GattEvent::Write(w) => decide_write(handles, conn, w.handle(), w.data()),
+        _ => WriteDecision::Default,
+    };
+
+    match decision {
+        WriteDecision::Reject(err) => match event.reject(err) {
+            Ok(reply) => reply.send().await,
+            Err(e) => defmt::warn!("ble: gatt reject failed ({})", defmt::Debug2Format(&e)),
+        },
+        WriteDecision::Default => match event.accept() {
+            Ok(reply) => reply.send().await,
+            Err(e) => defmt::warn!("ble: gatt accept failed ({})", defmt::Debug2Format(&e)),
+        },
+        WriteDecision::Accept(action) => {
+            // Only fire the post-accept action when the ATT reply
+            // actually went out — a failed `accept()` means the
+            // attribute server didn't store any new bytes, so calling
+            // e.g. `commit_provisioning` against a stale GATT table
+            // would persist the wrong value.
+            let accepted = match event.accept() {
+                Ok(reply) => {
+                    reply.send().await;
+                    true
+                }
+                Err(e) => {
+                    defmt::warn!("ble: gatt accept failed ({})", defmt::Debug2Format(&e));
+                    false
+                }
+            };
+            if !accepted {
+                return;
+            }
+            apply_write_action(server, conn, action).await;
+        }
+    }
+}
+
+/// Inspect a write event and decide whether to accept, reject, or
+/// pass through. For known control writes (audio + avatar services),
+/// require an authenticated link and decode the payload via
+/// [`stackchan_net::ble_command`]. For everything else (including
+/// the existing provisioning SSID write), keep the historical
+/// accept-and-store-into-the-GATT-table behaviour.
+fn decide_write<P: PacketPool>(
+    handles: &WriteHandles,
+    conn: &GattConnection<'_, '_, P>,
+    handle: u16,
+    data: &[u8],
+) -> WriteDecision {
+    if handle == handles.psk {
+        return WriteDecision::Accept(WriteAction::ProvisioningPsk);
+    }
+    let is_control = handle == handles.volume
+        || handle == handles.mute
+        || handle == handles.emotion_write
+        || handle == handles.look_at
+        || handle == handles.reset
+        || handle == handles.speak;
+    if !is_control {
+        return WriteDecision::Default;
+    }
+    if !is_authenticated(conn) {
+        return WriteDecision::Reject(AttErrorCode::INSUFFICIENT_AUTHENTICATION);
+    }
+    let result = if handle == handles.volume {
+        ble_command::decode_volume(data).map(WriteAction::Volume)
+    } else if handle == handles.mute {
+        ble_command::decode_mute(data).map(WriteAction::Mute)
+    } else if handle == handles.emotion_write {
+        ble_command::decode_emotion_write(data).map(WriteAction::Remote)
+    } else if handle == handles.look_at {
+        ble_command::decode_look_at(data).map(WriteAction::Remote)
+    } else if handle == handles.reset {
+        ble_command::decode_reset(data).map(|()| WriteAction::RemoteReset)
+    } else {
+        // handles.speak by elimination, but match explicitly so adding
+        // a control characteristic without wiring a decoder fails fast.
+        debug_assert_eq!(handle, handles.speak);
+        ble_command::decode_speak(data).map(WriteAction::Remote)
+    };
+    match result {
+        Ok(action) => WriteDecision::Accept(action),
+        Err(e) => {
+            defmt::warn!(
+                "ble: control write rejected (handle={=u16:04x}, {})",
+                handle,
+                defmt::Debug2Format(&e)
+            );
+            WriteDecision::Reject(att_error_for(&e))
+        }
+    }
+}
+
+/// Map a [`BleError`] from the wire-format codec to the ATT error
+/// code the central sees. Bad length → `INVALID_ATTRIBUTE_VALUE_LENGTH`,
+/// numeric range overruns → `OUT_OF_RANGE`, unknown enum bytes →
+/// `VALUE_NOT_ALLOWED`.
+const fn att_error_for(err: &BleError) -> AttErrorCode {
+    match err {
+        BleError::BadLength { .. } => AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH,
+        BleError::VolumeOutOfRange(_) | BleError::LookAtOutOfRange { .. } => {
+            AttErrorCode::OUT_OF_RANGE
+        }
+        BleError::BadMuteByte(_)
+        | BleError::UnknownEmotion(_)
+        | BleError::UnknownLocale(_)
+        | BleError::UnknownPhrase(_) => AttErrorCode::VALUE_NOT_ALLOWED,
+    }
+}
+
+/// Run the post-accept side of a control write — signal the relevant
+/// firmware sink and (for audio writes) persist to SD.
+async fn apply_write_action<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    action: WriteAction,
+) {
+    match action {
+        WriteAction::ProvisioningPsk => commit_provisioning(server, conn).await,
+        WriteAction::Volume(level) => {
+            log_audio_outcome("volume", crate::audio::persist_volume(level).await);
+        }
+        WriteAction::Mute(muted) => {
+            log_audio_outcome("mute", crate::audio::persist_mute(muted).await);
+        }
+        WriteAction::Remote(cmd) => {
+            defmt::info!("ble: remote command {}", defmt::Debug2Format(&cmd));
+            REMOTE_COMMAND_SIGNAL.signal(cmd);
+        }
+        WriteAction::RemoteReset => {
+            defmt::info!("ble: remote reset");
+            REMOTE_COMMAND_SIGNAL.signal(stackchan_core::RemoteCommand::Reset);
+        }
+    }
+}
+
+/// Whether the connection is currently encrypted *and* authenticated
+/// (passkey-confirmed bond). Plain `Encrypted` is the `JustWorks`
+/// outcome — any nearby central can force that without the user
+/// confirming a code, so it doesn't gate control writes.
+fn is_authenticated<P: PacketPool>(conn: &GattConnection<'_, '_, P>) -> bool {
+    matches!(
+        conn.raw().security_level(),
+        Ok(SecurityLevel::EncryptedAuthenticated)
+    )
+}
+
+/// Single-line log for an audio persist outcome. Keeps the dispatch
+/// arm a one-liner and centralises the warn-vs-info branching.
+fn log_audio_outcome(field: &str, outcome: AudioPersistOutcome) {
+    match outcome {
+        AudioPersistOutcome::Persisted => {
+            defmt::info!("ble: {} persisted", field);
+        }
+        AudioPersistOutcome::NoSnapshot => {
+            defmt::warn!(
+                "ble: {} write — config snapshot unavailable, dropping",
+                field
+            );
+        }
+        AudioPersistOutcome::NoStorage => {
+            defmt::warn!("ble: {} write — no SD mounted, dropping", field);
+        }
+        AudioPersistOutcome::WriteFailed => {
+            defmt::warn!("ble: {} write — SD persist failed, dropping", field);
+        }
+    }
+}
+
+/// Periodic battery notify (1 Hz) + snapshot-diff change notifies for
+/// emotion / volume / mute.
 ///
-/// Reads the snapshot every tick. Battery percent always notifies so
-/// first-time subscribers see a value within a second. Emotion notifies
-/// only on transition — the value barely changes at steady state, so
-/// notifying every tick would waste airtime and flicker in nRF Connect.
+/// Battery percent always notifies so first-time subscribers see a
+/// value within a second. The other characteristics notify only on
+/// transition — at steady state they barely change, and pushing a
+/// tick whenever nothing moved would waste airtime and flicker in
+/// nRF Connect. Reading the [`AvatarSnapshot`] each tick is the
+/// single source of truth: it's already updated from the audio task
+/// on persist + the render task on emotion change, so BLE just diffs.
 async fn notify_task<P: PacketPool>(
     server: &StackchanServer<'_>,
     conn: &GattConnection<'_, '_, P>,
 ) {
     let battery_handle = server.battery.level;
     let emotion_handle = server.stackchan.emotion;
+    let volume_handle = server.audio.volume;
+    let mute_handle = server.audio.mute;
     let mut last_emotion: Option<Emotion> = None;
+    let mut last_volume: Option<u8> = None;
+    let mut last_mute: Option<bool> = None;
 
     loop {
         let snap = snapshot::read();
@@ -484,23 +790,79 @@ async fn notify_task<P: PacketPool>(
         }
 
         let emotion_byte = snap.emotion.wire_byte();
-        if let Err(e) = server.set(&emotion_handle, &emotion_byte) {
-            defmt::warn!(
-                "ble: emotion table set failed ({})",
-                defmt::Debug2Format(&e)
-            );
-        }
-        if last_emotion != Some(snap.emotion) {
-            last_emotion = Some(snap.emotion);
-            if let Err(e) = emotion_handle.notify(conn, &emotion_byte).await {
-                defmt::trace!(
-                    "ble: emotion notify skipped ({}) — peer not subscribed?",
-                    defmt::Debug2Format(&e)
-                );
-            }
-        }
+        notify_if_changed(
+            server,
+            conn,
+            &emotion_handle,
+            "emotion",
+            &mut last_emotion,
+            snap.emotion,
+            &emotion_byte,
+        )
+        .await;
+
+        let volume_byte = snap.audio.volume_pct;
+        notify_if_changed(
+            server,
+            conn,
+            &volume_handle,
+            "volume",
+            &mut last_volume,
+            volume_byte,
+            &volume_byte,
+        )
+        .await;
+
+        let mute_byte = ble_command::encode_mute(snap.audio.muted);
+        notify_if_changed(
+            server,
+            conn,
+            &mute_handle,
+            "mute",
+            &mut last_mute,
+            snap.audio.muted,
+            &mute_byte,
+        )
+        .await;
 
         Timer::after(BATTERY_NOTIFY_PERIOD).await;
+    }
+}
+
+/// Update the GATT table value and emit a notify only when the
+/// snapshot field changed since the last tick. Caller passes the
+/// observed-state cache (`last`), the new state value (`current`),
+/// and the byte payload to set + notify (already encoded).
+async fn notify_if_changed<T, V, P>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    handle: &Characteristic<V>,
+    field: &str,
+    last: &mut Option<T>,
+    current: T,
+    bytes: &V,
+) where
+    T: Copy + PartialEq,
+    V: trouble_host::prelude::FromGatt,
+    P: PacketPool,
+{
+    if let Err(e) = server.set(handle, bytes) {
+        defmt::warn!(
+            "ble: {} table set failed ({})",
+            field,
+            defmt::Debug2Format(&e)
+        );
+    }
+    if *last == Some(current) {
+        return;
+    }
+    *last = Some(current);
+    if let Err(e) = handle.notify(conn, bytes).await {
+        defmt::trace!(
+            "ble: {} notify skipped ({}) — peer not subscribed?",
+            field,
+            defmt::Debug2Format(&e)
+        );
     }
 }
 
@@ -523,6 +885,27 @@ async fn populate_provisioning_ssid(server: &StackchanServer<'_>) {
     }
     if let Err(e) = server.set(&server.provisioning.ssid, &s) {
         defmt::warn!("ble: provisioning SSID set ({})", defmt::Debug2Format(&e));
+    }
+}
+
+/// Pre-fill the audio service's volume + mute characteristics with
+/// the persisted config so a phone reading them at connect time sees
+/// the active values rather than zeros. The notify loop later catches
+/// any change made between this snapshot and the central's read.
+fn populate_audio_state(server: &StackchanServer<'_>) {
+    let snap = snapshot::read();
+    if let Err(e) = server.set(&server.audio.volume, &snap.audio.volume_pct) {
+        defmt::warn!(
+            "ble: audio volume initial set failed ({})",
+            defmt::Debug2Format(&e)
+        );
+    }
+    let mute_byte = ble_command::encode_mute(snap.audio.muted);
+    if let Err(e) = server.set(&server.audio.mute, &mute_byte) {
+        defmt::warn!(
+            "ble: audio mute initial set failed ({})",
+            defmt::Debug2Format(&e)
+        );
     }
 }
 

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -645,11 +645,20 @@ fn decide_write<P: PacketPool>(
         ble_command::decode_look_at(data).map(WriteAction::Remote)
     } else if handle == handles.reset {
         ble_command::decode_reset(data).map(|()| WriteAction::RemoteReset)
-    } else {
-        // handles.speak by elimination, but match explicitly so adding
-        // a control characteristic without wiring a decoder fails fast.
-        debug_assert_eq!(handle, handles.speak);
+    } else if handle == handles.speak {
         ble_command::decode_speak(data).map(WriteAction::Remote)
+    } else {
+        // Unreachable on the strength of the `is_control` gate above
+        // — every handle counted there must have a decode arm here.
+        // If a future control characteristic is added to `is_control`
+        // without a matching decode branch, log loudly and reject the
+        // write rather than silently mishandling it. (`debug_assert!`
+        // is the wrong tool: it compiles out in release.)
+        defmt::error!(
+            "ble: control write dispatch missing decode arm (handle={=u16:04x})",
+            handle
+        );
+        return WriteDecision::Reject(AttErrorCode::UNLIKELY_ERROR);
     };
     match result {
         Ok(action) => WriteDecision::Accept(action),

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -484,30 +484,7 @@ async fn handle_post_volume(socket: &mut TcpSocket<'_>, body: &str) -> Result<()
             return write_text(socket, 400, &body).await;
         }
     };
-    let Some(current) = crate::storage::CONFIG_SNAPSHOT.lock().await.clone() else {
-        return write_text(socket, 503, "config snapshot unavailable\n").await;
-    };
-    let mut new_config = current;
-    new_config.audio.volume_pct = level;
-    let write_result =
-        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
-    match write_result {
-        Some(Ok(())) => {
-            defmt::info!("http: POST /volume persisted (level={=u8})", level);
-            snapshot::update_audio(new_config.audio);
-            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
-            crate::audio::AUDIO_VOLUME_SIGNAL.signal(level);
-            write_no_content(socket).await
-        }
-        Some(Err(e)) => {
-            defmt::warn!("http: POST /volume write failed ({})", e);
-            write_text(socket, 500, "config write failed\n").await
-        }
-        None => {
-            defmt::warn!("http: POST /volume rejected (no SD mounted)");
-            write_text(socket, 503, "no SD card mounted\n").await
-        }
-    }
+    audio_persist_to_http(socket, crate::audio::persist_volume(level).await).await
 }
 
 /// `POST /mute` — parse `{"muted": <bool>}`, persist to
@@ -529,29 +506,24 @@ async fn handle_post_mute(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), 
             return write_text(socket, 400, &body).await;
         }
     };
-    let Some(current) = crate::storage::CONFIG_SNAPSHOT.lock().await.clone() else {
-        return write_text(socket, 503, "config snapshot unavailable\n").await;
-    };
-    let mut new_config = current;
-    new_config.audio.muted = muted;
-    let write_result =
-        crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
-    match write_result {
-        Some(Ok(())) => {
-            defmt::info!("http: POST /mute persisted (muted={=bool})", muted);
-            snapshot::update_audio(new_config.audio);
-            *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
-            crate::audio::AUDIO_MUTE_SIGNAL.signal(muted);
-            write_no_content(socket).await
+    audio_persist_to_http(socket, crate::audio::persist_mute(muted).await).await
+}
+
+/// Map an [`crate::audio::AudioPersistOutcome`] to its HTTP response.
+/// Shared by `POST /volume` and `POST /mute` so the two routes always
+/// surface the same status codes for matching outcomes.
+async fn audio_persist_to_http(
+    socket: &mut TcpSocket<'_>,
+    outcome: crate::audio::AudioPersistOutcome,
+) -> Result<(), HttpError> {
+    use crate::audio::AudioPersistOutcome;
+    match outcome {
+        AudioPersistOutcome::Persisted => write_no_content(socket).await,
+        AudioPersistOutcome::NoSnapshot => {
+            write_text(socket, 503, "config snapshot unavailable\n").await
         }
-        Some(Err(e)) => {
-            defmt::warn!("http: POST /mute write failed ({})", e);
-            write_text(socket, 500, "config write failed\n").await
-        }
-        None => {
-            defmt::warn!("http: POST /mute rejected (no SD mounted)");
-            write_text(socket, 503, "no SD card mounted\n").await
-        }
+        AudioPersistOutcome::NoStorage => write_text(socket, 503, "no SD card mounted\n").await,
+        AudioPersistOutcome::WriteFailed => write_text(socket, 500, "config write failed\n").await,
     }
 }
 

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -40,6 +40,11 @@ shape of the on-disk config and the RON file `PUT /settings` round-trips.
   (no `serde`, no `ron` — see the module doc for why)
 - `src/bare_json.rs` — hand-rolled JSON parser/renderer used by the
   firmware HTTP control plane on `GET /settings` / `PUT /settings`
+- `src/http_command.rs` — JSON body parsers for `POST /emotion`,
+  `/look-at`, `/speak`, `/volume`, `/mute`
+- `src/ble_command.rs` — fixed-length wire-format codecs for the
+  BLE audio + avatar control characteristics, with stable byte
+  mappings for `Emotion` / `PhraseId` / `Locale`
 - `src/error.rs` — `ConfigError` (parse / serialize / validation variants)
 - `tests/golden_config.rs` + `tests/fixtures/*.ron` — round-trip and
   validation coverage against hand-written fixtures
@@ -58,7 +63,8 @@ propagates a `ConfigError` up to a panic — it logs and uses defaults.
 - OTA manifests — firmware updates are a separate concern.
 - Captive portal / soft-AP setup flow — first-boot UX deferred.
 - Persona / character data — belongs to the AI tier (deferred).
-- BLE pairing config — out of scope.
+- BLE pairing-key serialisation — owned by the firmware
+  `crate::ble::bonds` module, not this crate.
 
 ## Security note
 

--- a/crates/stackchan-net/src/ble_command.rs
+++ b/crates/stackchan-net/src/ble_command.rs
@@ -222,7 +222,7 @@ pub fn decode_look_at(payload: &[u8]) -> Result<RemoteCommand, BleError> {
     let pan_centi = i16::from_le_bytes([payload[0], payload[1]]);
     let tilt_centi = i16::from_le_bytes([payload[2], payload[3]]);
     let hold_ms = u16::from_le_bytes([payload[4], payload[5]]);
-    if !pan_in_range(pan_centi) || !pan_in_range(tilt_centi) {
+    if !axis_in_range(pan_centi) || !axis_in_range(tilt_centi) {
         return Err(BleError::LookAtOutOfRange {
             pan: pan_centi,
             tilt: tilt_centi,
@@ -300,9 +300,10 @@ const fn resolve_hold(hold_ms: u16) -> u32 {
     }
 }
 
-/// Bounds check for a signed centi-degree axis used by look-at writes.
-/// Rejects anything outside <code>±[LOOK_AT_RANGE_CENTI_DEG]</code>.
-const fn pan_in_range(centi: i16) -> bool {
+/// Bounds check for either pan or tilt — both axes share the same
+/// wire-level range gate. Rejects anything outside
+/// <code>±[LOOK_AT_RANGE_CENTI_DEG]</code>.
+const fn axis_in_range(centi: i16) -> bool {
     centi >= -LOOK_AT_RANGE_CENTI_DEG && centi <= LOOK_AT_RANGE_CENTI_DEG
 }
 
@@ -533,6 +534,24 @@ mod tests {
             decode_look_at(&payload),
             Err(BleError::LookAtOutOfRange { .. })
         ));
+    }
+
+    #[test]
+    fn look_at_rejects_tilt_out_of_range() {
+        // Tilt rides the same gate as pan but through a separate
+        // axis_in_range call — pin both axes so a future split (e.g.
+        // the asymmetric servo travel of MAX_TILT_DEG / MIN_TILT_DEG)
+        // can't drop tilt validation by accident.
+        let mut payload = [0u8; LOOK_AT_LEN];
+        let bad_tilt: i16 = LOOK_AT_RANGE_CENTI_DEG + 1;
+        payload[2..4].copy_from_slice(&bad_tilt.to_le_bytes());
+        match decode_look_at(&payload) {
+            Err(BleError::LookAtOutOfRange { pan, tilt }) => {
+                assert_eq!(pan, 0);
+                assert_eq!(tilt, bad_tilt);
+            }
+            other => panic!("expected LookAtOutOfRange, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/stackchan-net/src/ble_command.rs
+++ b/crates/stackchan-net/src/ble_command.rs
@@ -1,0 +1,631 @@
+//! BLE control-plane wire formats.
+//!
+//! Pairs with the GATT services declared in the firmware
+//! (`crates/stackchan-firmware/src/ble/server.rs`). Each function
+//! decodes the raw bytes from one characteristic write into a typed
+//! value the firmware can act on, or returns a [`BleError`] the
+//! firmware maps to an ATT error code.
+//!
+//! Lives in `stackchan-net` (not `stackchan-firmware`) so the codec
+//! tests run on host — the firmware crate is
+//! `xtensa-esp32s3-none-elf`-only and its `cfg(test)` modules are
+//! never executed by `just check`. Same shape as the
+//! [`crate::http_command`] parsers next door.
+//!
+//! ## Wire conventions
+//!
+//! - Multi-byte integers are **little-endian** (BLE attribute layout).
+//! - Variant-bearing bytes (`Emotion`, `PhraseId`, `Locale`) use the
+//!   byte mappings declared as `pub const`s in this module. Those
+//!   mappings are **wire-stable across firmware releases** — the
+//!   round-trip tests at the bottom of this file enforce that adding
+//!   a new variant must take the next free byte rather than shuffling
+//!   existing assignments.
+//! - `hold_ms` fields encode `0` as "use [`DEFAULT_HOLD_MS`]". Encoding
+//!   it inline keeps every characteristic fixed-length for a given
+//!   schema, which is friendlier to the gatt-service macro than
+//!   variable-length payloads.
+//!
+//! ## Characteristic layout
+//!
+//! | Char         | Bytes | Layout                                              |
+//! |--------------|-------|-----------------------------------------------------|
+//! | volume       | 1     | `u8` 0..=100                                        |
+//! | mute         | 1     | `u8` 0\|1                                           |
+//! | reset        | 1     | any single byte (trigger; value ignored)            |
+//! | emotion      | 3     | `u8` emotion + `u16` hold_ms                        |
+//! | look-at      | 6     | `i16` pan + `i16` tilt + `u16` hold_ms (centi-deg)  |
+//! | speak        | 2     | `u8` phrase + `u8` locale                           |
+
+use stackchan_core::voice::{Locale, PhraseId, Priority};
+use stackchan_core::{Emotion, Pose, RemoteCommand};
+
+/// Default hold window when a write payload signals "use default" by
+/// encoding `hold_ms = 0`.
+///
+/// Matches [`crate::http_command::DEFAULT_HOLD_MS`] so HTTP and BLE
+/// writes that omit a hold land on the same number.
+pub const DEFAULT_HOLD_MS: u32 = 30_000;
+
+/// Wire-level outer bound for the `i16` pan/tilt centi-degree fields.
+///
+/// `±180°·100 = ±18 000`. The servo driver applies its own (tighter)
+/// motion limits; this wire bound only catches obviously corrupt or
+/// fat-fingered values so the firmware never has to reason about an
+/// `i16` that overflows degree space.
+pub const LOOK_AT_RANGE_CENTI_DEG: i16 = 18_000;
+
+/// Expected payload length for the volume characteristic.
+pub const VOLUME_LEN: usize = 1;
+/// Expected payload length for the mute characteristic.
+pub const MUTE_LEN: usize = 1;
+/// Expected payload length for the reset characteristic.
+pub const RESET_LEN: usize = 1;
+/// Expected payload length for the emotion-write characteristic
+/// (`u8` emotion + `u16` `hold_ms`).
+pub const EMOTION_WRITE_LEN: usize = 3;
+/// Expected payload length for the look-at characteristic
+/// (`i16` pan + `i16` tilt + `u16` `hold_ms`).
+pub const LOOK_AT_LEN: usize = 6;
+/// Expected payload length for the speak characteristic
+/// (`u8` phrase + `u8` locale).
+pub const SPEAK_LEN: usize = 2;
+
+/// Wire byte for [`Emotion::Neutral`].
+pub const EMOTION_NEUTRAL: u8 = 0;
+/// Wire byte for [`Emotion::Happy`].
+pub const EMOTION_HAPPY: u8 = 1;
+/// Wire byte for [`Emotion::Sad`].
+pub const EMOTION_SAD: u8 = 2;
+/// Wire byte for [`Emotion::Sleepy`].
+pub const EMOTION_SLEEPY: u8 = 3;
+/// Wire byte for [`Emotion::Surprised`].
+pub const EMOTION_SURPRISED: u8 = 4;
+/// Wire byte for [`Emotion::Angry`].
+pub const EMOTION_ANGRY: u8 = 5;
+
+/// Wire byte for [`Locale::En`].
+pub const LOCALE_EN: u8 = 0;
+/// Wire byte for [`Locale::Ja`].
+pub const LOCALE_JA: u8 = 1;
+
+/// Wire byte for [`PhraseId::WakeChirp`].
+pub const PHRASE_WAKE_CHIRP: u8 = 0;
+/// Wire byte for [`PhraseId::PickupChirp`].
+pub const PHRASE_PICKUP_CHIRP: u8 = 1;
+/// Wire byte for [`PhraseId::StartleChirp`].
+pub const PHRASE_STARTLE_CHIRP: u8 = 2;
+/// Wire byte for [`PhraseId::LowBatteryChirp`].
+pub const PHRASE_LOW_BATTERY_CHIRP: u8 = 3;
+/// Wire byte for [`PhraseId::CameraModeEnteredChirp`].
+pub const PHRASE_CAMERA_MODE_ENTERED_CHIRP: u8 = 4;
+/// Wire byte for [`PhraseId::CameraModeExitedChirp`].
+pub const PHRASE_CAMERA_MODE_EXITED_CHIRP: u8 = 5;
+/// Wire byte for [`PhraseId::Greeting`].
+pub const PHRASE_GREETING: u8 = 6;
+/// Wire byte for [`PhraseId::AcknowledgeName`].
+pub const PHRASE_ACKNOWLEDGE_NAME: u8 = 7;
+/// Wire byte for [`PhraseId::BatteryLow`].
+pub const PHRASE_BATTERY_LOW: u8 = 8;
+
+/// Decoder error surface — every variant maps to one ATT error code in
+/// the firmware. Kept small; a [`Debug`] dump is the user-facing log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BleError {
+    /// Payload byte length didn't match the characteristic's fixed shape.
+    /// Maps to ATT `INVALID_ATTRIBUTE_VALUE_LENGTH` (0x0d).
+    BadLength {
+        /// Expected length for this characteristic.
+        expected: usize,
+        /// Actual length the central wrote.
+        actual: usize,
+    },
+    /// Volume byte exceeded `100`. Maps to ATT `OUT_OF_RANGE` (0xFF).
+    VolumeOutOfRange(u8),
+    /// Mute byte was neither `0` nor `1`. Maps to ATT `VALUE_NOT_ALLOWED`
+    /// (0x13) — strict so a buggy client surfaces fast.
+    BadMuteByte(u8),
+    /// Emotion byte didn't match any [`EMOTION_*`](EMOTION_NEUTRAL)
+    /// constant. Maps to ATT `VALUE_NOT_ALLOWED`.
+    UnknownEmotion(u8),
+    /// Locale byte didn't match any [`LOCALE_*`](LOCALE_EN) constant.
+    /// Maps to ATT `VALUE_NOT_ALLOWED`.
+    UnknownLocale(u8),
+    /// Phrase byte didn't match any [`PHRASE_*`](PHRASE_WAKE_CHIRP)
+    /// constant. Maps to ATT `VALUE_NOT_ALLOWED`.
+    UnknownPhrase(u8),
+    /// Pan or tilt centi-degrees exceeded `±LOOK_AT_RANGE_CENTI_DEG`
+    /// (see [`LOOK_AT_RANGE_CENTI_DEG`]). Maps to ATT `OUT_OF_RANGE`.
+    LookAtOutOfRange {
+        /// Submitted pan in centi-degrees.
+        pan: i16,
+        /// Submitted tilt in centi-degrees.
+        tilt: i16,
+    },
+}
+
+/// Decode the volume-write payload into a percent (`0..=100`).
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`VOLUME_LEN`] bytes.
+/// - [`BleError::VolumeOutOfRange`] when the byte exceeds 100.
+pub fn decode_volume(payload: &[u8]) -> Result<u8, BleError> {
+    expect_len(payload, VOLUME_LEN)?;
+    let v = payload[0];
+    if v > 100 {
+        return Err(BleError::VolumeOutOfRange(v));
+    }
+    Ok(v)
+}
+
+/// Decode the mute-write payload into a `bool`.
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`MUTE_LEN`] bytes.
+/// - [`BleError::BadMuteByte`] for any byte that isn't `0` or `1`.
+pub fn decode_mute(payload: &[u8]) -> Result<bool, BleError> {
+    expect_len(payload, MUTE_LEN)?;
+    match payload[0] {
+        0 => Ok(false),
+        1 => Ok(true),
+        b => Err(BleError::BadMuteByte(b)),
+    }
+}
+
+/// Decode the reset-write payload (any 1-byte value triggers the reset).
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`RESET_LEN`] bytes.
+pub const fn decode_reset(payload: &[u8]) -> Result<(), BleError> {
+    expect_len(payload, RESET_LEN)
+}
+
+/// Decode the emotion-write payload into a [`RemoteCommand::SetEmotion`].
+///
+/// Layout (3 bytes): `[emotion: u8, hold_ms: u16 LE]`.
+/// `hold_ms == 0` → use [`DEFAULT_HOLD_MS`].
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`EMOTION_WRITE_LEN`] bytes.
+/// - [`BleError::UnknownEmotion`] for an unmapped emotion byte.
+pub fn decode_emotion_write(payload: &[u8]) -> Result<RemoteCommand, BleError> {
+    expect_len(payload, EMOTION_WRITE_LEN)?;
+    let emotion = decode_emotion_byte(payload[0])?;
+    let hold_ms = u16::from_le_bytes([payload[1], payload[2]]);
+    Ok(RemoteCommand::SetEmotion {
+        emotion,
+        hold_ms: resolve_hold(hold_ms),
+    })
+}
+
+/// Decode the look-at write payload into a [`RemoteCommand::LookAt`].
+///
+/// Layout (6 bytes): `[pan: i16 LE, tilt: i16 LE, hold_ms: u16 LE]`,
+/// pan/tilt in centi-degrees. `hold_ms == 0` → use [`DEFAULT_HOLD_MS`].
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`LOOK_AT_LEN`] bytes.
+/// - [`BleError::LookAtOutOfRange`] when `|pan|` or `|tilt|` exceed
+///   [`LOOK_AT_RANGE_CENTI_DEG`].
+pub fn decode_look_at(payload: &[u8]) -> Result<RemoteCommand, BleError> {
+    expect_len(payload, LOOK_AT_LEN)?;
+    let pan_centi = i16::from_le_bytes([payload[0], payload[1]]);
+    let tilt_centi = i16::from_le_bytes([payload[2], payload[3]]);
+    let hold_ms = u16::from_le_bytes([payload[4], payload[5]]);
+    if !pan_in_range(pan_centi) || !pan_in_range(tilt_centi) {
+        return Err(BleError::LookAtOutOfRange {
+            pan: pan_centi,
+            tilt: tilt_centi,
+        });
+    }
+    Ok(RemoteCommand::LookAt {
+        target: Pose {
+            pan_deg: f32::from(pan_centi) / 100.0,
+            tilt_deg: f32::from(tilt_centi) / 100.0,
+        },
+        hold_ms: resolve_hold(hold_ms),
+    })
+}
+
+/// Decode the speak-write payload into a [`RemoteCommand::Speak`].
+///
+/// Layout (2 bytes): `[phrase: u8, locale: u8]`.
+/// Priority is implicitly [`Priority::Normal`] — the BLE surface
+/// doesn't expose elevated priorities; modifier-internal callers go
+/// through `audio::try_dispatch_utterance` directly, same as HTTP.
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`SPEAK_LEN`] bytes.
+/// - [`BleError::UnknownPhrase`] / [`BleError::UnknownLocale`] for
+///   unmapped variant bytes.
+pub fn decode_speak(payload: &[u8]) -> Result<RemoteCommand, BleError> {
+    expect_len(payload, SPEAK_LEN)?;
+    let phrase = decode_phrase_byte(payload[0])?;
+    let locale = decode_locale_byte(payload[1])?;
+    Ok(RemoteCommand::Speak {
+        phrase,
+        locale,
+        priority: Priority::Normal,
+    })
+}
+
+/// Encode an [`Emotion`] for the read side of the emotion characteristic.
+/// Identical to [`Emotion::wire_byte`]; re-exported here so callers
+/// reach for a single `ble_command` import path when speaking BLE.
+#[must_use]
+pub const fn encode_emotion(emotion: Emotion) -> u8 {
+    emotion.wire_byte()
+}
+
+/// Encode a mute flag as the single byte the mute characteristic
+/// publishes on read / notify.
+#[must_use]
+pub const fn encode_mute(muted: bool) -> u8 {
+    if muted { 1 } else { 0 }
+}
+
+/// Reject a payload whose length doesn't match the characteristic's
+/// fixed shape. Centralises the [`BleError::BadLength`] construction
+/// so each decoder reads as a single guard line.
+const fn expect_len(payload: &[u8], expected: usize) -> Result<(), BleError> {
+    if payload.len() == expected {
+        Ok(())
+    } else {
+        Err(BleError::BadLength {
+            expected,
+            actual: payload.len(),
+        })
+    }
+}
+
+/// Translate the `0`-means-default sentinel into [`DEFAULT_HOLD_MS`].
+/// Any non-zero u16 widens to its `u32` equivalent unchanged.
+const fn resolve_hold(hold_ms: u16) -> u32 {
+    if hold_ms == 0 {
+        DEFAULT_HOLD_MS
+    } else {
+        hold_ms as u32
+    }
+}
+
+/// Bounds check for a signed centi-degree axis used by look-at writes.
+/// Rejects anything outside <code>±[LOOK_AT_RANGE_CENTI_DEG]</code>.
+const fn pan_in_range(centi: i16) -> bool {
+    centi >= -LOOK_AT_RANGE_CENTI_DEG && centi <= LOOK_AT_RANGE_CENTI_DEG
+}
+
+/// Translate an emotion wire byte back to the [`Emotion`] variant or
+/// surface [`BleError::UnknownEmotion`] if the byte is unmapped.
+const fn decode_emotion_byte(b: u8) -> Result<Emotion, BleError> {
+    match b {
+        EMOTION_NEUTRAL => Ok(Emotion::Neutral),
+        EMOTION_HAPPY => Ok(Emotion::Happy),
+        EMOTION_SAD => Ok(Emotion::Sad),
+        EMOTION_SLEEPY => Ok(Emotion::Sleepy),
+        EMOTION_SURPRISED => Ok(Emotion::Surprised),
+        EMOTION_ANGRY => Ok(Emotion::Angry),
+        other => Err(BleError::UnknownEmotion(other)),
+    }
+}
+
+/// Translate a locale wire byte back to the [`Locale`] variant or
+/// surface [`BleError::UnknownLocale`] if the byte is unmapped.
+const fn decode_locale_byte(b: u8) -> Result<Locale, BleError> {
+    match b {
+        LOCALE_EN => Ok(Locale::En),
+        LOCALE_JA => Ok(Locale::Ja),
+        other => Err(BleError::UnknownLocale(other)),
+    }
+}
+
+/// Translate a phrase wire byte back to the [`PhraseId`] variant or
+/// surface [`BleError::UnknownPhrase`] if the byte is unmapped.
+const fn decode_phrase_byte(b: u8) -> Result<PhraseId, BleError> {
+    match b {
+        PHRASE_WAKE_CHIRP => Ok(PhraseId::WakeChirp),
+        PHRASE_PICKUP_CHIRP => Ok(PhraseId::PickupChirp),
+        PHRASE_STARTLE_CHIRP => Ok(PhraseId::StartleChirp),
+        PHRASE_LOW_BATTERY_CHIRP => Ok(PhraseId::LowBatteryChirp),
+        PHRASE_CAMERA_MODE_ENTERED_CHIRP => Ok(PhraseId::CameraModeEnteredChirp),
+        PHRASE_CAMERA_MODE_EXITED_CHIRP => Ok(PhraseId::CameraModeExitedChirp),
+        PHRASE_GREETING => Ok(PhraseId::Greeting),
+        PHRASE_ACKNOWLEDGE_NAME => Ok(PhraseId::AcknowledgeName),
+        PHRASE_BATTERY_LOW => Ok(PhraseId::BatteryLow),
+        other => Err(BleError::UnknownPhrase(other)),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: literal compares, match-with-panic for variant extraction"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn volume_accepts_in_range() {
+        for pct in [0u8, 1, 50, 99, 100] {
+            assert_eq!(decode_volume(&[pct]).unwrap(), pct);
+        }
+    }
+
+    #[test]
+    fn volume_rejects_above_100() {
+        assert_eq!(decode_volume(&[101]), Err(BleError::VolumeOutOfRange(101)));
+        assert_eq!(decode_volume(&[200]), Err(BleError::VolumeOutOfRange(200)));
+    }
+
+    #[test]
+    fn volume_rejects_wrong_length() {
+        assert_eq!(
+            decode_volume(&[]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 0
+            })
+        );
+        assert_eq!(
+            decode_volume(&[10, 20]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn mute_round_trips_both_booleans() {
+        assert!(!decode_mute(&[encode_mute(false)]).unwrap());
+        assert!(decode_mute(&[encode_mute(true)]).unwrap());
+    }
+
+    #[test]
+    fn mute_rejects_non_boolean_byte() {
+        assert_eq!(decode_mute(&[2]), Err(BleError::BadMuteByte(2)));
+        assert_eq!(decode_mute(&[0xFF]), Err(BleError::BadMuteByte(0xFF)));
+    }
+
+    #[test]
+    fn reset_accepts_any_single_byte() {
+        assert!(decode_reset(&[0]).is_ok());
+        assert!(decode_reset(&[0xFF]).is_ok());
+    }
+
+    #[test]
+    fn reset_rejects_wrong_length() {
+        assert_eq!(
+            decode_reset(&[]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 0
+            })
+        );
+        assert_eq!(
+            decode_reset(&[1, 2]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn emotion_write_round_trips_every_variant() {
+        // Pin the byte/variant binding: every Emotion variant must
+        // round-trip through encode → decode_emotion_write so adding
+        // a variant forces an explicit byte choice rather than a
+        // silent shuffle.
+        for variant in [
+            Emotion::Neutral,
+            Emotion::Happy,
+            Emotion::Sad,
+            Emotion::Sleepy,
+            Emotion::Surprised,
+            Emotion::Angry,
+        ] {
+            let mut payload = [0u8; EMOTION_WRITE_LEN];
+            payload[0] = encode_emotion(variant);
+            // hold_ms 5000 little-endian.
+            payload[1..3].copy_from_slice(&5000u16.to_le_bytes());
+            match decode_emotion_write(&payload).unwrap() {
+                RemoteCommand::SetEmotion { emotion, hold_ms } => {
+                    assert_eq!(emotion, variant);
+                    assert_eq!(hold_ms, 5000);
+                }
+                other => panic!("expected SetEmotion, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn emotion_write_zero_hold_falls_back_to_default() {
+        let payload = [EMOTION_HAPPY, 0, 0];
+        match decode_emotion_write(&payload).unwrap() {
+            RemoteCommand::SetEmotion { hold_ms, .. } => {
+                assert_eq!(hold_ms, DEFAULT_HOLD_MS);
+            }
+            other => panic!("expected SetEmotion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn emotion_write_rejects_unknown_byte() {
+        let payload = [42, 0, 0];
+        assert_eq!(
+            decode_emotion_write(&payload),
+            Err(BleError::UnknownEmotion(42))
+        );
+    }
+
+    #[test]
+    fn emotion_write_rejects_wrong_length() {
+        assert_eq!(
+            decode_emotion_write(&[EMOTION_HAPPY, 0]),
+            Err(BleError::BadLength {
+                expected: 3,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn look_at_decodes_signed_centi_degrees() {
+        let mut payload = [0u8; LOOK_AT_LEN];
+        payload[0..2].copy_from_slice(&(-1234i16).to_le_bytes());
+        payload[2..4].copy_from_slice(&5678i16.to_le_bytes());
+        payload[4..6].copy_from_slice(&2000u16.to_le_bytes());
+        match decode_look_at(&payload).unwrap() {
+            RemoteCommand::LookAt { target, hold_ms } => {
+                assert_eq!(target.pan_deg, -12.34);
+                assert_eq!(target.tilt_deg, 56.78);
+                assert_eq!(hold_ms, 2000);
+            }
+            other => panic!("expected LookAt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_zero_hold_falls_back_to_default() {
+        let payload = [0u8; LOOK_AT_LEN];
+        match decode_look_at(&payload).unwrap() {
+            RemoteCommand::LookAt { hold_ms, .. } => {
+                assert_eq!(hold_ms, DEFAULT_HOLD_MS);
+            }
+            other => panic!("expected LookAt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_rejects_pan_out_of_range() {
+        let mut payload = [0u8; LOOK_AT_LEN];
+        let bad_pan: i16 = LOOK_AT_RANGE_CENTI_DEG + 1;
+        payload[0..2].copy_from_slice(&bad_pan.to_le_bytes());
+        match decode_look_at(&payload) {
+            Err(BleError::LookAtOutOfRange { pan, tilt }) => {
+                assert_eq!(pan, bad_pan);
+                assert_eq!(tilt, 0);
+            }
+            other => panic!("expected LookAtOutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_rejects_negative_pan_out_of_range() {
+        let mut payload = [0u8; LOOK_AT_LEN];
+        let bad_pan: i16 = -LOOK_AT_RANGE_CENTI_DEG - 1;
+        payload[0..2].copy_from_slice(&bad_pan.to_le_bytes());
+        assert!(matches!(
+            decode_look_at(&payload),
+            Err(BleError::LookAtOutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn look_at_accepts_range_endpoints() {
+        for pan in [-LOOK_AT_RANGE_CENTI_DEG, LOOK_AT_RANGE_CENTI_DEG] {
+            let mut payload = [0u8; LOOK_AT_LEN];
+            payload[0..2].copy_from_slice(&pan.to_le_bytes());
+            assert!(decode_look_at(&payload).is_ok(), "pan={pan}");
+        }
+    }
+
+    #[test]
+    fn look_at_rejects_wrong_length() {
+        assert_eq!(
+            decode_look_at(&[0; 5]),
+            Err(BleError::BadLength {
+                expected: 6,
+                actual: 5
+            })
+        );
+    }
+
+    #[test]
+    fn speak_round_trips_every_locale() {
+        for (variant, byte) in [(Locale::En, LOCALE_EN), (Locale::Ja, LOCALE_JA)] {
+            match decode_speak(&[PHRASE_GREETING, byte]).unwrap() {
+                RemoteCommand::Speak { locale, .. } => assert_eq!(locale, variant),
+                other => panic!("expected Speak, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn speak_round_trips_every_phrase() {
+        // Every PhraseId variant must round-trip — adding a phrase
+        // without giving it a wire byte fails this test, forcing a
+        // deliberate byte assignment.
+        for (variant, byte) in [
+            (PhraseId::WakeChirp, PHRASE_WAKE_CHIRP),
+            (PhraseId::PickupChirp, PHRASE_PICKUP_CHIRP),
+            (PhraseId::StartleChirp, PHRASE_STARTLE_CHIRP),
+            (PhraseId::LowBatteryChirp, PHRASE_LOW_BATTERY_CHIRP),
+            (
+                PhraseId::CameraModeEnteredChirp,
+                PHRASE_CAMERA_MODE_ENTERED_CHIRP,
+            ),
+            (
+                PhraseId::CameraModeExitedChirp,
+                PHRASE_CAMERA_MODE_EXITED_CHIRP,
+            ),
+            (PhraseId::Greeting, PHRASE_GREETING),
+            (PhraseId::AcknowledgeName, PHRASE_ACKNOWLEDGE_NAME),
+            (PhraseId::BatteryLow, PHRASE_BATTERY_LOW),
+        ] {
+            match decode_speak(&[byte, LOCALE_EN]).unwrap() {
+                RemoteCommand::Speak { phrase, .. } => assert_eq!(phrase, variant),
+                other => panic!("expected Speak, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn speak_priority_is_normal() {
+        match decode_speak(&[PHRASE_GREETING, LOCALE_EN]).unwrap() {
+            RemoteCommand::Speak { priority, .. } => assert_eq!(priority, Priority::Normal),
+            other => panic!("expected Speak, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn speak_rejects_unknown_phrase_byte() {
+        assert_eq!(
+            decode_speak(&[0xEE, LOCALE_EN]),
+            Err(BleError::UnknownPhrase(0xEE))
+        );
+    }
+
+    #[test]
+    fn speak_rejects_unknown_locale_byte() {
+        assert_eq!(
+            decode_speak(&[PHRASE_GREETING, 0xEE]),
+            Err(BleError::UnknownLocale(0xEE))
+        );
+    }
+
+    #[test]
+    fn speak_rejects_wrong_length() {
+        assert_eq!(
+            decode_speak(&[PHRASE_GREETING]),
+            Err(BleError::BadLength {
+                expected: 2,
+                actual: 1
+            })
+        );
+    }
+}

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -50,6 +50,7 @@ extern crate alloc;
 
 pub mod bare;
 pub mod bare_json;
+pub mod ble_command;
 pub mod config;
 pub mod error;
 pub mod http_command;

--- a/crates/stackchan-sim/Cargo.toml
+++ b/crates/stackchan-sim/Cargo.toml
@@ -29,6 +29,11 @@ heapless = "0.8"
 # OpenGL rendering and the bundled default fonts.
 eframe = { version = "0.34", optional = true }
 
+[dev-dependencies]
+# Used by `tests/ble_remote_command.rs` to round-trip raw BLE
+# characteristic payloads through the same decoder the firmware uses.
+stackchan-net = { path = "../stackchan-net", default-features = false }
+
 [features]
 # Default: lib-only, no GUI dep tree.
 default = []

--- a/crates/stackchan-sim/tests/ble_remote_command.rs
+++ b/crates/stackchan-sim/tests/ble_remote_command.rs
@@ -1,0 +1,151 @@
+//! End-to-end coverage from BLE wire payload to entity behaviour.
+//!
+//! Asserts that decoding a raw characteristic payload via
+//! [`stackchan_net::ble_command`] and feeding the resulting
+//! [`RemoteCommand`] into the same modifier stack the firmware runs
+//! produces the entity transitions an operator would expect — the
+//! tests are how we guard against silent drift between the BLE wire
+//! contract and the host-side semantics.
+
+#![allow(
+    clippy::doc_markdown,
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: doc comments freely reference type names without backticks; \
+              match-with-panic is the cleanest pattern for value extraction on enum \
+              variants in tests"
+)]
+
+use stackchan_core::modifiers::{
+    HeadFromAttention, HeadFromEmotion, IdleHeadDrift, RemoteCommandModifier,
+};
+use stackchan_core::{Attention, Director, Emotion, Entity, Instant, RemoteCommand};
+use stackchan_net::ble_command::{
+    self, EMOTION_HAPPY, EMOTION_WRITE_LEN, LOCALE_EN, LOOK_AT_LEN, PHRASE_GREETING, SPEAK_LEN,
+};
+
+const TICK_MS: u64 = 33;
+
+fn run_for(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, ticks: u64) -> Instant {
+    let mut last = Instant::from_millis(start_ms);
+    for t in 0..ticks {
+        last = Instant::from_millis(start_ms + t * TICK_MS);
+        director.run(entity, last);
+    }
+    last
+}
+
+#[test]
+fn ble_emotion_payload_holds_emotion_via_director() {
+    // Build the payload as the central would: u8 emotion + u16 LE
+    // hold_ms = 1500 ms.
+    let mut payload = [0u8; EMOTION_WRITE_LEN];
+    payload[0] = EMOTION_HAPPY;
+    payload[1..3].copy_from_slice(&1_500u16.to_le_bytes());
+
+    let cmd = ble_command::decode_emotion_write(&payload).unwrap();
+    match cmd {
+        RemoteCommand::SetEmotion { emotion, hold_ms } => {
+            assert_eq!(emotion, Emotion::Happy);
+            assert_eq!(hold_ms, 1_500);
+        }
+        other => panic!("expected SetEmotion, got {other:?}"),
+    }
+
+    let mut entity = Entity::default();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut remote).unwrap();
+
+    entity.input.remote_command = Some(cmd);
+    director.run(&mut entity, Instant::from_millis(0));
+
+    // Even if an autonomous driver tries to flip emotion mid-hold, the
+    // remote command's hold pins the BLE-requested value.
+    entity.mind.affect.emotion = Emotion::Sleepy;
+    director.run(&mut entity, Instant::from_millis(100));
+    assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+}
+
+#[test]
+fn ble_look_at_payload_drives_motor_pose_via_head_from_attention() {
+    // Wire payload: pan = 1500 centi-deg (15.0°), tilt = -300
+    // centi-deg (-3.0°), hold = 2000 ms.
+    let mut payload = [0u8; LOOK_AT_LEN];
+    payload[0..2].copy_from_slice(&1_500i16.to_le_bytes());
+    payload[2..4].copy_from_slice(&(-300i16).to_le_bytes());
+    payload[4..6].copy_from_slice(&2_000u16.to_le_bytes());
+
+    let cmd = ble_command::decode_look_at(&payload).unwrap();
+    let target = match cmd {
+        RemoteCommand::LookAt { target, hold_ms } => {
+            assert!((target.pan_deg - 15.0).abs() < f32::EPSILON);
+            assert!((target.tilt_deg + 3.0).abs() < f32::EPSILON);
+            assert_eq!(hold_ms, 2_000);
+            target
+        }
+        other => panic!("expected LookAt, got {other:?}"),
+    };
+
+    let mut entity = Entity::default();
+    let mut head_drift = IdleHeadDrift::new();
+    let mut emo = HeadFromEmotion::new();
+    let mut head_from_attention = HeadFromAttention::new();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut head_drift).unwrap();
+    director.add_modifier(&mut emo).unwrap();
+    director.add_modifier(&mut head_from_attention).unwrap();
+    director.add_modifier(&mut remote).unwrap();
+
+    entity.input.remote_command = Some(cmd);
+    run_for(&mut director, &mut entity, 0, 60);
+
+    let pan = entity.motor.head_pose.pan_deg;
+    assert!(
+        pan > 5.0,
+        "expected head pan to track toward BLE-requested target ({}°), got {pan}",
+        target.pan_deg
+    );
+    assert!(
+        matches!(entity.mind.attention, Attention::Tracking { target: t, .. } if t == target),
+        "expected attention to lock onto BLE-requested target, got {:?}",
+        entity.mind.attention
+    );
+}
+
+#[test]
+fn ble_speak_payload_routes_to_remote_command_speak() {
+    let payload = [PHRASE_GREETING, LOCALE_EN];
+    assert_eq!(payload.len(), SPEAK_LEN);
+    let cmd = ble_command::decode_speak(&payload).unwrap();
+    match cmd {
+        RemoteCommand::Speak { phrase, locale, .. } => {
+            assert_eq!(phrase, stackchan_core::voice::PhraseId::Greeting);
+            assert_eq!(locale, stackchan_core::voice::Locale::En);
+        }
+        other => panic!("expected Speak, got {other:?}"),
+    }
+}
+
+#[test]
+fn ble_reset_payload_releases_attention_hold() {
+    let mut entity = Entity::default();
+    let mut remote = RemoteCommandModifier::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut remote).unwrap();
+
+    // Pin attention via a BLE look-at, then release via a BLE reset.
+    let mut look = [0u8; LOOK_AT_LEN];
+    look[0..2].copy_from_slice(&500i16.to_le_bytes());
+    let look_cmd = ble_command::decode_look_at(&look).unwrap();
+    entity.input.remote_command = Some(look_cmd);
+    run_for(&mut director, &mut entity, 0, 5);
+    assert!(matches!(entity.mind.attention, Attention::Tracking { .. }));
+
+    // Reset is any 1-byte trigger.
+    ble_command::decode_reset(&[0]).unwrap();
+    entity.input.remote_command = Some(RemoteCommand::Reset);
+    run_for(&mut director, &mut entity, 1_000, 2);
+    assert_eq!(entity.mind.attention, Attention::None);
+}


### PR DESCRIPTION
## Summary

- Two new GATT services so a paired BLE central can drive the firmware end-to-end without joining the LAN: audio (`8a1c0020-...`, volume + mute as r/w/notify) and avatar control (`8a1c0030-...`, write-only emotion / look-at / reset / speak).
- Wire formats lifted to `stackchan-net::ble_command` with host-side unit tests and stable byte mappings for `Emotion` / `PhraseId` / `Locale` — round-trip tests pin every variant so adding a new variant forces a deliberate byte choice.
- Audio persistence dedup'd into `audio::persist_volume` / `audio::persist_mute`; HTTP `POST /volume` / `POST /mute` and the new BLE writes share one SD-writeback path so the two control planes can never drift apart.
- Control writes require an `EncryptedAuthenticated` link — unpaired centrals get `INSUFFICIENT_AUTHENTICATION`; bad payloads get `INVALID_ATTRIBUTE_VALUE_LENGTH` / `OUT_OF_RANGE` / `VALUE_NOT_ALLOWED`.
- Notify loop now diffs the `AvatarSnapshot` each tick for emotion / volume / mute, so subscribed centrals see HTTP-side changes within ~1 s without any new `Signal` plumbing.

## Test plan
- [x] `just ci` passes (fmt + workspace clippy + host tests + cargo-deny + workspace doc-lint)
- [x] `just clippy-firmware` (`cargo +esp clippy --release -- -D warnings`)
- [x] `cargo test -p stackchan-net --lib ble_command::` — 23/23 codec tests
- [x] `cargo test -p stackchan-sim --test ble_remote_command` — 4/4 sim integration tests
- [ ] Manual: `just fmr`, pair from nRF Connect, write each new characteristic, verify accept/reject + state notify
- [ ] Manual: confirm HTTP `POST /volume` continues to work and reflects via BLE notify