### PR TITLE
feat(firmware): live introspection — sensors, events, task health

### DIFF
--- a/crates/stackchan-firmware/src/ambient.rs
+++ b/crates/stackchan-firmware/src/ambient.rs
@@ -52,6 +52,7 @@ pub async fn run_ambient_loop<I: AsyncI2c>(bus: I) -> ! {
         crate::watchdog::AMBIENT.beat();
         match als.read_ambient().await {
             Ok(reading) => {
+                crate::net::snapshot::update_ambient_lux(reading.lux);
                 AMBIENT_LUX_SIGNAL.signal(reading.lux);
                 defmt::debug!(
                     "LTR-553: ch0={=u16} ch1={=u16} lux={=f32}",

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -832,6 +832,7 @@ async fn run_rms_loop<BUFFER>(
                     );
                 }
                 consecutive_dma_errs = consecutive_dma_errs.saturating_add(1);
+                crate::net::snapshot::update_audio_rms(0.0);
                 AUDIO_RMS_SIGNAL.signal(AudioRms(0.0));
                 sum_sq = 0.0;
                 count = 0;
@@ -880,6 +881,7 @@ async fn run_rms_loop<BUFFER>(
                 // above 1.0 (~3e-5). Clamp so consumers can rely on the
                 // documented [0, 1] contract.
                 let rms_norm = (mean_sq / FULL_SCALE_SQ).sqrt().min(1.0);
+                crate::net::snapshot::update_audio_rms(rms_norm);
                 AUDIO_RMS_SIGNAL.signal(AudioRms(rms_norm));
 
                 sum_sq = 0.0;

--- a/crates/stackchan-firmware/src/body_touch.rs
+++ b/crates/stackchan-firmware/src/body_touch.rs
@@ -56,10 +56,14 @@ pub async fn run_body_touch_loop<I: AsyncI2c>(bus: I) -> ! {
     loop {
         match chip.read_touch().await {
             Ok(touch) => {
+                let left = intensity_u8(touch.intensity.0);
+                let centre = intensity_u8(touch.intensity.1);
+                let right = intensity_u8(touch.intensity.2);
+                crate::net::snapshot::update_body_touch(left, centre, right);
                 BODY_TOUCH_SIGNAL.signal(BodyTouch {
-                    left: intensity_u8(touch.intensity.0),
-                    centre: intensity_u8(touch.intensity.1),
-                    right: intensity_u8(touch.intensity.2),
+                    left,
+                    centre,
+                    right,
                 });
             }
             Err(e) => defmt::warn!("Si12T: read_touch failed: {}", defmt::Debug2Format(&e),),

--- a/crates/stackchan-firmware/src/event_log.rs
+++ b/crates/stackchan-firmware/src/event_log.rs
@@ -1,0 +1,171 @@
+//! Bounded RAM ring of operator-visible events.
+//!
+//! Records lifecycle transitions (boot, Wi-Fi up/down, SD mount), control
+//! actions (authenticated POSTs), and warnings. The HTTP handler reads
+//! recent entries via `GET /events` so an operator can see what the
+//! device did without having to attach to defmt-over-USB.
+//!
+//! Storage: a single critical-section-guarded `[Entry; CAP]` ring — small
+//! enough to live in internal SRAM. Volatile by design (drains on reset);
+//! persistent panic capture is a separate concern.
+
+use core::fmt::Write as _;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_time::Instant;
+use heapless::String;
+
+/// Capacity of the ring.
+///
+/// 128 slots × ~88 bytes ≈ 11 KiB — tiny enough for internal SRAM.
+pub const CAP: usize = 128;
+
+/// Maximum length of an event message.
+///
+/// 64 bytes is enough for any `format!`-style line the firmware emits today.
+pub const MSG_MAX: usize = 64;
+
+/// Event severity / source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    /// Boot, Wi-Fi link transitions, SD mount/unmount, settings PUT.
+    Lifecycle,
+    /// Authenticated control-plane action (POST /emotion, /look-at, ...).
+    Control,
+    /// Anything the firmware also emitted at warn/error level.
+    Warn,
+}
+
+impl Kind {
+    /// Wire-format label written into the JSON response.
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Lifecycle => "lifecycle",
+            Self::Control => "control",
+            Self::Warn => "warn",
+        }
+    }
+}
+
+/// One ring entry.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    /// Monotonic-clock timestamp at the moment of recording.
+    pub at_ms: u64,
+    /// Severity / source bucket.
+    pub kind: Kind,
+    /// Human-readable message, capped at [`MSG_MAX`].
+    pub message: String<MSG_MAX>,
+}
+
+impl Entry {
+    /// All-zero placeholder. Used for ring-buffer initialisation; the
+    /// reader skips entries with `at_ms == 0` until the producer
+    /// overwrites them.
+    const fn empty() -> Self {
+        Self {
+            at_ms: 0,
+            kind: Kind::Lifecycle,
+            message: String::new(),
+        }
+    }
+}
+
+/// Ring-buffer state behind a single critical-section mutex.
+///
+/// Writes are rare (bounded by control actions + lifecycle transitions);
+/// reads are rare (HTTP request). Lock contention is a non-issue, so a
+/// blocking mutex keeps the call sites cheap and lets the panic handler
+/// — when it eventually lands — reach this without going through async.
+struct Ring {
+    /// Head index — next write position. Wraps at [`CAP`].
+    head: usize,
+    /// Total writes since boot. Used to compute the iteration start
+    /// point and to expose a monotonically-increasing event count.
+    total: u64,
+    /// Backing storage. Empty entries (`at_ms == 0`) before `total >=
+    /// CAP` are skipped by the reader.
+    slots: [Entry; CAP],
+}
+
+impl Ring {
+    /// Construct an empty ring.
+    const fn new() -> Self {
+        Self {
+            head: 0,
+            total: 0,
+            slots: [const { Entry::empty() }; CAP],
+        }
+    }
+}
+
+/// The single backing ring. Locked via a blocking critical-section
+/// mutex; held only across short cell-replace operations.
+static RING: Mutex<CriticalSectionRawMutex, core::cell::RefCell<Ring>> =
+    Mutex::new(core::cell::RefCell::new(Ring::new()));
+
+/// Record an event. Truncates the message at [`MSG_MAX`] without
+/// erroring — operator-visible noise should never panic the firmware.
+pub fn record(kind: Kind, message: &str) {
+    let mut msg: String<MSG_MAX> = String::new();
+    if msg.push_str(message).is_err() {
+        // Fall back to a char-by-char copy that respects boundaries.
+        msg.clear();
+        for ch in message.chars() {
+            if msg.push(ch).is_err() {
+                break;
+            }
+        }
+    }
+    let now = Instant::now().as_millis();
+    RING.lock(|cell| {
+        let mut ring = cell.borrow_mut();
+        let head = ring.head;
+        ring.slots[head] = Entry {
+            at_ms: now,
+            kind,
+            message: msg,
+        };
+        ring.head = (head + 1) % CAP;
+        ring.total = ring.total.saturating_add(1);
+    });
+}
+
+/// Convenience for the common `format!`-style call path.
+pub fn record_fmt(kind: Kind, args: core::fmt::Arguments<'_>) {
+    let mut buf: String<MSG_MAX> = String::new();
+    let _ = buf.write_fmt(args);
+    record(kind, &buf);
+}
+
+/// Snapshot copy of the most recent up-to-`limit` entries, oldest first.
+///
+/// Returns the total event count and a `heapless::Vec` so the caller can
+/// shape the JSON payload without holding the mutex across the write.
+#[must_use]
+pub fn drain_recent(limit: usize) -> (u64, heapless::Vec<Entry, CAP>) {
+    let take = limit.min(CAP);
+    RING.lock(|cell| {
+        let ring = cell.borrow();
+        let mut out: heapless::Vec<Entry, CAP> = heapless::Vec::new();
+        if ring.total == 0 {
+            return (0, out);
+        }
+        // `total` is u64 but always clamps to CAP for indexing — usize
+        // suffices and the cast can't truncate after `min(CAP)`.
+        let total_usize = usize::try_from(ring.total).unwrap_or(usize::MAX);
+        let count = total_usize.min(CAP).min(take);
+        // Walk back `count` slots from `head` (exclusive) so the result
+        // is oldest-first within the window the caller asked for.
+        let start = (ring.head + CAP - count) % CAP;
+        for i in 0..count {
+            let entry = &ring.slots[(start + i) % CAP];
+            // Bounded `heapless::Vec` — the `count.min(CAP).min(take)`
+            // upper bound guarantees push always succeeds.
+            let _ = out.push(entry.clone());
+        }
+        (ring.total, out)
+    })
+}

--- a/crates/stackchan-firmware/src/imu.rs
+++ b/crates/stackchan-firmware/src/imu.rs
@@ -106,7 +106,10 @@ pub async fn run_imu_loop<I: AsyncI2c>(bus: I) -> ! {
     loop {
         crate::watchdog::IMU.beat();
         match imu.read_measurement().await {
-            Ok(m) => IMU_SIGNAL.signal(m),
+            Ok(m) => {
+                crate::net::snapshot::update_imu(m.accel_g, m.gyro_dps);
+                IMU_SIGNAL.signal(m);
+            }
             Err(e) => defmt::warn!("BMI270: read failed: {}", defmt::Debug2Format(&e)),
         }
         ticker.next().await;

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -25,6 +25,7 @@ pub mod body_touch;
 pub mod button;
 pub mod camera;
 pub mod clock;
+pub mod event_log;
 pub mod framebuffer;
 pub mod head;
 pub mod imu;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -25,8 +25,8 @@
 extern crate alloc;
 
 use stackchan_firmware::{
-    ambient, audio, ble, board, body_touch, button, camera, clock, framebuffer, head, imu, ir,
-    leds, net, power, storage, touch, tracking_trace, wallclock, watchdog,
+    ambient, audio, ble, board, body_touch, button, camera, clock, event_log, framebuffer, head,
+    imu, ir, leds, net, power, storage, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -1191,6 +1191,7 @@ async fn main(spawner: Spawner) -> ! {
     }
 
     defmt::info!("boot complete — idle heartbeat");
+    event_log::record(event_log::Kind::Lifecycle, "boot complete");
     loop {
         Timer::after(Duration::from_secs(5)).await;
         defmt::debug!("heartbeat");

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -14,6 +14,14 @@
 //!   `AvatarSnapshot` updates. Sends an initial event on connect,
 //!   then one event per change (throttled at the producer to ~10 Hz),
 //!   plus a `: heartbeat` SSE comment every 15 s.
+//! - `GET /sensors` — `SensorsSnapshot` JSON: IMU accel/gyro,
+//!   ambient lux, audio RMS, body-touch zones. Mirrored from each
+//!   producer task into a snapshot static so the HTTP read never
+//!   touches the source `Signal` channels (single-consumer/race).
+//! - `GET /tasks` — watchdog channel health: per-task heartbeat
+//!   delta in the last window + a `stale` flag.
+//! - `GET /events` — recent operator-visible events (lifecycle,
+//!   control actions, warnings) from a bounded RAM ring.
 //! - `POST /emotion` — JSON `{"emotion": "...", "hold_ms": ...}`.
 //!   Sets affect + holds `mind.autonomy` against the autonomous
 //!   emotion drivers for `hold_ms` (default
@@ -284,6 +292,13 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         if !authorized {
             return Err(HttpError::Unauthorized);
         }
+        // Record every authenticated write so an operator can see what
+        // the dashboard / nRF Connect / curl session has been doing.
+        // Stays after the auth gate to avoid logging probe traffic.
+        crate::event_log::record_fmt(
+            crate::event_log::Kind::Control,
+            format_args!("{method} {path}"),
+        );
     }
 
     match (method, path) {
@@ -291,6 +306,18 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("GET", "/health") => write_json(socket, 200, &health_body()).await,
         ("GET", "/state") => write_json(socket, 200, &state_body(snapshot::read())).await,
         ("GET", "/state/stream") => handle_state_stream(socket).await,
+        ("GET", "/sensors") => {
+            write_json(socket, 200, &sensors_body(snapshot::read_sensors())).await
+        }
+        ("GET", "/tasks") => {
+            write_json(
+                socket,
+                200,
+                &tasks_body(crate::watchdog::read_tasks_snapshot()),
+            )
+            .await
+        }
+        ("GET", "/events") => write_json(socket, 200, &events_body()).await,
         ("GET", "/settings") => handle_get_settings(socket).await,
         ("PUT", "/settings") => handle_put_settings(socket, body).await,
         ("POST", "/emotion") => handle_remote(socket, json::parse_set_emotion(body)).await,
@@ -445,6 +472,7 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
                 new_config.wifi.ssid.as_str(),
                 new_config.mdns.hostname.as_str()
             );
+            crate::event_log::record(crate::event_log::Kind::Lifecycle, "settings persisted");
             // Soft-reconnect Wi-Fi only when the credentials actually
             // changed. Comparing against the pre-merge snapshot avoids
             // a needless link drop when the dashboard re-PUTs the
@@ -666,6 +694,100 @@ fn state_body(s: AvatarSnapshot) -> String {
         muted = s.audio.muted,
         camera_mode = s.camera_mode,
     )
+}
+
+/// Serialise the `/sensors` body. `null` for sensors that haven't
+/// produced a sample yet; numbers (with two decimal places for accel /
+/// gyro / lux, four for the audio-RMS norm) elsewhere.
+fn sensors_body(s: snapshot::SensorsSnapshot) -> String {
+    let imu = s.imu.map_or_else(
+        || String::from("null"),
+        |i| {
+            let (ax, ay, az) = i.accel_g;
+            let (gx, gy, gz) = i.gyro_dps;
+            format!(
+                "{{\"accel_g\":[{ax:.3},{ay:.3},{az:.3}],\"gyro_dps\":[{gx:.2},{gy:.2},{gz:.2}]}}"
+            )
+        },
+    );
+    let lux = s
+        .ambient_lux
+        .map_or_else(|| String::from("null"), |l| format!("{l:.2}"));
+    let body_touch = s.body_touch.map_or_else(
+        || String::from("null"),
+        |b| {
+            format!(
+                "{{\"left\":{},\"centre\":{},\"right\":{}}}",
+                b.left, b.centre, b.right
+            )
+        },
+    );
+    format!(
+        "{{\"imu\":{imu},\"ambient_lux\":{lux},\"audio_rms\":{rms:.4},\"body_touch\":{body_touch}}}\n",
+        rms = s.audio_rms,
+    )
+}
+
+/// Serialise the `/tasks` body — per-channel watchdog health.
+fn tasks_body(s: crate::watchdog::TasksSnapshot) -> String {
+    use core::fmt::Write as _;
+    let mut out = format!("{{\"window_ms\":{},\"channels\":[", s.window_ms);
+    for (i, ch) in s.channels.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        let _ = write!(
+            out,
+            "{{\"name\":\"{}\",\"delta\":{},\"min_per_window\":{},\"stale\":{}}}",
+            ch.name, ch.delta, ch.min_per_window, ch.stale
+        );
+    }
+    out.push_str("]}\n");
+    out
+}
+
+/// Serialise the `/events` body — recent ring entries, oldest first.
+fn events_body() -> String {
+    use crate::event_log;
+    use core::fmt::Write as _;
+    let (total, entries) = event_log::drain_recent(event_log::CAP);
+    let mut out = format!("{{\"total\":{total},\"events\":[");
+    for (i, e) in entries.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        let _ = write!(
+            out,
+            "{{\"at_ms\":{},\"kind\":\"{}\",\"message\":\"{}\"}}",
+            e.at_ms,
+            e.kind.wire_str(),
+            json_escape(&e.message),
+        );
+    }
+    out.push_str("]}\n");
+    out
+}
+
+/// Minimal JSON string escaper — backslash, quote, and control bytes
+/// get the `\\uNNNN` form. Event messages are firmware-controlled (no
+/// user input lands here unredacted) so this stays simple.
+fn json_escape(s: &str) -> String {
+    use core::fmt::Write as _;
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Write `status` + `body` as `application/json`.

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -176,6 +176,107 @@ pub fn update_audio(audio: AudioConfig) {
     });
 }
 
+/// Sensors snapshot — populated by the producer tasks via the
+/// `update_*` mirrors below.
+///
+/// HTTP reads through [`read_sensors`] for `GET /sensors` without ever
+/// touching the source `Signal` channels (which are single-consumer /
+/// latest-wins by design — the render task already drains them).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct SensorsSnapshot {
+    /// Most recent IMU reading. `None` until the BMI270 init succeeds.
+    pub imu: Option<ImuFields>,
+    /// Most recent ambient-light reading in lux. `None` until the
+    /// `LTR-553` publishes its first sample.
+    pub ambient_lux: Option<f32>,
+    /// Most recent microphone-RMS sample, normalised 0..=1. `0.0`
+    /// before the audio task spins up (the audio loop publishes
+    /// `AudioRms(0.0)` on DMA stalls too, so this overlaps).
+    pub audio_rms: f32,
+    /// Latest body-touch zones (left, centre, right) on the
+    /// 0..=3 intensity scale. `None` until `Si12T` init reports a value.
+    pub body_touch: Option<BodyTouchFields>,
+}
+
+/// Wire-format IMU sample.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ImuFields {
+    /// Accelerometer reading in g units.
+    pub accel_g: (f32, f32, f32),
+    /// Gyroscope reading in degrees per second.
+    pub gyro_dps: (f32, f32, f32),
+}
+
+/// Wire-format body-touch reading. Mirrors `stackchan_core::BodyTouch`
+/// but lives here so the HTTP layer can serialize it without pulling
+/// in core's wider type surface.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BodyTouchFields {
+    /// Left-zone intensity 0..=3.
+    pub left: u8,
+    /// Centre-zone intensity 0..=3.
+    pub centre: u8,
+    /// Right-zone intensity 0..=3.
+    pub right: u8,
+}
+
+/// Backing static. Updates use cell-replace under a critical section
+/// to match the rest of this module's `Cell<T>`-in-`Mutex` pattern.
+pub static SENSORS_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<SensorsSnapshot>> =
+    Mutex::new(core::cell::Cell::new(SensorsSnapshot {
+        imu: None,
+        ambient_lux: None,
+        audio_rms: 0.0,
+        body_touch: None,
+    }));
+
+/// Read the current sensors snapshot.
+#[must_use]
+pub fn read_sensors() -> SensorsSnapshot {
+    SENSORS_SNAPSHOT.lock(core::cell::Cell::get)
+}
+
+/// Mirror an IMU sample. Called by the IMU task right after each
+/// successful read.
+pub fn update_imu(accel_g: (f32, f32, f32), gyro_dps: (f32, f32, f32)) {
+    SENSORS_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.imu = Some(ImuFields { accel_g, gyro_dps });
+        cell.set(s);
+    });
+}
+
+/// Mirror the latest ambient-light reading.
+pub fn update_ambient_lux(lux: f32) {
+    SENSORS_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.ambient_lux = Some(lux);
+        cell.set(s);
+    });
+}
+
+/// Mirror the latest audio-RMS sample (already normalised 0..=1).
+pub fn update_audio_rms(rms: f32) {
+    SENSORS_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.audio_rms = rms;
+        cell.set(s);
+    });
+}
+
+/// Mirror the latest body-touch zone state.
+pub fn update_body_touch(left: u8, centre: u8, right: u8) {
+    SENSORS_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.body_touch = Some(BodyTouchFields {
+            left,
+            centre,
+            right,
+        });
+        cell.set(s);
+    });
+}
+
 /// Replace the camera-mode field.
 ///
 /// Called by every producer of [`crate::camera::CAMERA_MODE_SIGNAL`]

