### PR TITLE
chore(deps): bump embedded-sdmmc from 0.8.2 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,13 +1639,14 @@ dependencies = [
 
 [[package]]
 name = "embedded-sdmmc"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1132a10f327a9dff9d0629124e8b26cb2b3a930ab3dfedbadd295c107955e92"
+checksum = "ce3c7f9ea039eeafc4a49597b7bd5ae3a1c8e51b2803a381cb0f29ce90fe1ec6"
 dependencies = [
  "byteorder",
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
+ "embedded-io 0.6.1",
  "heapless 0.8.0",
 ]
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -41,7 +41,7 @@ stackchan-net = { path = "../stackchan-net", default-features = false }
 # in `sd_spi.rs` provides the SD-side adapter (with GPIO35 OE flip).
 # Sync (blocking); SD I/O happens at boot + during `PUT /settings`,
 # never during steady-state render.
-embedded-sdmmc = { version = "0.8", default-features = false, features = ["defmt-log"] }
+embedded-sdmmc = { version = "0.9", default-features = false, features = ["defmt-log"] }
 # `heapless::Vec` for the per-frame multi-target candidate list
 # translated from `tracker::Outcome.candidates` into the engine's
 # `TrackingObservation`. Matches the cap (`MAX_CANDIDATES`).
@@ -53,7 +53,7 @@ heapless = "0.8"
 # BLE module reaches for `heapless_09`.
 heapless_09 = { package = "heapless", version = "0.9" }
 embedded-graphics = { workspace = true }
-# `embedded_hal::spi::SpiDevice` (sync) is what `embedded-sdmmc 0.8`
+# `embedded_hal::spi::SpiDevice` (sync) is what `embedded-sdmmc`
 # wants from the SD client wrapper. The async equivalent is also
 # imported below for shared-bus I²C and other tasks.
 embedded-hal = { workspace = true }

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -221,7 +221,7 @@ where
         // Force card init by querying capacity. Returns once the SD
         // has answered ACMD41 and entered the data state.
         sd_card.num_bytes().map_err(|_| StorageError::CardInit)?;
-        let mut mgr = VolumeManager::new(sd_card, EpochTime);
+        let mgr = VolumeManager::new(sd_card, EpochTime);
         // Probe FAT volume 0 and immediately drop the handle — we
         // re-open per call so callers don't have to thread lifetimes.
         // Explicit `drop` so the borrow on `mgr` ends before we move
@@ -242,12 +242,12 @@ where
     /// [`StorageError::TooLarge`] if the file exceeds `MAX_CONFIG_BYTES`,
     /// [`StorageError::NotUtf8`] / [`StorageError::Decode`] on parse failure.
     pub fn read_config(&mut self) -> Result<stackchan_net::Config, StorageError> {
-        let mut volume = self
+        let volume = self
             .mgr
             .open_volume(VolumeIdx(0))
             .map_err(|_| StorageError::Volume)?;
-        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
-        let mut file = root
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let file = root
             .open_file_in_dir(CONFIG_FILE, Mode::ReadOnly)
             .map_err(|_| StorageError::FileNotFound)?;
 
@@ -294,12 +294,12 @@ where
     /// [`StorageError::TooLarge`] if the file exceeds
     /// [`MAX_BONDS_BYTES`].
     pub fn read_bonds(&mut self) -> Result<Vec<u8>, StorageError> {
-        let mut volume = self
+        let volume = self
             .mgr
             .open_volume(VolumeIdx(0))
             .map_err(|_| StorageError::Volume)?;
-        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
-        let Ok(mut file) = root.open_file_in_dir(BONDS_FILE, Mode::ReadOnly) else {
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(file) = root.open_file_in_dir(BONDS_FILE, Mode::ReadOnly) else {
             return Ok(Vec::new());
         };
         let len = file.length();
@@ -351,13 +351,13 @@ where
     }
 
     /// Truncate-write `data` into `name`.
-    fn write_file(&mut self, name: &str, data: &[u8]) -> Result<(), StorageError> {
-        let mut volume = self
+    fn write_file(&self, name: &str, data: &[u8]) -> Result<(), StorageError> {
+        let volume = self
             .mgr
             .open_volume(VolumeIdx(0))
             .map_err(|_| StorageError::Volume)?;
-        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
-        let mut file = root
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let file = root
             .open_file_in_dir(name, Mode::ReadWriteCreateOrTruncate)
             .map_err(|_| StorageError::Write)?;
         file.write(data).map_err(|_| StorageError::Write)?;
@@ -366,19 +366,19 @@ where
     }
 
     /// Copy `from`'s bytes into `to` (truncating any prior `to`),
-    /// then delete `from`. embedded-sdmmc 0.8 has no first-class
-    /// rename, so we do the copy-and-delete dance — the cost is
-    /// the file's read+write twice, which for the schema-v1 config
-    /// (<1 KiB) is negligible.
-    fn copy_then_delete(&mut self, from: &str, to: &str) -> Result<(), StorageError> {
-        let mut volume = self
+    /// then delete `from`. embedded-sdmmc has no first-class rename,
+    /// so we do the copy-and-delete dance — the cost is the file's
+    /// read+write twice, which for the schema-v1 config (<1 KiB) is
+    /// negligible.
+    fn copy_then_delete(&self, from: &str, to: &str) -> Result<(), StorageError> {
+        let volume = self
             .mgr
             .open_volume(VolumeIdx(0))
             .map_err(|_| StorageError::Volume)?;
-        let mut root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
 
         let staged: Vec<u8> = {
-            let mut src = root
+            let src = root
                 .open_file_in_dir(from, Mode::ReadOnly)
                 .map_err(|_| StorageError::Write)?;
             let len = src.length();
@@ -392,7 +392,7 @@ where
         };
 
         {
-            let mut dst = root
+            let dst = root
                 .open_file_in_dir(to, Mode::ReadWriteCreateOrTruncate)
                 .map_err(|_| StorageError::Write)?;
             dst.write(&staged).map_err(|_| StorageError::Write)?;


### PR DESCRIPTION
## Summary

- Bumps `embedded-sdmmc` 0.8.2 → 0.9.0 in `crates/stackchan-firmware`.
- 0.9 moves the navigator API (`open_root_dir`, `open_file_in_dir`, `read`, `write`, `flush`) from `&mut self` to `&self` via interior mutability. Strict clippy (`-D warnings`) flags the now-needless `mut` bindings; this PR removes them.
- The two private helpers (`write_file`, `copy_then_delete`) drop from `&mut self` to `&self` to satisfy `clippy::needless_pass_by_ref_mut`. Public `Storage` methods stay `&mut self` so the SD-bus serialization invariant the shared lock implies stays explicit at the API surface.
- Supersedes #181 (dependabot's bump only touched the manifest + lockfile; the clippy follow-through is what was missing).

## Test plan

- [x] `cargo +esp clippy --release -- -D warnings` (firmware) — clean
- [x] `cargo +esp build --release` (firmware) — builds
- [x] `just check` (host fmt + clippy + tests + doctests) — passes
- [ ] Smoke-flash to device — config read/write + bonds round-trip + capture write