### PR TITLE
feat(firmware): voice-gated frame-centre face cascade

### DIFF
--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -546,6 +546,52 @@ mod tests {
     }
 
     #[test]
+    fn listening_attention_with_engaged_face_turns_head_toward_face() {
+        // The voice-attention path: a still speaker triggers `Listening`
+        // while the firmware-side cascade (widened during listening) has
+        // locked their face. The head must drive toward the face yaw —
+        // not fall through to the tilt-only listening pose.
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = listening(0);
+        entity.mind.engagement = Engagement::Locked {
+            // -0.5 × HALF_FOV_H_DEG (31°) → the face is left-of-centre.
+            centroid: (-0.5_f32, 0.0_f32),
+            at: Instant::from_millis(0),
+        };
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+
+        // Pan must come from the face centroid, not from the tilt-only
+        // Listening fallback (which would leave pan_deg at 0).
+        assert!(
+            entity.motor.head_pose.pan_deg < -1.0,
+            "Listening + locked face must yaw toward the face (got pan_deg = {})",
+            entity.motor.head_pose.pan_deg,
+        );
+    }
+
+    #[test]
+    fn listening_attention_without_engagement_falls_back_to_tilt() {
+        // Regression guard for the no-face-locked path: when listening
+        // fires but the camera has no face, head goes through the
+        // existing tilt-only ease (no yaw contribution).
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+        entity.mind.attention = listening(0);
+        // Engagement stays at default (Idle, no centroid).
+        // First tick anchors `listen_since`; second tick (one full ease
+        // window later) reaches peak bias.
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+        entity.tick.now = Instant::from_millis(LISTEN_HEAD_EASE_MS);
+        m.update(&mut entity);
+
+        assert_eq!(entity.motor.head_pose.pan_deg, 0.0);
+        assert_eq!(entity.motor.head_pose.tilt_deg, LISTEN_HEAD_TILT_DEG);
+    }
+
+    #[test]
     fn engaged_releasing_state_keeps_face_target() {
         // Releasing must keep driving the head toward the last-known
         // face centroid for the search beat — the lost-target

--- a/crates/stackchan-firmware/src/camera.rs
+++ b/crates/stackchan-firmware/src/camera.rs
@@ -136,10 +136,12 @@ pub static CAMERA_CAPTURE_REQUEST: Signal<CriticalSectionRawMutex, ()> = Signal:
 /// `Idle`, so the head only does the cocked-up listening tilt and
 /// never turns toward them.
 ///
-/// `Signal` semantics (latest-wins) match the use: stale values lose
-/// to the next tick. A missing value (`try_take` returns `None` —
-/// happens only before the first render tick) is treated as
-/// "not listening," which is the safe default.
+/// `Signal` semantics (latest-wins) match the use, but `try_take`
+/// *consumes* the value — and the camera task ticks independently of
+/// the render task, so a fresh `try_take` between two render publishes
+/// would read `None`. The camera task therefore shadows the hint in a
+/// local boolean and only updates it when `try_take` returns `Some`,
+/// preserving the last-known state across frames.
 pub static LISTENING_HINT_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
 
 /// Most-recently completed camera frame as a static slice.
@@ -411,6 +413,12 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
     // the full 30 FPS cadence (otherwise face_present would flicker
     // at the cascade period and never accumulate hits).
     let mut last_face: Option<FaceDetection> = None;
+    // Last observed value of `LISTENING_HINT_SIGNAL`. Updated only
+    // when `try_take` returns `Some` — the camera task and render
+    // task tick independently, so a `try_take` between two render
+    // publishes would otherwise read `None` and silently drop the
+    // hint to `false` mid-listening-session.
+    let mut is_listening: bool = false;
 
     loop {
         // Pick the buffer to fill on this iteration; the OTHER one
@@ -523,7 +531,10 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
             // statically less than u16::MAX (320, 240), so the cast is
             // safe — `u16::try_from` would panic-or-error on values
             // that the binary's compile-time constants make impossible.
-            let listening = LISTENING_HINT_SIGNAL.try_take().unwrap_or(false);
+            if let Some(hint) = LISTENING_HINT_SIGNAL.try_take() {
+                is_listening = hint;
+            }
+            let listening = is_listening;
             let scoring_frame = cascade_phase == 0;
             cascade_phase = (cascade_phase + 1) % CASCADE_PERIOD;
             let scan_centroid = outcome

--- a/crates/stackchan-firmware/src/camera.rs
+++ b/crates/stackchan-firmware/src/camera.rs
@@ -125,6 +125,23 @@ pub static CAMERA_MODE_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::n
 /// RTT, and (b) writes the raw RGB565 frame to `/sd/CAPTURE.565`.
 pub static CAMERA_CAPTURE_REQUEST: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
+/// Listening-attention hint, render task → camera task.
+///
+/// Republished after every director tick: `true` while
+/// `entity.mind.attention` is `Listening`. The camera task widens face
+/// detection on the strength of this hint — when no motion candidate
+/// is present and listening is active, it scans the cascade around the
+/// frame centre instead of skipping. Without this widening a still
+/// speaker (voice fires but they're not moving) leaves engagement at
+/// `Idle`, so the head only does the cocked-up listening tilt and
+/// never turns toward them.
+///
+/// `Signal` semantics (latest-wins) match the use: stale values lose
+/// to the next tick. A missing value (`try_take` returns `None` —
+/// happens only before the first render tick) is treated as
+/// "not listening," which is the safe default.
+pub static LISTENING_HINT_SIGNAL: Signal<CriticalSectionRawMutex, bool> = Signal::new();
+
 /// Most-recently completed camera frame as a static slice.
 ///
 /// The camera task copies each just-filled DMA buffer into one of two
@@ -484,48 +501,64 @@ pub async fn run_camera_task(p: CameraPeripherals) -> ! {
             last_step_at = now;
             let outcome = tracker.step(view, dt_ms);
 
-            // Motion-gated face cascade. Two layers of gating:
+            // Face cascade gating. Three layers:
             //
-            // 1. Run only if there's at least one motion candidate
-            //    to score (cheap reject for static scenes).
+            // 1. Pick a scan ROI centroid:
+            //    - Motion candidate present → scan around the largest
+            //      blob (the moving thing is the most likely face).
+            //    - No motion but `listening` → scan the frame centre
+            //      so a still speaker is detected during voice
+            //      attention (otherwise engagement stays Idle and the
+            //      head only does the cocked-up listening tilt).
+            //    - Otherwise → skip; let `last_face` go stale via the
+            //      cascade-period miss path.
             // 2. Run only every `CASCADE_PERIOD`-th camera frame
             //    (cooperative time-share so the cascade's ~80–120 ms
             //    cost amortises across multiple 33 ms frames).
-            //
-            // On intervening frames we replay `last_face` so engagement
-            // hysteresis sees a stable face signal across the full
-            // capture cadence. `last_face` is cleared whenever the
-            // cascade runs and finds no face, OR when motion drops
-            // (no candidate to score = the user moved out of frame).
+            // 3. On intervening frames replay `last_face` so the
+            //    engagement state machine sees a stable face signal
+            //    across the full capture cadence.
             //
             // FRAME_WIDTH/HEIGHT are u32 const QVGA dims; they're
             // statically less than u16::MAX (320, 240), so the cast is
             // safe — `u16::try_from` would panic-or-error on values
             // that the binary's compile-time constants make impossible.
+            let listening = LISTENING_HINT_SIGNAL.try_take().unwrap_or(false);
             let scoring_frame = cascade_phase == 0;
             cascade_phase = (cascade_phase + 1) % CASCADE_PERIOD;
-            if outcome.candidates.is_empty() {
-                // No motion → no candidate → forget the last face;
-                // engagement releases through the natural miss path.
-                last_face = None;
-            } else if scoring_frame {
-                #[allow(
-                    clippy::cast_possible_truncation,
-                    reason = "FRAME_WIDTH=320, FRAME_HEIGHT=240; both fit u16 trivially"
-                )]
-                let det = outcome.candidates.first().and_then(|c| {
-                    FRONTAL_FACE.scan_around_centroid(
+            let scan_centroid = outcome
+                .candidates
+                .first()
+                .map(|c| c.centroid)
+                .or_else(|| listening.then_some((0.0, 0.0)));
+            match (scan_centroid, scoring_frame) {
+                (Some(centroid), true) => {
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        reason = "FRAME_WIDTH=320, FRAME_HEIGHT=240; both fit u16 trivially"
+                    )]
+                    let det = FRONTAL_FACE.scan_around_centroid(
                         view,
                         FRAME_WIDTH as u16,
                         FRAME_HEIGHT as u16,
-                        c.centroid,
+                        centroid,
                         CASCADE_ROI_DIM,
                         cascade_scratch,
-                    )
-                });
-                last_face = det;
+                    );
+                    last_face = det;
+                }
+                (Some(_), false) => {
+                    // Mid-cascade-period: keep `last_face` from the
+                    // previous scoring frame so engagement hysteresis
+                    // sees a stable signal.
+                }
+                (None, _) => {
+                    // No motion and not listening → forget the last
+                    // face; engagement releases through the natural
+                    // miss path.
+                    last_face = None;
+                }
             }
