### PR TITLE
feat(firmware): camera-mode toggle via HTTP + BLE control planes

### DIFF
--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -107,14 +107,15 @@ joining the LAN. Services exposed: Device Information (`0x180A` —
 manufacturer / model / firmware revision), Battery (`0x180F`), a
 Stack-chan custom service for emotion read+notify, a Wi-Fi
 provisioning service for SSID + PSK writes, an audio service
-(`8a1c0020-...`) for volume + mute read+write+notify, and an avatar
+(`8a1c0020-...`) for volume + mute read+write+notify, an avatar
 control service (`8a1c0030-...`) for emotion / look-at / reset /
-speak writes. Control writes require an authenticated bond
-(passkey-confirmed pairing). The notify task diffs the avatar
-snapshot every tick so subscribed centrals see HTTP-side changes
-without explicit polling. Wi-Fi and BLE share the radio via
-`esp-radio`'s coex scheduler; expect a small Wi-Fi airtime tax when
-a BLE central is connected.
+speak writes, and a view service (`8a1c0040-...`) for the LCD
+camera-preview / avatar toggle. Control writes require an
+authenticated bond (passkey-confirmed pairing). The notify task
+diffs the avatar snapshot every tick so subscribed centrals see
+HTTP-side changes without explicit polling. Wi-Fi and BLE share the
+radio via `esp-radio`'s coex scheduler; expect a small Wi-Fi airtime
+tax when a BLE central is connected.
 
 ## I²C Bus Sharing
 

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -35,6 +35,11 @@
 //!    [`stackchan_net::ble_command`] and signals
 //!    [`crate::net::http::REMOTE_COMMAND_SIGNAL`], the same channel
 //!    the HTTP control plane drives.
+//! 7. **View service** (`8a1c0040-…`) — display-mode toggles. Today
+//!    just the camera-mode flag (`8a1c0041-…`, `read + write +
+//!    notify`) that mirrors HTTP `POST /camera/mode`. Updates write
+//!    the avatar snapshot directly + signal the render task; no SD
+//!    writeback (camera mode is intentionally ephemeral).
 //!
 //! ## Security
 //!
@@ -69,6 +74,7 @@ use trouble_host::Address;
 use trouble_host::prelude::*;
 
 use crate::audio::AudioPersistOutcome;
+use crate::camera::CAMERA_MODE_SIGNAL;
 use crate::net::http::REMOTE_COMMAND_SIGNAL;
 use crate::net::snapshot;
 use crate::net::wifi::{WIFI_RECONFIG, WifiCreds};
@@ -144,6 +150,10 @@ pub struct StackchanServer {
     /// (write only). Mirrors HTTP `POST /emotion`, `/look-at`,
     /// `/reset`, `/speak`.
     pub avatar: AvatarControlService,
+    /// View service — display-related toggles. Currently exposes
+    /// camera-mode (read + write + notify); future entries may add
+    /// LCD brightness / render mode. Mirrors HTTP `POST /camera/mode`.
+    pub view: ViewService,
 }
 
 #[allow(missing_docs)]
@@ -220,6 +230,24 @@ pub struct AvatarControlService {
     /// [`stackchan_net::ble_command::decode_speak`].
     #[characteristic(uuid = "8a1c0034-7b3f-4d52-9c6e-5f5ba1e5cf01", write, value = [0u8; SPEAK_LEN])]
     pub speak: [u8; SPEAK_LEN],
+}
+
+#[allow(missing_docs)]
+#[gatt_service(uuid = "8a1c0040-7b3f-4d52-9c6e-5f5ba1e5cf01")]
+pub struct ViewService {
+    /// LCD display-mode toggle. `0 = avatar`, `1 = camera preview`.
+    /// `read + write + notify`. Decoded via
+    /// [`stackchan_net::ble_command::decode_camera_mode`]; writes
+    /// route through [`crate::net::snapshot::update_camera_mode`] +
+    /// [`crate::camera::CAMERA_MODE_SIGNAL`].
+    #[characteristic(
+        uuid = "8a1c0041-7b3f-4d52-9c6e-5f5ba1e5cf01",
+        read,
+        write,
+        notify,
+        value = 0
+    )]
+    pub camera_mode: u8,
 }
 
 #[allow(missing_docs)]
