### PR TITLE
feat(web): missing controls — speak, camera, presets, keyboard shortcuts

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,18 +1,33 @@
-import { onMount } from "solid-js";
+import { onCleanup, onMount } from "solid-js";
 import { connectStream } from "./store";
 import { ConnStatus } from "./components/ConnStatus";
 import { State } from "./components/State";
 import { Emotion } from "./components/Emotion";
 import { LookAt } from "./components/LookAt";
 import { Audio } from "./components/Audio";
+import { Camera } from "./components/Camera";
 import { Events } from "./components/Events";
 import { Sensors } from "./components/Sensors";
 import { Settings } from "./components/Settings";
+import { Speak } from "./components/Speak";
 import { TaskHealth } from "./components/TaskHealth";
 import { Toast } from "./components/Toast";
 
+const EMOTION_KEYS: Record<string, string> = {
+  "1": "neutral",
+  "2": "happy",
+  "3": "sad",
+  "4": "sleepy",
+  "5": "surprised",
+  "6": "angry",
+};
+
 export function App() {
-  onMount(connectStream);
+  onMount(() => {
+    connectStream();
+    document.addEventListener("keydown", onKeyDown);
+  });
+  onCleanup(() => document.removeEventListener("keydown", onKeyDown));
   return (
     <>
       <main>
@@ -24,6 +39,8 @@ export function App() {
         <Emotion />
         <LookAt />
         <Audio />
+        <Speak />
+        <Camera />
         <Sensors />
         <TaskHealth />
         <Events />
@@ -32,4 +49,35 @@ export function App() {
       <Toast />
     </>
   );
+}
+
+function onKeyDown(ev: KeyboardEvent) {
+  // Don't hijack typing in form fields.
+  const t = ev.target as HTMLElement | null;
+  if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT")) {
+    return;
+  }
+  if (ev.altKey || ev.ctrlKey || ev.metaKey) return;
+
+  const k = ev.key.toLowerCase();
+  const emotion = EMOTION_KEYS[ev.key];
+  if (emotion) {
+    const btn = document.querySelector<HTMLButtonElement>(`button[data-emotion="${emotion}"]`);
+    btn?.click();
+    ev.preventDefault();
+    return;
+  }
+  if (k === "r") {
+    document.querySelector<HTMLButtonElement>('button[data-shortcut="reset"]')?.click();
+    ev.preventDefault();
+    return;
+  }
+  if (k === "m") {
+    // Mute button is the only button literal "Mute" or "Unmute".
+    const btn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((b) =>
+      /^(mute|unmute)$/i.test(b.textContent?.trim() ?? ""),
+    );
+    btn?.click();
+    ev.preventDefault();
+  }
 }

--- a/web/src/components/Camera.tsx
+++ b/web/src/components/Camera.tsx
@@ -1,0 +1,47 @@
+import { Show, createMemo } from "solid-js";
+import { authedFetch, postJson } from "../auth";
+import { showToast, snapshot } from "../store";
+
+export function Camera() {
+  const previewActive = createMemo(() => snapshot()?.camera_mode ?? false);
+
+  const toggleMode = async () => {
+    const next = !previewActive();
+    try {
+      await postJson("/camera/mode", { enabled: next });
+      showToast(next ? "camera preview" : "avatar mode");
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  const capture = async () => {
+    try {
+      const res = await authedFetch("/camera/capture", { method: "POST" });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${text || res.statusText}`);
+      }
+      showToast("capture queued — eject SD to view CAPTURE.565");
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Camera</h2>
+      <div class="btn-row">
+        <button type="button" onClick={toggleMode}>
+          <Show when={previewActive()} fallback="Show preview">
+            Hide preview
+          </Show>
+        </button>
+        <button type="button" onClick={capture}>
+          Capture frame
+        </button>
+      </div>
+      <small>Preview swaps the LCD between avatar and live camera; tracking continues either way. Capture writes /sd/CAPTURE.565 (raw QVGA RGB565, ~150 KB).</small>
+    </section>
+  );
+}

--- a/web/src/components/Emotion.tsx
+++ b/web/src/components/Emotion.tsx
@@ -1,15 +1,17 @@
-import { For } from "solid-js";
+import { For, createSignal } from "solid-js";
 import { postJson } from "../auth";
 import { showToast } from "../store";
 
 const EMOTIONS = ["neutral", "happy", "sad", "sleepy", "surprised", "angry"] as const;
-const HOLD_MS = 30_000;
+const HOLD_PRESETS_S = [5, 10, 30, 60, 120] as const;
 
 export function Emotion() {
+  const [holdSec, setHoldSec] = createSignal<number>(30);
+
   const send = async (emotion: string) => {
     try {
-      await postJson("/emotion", { emotion, hold_ms: HOLD_MS });
-      showToast(`emotion → ${emotion}`);
+      await postJson("/emotion", { emotion, hold_ms: holdSec() * 1000 });
+      showToast(`emotion → ${emotion} (${holdSec()}s)`);
     } catch (e) {
       showToast((e as Error).message, true);
     }
@@ -30,16 +32,32 @@ export function Emotion() {
       <div class="btn-row">
         <For each={EMOTIONS}>
           {(name) => (
-            <button onClick={() => send(name)}>
+            <button onClick={() => send(name)} data-emotion={name}>
               {name.charAt(0).toUpperCase() + name.slice(1)}
             </button>
           )}
         </For>
-        <button onClick={reset} style="margin-left:auto">
+        <button onClick={reset} style="margin-left:auto" data-shortcut="reset">
           Reset
         </button>
       </div>
-      <small>Holds the emotion for 30 s, then autonomous behaviour resumes.</small>
+      <label style="margin-top:8px">
+        Hold: <span>{holdSec()} s</span>
+        <div class="btn-row" style="margin-top:4px">
+          <For each={HOLD_PRESETS_S}>
+            {(v) => (
+              <button
+                type="button"
+                onClick={() => setHoldSec(v)}
+                style={holdSec() === v ? "border-color:var(--accent)" : ""}
+              >
+                {v}s
+              </button>
+            )}
+          </For>
+        </div>
+      </label>
+      <small>Keys 1-6 fire the emotion at the configured hold; R resets, M toggles mute.</small>
     </section>
   );
 }

--- a/web/src/components/Speak.tsx
+++ b/web/src/components/Speak.tsx
@@ -1,0 +1,69 @@
+import { createSignal } from "solid-js";
+import { postJson } from "../auth";
+import { showToast } from "../store";
+
+const PHRASES = [
+  "wake_chirp",
+  "pickup_chirp",
+  "startle_chirp",
+  "low_battery_chirp",
+  "camera_mode_entered_chirp",
+  "camera_mode_exited_chirp",
+  "greeting",
+  "acknowledge_name",
+  "battery_low",
+] as const;
+
+const LOCALES = ["en", "ja"] as const;
+
+export function Speak() {
+  const [phrase, setPhrase] = createSignal<(typeof PHRASES)[number]>("greeting");
+  const [locale, setLocale] = createSignal<(typeof LOCALES)[number]>("en");
+
+  const send = async () => {
+    try {
+      await postJson("/speak", { phrase: phrase(), locale: locale() });
+      showToast(`speak ${phrase()} (${locale()})`);
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Speak</h2>
+      <div class="grid grid-2">
+        <label>
+          Phrase
+          <select
+            onChange={(e) => setPhrase(e.currentTarget.value as (typeof PHRASES)[number])}
+          >
+            {PHRASES.map((p) => (
+              <option value={p} selected={p === phrase()}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Locale
+          <select
+            onChange={(e) => setLocale(e.currentTarget.value as (typeof LOCALES)[number])}
+          >
+            {LOCALES.map((l) => (
+              <option value={l} selected={l === locale()}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div class="btn-row" style="margin-top:8px">
+        <button type="button" onClick={send}>
+          Speak
+        </button>
+      </div>
+      <small>Phrases bake into firmware as PCM clips. SFX chirps fall back to the same locale either way.</small>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Surface the existing HTTP endpoints that didn't have UI counterparts.

- **Speak** panel — dropdown of every baked `PhraseId` (chirps + verbal phrases) + locale picker (en / ja). One Speak button POSTs to `/speak`.
- **Camera** panel — Show/Hide preview reads `camera_mode` from the live snapshot; Capture frame POSTs `/camera/capture`.
- **Emotion** panel — adds a hold-time selector (5 / 10 / 30 / 60 / 120 s presets) instead of the previous hard-coded 30 s. Selected preset highlights with the accent border.
- **Keyboard shortcuts** — `1-6` fire the corresponding emotion at the current hold; `R` resets; `M` toggles mute. Form fields and modifier keys are excluded.

Web-only PR; firmware endpoints unchanged. Bundle ~26 KB → ~30 KB raw, ~10 KB → ~11 KB gzipped.

Third of five planned PRs to expand admin tooling.

## Test plan
- [x] `just clippy-firmware` — firmware clippy still clean (only the gzip bundle changed).
- [x] `npm run build` — typecheck + vite build clean.
- [ ] Flash device, verify Speak panel triggers each phrase.
- [ ] Verify Camera Show preview / Hide preview / Capture frame work.
- [ ] Verify keyboard shortcuts only fire when not in a form field.
- [ ] Verify hold preset selection persists across emotion clicks.