### PR TITLE
feat(net): operator-tunable tracker FOV via PUT /settings

### DIFF
--- a/crates/stackchan-firmware/src/camera.rs
+++ b/crates/stackchan-firmware/src/camera.rs
@@ -371,9 +371,14 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
     const CASCADE_PERIOD: u8 = 8;
 
     // Tracker: block-grid motion analysis on each captured frame.
-    // Defaults are tuned in the `tracker` crate; tweak via
-    // `TrackerConfig` here if on-device tuning calls for it.
-    let mut tracker = Tracker::new(TrackerConfig::DEFAULT);
+    // Algorithm tuning (P-gain, block thresholds, dead zones, ...)
+    // stays compile-time in `TrackerConfig::DEFAULT`. The
+    // operator-tunable subset (lens FOV, EMA smoothing, orientation
+    // flips) is overlaid from the persisted `STACKCHAN.RON` so a
+    // calibration change doesn't need a re-flash. Falls back to the
+    // tracker crate defaults when no SD config is loaded yet.
+    let tracker_config = build_tracker_config().await;
+    let mut tracker = Tracker::new(tracker_config);
     let mut last_step_at = Instant::now();
     // Cascade scratch lives in PSRAM (~120 KiB) and is reused for
     // every frame. `Box::leak` hands us a `&'static mut` view that
@@ -698,6 +703,33 @@ fn log_capture_stats(buffer_idx: usize, frame: &[u8]) {
         }
     }
     defmt::info!("camera: thumbnail (RGB565, 32x24): {=[?]}", thumb);
+}
+
+/// Compose a runtime [`TrackerConfig`] from
+/// [`TrackerConfig::DEFAULT`] plus the operator-tunable overlay
+/// from `STACKCHAN.RON` (lens FOV, EMA smoothing, orientation
+/// flips). Returns the bare default if no config snapshot is
+/// available yet (e.g. no SD card mounted).
+async fn build_tracker_config() -> TrackerConfig {
+    let mut cfg = TrackerConfig::DEFAULT;
+    if let Some(snap) = crate::storage::CONFIG_SNAPSHOT.lock().await.as_ref() {
+        cfg.fov_h_deg = snap.tracker.fov_h_deg;
+        cfg.fov_v_deg = snap.tracker.fov_v_deg;
+        cfg.target_smoothing_alpha = snap.tracker.target_smoothing_alpha;
+        cfg.flip_x = snap.tracker.flip_x;
+        cfg.flip_y = snap.tracker.flip_y;
+        defmt::info!(
+            "camera: tracker overlay applied (fov_h={=f32} fov_v={=f32} alpha={=f32} flip_x={=bool} flip_y={=bool})",
+            cfg.fov_h_deg,
+            cfg.fov_v_deg,
+            cfg.target_smoothing_alpha,
+            cfg.flip_x,
+            cfg.flip_y,
+        );
+    } else {
+        defmt::info!("camera: tracker overlay skipped — no SD config snapshot");
+    }
+    cfg
 }
 
 /// Persist a captured frame to `/sd/CAPTURE.565`. Logs success

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -428,32 +428,11 @@ impl<'a> Parser<'a> {
 
     /// Parse a contiguous run of number-shaped bytes as `f32`. Used
     /// for the tracker block's `fov_h_deg` / `fov_v_deg` /
-    /// `target_smoothing_alpha`. Accepts a leading `-`, decimal point,
-    /// and exponent — delegated to `f32::from_str` for the heavy
-    /// lifting. Range checks live in [`validate`].
+    /// `target_smoothing_alpha`. Delegates to [`scan_f32`] so the
+    /// JSON parser in [`crate::bare_json`] consumes the identical
+    /// grammar — single source of truth for number-shape recognition.
     fn parse_f32(&mut self) -> Result<f32, ConfigError> {
-        let bytes = self.input.as_bytes();
-        let mut end = 0;
-        while end < bytes.len() {
-            let b = bytes[end];
-            if b == b'-' || b == b'+' || b == b'.' || b == b'e' || b == b'E' || b.is_ascii_digit() {
-                end += 1;
-            } else {
-                break;
-            }
-        }
-        if end == 0 {
-            return Err(bare_err("expected float literal", ""));
-        }
-        let (digits, rest) = self.input.split_at(end);
-        let parsed: f32 = digits
-            .parse()
-            .map_err(|_| bare_err("not an f32 literal", digits))?;
-        if !parsed.is_finite() {
-            return Err(bare_err("f32 literal is non-finite", digits));
-        }
-        self.input = rest;
-        Ok(parsed)
+        scan_f32(&mut self.input)
     }
 
     /// Parse a bare `true` or `false` literal.
@@ -604,6 +583,49 @@ impl<'a> Parser<'a> {
             Err(bare_err("expected char", &c.to_string()))
         }
     }