@@ -320,7 +348,7 @@ pub async fn run_ble_peripheral<C: Controller>(
 
     populate_dis(&server);
     populate_provisioning_ssid(&server).await;
-    populate_audio_state(&server);
+    populate_read_state(&server);
 
     let advertise_serve = async {
         loop {
@@ -447,6 +475,8 @@ struct WriteHandles {
     reset: u16,
     /// Avatar speak trigger.
     speak: u16,
+    /// View camera-mode toggle.
+    camera_mode: u16,
 }
 
 impl WriteHandles {
@@ -462,6 +492,7 @@ impl WriteHandles {
             look_at: server.avatar.look_at.handle,
             reset: server.avatar.reset.handle,
             speak: server.avatar.speak.handle,
+            camera_mode: server.view.camera_mode.handle,
         }
     }
 }
@@ -483,6 +514,10 @@ enum WriteAction {
     /// Forward a synthesised reset onto [`REMOTE_COMMAND_SIGNAL`].
     /// Reset has no decoded payload but needs the same dispatch shape.
     RemoteReset,
+    /// Apply a new camera-mode flag via
+    /// [`crate::net::snapshot::update_camera_mode`] +
+    /// [`CAMERA_MODE_SIGNAL`].
+    CameraMode(bool),
 }
 
 /// Decision the dispatcher takes for one Gatt event.
@@ -628,7 +663,8 @@ fn decide_write<P: PacketPool>(
         || handle == handles.emotion_write
         || handle == handles.look_at
         || handle == handles.reset
-        || handle == handles.speak;
+        || handle == handles.speak
+        || handle == handles.camera_mode;
     if !is_control {
         return WriteDecision::Default;
     }
@@ -647,6 +683,8 @@ fn decide_write<P: PacketPool>(
         ble_command::decode_reset(data).map(|()| WriteAction::RemoteReset)
     } else if handle == handles.speak {
         ble_command::decode_speak(data).map(WriteAction::Remote)
+    } else if handle == handles.camera_mode {
+        ble_command::decode_camera_mode(data).map(WriteAction::CameraMode)
     } else {
         // Unreachable on the strength of the `is_control` gate above
         // — every handle counted there must have a decode arm here.
@@ -684,6 +722,7 @@ const fn att_error_for(err: &BleError) -> AttErrorCode {
             AttErrorCode::OUT_OF_RANGE
         }
         BleError::BadMuteByte(_)
+        | BleError::BadCameraModeByte(_)
         | BleError::UnknownEmotion(_)
         | BleError::UnknownLocale(_)
         | BleError::UnknownPhrase(_) => AttErrorCode::VALUE_NOT_ALLOWED,
@@ -712,6 +751,11 @@ async fn apply_write_action<P: PacketPool>(
         WriteAction::RemoteReset => {
             defmt::info!("ble: remote reset");
             REMOTE_COMMAND_SIGNAL.signal(stackchan_core::RemoteCommand::Reset);
+        }
+        WriteAction::CameraMode(active) => {
+            defmt::info!("ble: camera_mode → {=bool}", active);
+            snapshot::update_camera_mode(active);
+            CAMERA_MODE_SIGNAL.signal(active);
         }
     }
 }
@@ -767,9 +811,11 @@ async fn notify_task<P: PacketPool>(
     let emotion_handle = server.stackchan.emotion;
     let volume_handle = server.audio.volume;
     let mute_handle = server.audio.mute;
+    let camera_mode_handle = server.view.camera_mode;
     let mut last_emotion: Option<Emotion> = None;
     let mut last_volume: Option<u8> = None;
     let mut last_mute: Option<bool> = None;
+    let mut last_camera_mode: Option<bool> = None;
 
     loop {
         let snap = snapshot::read();
@@ -831,6 +877,18 @@ async fn notify_task<P: PacketPool>(
             &mut last_mute,
             snap.audio.muted,
             &mute_byte,
+        )
+        .await;
+
+        let camera_mode_byte = ble_command::encode_camera_mode(snap.camera_mode);
+        notify_if_changed(
+            server,
+            conn,
+            &camera_mode_handle,
+            "camera_mode",
+            &mut last_camera_mode,
+            snap.camera_mode,
+            &camera_mode_byte,
         )
         .await;
 
@@ -897,11 +955,12 @@ async fn populate_provisioning_ssid(server: &StackchanServer<'_>) {
     }
 }
 
-/// Pre-fill the audio service's volume + mute characteristics with
-/// the persisted config so a phone reading them at connect time sees
-/// the active values rather than zeros. The notify loop later catches
-/// any change made between this snapshot and the central's read.
-fn populate_audio_state(server: &StackchanServer<'_>) {
+/// Pre-fill read-side characteristic values from the avatar snapshot
+/// so a phone reading them at connect time sees current state rather
+/// than zeros. Covers the audio service (volume + mute) and the view
+/// service (`camera_mode`). The notify loop later catches any change
+/// made between this snapshot and the central's read.
+fn populate_read_state(server: &StackchanServer<'_>) {
     let snap = snapshot::read();
     if let Err(e) = server.set(&server.audio.volume, &snap.audio.volume_pct) {
         defmt::warn!(
@@ -913,6 +972,13 @@ fn populate_audio_state(server: &StackchanServer<'_>) {
     if let Err(e) = server.set(&server.audio.mute, &mute_byte) {
         defmt::warn!(
             "ble: audio mute initial set failed ({})",
+            defmt::Debug2Format(&e)
+        );
+    }
+    let camera_mode_byte = ble_command::encode_camera_mode(snap.camera_mode);
+    if let Err(e) = server.set(&server.view.camera_mode, &camera_mode_byte) {
+        defmt::warn!(
+            "ble: view camera_mode initial set failed ({})",
             defmt::Debug2Format(&e)
         );
     }

--- a/crates/stackchan-firmware/src/button.rs
+++ b/crates/stackchan-firmware/src/button.rs
@@ -46,15 +46,6 @@ const POLL_PERIOD_MS: u64 = 50;
 /// `SYS_CTL[2]`.
 pub const LONG_PRESS_MS: u64 = 600;
 
-/// Camera-mode toggle state. The button task is the sole producer
-/// of [`CAMERA_MODE_SIGNAL`] from user input, so it owns the
-/// "currently active" tracking that the toggle gesture inverts.
-/// Starts `false` (avatar mode), matching the firmware's boot state.
-struct ModeState {
-    /// `true` when camera-mode is currently active.
-    camera_active: bool,
-}
-
 /// Enable the press- and release-edge IRQs, then loop forever
 /// classifying each press as either a short tap or a long press.
 pub async fn run_button_loop<I: AsyncI2c>(bus: I) -> ! {
@@ -72,9 +63,6 @@ pub async fn run_button_loop<I: AsyncI2c>(bus: I) -> ! {
         LONG_PRESS_MS,
     );
 
-    let mut state = ModeState {
-        camera_active: false,
-    };
     let mut press_started: Option<Instant> = None;
     let mut long_press_fired = false;
     let mut ticker = Ticker::every(Duration::from_millis(POLL_PERIOD_MS));
@@ -98,13 +86,16 @@ pub async fn run_button_loop<I: AsyncI2c>(bus: I) -> ! {
                     && !long_press_fired
                     && started.elapsed().as_millis() >= LONG_PRESS_MS
                 {
-                    state.camera_active = !state.camera_active;
-                    defmt::info!(
-                        "AXP2101 button: long-press → camera_mode={=bool}",
-                        state.camera_active,
-                    );
-                    crate::net::snapshot::update_camera_mode(state.camera_active);
-                    CAMERA_MODE_SIGNAL.signal(state.camera_active);
+                    // Read the canonical state from the snapshot rather
+                    // than tracking a local mirror — HTTP `POST
+                    // /camera/mode` and the BLE view-service write also
+                    // flip this field, and a stale local would invert
+                    // their value on the next long-press, swallowing
+                    // the user's button press.
+                    let next = !crate::net::snapshot::read().camera_mode;
+                    defmt::info!("AXP2101 button: long-press → camera_mode={=bool}", next);
+                    crate::net::snapshot::update_camera_mode(next);
+                    CAMERA_MODE_SIGNAL.signal(next);
                     long_press_fired = true;
                 }
 

--- a/crates/stackchan-firmware/src/button.rs
+++ b/crates/stackchan-firmware/src/button.rs
@@ -103,6 +103,7 @@ pub async fn run_button_loop<I: AsyncI2c>(bus: I) -> ! {
                         "AXP2101 button: long-press → camera_mode={=bool}",
                         state.camera_active,
                     );
+                    crate::net::snapshot::update_camera_mode(state.camera_active);
                     CAMERA_MODE_SIGNAL.signal(state.camera_active);
                     long_press_fired = true;
                 }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -26,6 +26,10 @@
 //!   Renders a [`stackchan_core::voice::PhraseId`] from the baked
 //!   catalog and queues it on the audio TX path. Fire-and-forget;
 //!   no avatar-state hold timer.
+//! - `POST /camera/mode` — JSON `{"enabled": <bool>}`. Flips the
+//!   LCD between camera preview and avatar; tracking continues in
+//!   either mode. Ephemeral (no SD writeback); a power-cycle returns
+//!   to avatar.
 //! - `GET /settings` — current persisted [`stackchan_net::Config`]
 //!   as JSON, with `wifi.psk` and `auth.token` redacted.
 //! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
@@ -286,6 +290,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,
         ("POST", "/volume") => handle_post_volume(socket, body).await,
         ("POST", "/mute") => handle_post_mute(socket, body).await,
+        ("POST", "/camera/mode") => handle_post_camera_mode(socket, body).await,
         ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
     }
@@ -527,6 +532,29 @@ async fn audio_persist_to_http(
     }
 }
 
+/// `POST /camera/mode` — parse `{"enabled": <bool>}`, update the
+/// avatar snapshot, and signal the render task to flip the LCD.
+/// Display-only — tracking continues in either mode. No SD writeback;
+/// camera mode is intentionally ephemeral so a power-cycle returns
+/// to avatar view.
+async fn handle_post_camera_mode(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let active = match json::parse_camera_mode(body) {
+        Ok(a) => a,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /camera/mode parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    snapshot::update_camera_mode(active);
+    crate::camera::CAMERA_MODE_SIGNAL.signal(active);
+    defmt::info!("http: POST /camera/mode → {=bool}", active);
+    write_no_content(socket).await
+}
+
 /// Apply a parsed remote command (or surface the parser error to the
 /// client). On success: signal the render task and respond `204 No
 /// Content`. On parse failure: respond `400 Bad Request` with a
@@ -606,7 +634,8 @@ fn state_body(s: AvatarSnapshot) -> String {
 \"head_actual\":{actual},\
 \"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\
 \"wifi\":{{\"connected\":{connected},\"ip\":{ip}}},\
-\"audio\":{{\"volume_pct\":{volume_pct},\"muted\":{muted}}}\
+\"audio\":{{\"volume_pct\":{volume_pct},\"muted\":{muted}}},\
+\"camera_mode\":{camera_mode}\
 }}\n",
         emotion = s.emotion.wire_str(),
         pan = s.head_pose.pan_deg,
@@ -614,6 +643,7 @@ fn state_body(s: AvatarSnapshot) -> String {
         connected = s.wifi.connected,
         volume_pct = s.audio.volume_pct,
         muted = s.audio.muted,
+        camera_mode = s.camera_mode,
     )
 }
 

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -58,6 +58,13 @@ pub struct AvatarSnapshot {
     /// successful `POST /volume` / `POST /mute` so the dashboard's
     /// SSE stream picks up the change without a full settings re-fetch.
     pub audio: AudioConfig,
+    /// Whether the LCD is currently showing the camera preview
+    /// (`true`) instead of the avatar (`false`). Display-only —
+    /// tracking still runs in either mode. Updated by every producer
+    /// of [`crate::camera::CAMERA_MODE_SIGNAL`] (button long-press,
+    /// HTTP `POST /camera/mode`, BLE view-service write) before the
+    /// signal fires, so the snapshot stays canonical.
+    pub camera_mode: bool,
 }
 
 impl AvatarSnapshot {
@@ -84,6 +91,7 @@ impl AvatarSnapshot {
             && self.battery == other.battery
             && self.wifi == other.wifi
             && self.audio == other.audio
+            && self.camera_mode == other.camera_mode
     }
 }
 
@@ -96,6 +104,7 @@ impl Default for AvatarSnapshot {
             battery: BatterySnapshot::default(),
             wifi: WifiSnapshot::default(),
             audio: AudioConfig::DEFAULT,
+            camera_mode: false,
         }
     }
 }
@@ -119,6 +128,7 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
             ip: None,
         },
         audio: AudioConfig::DEFAULT,
+        camera_mode: false,
     }));
 
 /// Replace the avatar/head fields. Called per render tick.
@@ -162,6 +172,21 @@ pub fn update_audio(audio: AudioConfig) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
         s.audio = audio;
+        cell.set(s);
+    });
+}
+
+/// Replace the camera-mode field.
+///
+/// Called by every producer of [`crate::camera::CAMERA_MODE_SIGNAL`]
+/// (button long-press, HTTP `POST /camera/mode`, BLE view-service
+/// write) so the snapshot flips before the signal fires — `GET
+/// /state` and BLE notify clients see the new value without waiting
+/// for the render loop to drain the signal.
+pub fn update_camera_mode(active: bool) {
+    AVATAR_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.camera_mode = active;
         cell.set(s);
     });
 }

