### PR TITLE
chore(ci): add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Add a `github-actions` entry to `.github/dependabot.yml` so pinned action versions in `.github/workflows/*.yml` get bumped weekly alongside cargo deps.
- Drop the GitHub-generated boilerplate comments now that the file is real config.

## Test plan
- [x] `dependabot.yml` syntax is the standard `version: 2` schema with two ecosystem entries
- [ ] After merge: confirm Dependabot picks up the new ecosystem on its next weekly run (no immediate-on-merge trigger; check the Insights → Dependency graph → Dependabot tab to validate the config parsed)