--- a/crates/stackchan-firmware/src/net/wifi.rs
+++ b/crates/stackchan-firmware/src/net/wifi.rs
@@ -165,6 +165,7 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
         match connect_outcome {
             Either::First(Ok(())) => {
                 defmt::info!("wifi: connected");
+                crate::event_log::record(crate::event_log::Kind::Lifecycle, "wifi: connected");
                 WIFI_LINK_SIGNAL.signal(WifiLinkState::Connected);
                 LINK_READY.store(true, Ordering::Release);
                 backoff_idx = 0;
@@ -177,6 +178,10 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
                 match live_outcome {
                     Either::First(()) => {
                         defmt::warn!("wifi: link dropped; reconnecting");
+                        crate::event_log::record(
+                            crate::event_log::Kind::Warn,
+                            "wifi: link dropped",
+                        );
                         WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
                     }
                     Either::Second(new_creds) => {

--- a/crates/stackchan-firmware/src/watchdog.rs
+++ b/crates/stackchan-firmware/src/watchdog.rs
@@ -18,6 +18,8 @@
 
 use core::sync::atomic::{AtomicU32, Ordering};
 
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_time::{Duration, Ticker};
 
 /// How often the watchdog task wakes to check every channel. 5 s gives
@@ -96,11 +98,104 @@ pub static POWER: Channel = Channel::new("power", 3);
 /// `SCServo` head-update loop. Beats once per 20 ms command tick.
 pub static HEAD: Channel = Channel::new("head", 150);
 
-/// Iterate every channel and warn on staleness. Internal helper, but
-/// exposed for unit testability.
+/// One row of [`TasksSnapshot`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TaskHealth {
+    /// Channel name. Stable identifier the dashboard renders.
+    pub name: &'static str,
+    /// Beats observed in the last [`WATCHDOG_PERIOD_MS`] window.
+    pub delta: u32,
+    /// Minimum acceptable beats per window — below this is stale.
+    pub min_per_window: u32,
+    /// Whether the last poll's delta fell below `min_per_window`.
+    pub stale: bool,
+}
+
+/// Read-side mirror of every monitored channel. Updated by
+/// [`run_watchdog_loop`] after each `check_all`; HTTP reads via
+/// [`read_tasks_snapshot`].
+#[derive(Debug, Clone, Copy)]
+pub struct TasksSnapshot {
+    /// Per-channel health, in declaration order.
+    pub channels: [TaskHealth; 5],
+    /// Window length in ms — surfaced so the dashboard can label the
+    /// "beats in last X" without hard-coding it on the JS side.
+    pub window_ms: u64,
+}
+
+impl TasksSnapshot {
+    /// Construct a snapshot with zero-delta entries for every channel.
+    /// Used as the initial value of [`TASKS_SNAPSHOT`] before the
+    /// watchdog has run its first poll.
+    const fn empty() -> Self {
+        Self {
+            channels: [
+                TaskHealth {
+                    name: "audio",
+                    delta: 0,
+                    min_per_window: AUDIO_MIN_PER_WINDOW,
+                    stale: false,
+                },
+                TaskHealth {
+                    name: "imu",
+                    delta: 0,
+                    min_per_window: IMU_MIN_PER_WINDOW,
+                    stale: false,
+                },
+                TaskHealth {
+                    name: "ambient",
+                    delta: 0,
+                    min_per_window: AMBIENT_MIN_PER_WINDOW,
+                    stale: false,
+                },
+                TaskHealth {
+                    name: "power",
+                    delta: 0,
+                    min_per_window: POWER_MIN_PER_WINDOW,
+                    stale: false,
+                },
+                TaskHealth {
+                    name: "head",
+                    delta: 0,
+                    min_per_window: HEAD_MIN_PER_WINDOW,
+                    stale: false,
+                },
+            ],
+            window_ms: WATCHDOG_PERIOD_MS,
+        }
+    }
+}
+
+/// Audio RMS loop — 33 ms tick, 50% jitter margin.
+const AUDIO_MIN_PER_WINDOW: u32 = 75;
+/// IMU polling loop — 10 ms tick, 50% jitter margin.
+const IMU_MIN_PER_WINDOW: u32 = 300;
+/// Ambient-light polling loop — 500 ms tick, 50% jitter margin.
+const AMBIENT_MIN_PER_WINDOW: u32 = 5;
+/// AXP2101 polling loop — 1 s tick, 50% jitter margin.
+const POWER_MIN_PER_WINDOW: u32 = 3;
+/// `SCServo` head loop — 20 ms tick, 50% jitter margin.
+const HEAD_MIN_PER_WINDOW: u32 = 150;
+
+/// Read-side mirror of every channel's last-poll outcome. Updated
+/// by [`run_watchdog_loop`] after each `check_all`; HTTP reads via
+/// [`read_tasks_snapshot`].
+static TASKS_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<TasksSnapshot>> =
+    Mutex::new(core::cell::Cell::new(TasksSnapshot::empty()));
+
+/// Cheap snapshot read for the HTTP `GET /tasks` handler.
+#[must_use]
+pub fn read_tasks_snapshot() -> TasksSnapshot {
+    TASKS_SNAPSHOT.lock(core::cell::Cell::get)
+}
+
+/// Iterate every channel, warn on staleness, and refresh
+/// [`TASKS_SNAPSHOT`]. Internal helper, but exposed for unit
+/// testability.
 fn check_all() {
     let channels: &[&Channel] = &[&AUDIO, &IMU, &AMBIENT, &POWER, &HEAD];
-    for ch in channels {
+    let mut snap = TasksSnapshot::empty();
+    for (i, ch) in channels.iter().enumerate() {
         let (delta, stale) = ch.check_and_reset();
         if stale {
             defmt::warn!(
@@ -111,7 +206,10 @@ fn check_all() {
                 ch.min_per_window,
             );
         }
+        snap.channels[i].delta = delta;
+        snap.channels[i].stale = stale;
     }
+    TASKS_SNAPSHOT.lock(|cell| cell.set(snap));
 }
 
 /// Embassy task entry point. Spawned once from `main.rs`. Runs the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,10 @@ import { State } from "./components/State";
 import { Emotion } from "./components/Emotion";
 import { LookAt } from "./components/LookAt";
 import { Audio } from "./components/Audio";
+import { Events } from "./components/Events";
+import { Sensors } from "./components/Sensors";
 import { Settings } from "./components/Settings";
+import { TaskHealth } from "./components/TaskHealth";
 import { Toast } from "./components/Toast";
 
 export function App() {
@@ -21,6 +24,9 @@ export function App() {
         <Emotion />
         <LookAt />
         <Audio />
+        <Sensors />
+        <TaskHealth />
+        <Events />
         <Settings />
       </main>
       <Toast />

--- a/web/src/components/Events.tsx
+++ b/web/src/components/Events.tsx
@@ -1,0 +1,66 @@
+import { For, Show, createSignal, onCleanup, onMount } from "solid-js";
+import type { EventsResponse } from "../types";
+import { showToast } from "../store";
+
+const POLL_MS = 3000;
+
+function fmtTimestamp(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h${m.toString().padStart(2, "0")}m${s.toString().padStart(2, "0")}s`;
+  if (m > 0) return `${m}m${s.toString().padStart(2, "0")}s`;
+  return `${s}s`;
+}
+
+export function Events() {
+  const [data, setData] = createSignal<EventsResponse | null>(null);
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const tick = async () => {
+    try {
+      const res = await fetch("/events");
+      if (!res.ok) return;
+      setData((await res.json()) as EventsResponse);
+    } catch (e) {
+      showToast(`/events: ${(e as Error).message}`, true);
+    }
+  };
+
+  onMount(() => {
+    void tick();
+    timer = setInterval(tick, POLL_MS);
+  });
+  onCleanup(() => {
+    if (timer != null) clearInterval(timer);
+  });
+
+  return (
+    <section>
+      <h2>Events</h2>
+      <Show when={data()} fallback={<small>waiting for first poll…</small>}>
+        {(s) => (
+          <>
+            <small>{s().total} since boot</small>
+            <div class="grid" style="margin-top:8px;font-family:ui-monospace,monospace;font-size:12px">
+              <For each={s().events.slice().reverse()}>
+                {(e) => (
+                  <div style="display:grid;grid-template-columns:max-content max-content 1fr;gap:8px;align-items:baseline">
+                    <span style="color:var(--muted);font-variant-numeric:tabular-nums">
+                      {fmtTimestamp(e.at_ms)}
+                    </span>
+                    <span style={`color:${e.kind === "warn" ? "var(--bad)" : e.kind === "control" ? "var(--accent)" : "var(--muted)"}`}>
+                      {e.kind}
+                    </span>
+                    <span>{e.message}</span>
+                  </div>
+                )}
+              </For>
+            </div>
+          </>
+        )}
+      </Show>
+    </section>
+  );
+}

--- a/web/src/components/Sensors.tsx
+++ b/web/src/components/Sensors.tsx
@@ -1,0 +1,66 @@
+import { Show, createSignal, onCleanup, onMount } from "solid-js";
+import type { SensorsSnapshot } from "../types";
+import { showToast } from "../store";
+
+const POLL_MS = 1000;
+
+function fmtVec(v: readonly [number, number, number], digits: number): string {
+  return `(${v[0].toFixed(digits)}, ${v[1].toFixed(digits)}, ${v[2].toFixed(digits)})`;
+}
+
+function intensityLabel(v: number): string {
+  if (v >= 3) return "high";
+  if (v === 2) return "mid";
+  if (v === 1) return "low";
+  return "—";
+}
+
+export function Sensors() {
+  const [data, setData] = createSignal<SensorsSnapshot | null>(null);
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const tick = async () => {
+    try {
+      const res = await fetch("/sensors");
+      if (!res.ok) return;
+      setData((await res.json()) as SensorsSnapshot);
+    } catch (e) {
+      showToast(`/sensors: ${(e as Error).message}`, true);
+    }
+  };
+
+  onMount(() => {
+    void tick();
+    timer = setInterval(tick, POLL_MS);
+  });
+  onCleanup(() => {
+    if (timer != null) clearInterval(timer);
+  });
+
+  return (
+    <section>
+      <h2>Sensors</h2>
+      <Show when={data()} fallback={<small>waiting for first poll…</small>}>
+        {(s) => (
+          <dl class="row">
+            <dt>IMU accel (g)</dt>
+            <dd>{s().imu ? fmtVec(s().imu!.accel_g, 3) : "—"}</dd>
+            <dt>IMU gyro (°/s)</dt>
+            <dd>{s().imu ? fmtVec(s().imu!.gyro_dps, 2) : "—"}</dd>
+            <dt>Ambient (lux)</dt>
+            <dd>{s().ambient_lux != null ? s().ambient_lux!.toFixed(2) : "—"}</dd>
+            <dt>Audio RMS</dt>
+            <dd>{s().audio_rms.toFixed(4)}</dd>
+            <dt>Body touch</dt>
+            <dd>
+              {s().body_touch
+                ? `L:${intensityLabel(s().body_touch!.left)} C:${intensityLabel(s().body_touch!.centre)} R:${intensityLabel(s().body_touch!.right)}`
+                : "—"}
+            </dd>
+          </dl>
+        )}
+      </Show>
+      <small>Polled every 1 s from GET /sensors. Producers mirror into a snapshot static; HTTP never drains the source signals.</small>
+    </section>
+  );
+}

--- a/web/src/components/TaskHealth.tsx
+++ b/web/src/components/TaskHealth.tsx
@@ -1,0 +1,54 @@
+import { For, Show, createSignal, onCleanup, onMount } from "solid-js";
+import type { TasksSnapshot } from "../types";
+import { showToast } from "../store";
+
+const POLL_MS = 5000;
+
+export function TaskHealth() {
+  const [data, setData] = createSignal<TasksSnapshot | null>(null);
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const tick = async () => {
+    try {
+      const res = await fetch("/tasks");
+      if (!res.ok) return;
+      setData((await res.json()) as TasksSnapshot);
+    } catch (e) {
+      showToast(`/tasks: ${(e as Error).message}`, true);
+    }
+  };
+
+  onMount(() => {
+    void tick();
+    timer = setInterval(tick, POLL_MS);
+  });
+  onCleanup(() => {
+    if (timer != null) clearInterval(timer);
+  });
+
+  return (
+    <section>
+      <h2>Task health</h2>
+      <Show when={data()} fallback={<small>waiting for first watchdog window…</small>}>
+        {(s) => (
+          <>
+            <dl class="row">
+              <For each={s().channels}>
+                {(ch) => (
+                  <>
+                    <dt>{ch.name}</dt>
+                    <dd>
+                      <span class={`dot ${ch.stale ? "bad" : "ok"}`} style="display:inline-block;margin-right:6px" />
+                      {ch.delta} / ≥{ch.min_per_window} beats
+                    </dd>
+                  </>
+                )}
+              </For>
+            </dl>
+            <small>Window: {s().window_ms} ms. Stale = below the cadence-derived minimum.</small>
+          </>
+        )}
+      </Show>
+    </section>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -35,3 +35,44 @@ export type Settings = {
   auth: { token: string };
   audio: AudioState;
 };
+
+export type Imu = {
+  accel_g: [number, number, number];
+  gyro_dps: [number, number, number];
+};
+
+export type BodyTouch = {
+  left: number;
+  centre: number;
+  right: number;
+};
+
+export type SensorsSnapshot = {
+  imu: Imu | null;
+  ambient_lux: number | null;
+  audio_rms: number;
+  body_touch: BodyTouch | null;
+};
+
+export type TaskHealth = {
+  name: string;
+  delta: number;
+  min_per_window: number;
+  stale: boolean;
+};
+
+export type TasksSnapshot = {
+  window_ms: number;
+  channels: TaskHealth[];
+};
+
+export type EventEntry = {
+  at_ms: number;
+  kind: "lifecycle" | "control" | "warn";
+  message: string;
+};
+
+export type EventsResponse = {
+  total: number;
+  events: EventEntry[];
+};


### PR DESCRIPTION
## Summary
- Three new GET routes surface what the device is doing without USB defmt:
  - `GET /sensors` — IMU accel/gyro, ambient lux, audio RMS, body-touch zones. Each producer task mirrors its latest reading into a new `SensorsSnapshot` static. HTTP reads never touch the source `Signal` channels — those stay single-consumer for the render task, sidestepping the drain race that `watchdog.rs` already documents.
  - `GET /tasks` — per-channel watchdog health. `run_watchdog_loop` now publishes each poll's deltas + stale flags into a new `TasksSnapshot` static.
  - `GET /events` — bounded RAM ring (new `event_log` module) of operator-visible events: lifecycle, control actions, warnings. 128 entries × ~88 B ≈ 11 KiB. Volatile.
- Three Solid panels in the dashboard: Sensors (1 Hz poll), Task health (5 s poll), Events (3 s poll). Bundle ~22 KB → ~26 KB raw, ~9 KB → ~10 KB gzipped.

Second of five planned PRs to expand admin tooling. Builds on the build pipeline from #205.

## Test plan
- [x] `just check` — host fmt + clippy + tests + doctests.
- [x] `just clippy-firmware` — strict clippy on default features.
- [x] Web bundle builds cleanly: 26.37 kB → 10.11 kB gzipped.
- [ ] Flash device, verify Sensors panel populates after IMU/ambient/body-touch init.
- [ ] Verify Task health flips audio/imu/etc to stale=true if the corresponding task is wedged.
- [ ] Verify Events panel records boot, wifi connect/disconnect, settings PUT, and authenticated POSTs.