--- a/crates/stackchan-net/src/ble_command.rs
+++ b/crates/stackchan-net/src/ble_command.rs
@@ -59,6 +59,8 @@ pub const LOOK_AT_RANGE_CENTI_DEG: i16 = 18_000;
 pub const VOLUME_LEN: usize = 1;
 /// Expected payload length for the mute characteristic.
 pub const MUTE_LEN: usize = 1;
+/// Expected payload length for the camera-mode characteristic.
+pub const CAMERA_MODE_LEN: usize = 1;
 /// Expected payload length for the reset characteristic.
 pub const RESET_LEN: usize = 1;
 /// Expected payload length for the emotion-write characteristic
@@ -125,6 +127,9 @@ pub enum BleError {
     /// Mute byte was neither `0` nor `1`. Maps to ATT `VALUE_NOT_ALLOWED`
     /// (0x13) — strict so a buggy client surfaces fast.
     BadMuteByte(u8),
+    /// Camera-mode byte was neither `0` nor `1`. Maps to ATT
+    /// `VALUE_NOT_ALLOWED` — same posture as [`Self::BadMuteByte`].
+    BadCameraModeByte(u8),
     /// Emotion byte didn't match any [`EMOTION_*`](EMOTION_NEUTRAL)
     /// constant. Maps to ATT `VALUE_NOT_ALLOWED`.
     UnknownEmotion(u8),
@@ -173,6 +178,24 @@ pub fn decode_mute(payload: &[u8]) -> Result<bool, BleError> {
         0 => Ok(false),
         1 => Ok(true),
         b => Err(BleError::BadMuteByte(b)),
+    }
+}
+
+/// Decode the camera-mode write payload into a `bool` (`true` =
+/// LCD shows camera preview, `false` = LCD shows avatar).
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`CAMERA_MODE_LEN`] bytes.
+/// - [`BleError::BadCameraModeByte`] for any byte that isn't `0`
+///   or `1`.
+pub fn decode_camera_mode(payload: &[u8]) -> Result<bool, BleError> {
+    expect_len(payload, CAMERA_MODE_LEN)?;
+    match payload[0] {
+        0 => Ok(false),
+        1 => Ok(true),
+        b => Err(BleError::BadCameraModeByte(b)),
     }
 }
 
