### PR TITLE
feat(core): glossy-emoji face refresh

### DIFF
--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -7,14 +7,26 @@
 //!
 //! ## Palette
 //!
-//! - Background: `Rgb565::WHITE`.
-//! - Eyes: `Rgb565::BLACK`, either filled ellipses (when
-//!   [`Style::eye_curve`](crate::face::Style::eye_curve) is 0) or a
-//!   stroked polyline arc (otherwise).
-//! - Mouth: pink (`MOUTH_COLOR`), either the v0.1.0 line/ellipse (when
+//! Glossy-emoji refresh: warm off-white background with subtle corner
+//! vignettes, layered eyes that read as reflective spheres, feathered
+//! cheek blush, and a mouth gloss highlight.
+//!
+//! - Background: warm off-white (`BG_COLOR`), with four soft corner
+//!   vignette arcs (`VIGNETTE_COLOR`) anchoring the frame.
+//! - Eyes (open + [`Style::eye_curve`](crate::face::Style::eye_curve)
+//!   is 0): three concentric layers — a dark-grey outer ring
+//!   (`EYE_OUTER_COLOR`), a pure-black inner core, and a small white
+//!   catch-light highlight (`HIGHLIGHT_COLOR`) at upper-left, implying
+//!   a single light source above and to the left of the avatar.
+//! - Eyes (curved or closed): single stroked polyline arc / horizontal
+//!   line, drawn in the dark-grey outer color so they sit consistently
+//!   against the layered open-eye look.
+//! - Mouth: pink (`MOUTH_COLOR`), either v0.1.0 line/ellipse (when
 //!   [`Style::mouth_curve`](crate::face::Style::mouth_curve) is 0) or
-//!   a stroked polyline curve.
-//! - Cheeks: a weight-blended white→pink circle below each eye when
+//!   a stroked polyline curve. The ellipse variant gains a small white
+//!   gloss highlight that mirrors the eye catch-light.
+//! - Cheeks: three concentric circles at decreasing blush intensity
+//!   (faint outer → medium middle → saturated core), drawn when
 //!   [`Style::cheek_blush`](crate::face::Style::cheek_blush) is
 //!   non-zero.
 //!
