### PR TITLE
feat(firmware): camera capture-to-SD via HTTP + BLE triggers

### DIFF
--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -109,13 +109,14 @@ Stack-chan custom service for emotion read+notify, a Wi-Fi
 provisioning service for SSID + PSK writes, an audio service
 (`8a1c0020-...`) for volume + mute read+write+notify, an avatar
 control service (`8a1c0030-...`) for emotion / look-at / reset /
-speak writes, and a view service (`8a1c0040-...`) for the LCD
-camera-preview / avatar toggle. Control writes require an
-authenticated bond (passkey-confirmed pairing). The notify task
-diffs the avatar snapshot every tick so subscribed centrals see
-HTTP-side changes without explicit polling. Wi-Fi and BLE share the
-radio via `esp-radio`'s coex scheduler; expect a small Wi-Fi airtime
-tax when a BLE central is connected.
+speak writes, and a view service (`8a1c0040-...`) with the LCD
+camera-preview / avatar toggle and a capture trigger (writes the
+latest QVGA RGB565 frame to `/sd/CAPTURE.565`). Control writes
+require an authenticated bond (passkey-confirmed pairing). The
+notify task diffs the avatar snapshot every tick so subscribed
+centrals see HTTP-side changes without explicit polling. Wi-Fi and
+BLE share the radio via `esp-radio`'s coex scheduler; expect a
+small Wi-Fi airtime tax when a BLE central is connected.
 
 ## I²C Bus Sharing
 

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -35,11 +35,12 @@
 //!    [`stackchan_net::ble_command`] and signals
 //!    [`crate::net::http::REMOTE_COMMAND_SIGNAL`], the same channel
 //!    the HTTP control plane drives.
-//! 7. **View service** (`8a1c0040-…`) — display-mode toggles. Today
-//!    just the camera-mode flag (`8a1c0041-…`, `read + write +
-//!    notify`) that mirrors HTTP `POST /camera/mode`. Updates write
-//!    the avatar snapshot directly + signal the render task; no SD
-//!    writeback (camera mode is intentionally ephemeral).
+//! 7. **View service** (`8a1c0040-…`) — display + capture
+//!    triggers. Camera-mode flag (`8a1c0041-…`, `read + write +
+//!    notify`) mirrors HTTP `POST /camera/mode`; camera-capture
+//!    (`8a1c0042-…`, `write`-only, any 1-byte trigger) mirrors HTTP
+//!    `POST /camera/capture` and signals the camera task to persist
+//!    the latest frame to `/sd/CAPTURE.565`.
 //!
 //! ## Security
 //!
@@ -248,6 +249,12 @@ pub struct ViewService {
         value = 0
     )]
     pub camera_mode: u8,
+    /// Camera-capture trigger. `write`-only — any 1-byte write
+    /// signals the camera task to write the latest QVGA RGB565 frame
+    /// to `/sd/CAPTURE.565`. Decoded via
+    /// [`stackchan_net::ble_command::decode_camera_capture`].
+    #[characteristic(uuid = "8a1c0042-7b3f-4d52-9c6e-5f5ba1e5cf01", write, value = 0)]
+    pub camera_capture: u8,
 }
 
 #[allow(missing_docs)]
@@ -477,6 +484,8 @@ struct WriteHandles {
     speak: u16,
     /// View camera-mode toggle.
     camera_mode: u16,
+    /// View camera-capture trigger.
+    camera_capture: u16,
 }
 
 impl WriteHandles {
@@ -493,6 +502,7 @@ impl WriteHandles {
             reset: server.avatar.reset.handle,
             speak: server.avatar.speak.handle,
             camera_mode: server.view.camera_mode.handle,
+            camera_capture: server.view.camera_capture.handle,
         }
     }
 }
@@ -518,6 +528,9 @@ enum WriteAction {
     /// [`crate::net::snapshot::update_camera_mode`] +
     /// [`CAMERA_MODE_SIGNAL`].
     CameraMode(bool),
+    /// Signal the camera task to persist the latest frame to
+    /// `/sd/CAPTURE.565`.
+    CameraCapture,
 }
 
 /// Decision the dispatcher takes for one Gatt event.