@@ -274,6 +297,16 @@ pub const fn encode_emotion(emotion: Emotion) -> u8 {
 #[must_use]
 pub const fn encode_mute(muted: bool) -> u8 {
     if muted { 1 } else { 0 }
+}
+
+/// Encode the camera-mode flag as the single byte the camera-mode
+/// characteristic publishes on read / notify.
+///
+/// Same `0`/`1` shape as [`encode_mute`]; kept distinct so a future
+/// encoding change to one flag doesn't accidentally migrate the other.
+#[must_use]
+pub const fn encode_camera_mode(active: bool) -> u8 {
+    if active { 1 } else { 0 }
 }
 
 /// Reject a payload whose length doesn't match the characteristic's
@@ -399,6 +432,42 @@ mod tests {
     fn mute_rejects_non_boolean_byte() {
         assert_eq!(decode_mute(&[2]), Err(BleError::BadMuteByte(2)));
         assert_eq!(decode_mute(&[0xFF]), Err(BleError::BadMuteByte(0xFF)));
+    }
+
+    #[test]
+    fn camera_mode_round_trips_both_booleans() {
+        assert!(!decode_camera_mode(&[encode_camera_mode(false)]).unwrap());
+        assert!(decode_camera_mode(&[encode_camera_mode(true)]).unwrap());
+    }
+
+    #[test]
+    fn camera_mode_rejects_non_boolean_byte() {
+        assert_eq!(
+            decode_camera_mode(&[2]),
+            Err(BleError::BadCameraModeByte(2))
+        );
+        assert_eq!(
+            decode_camera_mode(&[0x10]),
+            Err(BleError::BadCameraModeByte(0x10))
+        );
+    }
+
+    #[test]
+    fn camera_mode_rejects_wrong_length() {
+        assert_eq!(
+            decode_camera_mode(&[]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 0
+            })
+        );
+        assert_eq!(
+            decode_camera_mode(&[0, 1]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 2
+            })
+        );
     }
 
     #[test]

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -241,6 +241,34 @@ pub fn parse_mute(body: &str) -> Result<bool, JsonError> {
     muted.ok_or(JsonError::MissingKey("muted"))
 }
 