+}
+
+/// Read a contiguous run of number-shaped bytes off the front of
+/// `input` and parse it as `f32`.
+///
+/// Accepted grammar: optional leading `-`, decimal digits, optional
+/// fractional part (`.digits`), optional exponent (`e[-]?digits` or
+/// `E[-]?digits`). A leading `+` is **rejected** — neither RFC 8259
+/// (JSON) nor the RON subset this crate emits ever produces one, so
+/// accepting it would let inputs round-trip through to f32 in
+/// shapes the rest of the pipeline never expects.
+///
+/// On success the consumed prefix is sliced off `*input` and the
+/// parsed value is returned. Non-finite parses (`inf`, `NaN`) are
+/// rejected even though they're not normally producible by the
+/// grammar, as belt-and-braces.
+///
+/// Shared between [`Parser::parse_f32`] (RON) and
+/// [`crate::bare_json::Parser::parse_f32`] (JSON) so the two wire
+/// formats can never disagree on which byte sequences are numbers.
+pub(crate) fn scan_f32(input: &mut &str) -> Result<f32, ConfigError> {
+    let bytes = input.as_bytes();
+    let mut end = 0;
+    while end < bytes.len() {
+        let b = bytes[end];
+        if b == b'-' || b == b'.' || b == b'e' || b == b'E' || b.is_ascii_digit() {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+    if end == 0 {
+        return Err(bare_err("expected float literal", ""));
+    }
+    let (digits, rest) = input.split_at(end);
+    let parsed: f32 = digits
+        .parse()
+        .map_err(|_| bare_err("not an f32 literal", digits))?;
+    if !parsed.is_finite() {
+        return Err(bare_err("f32 literal is non-finite", digits));
+    }
+    *input = rest;
+    Ok(parsed)
 }
 
 /// Build a `BareParse` error. The format-arg pattern keeps the

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -22,7 +22,7 @@ use core::fmt::Write as _;
 
 use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{
-    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate,
+    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, TrackerSettings, WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -86,6 +86,18 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     let _ = writeln!(out, "        muted: {},", config.audio.muted);
     out.push_str("    ),\n");
 
+    out.push_str("    tracker: (\n");
+    let _ = writeln!(out, "        fov_h_deg: {},", config.tracker.fov_h_deg);
+    let _ = writeln!(out, "        fov_v_deg: {},", config.tracker.fov_v_deg);
+    let _ = writeln!(
+        out,
+        "        target_smoothing_alpha: {},",
+        config.tracker.target_smoothing_alpha
+    );
+    let _ = writeln!(out, "        flip_x: {},", config.tracker.flip_x);
+    let _ = writeln!(out, "        flip_y: {},", config.tracker.flip_y);
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -134,6 +146,7 @@ impl<'a> Parser<'a> {
         let mut time: Option<TimeConfig> = None;
         let mut auth: Option<AuthConfig> = None;
         let mut audio: Option<AudioConfig> = None;
+        let mut tracker: Option<TrackerSettings> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -150,6 +163,7 @@ impl<'a> Parser<'a> {
                 "time" => time = Some(self.parse_time()?),
                 "auth" => auth = Some(self.parse_auth()?),
                 "audio" => audio = Some(self.parse_audio()?),
+                "tracker" => tracker = Some(self.parse_tracker()?),
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -163,12 +177,13 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
-            // `auth` and `audio` are optional for migration: SD cards
-            // written before each block landed lack them, and the
-            // defaults (empty token = auth disabled; volume_pct = 50,
-            // muted = false) match the firmware's prior behaviour.
+            // `auth`, `audio`, and `tracker` are optional for
+            // migration: SD cards written before each block landed
+            // lack them, and the defaults match the firmware's prior
+            // hard-coded behaviour.
             auth: auth.unwrap_or_default(),
             audio: audio.unwrap_or_default(),
+            tracker: tracker.unwrap_or_default(),
         })
     }
 
@@ -335,6 +350,54 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parse the `tracker: (...)` block. Five fields, all optional;
+    /// missing fields fall back to [`TrackerSettings::DEFAULT`] so a
+    /// SD card written before this block existed reproduces the
+    /// pre-runtime-config tracker behaviour exactly.
+    fn parse_tracker(&mut self) -> Result<TrackerSettings, ConfigError> {
+        self.expect_char('(')?;
+        // `pan_fov` / `tilt_fov` rather than `fov_h_deg` / `fov_v_deg`
+        // for the locals — clippy's `similar_names` flags the latter
+        // as too close. The struct fields keep the on-the-wire names.
+        let mut pan_fov: Option<f32> = None;
+        let mut tilt_fov: Option<f32> = None;
+        let mut alpha: Option<f32> = None;
+        let mut flip_x: Option<bool> = None;
+        let mut flip_y: Option<bool> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "fov_h_deg" => pan_fov = Some(self.parse_f32()?),
+                "fov_v_deg" => tilt_fov = Some(self.parse_f32()?),
+                "target_smoothing_alpha" => {
+                    alpha = Some(self.parse_f32()?);
+                }
+                "flip_x" => flip_x = Some(self.parse_bool()?),
+                "flip_y" => flip_y = Some(self.parse_bool()?),
+                other => return Err(bare_err("unknown tracker field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in tracker", ""));
+            }
+        }
+        let defaults = TrackerSettings::DEFAULT;
+        Ok(TrackerSettings {
+            fov_h_deg: pan_fov.unwrap_or(defaults.fov_h_deg),
+            fov_v_deg: tilt_fov.unwrap_or(defaults.fov_v_deg),
+            target_smoothing_alpha: alpha.unwrap_or(defaults.target_smoothing_alpha),
+            flip_x: flip_x.unwrap_or(defaults.flip_x),
+            flip_y: flip_y.unwrap_or(defaults.flip_y),
+        })
+    }
+
     /// Parse a contiguous run of decimal digits as a `u8`. Used for
     /// `audio.volume_pct`. Range gating is left to [`validate`] so the
     /// out-of-range surface lands on `ConfigError::InvalidVolumePct`