@@ -664,7 +677,8 @@ fn decide_write<P: PacketPool>(
         || handle == handles.look_at
         || handle == handles.reset
         || handle == handles.speak
-        || handle == handles.camera_mode;
+        || handle == handles.camera_mode
+        || handle == handles.camera_capture;
     if !is_control {
         return WriteDecision::Default;
     }
@@ -685,6 +699,8 @@ fn decide_write<P: PacketPool>(
         ble_command::decode_speak(data).map(WriteAction::Remote)
     } else if handle == handles.camera_mode {
         ble_command::decode_camera_mode(data).map(WriteAction::CameraMode)
+    } else if handle == handles.camera_capture {
+        ble_command::decode_camera_capture(data).map(|()| WriteAction::CameraCapture)
     } else {
         // Unreachable on the strength of the `is_control` gate above
         // — every handle counted there must have a decode arm here.
@@ -756,6 +772,10 @@ async fn apply_write_action<P: PacketPool>(
             defmt::info!("ble: camera_mode → {=bool}", active);
             snapshot::update_camera_mode(active);
             CAMERA_MODE_SIGNAL.signal(active);
+        }
+        WriteAction::CameraCapture => {
+            defmt::info!("ble: camera_capture → signal queued");
+            crate::camera::CAMERA_CAPTURE_REQUEST.signal(());
         }
     }
 }

--- a/crates/stackchan-firmware/src/camera.rs
+++ b/crates/stackchan-firmware/src/camera.rs
@@ -116,12 +116,13 @@ pub const PIXEL_CLOCK_HZ: u32 = 20_000_000;
 /// signalled last, matching the user's intent.
 pub static CAMERA_MODE_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
-/// Capture-still trigger published by the render task.
+/// Capture-still trigger.
 ///
-/// The render task signals this when the user taps in camera mode
-/// (a tap-while-camera-mode = "save this frame"). The camera task
-/// snapshots the most recently completed buffer and emits a stats +
-/// thumbnail-strip log over RTT. No flash storage; capture is RTT-only.
+/// Three producers: a tap in camera-mode (render task), HTTP `POST
+/// /camera/capture`, and the BLE view-service capture characteristic.
+/// On each request the camera task snapshots the most recently
+/// completed buffer and (a) emits a stats + thumbnail-strip log over
+/// RTT, and (b) writes the raw RGB565 frame to `/sd/CAPTURE.565`.
 pub static CAMERA_CAPTURE_REQUEST: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
 /// Most-recently completed camera frame as a static slice.
@@ -545,9 +546,14 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
             });
 
             // Honour any pending capture request — log frame stats +
-            // a 32×24 RGB565 thumbnail strip over RTT.
+            // a 32×24 RGB565 thumbnail strip over RTT, then persist
+            // the raw frame to `/sd/CAPTURE.565`. The SD write blocks
+            // the executor for ~200 ms; render will skip a few frames
+            // during the write, which is acceptable for an
+            // operator-triggered debug action.
             if CAMERA_CAPTURE_REQUEST.try_take().is_some() {
                 log_capture_stats(active_idx, view);
+                save_capture_to_sd(view).await;
             }
         }
 
@@ -692,6 +698,21 @@ fn log_capture_stats(buffer_idx: usize, frame: &[u8]) {
         }
     }
     defmt::info!("camera: thumbnail (RGB565, 32x24): {=[?]}", thumb);
+}
+
+/// Persist a captured frame to `/sd/CAPTURE.565`. Logs success
+/// (with byte count + filename) or the failure mode the operator
+/// needs to act on (no SD mounted, SPI/FAT error). Never panics.
+async fn save_capture_to_sd(frame: &[u8]) {
+    let result = crate::storage::with_storage(|s| s.write_capture(frame)).await;
+    match result {
+        Some(Ok(())) => defmt::info!(
+            "camera: capture saved to /sd/CAPTURE.565 ({=usize} bytes raw RGB565 BE)",
+            frame.len()
+        ),
+        Some(Err(e)) => defmt::warn!("camera: capture write failed ({})", e),
+        None => defmt::warn!("camera: capture skipped — no SD mounted"),
+    }
 }
 
 /// Park the task forever. Used when init fails irrecoverably so the

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -30,6 +30,10 @@
 //!   LCD between camera preview and avatar; tracking continues in
 //!   either mode. Ephemeral (no SD writeback); a power-cycle returns
 //!   to avatar.
+//! - `POST /camera/capture` — empty body. Signals the camera task to
+//!   write the latest QVGA RGB565 frame to `/sd/CAPTURE.565`; returns
+//!   `202 Accepted`. The SD write happens asynchronously inside the
+//!   camera task and stalls render for ~200 ms during the SPI burst.
 //! - `GET /settings` — current persisted [`stackchan_net::Config`]
 //!   as JSON, with `wifi.psk` and `auth.token` redacted.
 //! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