+/// Parse a `POST /camera/mode` body into a `bool`. Drives the
+/// LCD display-mode toggle (`true` = camera preview, `false` =
+/// avatar). Display-only — tracking still runs in either mode.
+///
+/// Required: `enabled` (boolean). No optional fields.
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys,
+/// unknown keys, malformed JSON shape, or non-boolean `enabled`
+/// values.
+pub fn parse_camera_mode(body: &str) -> Result<bool, JsonError> {
+    let mut enabled: Option<bool> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "enabled" => {
+                if enabled.is_some() {
+                    return Err(JsonError::DuplicateKey("enabled"));
+                }
+                enabled = Some(parse_bool(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    enabled.ok_or(JsonError::MissingKey("enabled"))
+}
+
 /// Single-pass byte cursor over the body. Each parse helper advances
 /// past the value it consumes (without consuming the trailing comma
 /// or `}` — those belong to [`visit_object`]).
@@ -806,5 +834,43 @@ mod tests {
     fn mute_rejects_unknown_key() {
         let body = r#"{"muted":true,"hold_ms":1000}"#;
         assert!(matches!(parse_mute(body), Err(JsonError::UnknownKey)));
+    }
+
+    #[test]
+    fn camera_mode_accepts_both_booleans() {
+        assert!(parse_camera_mode(r#"{"enabled":true}"#).unwrap());
+        assert!(!parse_camera_mode(r#"{"enabled":false}"#).unwrap());
+    }
+
+    #[test]
+    fn camera_mode_rejects_missing_field() {
+        assert!(matches!(
+            parse_camera_mode(r"{}"),
+            Err(JsonError::MissingKey("enabled"))
+        ));
+    }
+
+    #[test]
+    fn camera_mode_rejects_non_boolean_value() {
+        assert!(matches!(
+            parse_camera_mode(r#"{"enabled":1}"#),
+            Err(JsonError::BadValue)
+        ));
+    }
+
+    #[test]
+    fn camera_mode_rejects_duplicate_key() {
+        assert!(matches!(
+            parse_camera_mode(r#"{"enabled":true,"enabled":false}"#),
+            Err(JsonError::DuplicateKey("enabled"))
+        ));
+    }
+
+    #[test]
+    fn camera_mode_rejects_unknown_key() {
+        assert!(matches!(
+            parse_camera_mode(r#"{"enabled":true,"hold_ms":1000}"#),
+            Err(JsonError::UnknownKey)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Adds HTTP `POST /camera/mode` and a BLE view service (`8a1c0040-...`, single r/w/notify u8 char) so the LCD camera-preview / avatar toggle is no longer button-only.
- New `camera_mode: bool` field on `AvatarSnapshot` — every producer (button task, HTTP handler, BLE handler) writes the snapshot before signalling `CAMERA_MODE_SIGNAL`, so `GET /state`, the SSE stream, and BLE notify all see the change without waiting for the render loop.
- Tracking continues in either mode; camera mode is intentionally ephemeral (no SD writeback) so a power-cycle returns to avatar.
- Wire formats live in `stackchan-net` (`http_command::parse_camera_mode`, `ble_command::decode_camera_mode` + `encode_camera_mode`) with host-side unit tests — same shape as the recent BLE control-plane work in #179.

## Test plan
- [x] `just check` (host: fmt + clippy + tests + doctests)
- [x] `just clippy-firmware` (`cargo +esp clippy --release -- -D warnings`)
- [x] `cargo test -p stackchan-net --lib` — 134 tests, including new camera_mode codec coverage on both http_command and ble_command
- [ ] Manual: long-press button → verify `GET /state` flips and BLE notify fires
- [ ] Manual: `curl -X POST http://stackchan.local/camera/mode -d '{"enabled":true}'` → LCD switches to preview, chirp plays
- [ ] Manual: pair via nRF Connect, write `8a1c0041-...` = `01` → LCD switches; write `00` → returns to avatar