@@ -361,6 +424,36 @@ impl<'a> Parser<'a> {
         self.input = rest;
         #[allow(clippy::cast_possible_truncation)]
         Ok(parsed as u8)
+    }
+
+    /// Parse a contiguous run of number-shaped bytes as `f32`. Used
+    /// for the tracker block's `fov_h_deg` / `fov_v_deg` /
+    /// `target_smoothing_alpha`. Accepts a leading `-`, decimal point,
+    /// and exponent — delegated to `f32::from_str` for the heavy
+    /// lifting. Range checks live in [`validate`].
+    fn parse_f32(&mut self) -> Result<f32, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() {
+            let b = bytes[end];
+            if b == b'-' || b == b'+' || b == b'.' || b == b'e' || b == b'E' || b.is_ascii_digit() {
+                end += 1;
+            } else {
+                break;
+            }
+        }
+        if end == 0 {
+            return Err(bare_err("expected float literal", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: f32 = digits
+            .parse()
+            .map_err(|_| bare_err("not an f32 literal", digits))?;
+        if !parsed.is_finite() {
+            return Err(bare_err("f32 literal is non-finite", digits));
+        }
+        self.input = rest;
+        Ok(parsed)
     }
 
     /// Parse a bare `true` or `false` literal.

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -578,34 +578,13 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse a JSON number into `f32`. Accepts the standard
-    /// `[-]?digits[.digits][e[+-]?digits]` shape; rejects
-    /// `NaN` / `inf` so the firmware's tracker init never sees a
-    /// non-finite value (the `validate` step also checks, but the
-    /// parser surfaces the error closer to the source byte).
+    /// Parse a JSON number into `f32`. Delegates to
+    /// [`crate::bare::scan_f32`] so the RON and JSON parsers consume
+    /// the identical grammar (and so a leading `+` is rejected
+    /// uniformly — RFC 8259 §6 disallows it, and the RON path also
+    /// has no use for it).
     fn parse_f32(&mut self) -> Result<f32, ConfigError> {
-        let bytes = self.input.as_bytes();
-        let mut end = 0;
-        while end < bytes.len() {
-            let b = bytes[end];
-            if b == b'-' || b == b'+' || b == b'.' || b == b'e' || b == b'E' || b.is_ascii_digit() {
-                end += 1;
-            } else {
-                break;
-            }
-        }
-        if end == 0 {
-            return Err(bare_err("expected float literal", ""));
-        }
-        let (digits, rest) = self.input.split_at(end);
-        let parsed: f32 = digits
-            .parse()
-            .map_err(|_| bare_err("not an f32 literal", digits))?;
-        if !parsed.is_finite() {
-            return Err(bare_err("f32 literal is non-finite", digits));
-        }
-        self.input = rest;
-        Ok(parsed)
+        crate::bare::scan_f32(&mut self.input)
     }
 
     /// Parse a contiguous run of decimal digits as `u8`. Out-of-range
@@ -1131,6 +1110,27 @@ mod tests {
         let parsed = parse_settings_json(input).unwrap();
         assert_eq!(parsed.audio.volume_pct, 75);
         assert!(parsed.audio.muted);
+    }
+
+    #[test]
+    fn tracker_fov_rejects_leading_plus() {
+        // RFC 8259 §6 disallows a leading `+` on JSON numbers; the
+        // shared `scan_f32` helper rejects it for both the RON and
+        // JSON parsers. Pin: a `+62.0` lands on `BareParse`, not
+        // silently sneaks through to `f32::from_str`.
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "tracker":{"fov_h_deg":+62.0,"fov_v_deg":49.0,
+                       "target_smoothing_alpha":1.0,
+                       "flip_x":false,"flip_y":false}
+        }"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::BareParse(_)),
+            "expected BareParse on leading-plus, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 use core::fmt::Write as _;
 
 use crate::config::{
-    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate,
+    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, TrackerSettings, WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -80,8 +80,8 @@ pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
 /// overwrites.
 ///
 /// Fields the wire format doesn't redact (`ssid`, `country`,
-/// `mdns.hostname`, `time.*`, `audio.*`) pass through from `new`
-/// unchanged.
+/// `mdns.hostname`, `time.*`, `audio.*`, `tracker.*`) pass through
+/// from `new` unchanged.
 #[must_use]
 pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
     Config {
@@ -104,6 +104,7 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
             },
         },
         audio: new.audio,
+        tracker: new.tracker,
     }
 }
 