@@ -291,6 +295,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/volume") => handle_post_volume(socket, body).await,
         ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("POST", "/camera/mode") => handle_post_camera_mode(socket, body).await,
+        ("POST", "/camera/capture") => handle_post_camera_capture(socket).await,
         ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
         _ => write_text(socket, 405, "method not allowed\n").await,
     }
@@ -553,6 +558,17 @@ async fn handle_post_camera_mode(socket: &mut TcpSocket<'_>, body: &str) -> Resu
     crate::camera::CAMERA_MODE_SIGNAL.signal(active);
     defmt::info!("http: POST /camera/mode → {=bool}", active);
     write_no_content(socket).await
+}
+
+/// `POST /camera/capture` — empty body, signals the camera task to
+/// snapshot the latest frame and persist it to `/sd/CAPTURE.565`.
+/// The actual SD write happens out-of-band (a few hundred ms later
+/// inside the camera task), so this returns `202 Accepted` rather
+/// than blocking the HTTP worker on the SPI write.
+async fn handle_post_camera_capture(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    crate::camera::CAMERA_CAPTURE_REQUEST.signal(());
+    defmt::info!("http: POST /camera/capture → signal queued");
+    write_text(socket, 202, "capture queued\n").await
 }
 
 /// Apply a parsed remote command (or surface the parser error to the

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -126,6 +126,13 @@ const BONDS_STAGING_FILE: &str = "BONDS.NEW";
 /// headroom for future record-layout additions.
 const MAX_BONDS_BYTES: u32 = 1024;
 
+/// Filename for the operator-triggered camera capture. Single fixed
+/// name (no rotation) so each capture overwrites the previous —
+/// the workflow is "trigger, eject SD, view, repeat", not a
+/// timestamped archive. Raw QVGA RGB565, big-endian, 320×240×2 =
+/// 153 600 bytes; convertible with a one-line numpy reshape.
+const CAPTURE_FILE: &str = "CAPTURE.565";
+
 /// Storage / FAT errors. Logged via `defmt::Format` at the firmware
 /// boundary; the operator triages from the boot log.
 #[derive(Debug, defmt::Format)]
@@ -304,6 +311,20 @@ where
         let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
         buf.truncate(n);
         Ok(buf)
+    }
+
+    /// Truncate-write the operator-triggered camera capture into
+    /// `/sd/CAPTURE.565`. No staging dance — a half-written capture
+    /// is just a half-written capture; the next trigger overwrites
+    /// it. The atomicity that matters for `STACKCHAN.RON` /
+    /// `BONDS.BIN` (boot must read a complete file) doesn't apply
+    /// here.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying SPI / FAT failure.
+    pub fn write_capture(&mut self, frame: &[u8]) -> Result<(), StorageError> {
+        self.write_file(CAPTURE_FILE, frame)
     }
 
     /// Atomically replace `/sd/BONDS.BIN` with `data`. Same staging-

--- a/crates/stackchan-net/src/ble_command.rs
+++ b/crates/stackchan-net/src/ble_command.rs
@@ -61,6 +61,8 @@ pub const VOLUME_LEN: usize = 1;
 pub const MUTE_LEN: usize = 1;
 /// Expected payload length for the camera-mode characteristic.
 pub const CAMERA_MODE_LEN: usize = 1;
+/// Expected payload length for the camera-capture trigger.
+pub const CAMERA_CAPTURE_LEN: usize = 1;
 /// Expected payload length for the reset characteristic.
 pub const RESET_LEN: usize = 1;
 /// Expected payload length for the emotion-write characteristic