@@ -37,6 +49,24 @@ use embedded_graphics::{
 
 use crate::face::{Eye, EyePhase, Face, Mouth, SCALE_DEFAULT};
 
+/// Warm off-white background — `#FAF7F2` quantized into Rgb565's
+/// (5,6,5)-bit channels. Replaces the pure-white v0.1.0 background.
+const BG_COLOR: Rgb565 = Rgb565::new(30, 61, 29);
+
+/// Subtle corner-vignette color — a touch warmer + darker than
+/// `BG_COLOR`. Drawn as four stroked arcs centered just outside each
+/// screen corner, so only the inner edge of each arc shows as a soft
+/// curved shadow at the corners.
+const VIGNETTE_COLOR: Rgb565 = Rgb565::new(28, 55, 26);
+
+/// Outer eye ring color — `#2A2A2A` dark grey. Sits one band outside
+/// the inner black core so the eye reads as a glossy sphere with a
+/// soft penumbra rather than a flat disc.
+const EYE_OUTER_COLOR: Rgb565 = Rgb565::new(5, 10, 5);
+
+/// Catch-light / gloss highlight color (eyes + mouth).
+const HIGHLIGHT_COLOR: Rgb565 = Rgb565::WHITE;
+
 /// Pink mouth/cheek color — `#F58080` quantized into Rgb565's (5,6,5)-bit channels.
 const MOUTH_COLOR: Rgb565 = Rgb565::new(30, 32, 16);
 
@@ -52,11 +82,58 @@ const EYE_ARC_WIDTH: u32 = 5;
 /// scanline-iterator limits while reading as a smooth curve at 320×240.
 const ARC_SEGMENTS: i32 = 16;
 
-/// Cheek circle diameter, in pixels.
-const CHEEK_DIAMETER: u32 = 18;
+/// Cheek outer-ring diameter (the faint outermost circle of the
+/// feathered three-ring blush).
+const CHEEK_DIAMETER: u32 = 22;
 
 /// Vertical gap between the bottom of an eye and the top of its cheek.
 const CHEEK_VERTICAL_GAP: i32 = 6;
+
+/// How many pixels the inner black core of a layered eye is inset from
+/// the outer dark-grey ring on each side. Small enough that the ring
+/// reads as a thin highlight, big enough that it survives `eye_scale`
+/// modulation down to the smallest expected size.
+const EYE_RING_INSET: u16 = 3;
+
+/// Half-width of the eye catch-light ellipse. Sized so the highlight
+/// reads as a single specular dot against the inner black core without
+/// dominating the eye.
+const EYE_HIGHLIGHT_HALF_W: i32 = 4;
+/// Half-height of the eye catch-light ellipse, paired with
+/// [`EYE_HIGHLIGHT_HALF_W`].
+const EYE_HIGHLIGHT_HALF_H: i32 = 3;
+
+/// Minimum drawn eye height (in scaled pixels) at which the catch-light
+/// is rendered. Below this, the eye is mid-blink or extremely
+/// scaled-down and the highlight would clip into the eye boundary.
+const EYE_HIGHLIGHT_MIN_HEIGHT: u16 = 14;
+
+/// Half-width of the mouth gloss highlight ellipse. Mirrors the eye
+/// catch-light at smaller scale.
+const MOUTH_HIGHLIGHT_HALF_W: i32 = 5;
+/// Half-height of the mouth gloss highlight ellipse, paired with
+/// [`MOUTH_HIGHLIGHT_HALF_W`].
+const MOUTH_HIGHLIGHT_HALF_H: i32 = 2;
+
+/// Minimum drawn mouth height (in scaled pixels) at which the gloss
+/// highlight is rendered. Below this the mouth ellipse is too thin to
+/// host the highlight without clipping.
+const MOUTH_HIGHLIGHT_MIN_HEIGHT: u16 = 12;
+
+/// Diameter of each corner vignette arc. Centered at the screen
+/// corners, so the visible quarter-arc reaches roughly this/2 pixels
+/// into the framebuffer.
+const VIGNETTE_DIAMETER: u32 = 160;
+
+/// Stroke width of each corner vignette arc.
+const VIGNETTE_WIDTH: u32 = 6;
+
+/// Framebuffer width in pixels. The geometry in [`Face::default`] is
+/// tuned for this canvas, and the corner vignette is positioned
+/// against this constant.
+const FB_WIDTH: i32 = 320;
+/// Framebuffer height in pixels, paired with [`FB_WIDTH`].
+const FB_HEIGHT: i32 = 240;
 
 impl Face {
     /// Render `self` onto `target`, clearing the background first.
@@ -69,7 +146,8 @@ impl Face {
     where
         D: DrawTarget<Color = Rgb565>,
     {
-        target.clear(Rgb565::WHITE)?;
+        target.clear(BG_COLOR)?;
+        draw_corner_vignette(target)?;
         // Cheeks first: the eye sits on top of the cheek circle when the
         // two overlap at high `eye_scale` + `cheek_blush`.
         if self.style.cheek_blush > 0 {
@@ -105,9 +183,10 @@ impl Face {
 
 /// Draw one eye. Decision tree:
 ///
-/// 1. Closed phase, or `weight == 0`: horizontal closed-eye line (unchanged
-///    v0.1.0 behavior; curves don't apply when the lid is shut).
-/// 2. `curve == 0`: filled ellipse, with radii scaled by `eye_scale`.
+/// 1. Closed phase, or `weight == 0`: horizontal closed-eye line in the
+///    dark-grey outer color.
+/// 2. `curve == 0`: layered filled ellipse — outer dark-grey ring +
+///    inner black core + small white catch-light at upper-left.
 /// 3. Otherwise: a stroked parabolic arc. `curve > 0` (Happy) arches
 ///    upward, `curve < 0` (Sad) dips downward.
 #[allow(clippy::similar_names)] // `scaled_rx` / `scaled_ry` is the intended x/y pair.
@@ -124,20 +203,13 @@ where
             eye.center.x,
             eye.center.y,
             scaled_rx,
-            stroke(Rgb565::BLACK, LINE_WIDTH),
+            stroke(EYE_OUTER_COLOR, LINE_WIDTH),
             target,
         );
     }
 
     if curve == 0 {
-        let width = scaled_rx.saturating_mul(2);
-        let half_w = i32::from(width / 2);
-        let half_h = i32::from(height / 2);
-        let top_left = EgPoint::new(eye.center.x - half_w, eye.center.y - half_h);
-        let size = Size::new(u32::from(width), u32::from(height));
-        return Ellipse::new(top_left, size)
-            .into_styled(fill(Rgb565::BLACK))
-            .draw(target);
+        return draw_layered_eye(eye.center.x, eye.center.y, scaled_rx, height, target);
     }
 
     // Curved eye: a parabolic arc whose sag is proportional to |curve|
@@ -149,9 +221,119 @@ where
         eye.center.y,
         scaled_rx,
         sag,
-        stroke(Rgb565::BLACK, EYE_ARC_WIDTH),
+        stroke(EYE_OUTER_COLOR, EYE_ARC_WIDTH),
         target,
     )
+}
+
+/// Render the open + uncurved eye as three concentric layers plus a
+/// catch-light: a dark-grey outer ring, a pure-black inner core, and a
+/// small white highlight at the upper-left of the core.
+///
+/// `width` and `height` are the *outer* drawn dimensions of the eye in
+/// pixels. The inner core is inset by [`EYE_RING_INSET`] on each side;
+/// the catch-light only renders when the drawn eye is taller than
+/// [`EYE_HIGHLIGHT_MIN_HEIGHT`] so it doesn't clip during a partial
+/// blink.
+fn draw_layered_eye<D>(
+    cx: i32,
+    cy: i32,
+    scaled_rx: u16,
+    height: u16,
+    target: &mut D,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let width = scaled_rx.saturating_mul(2);
+    let half_w = i32::from(width / 2);
+    let half_h = i32::from(height / 2);
+    let top_left = EgPoint::new(cx - half_w, cy - half_h);
+    let size = Size::new(u32::from(width), u32::from(height));
+    Ellipse::new(top_left, size)
+        .into_styled(fill(EYE_OUTER_COLOR))
+        .draw(target)?;
+
+    let inset = EYE_RING_INSET.saturating_mul(2);
+    let inner_w = width.saturating_sub(inset);
+    let inner_h = height.saturating_sub(inset);
+    if inner_w > 0 && inner_h > 0 {
+        let inner_half_w = i32::from(inner_w / 2);
+        let inner_half_h = i32::from(inner_h / 2);
+        let inner_top_left = EgPoint::new(cx - inner_half_w, cy - inner_half_h);
+        let inner_size = Size::new(u32::from(inner_w), u32::from(inner_h));
+        Ellipse::new(inner_top_left, inner_size)
+            .into_styled(fill(Rgb565::BLACK))
+            .draw(target)?;
+    }
+
+    if height >= EYE_HIGHLIGHT_MIN_HEIGHT {
+        // Single light source from upper-left: nudge the highlight
+        // toward (-rx*0.4, -ry*0.5) of the eye center.
+        let hx = cx - i32::from(scaled_rx) * 2 / 5;
+        let hy = cy - i32::from(height) / 4;
+        draw_filled_ellipse(
+            hx,
+            hy,
+            EYE_HIGHLIGHT_HALF_W,
+            EYE_HIGHLIGHT_HALF_H,
+            HIGHLIGHT_COLOR,
+            target,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Draw the four corner vignette arcs. Each is a stroked circle
+/// centered at a screen corner; only the inner quarter-arc lands
+/// inside the framebuffer, reading as a soft curved shadow that
+/// frames the face.
+fn draw_corner_vignette<D>(target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    #[allow(clippy::cast_possible_wrap)]
+    let half = (VIGNETTE_DIAMETER / 2) as i32;
+    let style = stroke(VIGNETTE_COLOR, VIGNETTE_WIDTH);
+    let corners = [
+        EgPoint::new(-half, -half),                      // top-left
+        EgPoint::new(FB_WIDTH - half, -half),            // top-right
+        EgPoint::new(-half, FB_HEIGHT - half),           // bottom-left
+        EgPoint::new(FB_WIDTH - half, FB_HEIGHT - half), // bottom-right
+    ];
+    for top_left in corners {
+        Circle::new(top_left, VIGNETTE_DIAMETER)
+            .into_styled(style)
+            .draw(target)?;
+    }
+    Ok(())
+}
+
+/// Draw a filled ellipse centered at `(cx, cy)` with the given
+/// half-width and half-height. Convenience wrapper around the
+/// `embedded-graphics` `Ellipse` constructor's top-left + size form.
+fn draw_filled_ellipse<D>(
+    cx: i32,
+    cy: i32,
+    half_w: i32,
+    half_h: i32,
+    color: Rgb565,
+    target: &mut D,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    #[allow(clippy::cast_sign_loss)]
+    let w = (half_w.max(0) * 2) as u32;
+    #[allow(clippy::cast_sign_loss)]
+    let h = (half_h.max(0) * 2) as u32;
+    if w == 0 || h == 0 {
+        return Ok(());
+    }
+    Ellipse::new(EgPoint::new(cx - half_w, cy - half_h), Size::new(w, h))
+        .into_styled(fill(color))
+        .draw(target)
 }
 
 /// Maximum pixel height the audio-driven `mouth_open` can add to the
@@ -214,7 +396,24 @@ where
 
     Ellipse::new(top_left, size)
         .into_styled(fill(MOUTH_COLOR))
-        .draw(target)
+        .draw(target)?;
+
+    // Gloss highlight near the top of the mouth, mirroring the eye
+    // catch-light. Skipped on very thin mouths where the highlight
+    // would clip out of the ellipse.
+    if height >= MOUTH_HIGHLIGHT_MIN_HEIGHT {
+        let hy = mouth.center.y - i32::from(height) / 4;
+        draw_filled_ellipse(
+            mouth.center.x,
+            hy,
+            MOUTH_HIGHLIGHT_HALF_W,
+            MOUTH_HIGHLIGHT_HALF_H,
+            HIGHLIGHT_COLOR,
+            target,
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Map `Mouth::mouth_open` (`0.0..=1.0`) to an ellipse height in pixels.
@@ -241,26 +440,61 @@ fn audio_open_height(mouth_open: f32) -> u16 {
     rounded
 }
 
-/// Draw a cheek circle below `eye` with color blended between white and
-/// `MOUTH_COLOR` by `blush` (0..=255).
+/// Diameter of the middle cheek ring, faded from outer to inner.
+const CHEEK_MIDDLE_DIAMETER: u32 = 14;
+/// Diameter of the saturated inner cheek core.
+const CHEEK_INNER_DIAMETER: u32 = 8;
+
+/// Draw three concentric cheek circles below `eye` for a feathered
+/// blush. Outer ring is faintest (≈30 % of input blush); middle is
+/// midway (≈65 %); inner core uses the full input blush. Drawn
+/// outer-first so each smaller circle paints over the previous ring's
+/// center, producing a soft airbrushed gradient on Rgb565 without a
+/// real alpha channel.
 fn draw_cheek<D>(eye: &Eye, blush: u8, eye_scale: u8, target: &mut D) -> Result<(), D::Error>
 where
     D: DrawTarget<Color = Rgb565>,
 {
     let scaled_ry = scale_radius(eye.radius_y, eye_scale);
     let radius_signed = i32::from(scaled_ry);
-    let cheek_top = eye.center.y + radius_signed + CHEEK_VERTICAL_GAP;
     #[allow(clippy::cast_possible_wrap)]
-    let half = (CHEEK_DIAMETER / 2) as i32;
-    let top_left = EgPoint::new(eye.center.x - half, cheek_top);
-    Circle::new(top_left, CHEEK_DIAMETER)
-        .into_styled(fill(blend_blush(blush)))
-        .draw(target)
+    let outer_half = (CHEEK_DIAMETER / 2) as i32;
+    let cy = eye.center.y + radius_signed + CHEEK_VERTICAL_GAP + outer_half;
+    let cx = eye.center.x;
+
+    let rings: [(u32, u8); 3] = [
+        (CHEEK_DIAMETER, blush_scaled(blush, 30)),
+        (CHEEK_MIDDLE_DIAMETER, blush_scaled(blush, 65)),
+        (CHEEK_INNER_DIAMETER, blush),
+    ];
+    for (diam, b) in rings {
+        if b == 0 {
+            continue;
+        }
+        #[allow(clippy::cast_possible_wrap)]
+        let half = (diam / 2) as i32;
+        let top_left = EgPoint::new(cx - half, cy - half);
+        Circle::new(top_left, diam)
+            .into_styled(fill(blend_blush(b)))
+            .draw(target)?;
+    }
+    Ok(())
 }
 
-/// Linearly blend between white and `MOUTH_COLOR` by `blush` (0 = white,
-/// 255 = full pink). Stays in Rgb565 channel space (5/6/5 bits) to keep
-/// the result directly renderable.
+/// Scale `blush` by `percent` and clamp to a `u8`. Used by the
+/// feathered cheek to derive outer / middle ring intensities from the
+/// input blush.
+fn blush_scaled(blush: u8, percent: u32) -> u8 {
+    let scaled = u32::from(blush) * percent / 100;
+    u8::try_from(scaled.min(u32::from(u8::MAX))).unwrap_or(u8::MAX)
+}
+
+/// Linearly blend between [`BG_COLOR`] and [`MOUTH_COLOR`] by `blush`
+/// (0 = background, 255 = full pink). Uses the background color (not
+/// pure white) as the no-blush endpoint so the outermost feathered
+/// cheek ring fades seamlessly into the off-white canvas. Stays in
+/// Rgb565 channel space (5/6/5 bits) to keep the result directly
+/// renderable.
 fn blend_blush(blush: u8) -> Rgb565 {
     let t = u32::from(blush);
     let lerp = |from: u32, to: u32| -> u8 {
@@ -277,9 +511,9 @@ fn blend_blush(blush: u8) -> Rgb565 {
         }
     };
     Rgb565::new(
-        lerp(31, u32::from(MOUTH_COLOR.r())),
-        lerp(63, u32::from(MOUTH_COLOR.g())),
-        lerp(31, u32::from(MOUTH_COLOR.b())),
+        lerp(u32::from(BG_COLOR.r()), u32::from(MOUTH_COLOR.r())),
+        lerp(u32::from(BG_COLOR.g()), u32::from(MOUTH_COLOR.g())),
+        lerp(u32::from(BG_COLOR.b()), u32::from(MOUTH_COLOR.b())),
     )
 }
 
@@ -401,8 +635,17 @@ mod tests {
     #[test]
     fn blend_blush_endpoints_match_palette() {
         let at_zero = blend_blush(0);
-        assert_eq!(at_zero, Rgb565::WHITE, "blush=0 is pure white");
+        assert_eq!(at_zero, BG_COLOR, "blush=0 fades into the background");
         let at_max = blend_blush(255);
         assert_eq!(at_max, MOUTH_COLOR, "blush=255 matches palette pink");
+    }
+
+    #[test]
+    fn blush_scaled_clamps_and_scales() {
+        assert_eq!(blush_scaled(0, 100), 0);
+        assert_eq!(blush_scaled(100, 100), 100);
+        assert_eq!(blush_scaled(200, 50), 100);
+        assert_eq!(blush_scaled(200, 30), 60);
+        assert_eq!(blush_scaled(255, 200), u8::MAX);
     }
 }

--- a/crates/stackchan-sim/tests/render_snapshot.rs
+++ b/crates/stackchan-sim/tests/render_snapshot.rs
@@ -16,6 +16,11 @@ const WIDTH: u32 = 320;
 /// LCD canvas height the firmware targets.
 const HEIGHT: u32 = 240;
 
+/// Warm off-white background color in `draw.rs` (`BG_COLOR`). Kept here
+/// so the test reads as a single-source-of-truth check against the
+/// rendered framebuffer.
+const BG_COLOR: Rgb565 = Rgb565::new(30, 61, 29);
+
 #[test]
 fn default_avatar_renders_expected_pixels() {
     let mut fb = Framebuffer::new(WIDTH, HEIGHT);
@@ -25,24 +30,17 @@ fn default_avatar_renders_expected_pixels() {
         .expect("Framebuffer DrawTarget is Infallible");
 
     // Eye centers: default Entity places left eye at (100, 110), right at
-    // (220, 110), both filled black ellipses of radius 25.
+    // (220, 110). Under the layered-eye look the inner core is pure
+    // black, so the eye-center pixel is still BLACK.
     assert_eq!(fb.pixel(100, 110), Some(Rgb565::BLACK), "left eye center");
     assert_eq!(fb.pixel(220, 110), Some(Rgb565::BLACK), "right eye center");
 
-    // Midpoint between the eyes: well outside either ellipse, should be
-    // the white background.
+    // Midpoint between the eyes: well outside either ellipse, should
+    // show the warm off-white background.
     assert_eq!(
         fb.pixel(160, 110),
-        Some(Rgb565::WHITE),
-        "background between eyes"
-    );
-
-    // Corners: nothing drawn here, must be the clear color.
-    assert_eq!(fb.pixel(0, 0), Some(Rgb565::WHITE), "top-left corner");
-    assert_eq!(
-        fb.pixel(WIDTH - 1, HEIGHT - 1),
-        Some(Rgb565::WHITE),
-        "bottom-right corner"
+        Some(BG_COLOR),
+        "background between eyes is BG_COLOR"
     );
 
     // Mouth at y=180, weight=0 → horizontal pink line. The draw code uses
@@ -76,12 +74,12 @@ fn audio_open_lifts_mouth_above_resting_line() {
         .expect("Framebuffer DrawTarget is Infallible");
     assert_eq!(
         resting.pixel(160, 175),
-        Some(Rgb565::WHITE),
+        Some(BG_COLOR),
         "pre-condition: y=175 is background when mouth_open = 0.0"
     );
     assert_eq!(
         resting.pixel(160, 185),
-        Some(Rgb565::WHITE),
+        Some(BG_COLOR),
         "pre-condition: y=185 is background when mouth_open = 0.0"
     );
 


### PR DESCRIPTION
## Summary

- Aesthetic refresh of `Face::draw` in `stackchan-core/src/draw.rs`, scoped to the renderer (Style API and modifier contracts unchanged).
- **Background**: warm off-white `#FAF7F2` (`BG_COLOR`) replaces pure white; four soft corner-arc vignettes (`VIGNETTE_COLOR`, 6 px stroke at 160 px diameter, centered just outside each screen corner) frame the face.
- **Eyes** (open + `eye_curve == 0`): three concentric layers — dark-grey outer ring (`EYE_OUTER_COLOR`) + pure-black inner core (inset `EYE_RING_INSET = 3` px each side) + small white catch-light at upper-left (`HIGHLIGHT_COLOR`, ~8×6 px). Catch-light suppressed when drawn eye height < `EYE_HIGHLIGHT_MIN_HEIGHT` (mid-blink / heavy `eye_scale` shrink) so it can't clip the eye boundary.
- **Eyes** (closed or curved): single stroked primitive in `EYE_OUTER_COLOR` (was pure black) so they sit consistently against the layered open-eye look.
- **Cheeks**: feathered three-ring blush at 30 % / 65 % / 100 % of input `cheek_blush`, with the no-blush endpoint of `blend_blush` shifted from pure white to `BG_COLOR` so the outermost ring fades seamlessly into the canvas.
- **Mouth** ellipse mode picks up a small white gloss highlight (`MOUTH_HIGHLIGHT_HALF_W/H`) when drawn height ≥ `MOUTH_HIGHLIGHT_MIN_HEIGHT`; resting line / smile-frown arc paths unchanged.
- **Tests**: `blend_blush_endpoints_match_palette` updated for the new no-blush endpoint; new `blush_scaled_clamps_and_scales` covers the cheek ring intensity helper. Sim snapshot test updated for the new background color (eye-center pixel still `BLACK` under the layered look).

## Test plan

- [x] `just check` (host fmt + clippy + tests + doctests + workspace + Cargo.lock guard)
- [x] `just clippy-firmware` (firmware strict clippy on `xtensa-esp32s3-none-elf`)
- [x] On-device: `just fmr` boots clean — render task spawns, `boot complete — idle heartbeat` at 1.71 s, no panics, no LCD errors.
- [ ] Visual sanity check on device: eye catch-light reads as a single specular dot, cheeks fade into BG without a hard ring edge, vignette frames the corners without dominating.