### PR TITLE
fix: address greptile feedback across the dashboard PRs

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -531,11 +531,15 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
     // doesn't clobber them. With no current snapshot (the brief
     // pre-storage-mount window), preserving against the default
     // empty values is a no-op — the parsed body wins.
-    let snapshot_for_merge = crate::storage::CONFIG_SNAPSHOT
-        .lock()
-        .await
-        .clone()
-        .unwrap_or_default();
+    //
+    // Track whether the snapshot was actually populated so the
+    // reboot-required diff doesn't compare against a synthesized
+    // default (which would falsely flag every first-boot PUT as
+    // requiring reboot just because the new value differs from the
+    // struct default).
+    let prior_snapshot = crate::storage::CONFIG_SNAPSHOT.lock().await.clone();
+    let had_prior_snapshot = prior_snapshot.is_some();
+    let snapshot_for_merge = prior_snapshot.unwrap_or_default();
     let new_config = stackchan_net::merge_settings_with_current(parsed_config, &snapshot_for_merge);
     let write_result =
         crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;
@@ -565,7 +569,12 @@ async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
             // SSE stream picks up volume / mute changes from a full
             // settings PUT without waiting for a reboot.
             snapshot::update_audio(new_config.audio);
-            let reboot_required = requires_reboot(&snapshot_for_merge, &new_config);
+            // First-boot PUT (no prior snapshot) can't have changed
+            // anything that was already running — every field in the
+            // synthesised default was never live, so reboot_required
+            // is unconditionally false.
+            let reboot_required =
+                had_prior_snapshot && requires_reboot(&snapshot_for_merge, &new_config);
             *crate::storage::CONFIG_SNAPSHOT.lock().await = Some(new_config);
             let body = format!("{{\"reboot_required\":{reboot_required}}}\n");
             write_json(socket, 200, &body).await
@@ -735,13 +744,34 @@ async fn handle_post_factory_reset(
     }
 }
 
-/// Look for a `"confirm":"erase"` pair anywhere in the body. The
-/// hand-rolled parsers in `stackchan-net` are JSON-aware, but the
-/// match here is loose on purpose — we only care whether the operator
-/// typed the magic string, not whether it sits at exactly the right
-/// JSON depth.
+/// Look for a `"confirm":"erase"` key/value pair anywhere in the
+/// body. The hand-rolled parsers in `stackchan-net` are JSON-aware,
+/// but the match here is loose on purpose — we only care whether the
+/// operator typed the magic key/value sequence, not whether it sits
+/// at exactly the right JSON depth.
+///
+/// Tolerates whitespace between the colon and the value (`"confirm"
+/// : "erase"`) but requires the two tokens to be paired — an unrelated
+/// `"erase"` somewhere else in the body, with `"confirm"` mapped to a
+/// different value, will not pass.
 fn body_confirms_erase(body: &str) -> bool {
-    body.contains("\"confirm\"") && body.contains("\"erase\"")
+    // Find `"confirm"` occurrences and check that the next non-space
+    // token is `:"erase"` (allowing optional whitespace either side
+    // of the colon).
+    let key = "\"confirm\"";
+    let mut search = body;
+    while let Some(idx) = search.find(key) {
+        let after = &search[idx + key.len()..];
+        let trimmed = after.trim_start();
+        if let Some(rest) = trimmed.strip_prefix(':') {
+            let v = rest.trim_start();
+            if v.starts_with("\"erase\"") {
+                return true;
+            }
+        }
+        search = &search[idx + key.len()..];
+    }
+    false
 }
 
 /// Apply a parsed remote command (or surface the parser error to the
@@ -837,8 +867,9 @@ fn state_body(s: AvatarSnapshot) -> String {
 }
 
 /// Serialise the `/sensors` body. `null` for sensors that haven't