@@ -162,6 +163,18 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         "\"volume_pct\":{},\"muted\":{}",
         config.audio.volume_pct, config.audio.muted
     );
+    out.push_str("},\"tracker\":{");
+    let _ = write!(
+        out,
+        "\"fov_h_deg\":{fov_h:?},\"fov_v_deg\":{fov_v:?},\
+         \"target_smoothing_alpha\":{alpha:?},\
+         \"flip_x\":{flip_x},\"flip_y\":{flip_y}",
+        fov_h = config.tracker.fov_h_deg,
+        fov_v = config.tracker.fov_v_deg,
+        alpha = config.tracker.target_smoothing_alpha,
+        flip_x = config.tracker.flip_x,
+        flip_y = config.tracker.flip_y,
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -217,6 +230,7 @@ impl<'a> Parser<'a> {
         let mut time: Option<TimeConfig> = None;
         let mut auth: Option<AuthConfig> = None;
         let mut audio: Option<AudioConfig> = None;
+        let mut tracker: Option<TrackerSettings> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -257,6 +271,12 @@ impl<'a> Parser<'a> {
                     }
                     audio = Some(self.parse_audio()?);
                 }
+                "tracker" => {
+                    if tracker.is_some() {
+                        return Err(bare_err("duplicate top-level field", "tracker"));
+                    }
+                    tracker = Some(self.parse_tracker()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -268,12 +288,13 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
-            // `auth` and `audio` are optional for migration: bodies
-            // emitted before each block landed don't have them, and
-            // the defaults (empty token = auth disabled; volume_pct
-            // = 50, muted = false) match prior behaviour.
+            // `auth`, `audio`, `tracker` are optional for migration:
+            // bodies emitted before each block landed don't have them,
+            // and the defaults match the firmware's prior hard-coded
+            // behaviour.
             auth: auth.unwrap_or_default(),
             audio: audio.unwrap_or_default(),
+            tracker: tracker.unwrap_or_default(),
         })
     }
 