@@ -207,6 +209,18 @@ pub fn decode_camera_mode(payload: &[u8]) -> Result<bool, BleError> {
 ///   than [`RESET_LEN`] bytes.
 pub const fn decode_reset(payload: &[u8]) -> Result<(), BleError> {
     expect_len(payload, RESET_LEN)
+}
+
+/// Decode the camera-capture trigger payload (any 1-byte value
+/// triggers a capture; the firmware snapshots the latest frame and
+/// writes it to `/sd/CAPTURE.565`).
+///
+/// # Errors
+///
+/// - [`BleError::BadLength`] when the central writes anything other
+///   than [`CAMERA_CAPTURE_LEN`] bytes.
+pub const fn decode_camera_capture(payload: &[u8]) -> Result<(), BleError> {
+    expect_len(payload, CAMERA_CAPTURE_LEN)
 }
 
 /// Decode the emotion-write payload into a [`RemoteCommand::SetEmotion`].
@@ -487,6 +501,30 @@ mod tests {
         );
         assert_eq!(
             decode_reset(&[1, 2]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 2
+            })
+        );
+    }
+
+    #[test]
+    fn camera_capture_accepts_any_single_byte() {
+        assert!(decode_camera_capture(&[0]).is_ok());
+        assert!(decode_camera_capture(&[0xFF]).is_ok());
+    }
+
+    #[test]
+    fn camera_capture_rejects_wrong_length() {
+        assert_eq!(
+            decode_camera_capture(&[]),
+            Err(BleError::BadLength {
+                expected: 1,
+                actual: 0
+            })
+        );
+        assert_eq!(
+            decode_camera_capture(&[1, 2]),
             Err(BleError::BadLength {
                 expected: 1,
                 actual: 2

--- a/docs/http.md
+++ b/docs/http.md
@@ -193,6 +193,46 @@ Persistent. Mute is independent of volume so unmuting restores the
 prior level — `volume = 0` is "audible but very quiet"; `muted =
 true` is the actual-silence path.
 
+### `POST /camera/mode`
+
+```
+$ curl -X POST http://stackchan.local/camera/mode \
+       -H 'Content-Type: application/json' \
+       -d '{"enabled":true}'
+```
+
+| Field   | Type | Required | Notes                                                |
+|---------|------|----------|------------------------------------------------------|
+| enabled | bool | yes      | `true` = LCD shows camera preview, `false` = avatar. |
+
+Display-only — tracking still runs in either mode. Ephemeral (no
+SD writeback); a power-cycle returns to avatar. Mirrored on the
+BLE view service (`8a1c0041-…`).
+
+### `POST /camera/capture`
+
+```
+$ curl -X POST http://stackchan.local/camera/capture
+```
+
+Empty body. Signals the camera task to write the latest QVGA
+RGB565 frame to `/sd/CAPTURE.565` (320 × 240 × 2 = 153 600 bytes,
+big-endian); each capture overwrites the previous file. Returns
+`202 Accepted` immediately — the SD write happens asynchronously
+and stalls render for ~200 ms during the SPI burst. Mirrored on
+the BLE view service (`8a1c0042-…`).
+
+Decode example (Python):
+
+```python
+import numpy as np
+raw = np.fromfile('CAPTURE.565', dtype='>u2').reshape(240, 320)
+r = ((raw >> 11) & 0x1F) * 255 // 31
+g = ((raw >>  5) & 0x3F) * 255 // 63
+b = ((raw      ) & 0x1F) * 255 // 31
+img = np.dstack([r, g, b]).astype('u1')
+```
+
 ## Persistent config
 
 The boot config lives at `/sd/STACKCHAN.RON` in the schema described


### PR DESCRIPTION
## Summary

- HTTP `POST /camera/capture` (empty body, returns 202) and BLE view-service write to `8a1c0042-...` (any 1-byte trigger) join the existing tap-in-camera-mode gesture as producers of `CAMERA_CAPTURE_REQUEST`.
- Camera task's existing capture handler now also writes the latest QVGA RGB565 frame (320×240×2 = 153 600 bytes, big-endian) to `/sd/CAPTURE.565` alongside the RTT thumbnail log. Single fixed filename — each capture overwrites; workflow is "trigger, eject SD, view, repeat".
- New `Storage::write_capture` helper bypasses the staging-then-copy dance the config + bonds files use. A half-written capture is just a half-written capture; atomicity matters for boot-read files, not for ad-hoc debug snapshots.
- Wire-format: `stackchan_net::ble_command::decode_camera_capture` (1-byte trigger, mirrors `decode_reset`); auth-gated with the rest of the BLE control surface.

The SD write blocks the executor for ~200 ms (one SPI burst); render skips a few frames during the write, which is acceptable for an operator-triggered debug action.

## Test plan
- [x] `just check` (host gates)
- [x] `just clippy-firmware` (release-mode strict clippy)
- [x] `cargo test -p stackchan-net --lib ble_command::` — 29/29 codec tests, including new capture coverage
- [ ] Manual: `curl -X POST http://stackchan.local/camera/capture` → check `/sd/CAPTURE.565` exists, `python -c "import numpy as np; np.fromfile('CAPTURE.565', dtype='>u2').reshape(240,320)"` decodes
- [ ] Manual: pair via nRF Connect, write `8a1c0042-...` = `01` → same file appears
- [ ] Manual: tap-in-camera-mode (existing path) still produces the file