-            // Else: keep `last_face` from the previous scoring frame.
 
             // Translate the firmware-side per-blob list into the
             // engine-side mirror type. Both are heapless::Vec with

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -72,7 +72,7 @@ use mipidsi::{
     options::{ColorInversion, ColorOrder},
 };
 use stackchan_core::{
-    Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
+    Attention, Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
     modifiers::{
         AttentionFromTracking, Blink, Breath, DormancyFromActivity, EmotionCycle,
         EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
@@ -478,6 +478,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // modifier — see `crate::director` for the full pipeline.
         director.run(&mut entity, now);
         tracking_trace.observe(&entity, now);
+
+        // Hint the camera task about Listening attention so it can
+        // widen face detection past motion-only candidates: a still
+        // speaker (voice fires while they sit motionless) gets a
+        // frame-centre cascade scan instead of an Idle engagement and
+        // the head turns toward them rather than just tilting up.
+        camera::LISTENING_HINT_SIGNAL
+            .signal(matches!(entity.mind.attention, Attention::Listening { .. }));
 
         // Drain speech intents raised this tick. Two parallel paths
         // during the chirp → utterance migration:


### PR DESCRIPTION
## Summary

- The face cascade only scored ROIs around motion blobs, so a still speaker (voice fires while sitting motionless) left engagement at `Idle`. The head-from-attention engagement-driven branch never had a centroid to drive yaw from, so the head only did the cocked-up listening tilt instead of turning toward the speaker.
- Add `LISTENING_HINT_SIGNAL` republished by the render task after each director tick (`true` while `entity.mind.attention` is `Listening`).
- Camera task uses the hint to widen detection: with no motion candidate but listening active, scan the cascade around the frame centre `(0, 0)`. Engagement state then advances normally and the existing head-from-engagement path turns the head toward the detected face.
- Regression-guard test in `head_from_attention.rs` pins the contract: `Listening + Engagement::Locked` must yaw toward the centroid (independent of attention state).

## Test plan

- [x] `just check` (host fmt + clippy + tests)
- [x] `just clippy-firmware` (firmware strict clippy)
- [x] `just ci` (cargo-deny + workspace doc-lint)
- [ ] On-device: speak in front of stationary Stack-chan with face roughly centred — head yaws toward face within ~1 s of voice trigger
- [ ] On-device: speak with face out of cascade ROI — head falls back to upward tilt only (existing behaviour preserved)
- [ ] On-device with `tracking-trace` feature: confirm `engagement` transitions fire during voice attention runs (Idle → Locking → Locked)