@@ -484,6 +505,109 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parse the `"tracker": { ... }` block. All five fields are
+    /// optional on the wire; missing fields fall back to
+    /// [`TrackerSettings::DEFAULT`]. Range validation lives in the
+    /// `validate` pass after parse so out-of-range values surface
+    /// with the exact offending number via `ConfigError::Invalid…`.
+    fn parse_tracker(&mut self) -> Result<TrackerSettings, ConfigError> {
+        self.expect_char('{')?;
+        // See `bare::parse_tracker` for the local-naming rationale.
+        let mut pan_fov: Option<f32> = None;
+        let mut tilt_fov: Option<f32> = None;
+        let mut alpha: Option<f32> = None;
+        let mut flip_x: Option<bool> = None;
+        let mut flip_y: Option<bool> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "fov_h_deg" => {
+                    if pan_fov.is_some() {
+                        return Err(bare_err("duplicate tracker field", "fov_h_deg"));
+                    }
+                    pan_fov = Some(self.parse_f32()?);
+                }
+                "fov_v_deg" => {
+                    if tilt_fov.is_some() {
+                        return Err(bare_err("duplicate tracker field", "fov_v_deg"));
+                    }
+                    tilt_fov = Some(self.parse_f32()?);
+                }
+                "target_smoothing_alpha" => {
+                    if alpha.is_some() {
+                        return Err(bare_err(
+                            "duplicate tracker field",
+                            "target_smoothing_alpha",
+                        ));
+                    }
+                    alpha = Some(self.parse_f32()?);
+                }
+                "flip_x" => {
+                    if flip_x.is_some() {
+                        return Err(bare_err("duplicate tracker field", "flip_x"));
+                    }
+                    flip_x = Some(self.parse_bool()?);
+                }
+                "flip_y" => {
+                    if flip_y.is_some() {
+                        return Err(bare_err("duplicate tracker field", "flip_y"));
+                    }
+                    flip_y = Some(self.parse_bool()?);
+                }
+                other => return Err(bare_err("unknown tracker field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in tracker", ""));
+            }
+        }
+        let defaults = TrackerSettings::DEFAULT;
+        Ok(TrackerSettings {
+            fov_h_deg: pan_fov.unwrap_or(defaults.fov_h_deg),
+            fov_v_deg: tilt_fov.unwrap_or(defaults.fov_v_deg),
+            target_smoothing_alpha: alpha.unwrap_or(defaults.target_smoothing_alpha),
+            flip_x: flip_x.unwrap_or(defaults.flip_x),
+            flip_y: flip_y.unwrap_or(defaults.flip_y),
+        })
+    }
+
+    /// Parse a JSON number into `f32`. Accepts the standard
+    /// `[-]?digits[.digits][e[+-]?digits]` shape; rejects
+    /// `NaN` / `inf` so the firmware's tracker init never sees a
+    /// non-finite value (the `validate` step also checks, but the
+    /// parser surfaces the error closer to the source byte).
+    fn parse_f32(&mut self) -> Result<f32, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() {
+            let b = bytes[end];
+            if b == b'-' || b == b'+' || b == b'.' || b == b'e' || b == b'E' || b.is_ascii_digit() {
+                end += 1;
+            } else {
+                break;
+            }
+        }
+        if end == 0 {
+            return Err(bare_err("expected float literal", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: f32 = digits
+            .parse()
+            .map_err(|_| bare_err("not an f32 literal", digits))?;
+        if !parsed.is_finite() {
+            return Err(bare_err("f32 literal is non-finite", digits));
+        }
+        self.input = rest;
+        Ok(parsed)
+    }
+
     /// Parse a contiguous run of decimal digits as `u8`. Out-of-range
     /// (>100) values pass parse but trip
     /// `ConfigError::InvalidVolumePct` in `validate` so the operator
@@ -664,6 +788,13 @@ mod tests {
             audio: AudioConfig {
                 volume_pct: 33,
                 muted: true,
+            },
+            tracker: TrackerSettings {
+                fov_h_deg: 60.0,
+                fov_v_deg: 45.0,
+                target_smoothing_alpha: 0.4,
+                flip_x: true,
+                flip_y: false,
             },
         }
     }
@@ -969,6 +1100,7 @@ mod tests {
                 volume_pct: 100,
                 muted: false,
             },
+            tracker: TrackerSettings::DEFAULT,
         };
         let rendered = render_settings_json(&config, false).unwrap();
         assert!(

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -162,10 +162,11 @@ impl Default for AudioConfig {
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct TrackerSettings {
     /// Camera horizontal field of view in degrees. GC0308 with the
-    /// CoreS3 lens is roughly 62°. Range: 1..=180.
+    /// CoreS3 lens is roughly 62°. Range: `(0, 180]` — must be
+    /// strictly positive and at most 180°.
     pub fov_h_deg: f32,
     /// Camera vertical field of view in degrees. ~49° on the same
-    /// lens. Range: 1..=180.
+    /// lens. Range: `(0, 180]` — same gate as `fov_h_deg`.
     pub fov_v_deg: f32,
     /// Single-pole EMA on the published target pose. `1.0` is the
     /// pass-through default; lower values add inertia. Range:

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -24,7 +24,7 @@ use crate::error::ConfigError;
 /// mDNS label, `time` points at `pool.ntp.org` so SNTP picks up
 /// once Wi-Fi is configured, and `auth.token` is empty so the HTTP
 /// control plane stays LAN-open until the operator opts in.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct Config {
     /// Wi-Fi station credentials and regulatory country code.
@@ -43,6 +43,12 @@ pub struct Config {
     /// /mute` write.
     #[cfg_attr(feature = "parse", serde(default))]
     pub audio: AudioConfig,
+    /// Camera-tracker tuning: lens FOV, target smoothing, and
+    /// orientation flips. Applied to the firmware tracker at boot;
+    /// changes via `PUT /settings` take effect on the next boot
+    /// (mirrors the mDNS / SNTP / audio-init pattern).
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub tracker: TrackerSettings,
 }
 
 /// Wi-Fi station credentials.
@@ -132,6 +138,60 @@ impl AudioConfig {
 }
 
 impl Default for AudioConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Operator-tunable subset of `tracker::TrackerConfig`.
+///
+/// These are the fields most likely to need adjustment in the field
+/// rather than at compile time. Lens FOV varies between hardware
+/// revisions, smoothing is a taste call, and orientation flips depend
+/// on physical mounting.
+///
+/// The full `tracker::TrackerConfig` algorithm tuning (P-gain, block
+/// thresholds, dead zones, idle behaviour, ...) stays compile-time
+/// only — operators shouldn't need it, and exposing it would balloon
+/// the schema for marginal value.
+///
+/// Defaults match `tracker::TrackerConfig::DEFAULT` so a missing
+/// `tracker:` block reproduces the firmware's pre-runtime-config
+/// behaviour exactly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct TrackerSettings {
+    /// Camera horizontal field of view in degrees. GC0308 with the
+    /// CoreS3 lens is roughly 62°. Range: 1..=180.
+    pub fov_h_deg: f32,
+    /// Camera vertical field of view in degrees. ~49° on the same
+    /// lens. Range: 1..=180.
+    pub fov_v_deg: f32,
+    /// Single-pole EMA on the published target pose. `1.0` is the
+    /// pass-through default; lower values add inertia. Range:
+    /// 0.05..=1.0 (clamped at the use site as defence-in-depth).
+    pub target_smoothing_alpha: f32,
+    /// Mirror the centroid horizontally before mapping to pan. Set
+    /// when the camera is mounted left-right reversed relative to the
+    /// head's pan direction.
+    pub flip_x: bool,
+    /// Mirror vertically. Set when the camera image is upside-down
+    /// relative to the head's tilt direction.
+    pub flip_y: bool,
+}
+
+impl TrackerSettings {
+    /// Const-evaluable default mirroring `tracker::TrackerConfig::DEFAULT`.
+    pub const DEFAULT: Self = Self {
+        fov_h_deg: 62.0,
+        fov_v_deg: 49.0,
+        target_smoothing_alpha: 1.0,
+        flip_x: false,
+        flip_y: false,
+    };
+}
+
+impl Default for TrackerSettings {
     fn default() -> Self {
         Self::DEFAULT
     }
@@ -236,7 +296,33 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
     if config.audio.volume_pct > 100 {
         return Err(ConfigError::InvalidVolumePct(config.audio.volume_pct));
     }
+    if !is_valid_fov_deg(config.tracker.fov_h_deg) {
+        return Err(ConfigError::InvalidFovDeg(config.tracker.fov_h_deg));
+    }
+    if !is_valid_fov_deg(config.tracker.fov_v_deg) {
+        return Err(ConfigError::InvalidFovDeg(config.tracker.fov_v_deg));
+    }
+    if !is_valid_smoothing_alpha(config.tracker.target_smoothing_alpha) {
+        return Err(ConfigError::InvalidSmoothingAlpha(
+            config.tracker.target_smoothing_alpha,
+        ));
+    }
     Ok(())
+}
+
+/// True iff `deg` is a finite positive value within `(0, 180]`. Lens
+/// FOVs outside that range can't be physical; rejecting at the
+/// validator catches typos before they reach the camera task.
+fn is_valid_fov_deg(deg: f32) -> bool {
+    deg.is_finite() && deg > 0.0 && deg <= 180.0
+}
+
+/// True iff `alpha` is a finite value in `[0.05, 1.0]`. Lower than
+/// 0.05 effectively freezes the published target for tens of seconds,
+/// which is a UX bug; higher than 1.0 has no defined meaning for an
+/// EMA. Matches the runtime clamp inside `Tracker::publish`.
+fn is_valid_smoothing_alpha(alpha: f32) -> bool {
+    alpha.is_finite() && (0.05..=1.0).contains(&alpha)
 }
 
 /// True iff `s` is exactly two uppercase ASCII letters (ISO-3166

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -77,6 +77,20 @@ pub enum ConfigError {
     #[error("audio.volume_pct must be 0..=100; got {0}")]
     InvalidVolumePct(u8),
 
+    /// `tracker.fov_h_deg` or `tracker.fov_v_deg` was non-finite,
+    /// non-positive, or larger than 180°. Lens FOVs outside that
+    /// range can't be physical; the carried `f32` is the offending
+    /// value.
+    #[error("tracker FOV must be a finite value in (0.0, 180.0]; got {0}")]
+    InvalidFovDeg(f32),
+
+    /// `tracker.target_smoothing_alpha` was outside `[0.05, 1.0]`.
+    /// Below 0.05 effectively freezes the published target;
+    /// above 1.0 has no defined meaning for an EMA. The carried
+    /// `f32` is the offending value.
+    #[error("tracker.target_smoothing_alpha must be in [0.05, 1.0]; got {0}")]
+    InvalidSmoothingAlpha(f32),
+
     /// Hand-rolled bare parser failure (firmware-side path that
     /// avoids `serde + ron`). Carries a short reason string in lieu
     /// of `ron`'s line/col `SpannedError` — the firmware logs this

--- a/docs/http.md
+++ b/docs/http.md
@@ -247,8 +247,18 @@ $ curl http://stackchan.local/settings
  "mdns":{"hostname":"stackchan"},
  "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
  "auth":{"token":"***"},
- "audio":{"volume_pct":50,"muted":false}}
+ "audio":{"volume_pct":50,"muted":false},
+ "tracker":{"fov_h_deg":62.0,"fov_v_deg":49.0,"target_smoothing_alpha":1.0,
+            "flip_x":false,"flip_y":false}}
 ```
+
+`tracker` carries the operator-tunable subset of the firmware
+tracker config: physical lens FOV (`fov_h_deg` / `fov_v_deg`),
+EMA smoothing on the published target (`target_smoothing_alpha`,
+`1.0` = pass-through, lower = more inertia), and centroid
+orientation flips for non-standard mountings. Algorithm tuning
+(P-gain, block thresholds, dead zones) stays compile-time. Changes
+take effect on next boot — same as `mdns.hostname` / `time.*`.
 
 `wifi.psk` and a non-empty `auth.token` are redacted to `***`.
 On `PUT /settings`, the server treats either sentinel as **"keep
@@ -268,7 +278,9 @@ $ curl -X PUT http://stackchan.local/settings \
             "mdns":{"hostname":"stackchan"},
             "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
             "auth":{"token":"s3cret"},
-            "audio":{"volume_pct":50,"muted":false}}'
+            "audio":{"volume_pct":50,"muted":false},
+            "tracker":{"fov_h_deg":62.0,"fov_v_deg":49.0,"target_smoothing_alpha":1.0,
+                       "flip_x":false,"flip_y":false}}'
 {"reboot_required":true}
 ```
 


### PR DESCRIPTION
## Summary

- Adds a `tracker:` block to `stackchan-net::Config` with the operator-relevant subset of `tracker::TrackerConfig`: `fov_h_deg` / `fov_v_deg` (lens FOV varies between hardware revisions), `target_smoothing_alpha` (taste), and `flip_x` / `flip_y` (orientation flips depend on physical mounting). Algorithm tuning (P-gain, block thresholds, dead zones) stays compile-time.
- Defaults match `tracker::TrackerConfig::DEFAULT`, so a SD card / `PUT /settings` body without a `tracker:` block reproduces the firmware's prior pre-runtime-config behaviour exactly. Optional in both the bare RON parser and the bare JSON parser for forward compat.
- Range validation: FOV in `(0.0, 180.0]`, `target_smoothing_alpha` in `[0.05, 1.0]`. Mirrors the runtime clamp inside `Tracker::publish` so a bad SD value fails fast at boot rather than silently freezing the tracker.
- Camera task now overlays the persisted tracker fields onto `TrackerConfig::DEFAULT` via a new `build_tracker_config()` helper before constructing the tracker. A change via `PUT /settings` takes effect on next boot — same pattern as `mdns.hostname` / `time.*`.

`Config: Eq` is dropped (TrackerSettings carries f32). `PartialEq` stays. No external consumers required Eq.

## Test plan
- [x] `just check` (host gates) + reproduced CI doc check locally with `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features`
- [x] `just clippy-firmware` (release-mode strict clippy)
- [x] `cargo test -p stackchan-net` — 136 pass; existing JSON / RON round-trip tests cover the new block via `full_config()` + the maximal-payload size cap test
- [ ] Manual: `curl http://stackchan.local/settings | jq .tracker` shows the new block; `PUT` with a custom `fov_h_deg`, reboot, verify the new value lands in `TrackerConfig::DEFAULT` overlay log line at boot