-/// produced a sample yet; numbers (with two decimal places for accel /
-/// gyro / lux, four for the audio-RMS norm) elsewhere.
+/// produced a sample yet; numbers elsewhere — three decimals for
+/// accel-g, two for gyro-dps and ambient lux, four for the audio-RMS
+/// norm.
 fn sensors_body(s: snapshot::SensorsSnapshot) -> String {
     let imu = s.imu.map_or_else(
         || String::from("null"),

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -329,8 +329,9 @@ where
 
     /// Delete every operator-visible file the firmware writes:
     /// `STACKCHAN.RON`, the staging file, `BONDS.BIN`, the bonds
-    /// staging file, and the camera capture. Best-effort — missing
-    /// files are not an error (a fresh device has none of them).
+    /// staging file, and the camera capture. Missing files are not
+    /// an error (a fresh device has none of them); SPI / FAT failures
+    /// are.
     ///
     /// Used by `POST /factory-reset`. After a successful wipe the
     /// caller is expected to trigger a soft reset; the boot path then
@@ -338,13 +339,17 @@ where
     ///
     /// # Errors
     ///
-    /// [`StorageError::Volume`] if the FAT volume can't be opened.
+    /// [`StorageError::Volume`] if the FAT volume can't be opened,
+    /// [`StorageError::Write`] if any present file fails to delete
+    /// (so the caller knows the wipe was partial and can decide
+    /// whether to skip the reboot).
     pub fn factory_reset(&mut self) -> Result<(), StorageError> {
         let volume = self
             .mgr
             .open_volume(VolumeIdx(0))
             .map_err(|_| StorageError::Volume)?;
         let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let mut first_error: Option<StorageError> = None;
         for name in [
             CONFIG_FILE,
             STAGING_FILE,
@@ -352,9 +357,23 @@ where
             BONDS_STAGING_FILE,
             CAPTURE_FILE,
         ] {
-            let _ = root.delete_file_in_dir(name);
+            // FileNotFound is the expected case for any file the
+            // operator never wrote — keep going. Anything else is a
+            // real I/O failure that the caller needs to see.
+            if let Err(e) = root.delete_file_in_dir(name)
+                && !matches!(e, embedded_sdmmc::Error::NotFound)
+            {
+                defmt::warn!(
+                    "factory_reset: delete '{=str}' failed ({})",
+                    name,
+                    defmt::Debug2Format(&e),
+                );
+                if first_error.is_none() {
+                    first_error = Some(StorageError::Write);
+                }
+            }
         }
-        Ok(())
+        first_error.map_or(Ok(()), Err)
     }
 
     /// Atomically replace `/sd/BONDS.BIN` with `data`. Same staging-

--- a/crates/stackchan-firmware/src/watchdog.rs
+++ b/crates/stackchan-firmware/src/watchdog.rs
@@ -194,6 +194,11 @@ pub fn read_tasks_snapshot() -> TasksSnapshot {
 /// testability.
 fn check_all() {
     let channels: &[&Channel] = &[&AUDIO, &IMU, &AMBIENT, &POWER, &HEAD];
+    // Pull `name` + `min_per_window` from the source `Channel` struct
+    // each tick rather than the hardcoded `empty()` table — if the
+    // `channels` slice ever reorders or grows out of sync with the
+    // `empty()` initialiser, the displayed names would silently
+    // disagree with reality.
     let mut snap = TasksSnapshot::empty();
     for (i, ch) in channels.iter().enumerate() {
         let (delta, stale) = ch.check_and_reset();
@@ -206,8 +211,12 @@ fn check_all() {
                 ch.min_per_window,
             );
         }
-        snap.channels[i].delta = delta;
-        snap.channels[i].stale = stale;
+        snap.channels[i] = TaskHealth {
+            name: ch.name,
+            delta,
+            min_per_window: ch.min_per_window,
+            stale,
+        };
     }
     TASKS_SNAPSHOT.lock(|cell| cell.set(snap));
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,11 +75,7 @@ function onKeyDown(ev: KeyboardEvent) {
     return;
   }
   if (k === "m") {
-    // Mute button is the only button literal "Mute" or "Unmute".
-    const btn = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find((b) =>
-      /^(mute|unmute)$/i.test(b.textContent?.trim() ?? ""),
-    );
-    btn?.click();
+    document.querySelector<HTMLButtonElement>('button[data-shortcut="mute"]')?.click();
     ev.preventDefault();
   }
 }

--- a/web/src/components/Audio.tsx
+++ b/web/src/components/Audio.tsx
@@ -65,7 +65,7 @@ export function Audio() {
         />
       </label>
       <div class="btn-row">
-        <button type="button" onClick={toggleMute}>
+        <button type="button" onClick={toggleMute} data-shortcut="mute">
           {muted() ? "Unmute" : "Mute"}
         </button>
       </div>

--- a/web/src/components/Emotion.tsx
+++ b/web/src/components/Emotion.tsx
@@ -41,8 +41,8 @@ export function Emotion() {
           Reset
         </button>
       </div>
-      <label style="margin-top:8px">
-        Hold: <span>{holdSec()} s</span>
+      <div style="margin-top:8px;font-size:12px;color:var(--muted)">
+        <span>Hold: {holdSec()} s</span>
         <div class="btn-row" style="margin-top:4px">
           <For each={HOLD_PRESETS_S}>
             {(v) => (
@@ -56,7 +56,7 @@ export function Emotion() {
             )}
           </For>
         </div>
-      </label>
+      </div>
       <small>Keys 1-6 fire the emotion at the configured hold; R resets, M toggles mute.</small>
     </section>
   );

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -65,7 +65,18 @@ export function Settings() {
         const text = await res.text().catch(() => "");
         throw new Error(`${res.status}: ${text || res.statusText}`);
       }
-      setAuthToken(newToken);
+      // The form pre-fills the redaction sentinel for both PSK and
+      // token; submitting unchanged sends `***` back, which the
+      // firmware treats as 'preserve'. Mirroring that into
+      // localStorage would clobber the real token, so only persist
+      // the new value when the operator actually typed something
+      // different.
+      if (newToken && newToken !== "***") {
+        setAuthToken(newToken);
+      } else if (newToken === "") {
+        // Operator cleared the field → auth disabled; clear localStorage too.
+        setAuthToken("");
+      }
       const reply = (await res.json().catch(() => ({}))) as { reboot_required?: boolean };
       showToast(
         reply.reboot_required
@@ -91,8 +102,13 @@ export function Settings() {
       a.href = url;
       const stamp = new Date().toISOString().replace(/[:T]/g, "-").slice(0, 19);
       a.download = `stackchan-backup-${stamp}.json`;
+      // Firefox needs the anchor in the document for programmatic
+      // clicks to trigger; revokeObjectURL needs to wait until after
+      // the browser starts fetching the URL.
+      document.body.appendChild(a);
       a.click();
-      URL.revokeObjectURL(url);
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
       showToast("backup downloaded");
     } catch (e) {
       showToast((e as Error).message, true);

--- a/web/src/components/Speak.tsx
+++ b/web/src/components/Speak.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { For, createSignal } from "solid-js";
 import { postJson } from "../auth";
 import { showToast } from "../store";
 
@@ -38,11 +38,13 @@ export function Speak() {
           <select
             onChange={(e) => setPhrase(e.currentTarget.value as (typeof PHRASES)[number])}
           >
-            {PHRASES.map((p) => (
-              <option value={p} selected={p === phrase()}>
-                {p}
-              </option>
-            ))}
+            <For each={PHRASES}>
+              {(p) => (
+                <option value={p} selected={p === phrase()}>
+                  {p}
+                </option>
+              )}
+            </For>
           </select>
         </label>
         <label>
@@ -50,11 +52,13 @@ export function Speak() {
           <select
             onChange={(e) => setLocale(e.currentTarget.value as (typeof LOCALES)[number])}
           >
-            {LOCALES.map((l) => (
-              <option value={l} selected={l === locale()}>
-                {l}
-              </option>
-            ))}
+            <For each={LOCALES}>
+              {(l) => (
+                <option value={l} selected={l === locale()}>
+                  {l}
+                </option>
+              )}
+            </For>
           </select>
         </label>
       </div>


### PR DESCRIPTION
## Summary
Addresses every greptile review comment from #205 / #207 / #209 / #210 / #212 — two P1 and six P2 findings.

### P1 — Settings.tsx wrote `***` sentinel into localStorage on every save
The dashboard pre-fills the redacted token into the form. Submitting unchanged sent `***` back; `setAuthToken('***')` then clobbered the operator's real token, breaking the next authenticated request. Now only persist when the field is non-empty and not the sentinel; an explicit clear still wipes localStorage.

### P1 — `FirmwareStorage::factory_reset` reported success on partial wipe
Per-file delete failures (other than `NotFound`) are now captured into a first-error slot and surfaced as `StorageError::Write`. The caller can decide whether to skip the reboot rather than silently rebooting onto a partially-wiped FS.

### P2 fixes
- **TaskHealth rows** — pulled from the live `Channel` struct each tick (`name` + `min_per_window`) instead of a hardcoded table; reordering the slice can no longer silently desync.
- **`sensors_body` docstring** — corrected to "three decimals for accel-g" to match the wire format.
- **Mute shortcut** — Audio button carries `data-shortcut="mute"`; dispatcher matches by attribute, consistent with the existing reset shortcut.
- **Emotion preset row** — replaced the `<label>` wrapper (which focused the first button on heading-click) with `<div>` + `<span>`.
- **Speak `<For>`** — `PHRASES` + `LOCALES` use `<For>` to match the codebase's reactivity pattern.
- **Settings download** — anchor now appends → clicks → removes; `revokeObjectURL` runs in a `setTimeout` so Firefox can start the fetch.
- **`requires_reboot` first-boot false-positive** — tracks whether `CONFIG_SNAPSHOT` was actually populated and short-circuits to `false` when it wasn't, so a first-boot PUT doesn't flag every default-distinct field as reboot-required.
- **`body_confirms_erase` paired check** — scans for `"confirm" : "erase"` as a paired sequence (with whitespace tolerance) instead of two independent `contains` calls.

## Test plan
- [x] `just check` — host fmt + clippy + tests + doctests.
- [x] `just clippy-firmware` — strict clippy clean.
- [x] `npm run build` — bundle ~32 KB → ~12 KB gzipped.
- [ ] Save settings without changing the token field → curl with the original token still works.
- [ ] Trigger factory-reset with a write-protected SD → 500 instead of 202 + reboot.
- [ ] First-boot PUT (no SD) → `reboot_required: false`.
- [ ] `curl -d '{"x":"confirm","y":"erase"}' …/factory-reset` → 400 (paired-check rejects unpaired keys).