### PR TITLE
feat(core): expand emotion palette with 7 new variants

### DIFF
--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -22,7 +22,7 @@ platform-independent heart of the firmware and the simulator.
 - `src/avatar.rs` — `Avatar`, `Eye`, `EyePhase`, `Mouth`, `Point`, `SCALE_DEFAULT`
 - `src/clock.rs` — `Clock` trait, `Instant` (millisecond-resolution monotonic)
 - `src/draw.rs` — `Avatar::draw` renders into any `embedded_graphics::DrawTarget<Color = Rgb565>`
-- `src/emotion.rs` — `Emotion` (Neutral, Happy, Sleepy, Surprised, Sad) and per-emotion style presets
+- `src/emotion.rs` — `Emotion` enum + `Emotion::ALL` catalogue. Per-emotion style targets live in `modifiers/style_from_emotion.rs::targets_for`
 - `src/head.rs` — `Pose`, `HeadDriver` trait, pan / tilt range constants
 - `src/leds.rs` — `LedFrame`, `render_leds` — maps avatar state to the 12-pixel ring
 - `src/modifiers/mod.rs` — `Modifier` trait + re-exports

--- a/crates/stackchan-core/src/emotion.rs
+++ b/crates/stackchan-core/src/emotion.rs
@@ -24,7 +24,7 @@ pub enum Emotion {
     /// no override of breath or blink rate.
     Doubt,
     /// Disinterested / under-engaged. Half-lidded eyes, slow blink, slow
-    /// deep breath, flat mouth — the antonym of `Happy` along the
+    /// deep breath, faint frown — the antonym of `Happy` along the
     /// engagement axis (rather than valence).
     Boring,
     /// Outgoing greeting / wave-hello affect. Wide bright eyes, big smile,
@@ -32,8 +32,7 @@ pub enum Emotion {
     /// kind.
     Hi,
     /// Smitten / affectionate. Heaviest blush of the catalogue + full
-    /// upward eye arc. The decorator layer adds heart overlays in PR 1b;
-    /// the base style stands alone here.
+    /// upward eye arc.
     Loved,
     /// Curiously interested. Wide eyes (smaller than `Surprised`), faint
     /// smile, light blush — investigative rather than reactive.
@@ -119,9 +118,16 @@ impl Emotion {
     /// (the firmware HTTP `/state` snapshot doesn't enumerate; the BLE
     /// GATT does, via [`Self::wire_byte`]).
     ///
-    /// The slice is exhaustive: omitting a variant compiles, but the
-    /// `wire_byte_mapping_is_stable` test below pins the order against
-    /// this list, so a missed entry surfaces as a test failure.
+    /// **Manually maintained — no compile-time exhaustiveness check.**
+    /// The exhaustive `match` arms in [`Self::wire_byte`] and
+    /// [`Self::wire_str`] are the compile-time guard against forgetting
+    /// an enum variant; this slice is *additionally* required for
+    /// downstream iteration (BLE GATT enumeration, the `http_command`
+    /// round-trip test, and the `wire_bytes_are_unique` /
+    /// `wire_strs_are_unique_and_lowercase` tests below). The
+    /// `all_length_matches_variant_count` test is a length-pin
+    /// trip-wire — adding a variant must bump the asserted count, which
+    /// forces a conscious update to this slice.
     pub const ALL: &'static [Self] = &[
         Self::Neutral,
         Self::Happy,
@@ -160,6 +166,22 @@ mod tests {
         assert_eq!(Emotion::Curious.wire_byte(), 10);
         assert_eq!(Emotion::Confused.wire_byte(), 11);
         assert_eq!(Emotion::Mad.wire_byte(), 12);
+    }
+
+    /// Length pin for [`Emotion::ALL`]. Mirrors the
+    /// `field_all_covers_every_variant` pattern in
+    /// [`crate::director::Field::ALL`]: the slice has no compile-time
+    /// exhaustiveness check, so we trip-wire the count to force a
+    /// conscious bump on every variant addition.
+    #[test]
+    fn all_length_matches_variant_count() {
+        assert_eq!(
+            Emotion::ALL.len(),
+            13,
+            "update Emotion::ALL when adding a variant — the exhaustive \
+             match in wire_byte is the only compile-time check; this \
+             slice has to be hand-extended too"
+        );
     }
 
     /// Every wire-byte index is unique. A copy-paste collision in the

--- a/crates/stackchan-core/src/emotion.rs
+++ b/crates/stackchan-core/src/emotion.rs
@@ -20,6 +20,32 @@ pub enum Emotion {
     /// `EmotionFromIntent` on a transition into `Intent::Shaken`. Not part
     /// of the autonomous `EmotionCycle` or touch-cycle order.
     Angry,
+    /// Skeptical / questioning. Slight downward eye curve + faint smile;
+    /// no override of breath or blink rate.
+    Doubt,
+    /// Disinterested / under-engaged. Half-lidded eyes, slow blink, slow
+    /// deep breath, flat mouth — the antonym of `Happy` along the
+    /// engagement axis (rather than valence).
+    Boring,
+    /// Outgoing greeting / wave-hello affect. Wide bright eyes, big smile,
+    /// elevated blink rate. Distinguished from `Happy` by intensity, not
+    /// kind.
+    Hi,
+    /// Smitten / affectionate. Heaviest blush of the catalogue + full
+    /// upward eye arc. The decorator layer adds heart overlays in PR 1b;
+    /// the base style stands alone here.
+    Loved,
+    /// Curiously interested. Wide eyes (smaller than `Surprised`), faint
+    /// smile, light blush — investigative rather than reactive.
+    Curious,
+    /// Uncertain / processing. Slight frown + elevated blink rate (often
+    /// reads as eye-flutter). Distinguished from `Doubt` by valence —
+    /// `Doubt` is skeptical-positive, `Confused` is unsettled-negative.
+    Confused,
+    /// Furious / much hotter than `Angry`. Deeper frown, heavier blush,
+    /// slower huffing breath, slightly squinted eyes. The default
+    /// `EmotionCycle` does not visit this — reactive only.
+    Mad,
 }
 
 impl Emotion {
@@ -48,6 +74,13 @@ impl Emotion {
             Self::Sleepy => "sleepy",
             Self::Surprised => "surprised",
             Self::Angry => "angry",
+            Self::Doubt => "doubt",
+            Self::Boring => "boring",
+            Self::Hi => "hi",
+            Self::Loved => "loved",
+            Self::Curious => "curious",
+            Self::Confused => "confused",
+            Self::Mad => "mad",
         }
     }
 
@@ -72,8 +105,38 @@ impl Emotion {
             Self::Sleepy => 3,
             Self::Surprised => 4,
             Self::Angry => 5,
+            Self::Doubt => 6,
+            Self::Boring => 7,
+            Self::Hi => 8,
+            Self::Loved => 9,
+            Self::Curious => 10,
+            Self::Confused => 11,
+            Self::Mad => 12,
         }
     }
+
+    /// Every variant in declaration order. Used by tests and tooling
+    /// (the firmware HTTP `/state` snapshot doesn't enumerate; the BLE
+    /// GATT does, via [`Self::wire_byte`]).
+    ///
+    /// The slice is exhaustive: omitting a variant compiles, but the
+    /// `wire_byte_mapping_is_stable` test below pins the order against
+    /// this list, so a missed entry surfaces as a test failure.
+    pub const ALL: &'static [Self] = &[
+        Self::Neutral,
+        Self::Happy,
+        Self::Sad,
+        Self::Sleepy,
+        Self::Surprised,
+        Self::Angry,
+        Self::Doubt,
+        Self::Boring,
+        Self::Hi,
+        Self::Loved,
+        Self::Curious,
+        Self::Confused,
+        Self::Mad,
+    ];
 }
 
 #[cfg(test)]
@@ -90,5 +153,45 @@ mod tests {
         assert_eq!(Emotion::Sleepy.wire_byte(), 3);
         assert_eq!(Emotion::Surprised.wire_byte(), 4);
         assert_eq!(Emotion::Angry.wire_byte(), 5);
+        assert_eq!(Emotion::Doubt.wire_byte(), 6);
+        assert_eq!(Emotion::Boring.wire_byte(), 7);
+        assert_eq!(Emotion::Hi.wire_byte(), 8);
+        assert_eq!(Emotion::Loved.wire_byte(), 9);
+        assert_eq!(Emotion::Curious.wire_byte(), 10);
+        assert_eq!(Emotion::Confused.wire_byte(), 11);
+        assert_eq!(Emotion::Mad.wire_byte(), 12);
+    }
+
+    /// Every wire-byte index is unique. A copy-paste collision in the
+    /// match arm above would silently break the GATT client decode
+    /// without this pin.
+    #[test]
+    fn wire_bytes_are_unique() {
+        let mut seen = [false; 256];
+        for &emotion in Emotion::ALL {
+            let byte = emotion.wire_byte() as usize;
+            assert!(
+                !seen[byte],
+                "duplicate wire byte {byte} for {emotion:?}; mapping must be one-to-one"
+            );
+            seen[byte] = true;
+        }
+    }
+
+    /// Every wire string is unique and lowercase. Catches both copy-paste
+    /// collisions and a stray uppercase that would skip the
+    /// `parse_emotion` lowercase match.
+    #[test]
+    fn wire_strs_are_unique_and_lowercase() {
+        for (i, &a) in Emotion::ALL.iter().enumerate() {
+            let wa = a.wire_str();
+            assert!(
+                wa.chars().all(|c| !c.is_uppercase()),
+                "wire_str `{wa}` contains uppercase; parse_emotion matches lowercase only"
+            );
+            for &b in &Emotion::ALL[i + 1..] {
+                assert_ne!(wa, b.wire_str(), "duplicate wire_str `{wa}`");
+            }
+        }
     }
 }

--- a/crates/stackchan-core/src/leds.rs
+++ b/crates/stackchan-core/src/leds.rs
@@ -104,6 +104,27 @@ const fn palette(emotion: Emotion) -> u32 {
         Emotion::Sleepy => 0x0030_1448,
         Emotion::Surprised => 0x0030_E0FF,
         Emotion::Angry => 0x00FF_2020,
+        // Skeptical violet — sits between `Sleepy`'s purple and the
+        // listening teal so it reads distinct from both.
+        Emotion::Doubt => 0x0080_5090,
+        // Muted olive — desaturated relative to every other entry,
+        // matching the disengaged feel.
+        Emotion::Boring => 0x0050_5040,
+        // Bright greeting yellow — warmer than `Happy`'s amber so the
+        // ring reads as a wave-hello rather than a steady glow.
+        Emotion::Hi => 0x00FF_E040,
+        // Heart-eye pink — adjacent to but distinct from the cheek-blush
+        // palette (`MOUTH_COLOR` ≈ #F58080).
+        Emotion::Loved => 0x00FF_60A0,
+        // Investigative seafoam — kept separate from `LISTEN_PALETTE`'s
+        // teal by shifting toward green, so a curious-while-listening
+        // pose still reads two distinct colours when intent overrides.
+        Emotion::Curious => 0x0040_D080,
+        // Muddy chartreuse — the unsettled cousin of `Curious`.
+        Emotion::Confused => 0x00A0_A030,
+        // Hotter red than `Angry` — saturates further into orange so the
+        // ring reads as escalation when the avatar transitions Angry → Mad.
+        Emotion::Mad => 0x00FF_4010,
     }
 }
 

--- a/crates/stackchan-core/src/modifiers/emotion_from_touch.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_touch.rs
@@ -86,10 +86,20 @@ const fn next_emotion(current: Emotion) -> Emotion {
         Emotion::Happy => Emotion::Sleepy,
         Emotion::Sleepy => Emotion::Surprised,
         Emotion::Surprised => Emotion::Sad,
-        // `Sad` wraps the cycle back to `Neutral`. `Angry` is
-        // reactive-only (set by `EmotionFromIntent` on shake) and exits to
-        // `Neutral` rather than threading into the cycle.
-        Emotion::Sad | Emotion::Angry => Emotion::Neutral,
+        // `Sad` wraps the cycle back to `Neutral`. The remaining
+        // variants are reactive-only (set by intent / sensor / remote
+        // modifiers) and exit to `Neutral` instead of threading into
+        // the touch-cycle, so a tap during e.g. `Mad` clears the
+        // override rather than rolling forward.
+        Emotion::Sad
+        | Emotion::Angry
+        | Emotion::Doubt
+        | Emotion::Boring
+        | Emotion::Hi
+        | Emotion::Loved
+        | Emotion::Curious
+        | Emotion::Confused
+        | Emotion::Mad => Emotion::Neutral,
     }
 }
 

--- a/crates/stackchan-core/src/modifiers/head_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_emotion.rs
@@ -81,6 +81,47 @@ const fn targets_for(emotion: Emotion) -> HeadBias {
             pan_deg: 0.0,
             tilt_deg: -2.0,
         },
+        Emotion::Doubt => HeadBias {
+            // Faint chin-down skeptical tilt.
+            pan_deg: 0.0,
+            tilt_deg: -1.0,
+        },
+        Emotion::Boring => HeadBias {
+            // Slumped chin-down — disengaged posture.
+            pan_deg: 0.0,
+            tilt_deg: -3.0,
+        },
+        Emotion::Hi => HeadBias {
+            // Chin-up greeting reach — bigger than `Happy`'s nod.
+            pan_deg: 0.0,
+            tilt_deg: 4.0,
+        },
+        Emotion::Loved => HeadBias {
+            // Soft chin-up affectionate lift — sits between `Happy` and
+            // `Hi` so the bias is unique per variant (clippy's
+            // match-same-arms catches the alternative).
+            pan_deg: 0.0,
+            tilt_deg: 3.5,
+        },
+        Emotion::Curious => HeadBias {
+            // Subtle chin-up to peer at the target — narrower than
+            // `Surprised`'s startle to keep the eye-widening separate
+            // from the head reaction.
+            pan_deg: 0.0,
+            tilt_deg: 1.0,
+        },
+        Emotion::Confused => HeadBias {
+            // Tiny chin-down "huh?" lean — slightly deeper than `Doubt`'s
+            // -1.0 so the bias is unique per variant.
+            pan_deg: 0.0,
+            tilt_deg: -1.5,
+        },
+        Emotion::Mad => HeadBias {
+            // Deeper chin-down glare than `Sad`'s -4.0 — escalates
+            // `Angry` along the intensity axis.
+            pan_deg: 0.0,
+            tilt_deg: -4.5,
+        },
     }
 }
 

--- a/crates/stackchan-core/src/modifiers/style_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_emotion.rs
@@ -52,6 +52,12 @@ struct StyleTarget {
 /// Constant look-up of the style target for every [`Emotion`] variant.
 /// Kept as a plain `match` (rather than a table) so adding a variant to
 /// `Emotion` surfaces as a compile error here.
+#[allow(
+    clippy::too_many_lines,
+    reason = "lookup table — splitting into per-emotion consts would shift \
+              the line count without simplifying the surface, and the inline \
+              comments next to each row are the load-bearing rationale"
+)]
 const fn targets_for(emotion: Emotion) -> StyleTarget {
     match emotion {
         Emotion::Neutral => StyleTarget {
@@ -119,6 +125,98 @@ const fn targets_for(emotion: Emotion) -> StyleTarget {
             blink_rate_scale: 96,
             breath_depth_scale: 180,
             open_weight: 80,
+            mouth_weight: 0,
+        },
+        Emotion::Doubt => StyleTarget {
+            // Skeptical-positive: slight downward eye arc with a faint
+            // smile that reads as "I'm not buying it but I'm amused."
+            // Distinguished from `Confused` by the +mouth_curve sign.
+            eye_curve: -15,
+            mouth_curve: 20,
+            cheek_blush: 0,
+            eye_scale: 110,
+            blink_rate_scale: 80,
+            breath_depth_scale: 110,
+            open_weight: 80,
+            mouth_weight: 0,
+        },
+        Emotion::Boring => StyleTarget {
+            // Disinterested: half-lidded eyes, slow blink, slow deep
+            // breath, very faint frown. Distinguished from `Sleepy` by a
+            // less-droopy lid and a non-zero mouth_curve.
+            eye_curve: 0,
+            mouth_curve: -15,
+            cheek_blush: 0,
+            eye_scale: SCALE_DEFAULT,
+            blink_rate_scale: 56,
+            breath_depth_scale: 150,
+            open_weight: 65,
+            mouth_weight: 0,
+        },
+        Emotion::Hi => StyleTarget {
+            // Outgoing greeting. Wider eyes than `Happy`, faster blink,
+            // bigger smile arc — reads as a wave-hello.
+            eye_curve: 50,
+            mouth_curve: 70,
+            cheek_blush: 100,
+            eye_scale: 140,
+            blink_rate_scale: 160,
+            breath_depth_scale: 110,
+            open_weight: 100,
+            mouth_weight: 0,
+        },
+        Emotion::Loved => StyleTarget {
+            // Smitten: full upward eye arc + heaviest blush of the
+            // catalogue. The decorator layer paints heart overlays on
+            // top in PR 1b; the base style stands alone here.
+            eye_curve: 90,
+            mouth_curve: 50,
+            cheek_blush: 220,
+            eye_scale: 110,
+            blink_rate_scale: 140,
+            breath_depth_scale: 110,
+            open_weight: 100,
+            mouth_weight: 0,
+        },
+        Emotion::Curious => StyleTarget {
+            // Investigative: wider-than-baseline eyes (smaller than
+            // `Surprised`), faint smile, light blush. The breath / blink
+            // hold near baseline so the wide-eye reads as attention,
+            // not startle.
+            eye_curve: 30,
+            mouth_curve: 25,
+            cheek_blush: 40,
+            eye_scale: 150,
+            blink_rate_scale: 110,
+            breath_depth_scale: SCALE_DEFAULT,
+            open_weight: 100,
+            mouth_weight: 0,
+        },
+        Emotion::Confused => StyleTarget {
+            // Unsettled-negative: matching downward curves on eyes and
+            // mouth + elevated blink rate (reads as eye-flutter).
+            // Mirrors `Doubt` along valence: same uncertainty, opposite
+            // mouth sign.
+            eye_curve: -20,
+            mouth_curve: -20,
+            cheek_blush: 0,
+            eye_scale: SCALE_DEFAULT,
+            blink_rate_scale: 160,
+            breath_depth_scale: SCALE_DEFAULT,
+            open_weight: 95,
+            mouth_weight: 0,
+        },
+        Emotion::Mad => StyleTarget {
+            // Hotter than `Angry`: deeper frown, heavier blush, slower
+            // huffing breath, narrower squint. The default
+            // `EmotionCycle` doesn't visit this — it's reactive only.
+            eye_curve: -55,
+            mouth_curve: -85,
+            cheek_blush: 120,
+            eye_scale: 100,
+            blink_rate_scale: 70,
+            breath_depth_scale: 200,
+            open_weight: 85,
             mouth_weight: 0,
         },
     }
@@ -498,5 +596,155 @@ mod tests {
         assert_eq!(ease(0, 100, 300, 300), 100);
         assert_eq!(ease(0, 100, 450, 300), 100);
         assert_eq!(ease(100, 0, 150, 300), 50);
+    }
+
+    /// Snap through each `Emotion` variant and assert the writer
+    /// produces a distinguishable style snapshot. Catches a copy-paste
+    /// where two variants accidentally end up with identical
+    /// `StyleTarget` rows.
+    #[test]
+    fn every_emotion_has_a_distinct_style_target() {
+        // Compare every pair. Any two variants that produce identical
+        // `StyleTarget` rows are a bug — the catalogue would have a
+        // visually invisible variant.
+        for (i, &a) in Emotion::ALL.iter().enumerate() {
+            for &b in &Emotion::ALL[i + 1..] {
+                assert_ne!(
+                    targets_for(a),
+                    targets_for(b),
+                    "{a:?} and {b:?} share a StyleTarget row — palettes must differ"
+                );
+            }
+        }
+    }
+
+    /// `Hi` is a louder `Happy`: bigger eye scale + faster blink. Pin
+    /// the relationship so a future palette tweak can't quietly swap
+    /// them along the engagement axis.
+    #[test]
+    fn hi_is_more_excited_than_happy() {
+        let h = targets_for(Emotion::Hi);
+        let happy = targets_for(Emotion::Happy);
+        assert!(
+            h.eye_scale > happy.eye_scale,
+            "Hi should widen eyes more than Happy ({} vs {})",
+            h.eye_scale,
+            happy.eye_scale,
+        );
+        assert!(
+            h.blink_rate_scale > happy.blink_rate_scale,
+            "Hi should blink faster than Happy ({} vs {})",
+            h.blink_rate_scale,
+            happy.blink_rate_scale,
+        );
+    }
+
+    /// `Loved` is the heaviest-blush variant — the decorator layer
+    /// stacks heart overlays on top, but the base style needs to stand
+    /// alone too.
+    #[test]
+    fn loved_has_the_heaviest_blush() {
+        let loved = targets_for(Emotion::Loved);
+        for &other in Emotion::ALL {
+            if other == Emotion::Loved {
+                continue;
+            }
+            assert!(
+                loved.cheek_blush >= targets_for(other).cheek_blush,
+                "Loved should have the heaviest cheek_blush; {other:?} has {}",
+                targets_for(other).cheek_blush,
+            );
+        }
+    }
+
+    /// `Mad` and `Angry` differ along the intensity axis — `Mad` is
+    /// the hotter one. Pin the inequality so a palette tweak can't
+    /// quietly invert the relationship.
+    #[test]
+    fn mad_is_hotter_than_angry() {
+        let mad = targets_for(Emotion::Mad);
+        let angry = targets_for(Emotion::Angry);
+        assert!(
+            mad.mouth_curve < angry.mouth_curve,
+            "Mad should frown deeper than Angry ({} vs {})",
+            mad.mouth_curve,
+            angry.mouth_curve,
+        );
+        assert!(
+            mad.cheek_blush > angry.cheek_blush,
+            "Mad should blush more than Angry ({} vs {})",
+            mad.cheek_blush,
+            angry.cheek_blush,
+        );
+        assert!(
+            mad.breath_depth_scale >= angry.breath_depth_scale,
+            "Mad should breathe at least as deeply as Angry ({} vs {})",
+            mad.breath_depth_scale,
+            angry.breath_depth_scale,
+        );
+    }
+
+    /// `Doubt` and `Confused` mirror each other along the valence
+    /// axis: same uncertainty signature, opposite mouth sign.
+    #[test]
+    fn doubt_and_confused_share_uncertainty_oppose_valence() {
+        let doubt = targets_for(Emotion::Doubt);
+        let confused = targets_for(Emotion::Confused);
+        // Both are below baseline on eye_curve (uncertain).
+        assert!(
+            doubt.eye_curve < 0 && confused.eye_curve < 0,
+            "both should drop eye_curve below 0; got Doubt {} / Confused {}",
+            doubt.eye_curve,
+            confused.eye_curve,
+        );
+        // Mouth sign disambiguates the pair.
+        assert!(
+            doubt.mouth_curve > 0 && confused.mouth_curve < 0,
+            "Doubt should smile faintly, Confused should frown; got {} / {}",
+            doubt.mouth_curve,
+            confused.mouth_curve,
+        );
+    }
+
+    /// `Boring` and `Sleepy` share the half-lidded look but differ on
+    /// `mouth_curve` and droop depth. Pin the distinguishing markers so
+    /// a future palette tweak doesn't collapse them into one.
+    #[test]
+    fn boring_is_distinguishable_from_sleepy() {
+        let boring = targets_for(Emotion::Boring);
+        let sleepy = targets_for(Emotion::Sleepy);
+        assert_ne!(
+            boring.mouth_curve, sleepy.mouth_curve,
+            "Boring's faint frown should distinguish it from Sleepy's flat mouth"
+        );
+        assert!(
+            boring.open_weight > sleepy.open_weight,
+            "Sleepy should droop more than Boring ({} vs {})",
+            sleepy.open_weight,
+            boring.open_weight,
+        );
+    }
+
+    /// `Curious` widens eyes more than baseline but less than `Surprised`.
+    /// Surprised is the wide-eye startle; Curious is the narrower
+    /// investigative gaze.
+    #[test]
+    fn curious_widens_less_than_surprised() {
+        let curious = targets_for(Emotion::Curious);
+        let surprised = targets_for(Emotion::Surprised);
+        assert!(
+            curious.eye_scale > SCALE_DEFAULT,
+            "Curious should be wider than baseline ({} vs {SCALE_DEFAULT})",
+            curious.eye_scale,
+        );
+        assert!(
+            curious.eye_scale < surprised.eye_scale,
+            "Curious should be narrower than Surprised ({} vs {})",
+            curious.eye_scale,
+            surprised.eye_scale,
+        );
+        // Surprised holds an open-mouth ellipse; Curious doesn't.
+        assert_eq!(curious.mouth_weight, 0);
+        assert!(surprised.mouth_weight > 0);
     }
 }

--- a/crates/stackchan-core/src/modifiers/style_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_emotion.rs
@@ -167,8 +167,9 @@ const fn targets_for(emotion: Emotion) -> StyleTarget {
         },
         Emotion::Loved => StyleTarget {
             // Smitten: full upward eye arc + heaviest blush of the
-            // catalogue. The decorator layer paints heart overlays on
-            // top in PR 1b; the base style stands alone here.
+            // catalogue. Reads as affectionate without any decorator
+            // overlay — heart overlays may stack on top later, but the
+            // base style stands alone.
             eye_curve: 90,
             mouth_curve: 50,
             cheek_blush: 220,
@@ -639,9 +640,9 @@ mod tests {
         );
     }
 
-    /// `Loved` is the heaviest-blush variant — the decorator layer
-    /// stacks heart overlays on top, but the base style needs to stand
-    /// alone too.
+    /// `Loved` is the heaviest-blush variant. Strict `>` (not `>=`) so a
+    /// future palette tweak that quietly ties Loved on blush surfaces
+    /// here as a real collision rather than passing silently.
     #[test]
     fn loved_has_the_heaviest_blush() {
         let loved = targets_for(Emotion::Loved);
@@ -650,7 +651,7 @@ mod tests {
                 continue;
             }
             assert!(
-                loved.cheek_blush >= targets_for(other).cheek_blush,
+                loved.cheek_blush > targets_for(other).cheek_blush,
                 "Loved should have the heaviest cheek_blush; {other:?} has {}",
                 targets_for(other).cheek_blush,
             );

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -407,7 +407,10 @@ where
 }
 
 /// Parse a quoted emotion string into the corresponding [`Emotion`]
-/// variant. Vocabulary is closed and lowercase.
+/// variant. Vocabulary is closed and lowercase, and mirrors the
+/// `Emotion::wire_str` round-trip target — see the
+/// `emotion_wire_str_round_trips_through_parser` test for the live
+/// pin against `Emotion::ALL`.
 fn parse_emotion(scanner: &mut Scanner<'_>) -> Result<Emotion, JsonError> {
     let raw = scanner.read_string()?;
     match raw {
@@ -417,6 +420,13 @@ fn parse_emotion(scanner: &mut Scanner<'_>) -> Result<Emotion, JsonError> {
         "sleepy" => Ok(Emotion::Sleepy),
         "surprised" => Ok(Emotion::Surprised),
         "angry" => Ok(Emotion::Angry),
+        "doubt" => Ok(Emotion::Doubt),
+        "boring" => Ok(Emotion::Boring),
+        "hi" => Ok(Emotion::Hi),
+        "loved" => Ok(Emotion::Loved),
+        "curious" => Ok(Emotion::Curious),
+        "confused" => Ok(Emotion::Confused),
+        "mad" => Ok(Emotion::Mad),
         _ => Err(JsonError::UnknownEmotion),
     }
 }
@@ -638,16 +648,10 @@ mod tests {
         // Every `Emotion` variant must round-trip through
         // `Emotion::wire_str` and `parse_set_emotion` — a `GET /state`
         // consumer should be able to post the emotion value back
-        // without case translation. A failure here would also surface
-        // an enum/parser mismatch from a newly added variant.
-        for variant in [
-            Emotion::Neutral,
-            Emotion::Happy,
-            Emotion::Sad,
-            Emotion::Sleepy,
-            Emotion::Surprised,
-            Emotion::Angry,
-        ] {
+        // without case translation. Iterating `Emotion::ALL` keeps the
+        // test in lockstep with the enum, so a newly added variant
+        // surfaces here automatically.
+        for &variant in Emotion::ALL {
             let wire = variant.wire_str();
             let body = alloc::format!(r#"{{"emotion":"{wire}"}}"#);
             match parse_set_emotion(&body).unwrap() {

--- a/crates/stackchan-sim/tests/render_snapshot.rs
+++ b/crates/stackchan-sim/tests/render_snapshot.rs
@@ -7,8 +7,15 @@
 //! *not* do a full pixel-hash snapshot — the set of asserted pixels is small
 //! enough to survive reasonable geometry tweaks.
 
+#![allow(
+    clippy::expect_used,
+    reason = "test-only: framebuffer DrawTarget is Infallible and the Director \
+              registry capacity is a compile-time constant in this fixture"
+)]
+
 use embedded_graphics::pixelcolor::{Rgb565, RgbColor};
-use stackchan_core::Entity;
+use stackchan_core::modifiers::StyleFromEmotion;
+use stackchan_core::{Director, Emotion, Entity, Instant};
 use stackchan_sim::Framebuffer;
 
 /// LCD canvas width the firmware targets.
@@ -108,6 +115,61 @@ fn audio_open_lifts_mouth_above_resting_line() {
 
     // Mouth centre stays pink.
     assert_eq!(open.pixel(160, 180), Some(mouth_pink), "mouth centre");
+}
+
+/// Render every `Emotion` variant through `StyleFromEmotion` and assert
+/// the resulting frame differs from the neutral baseline. Catches a
+/// palette row that accidentally matches `Neutral`'s style — visually
+/// invisible, but a regression we'd otherwise only spot on hardware.
+///
+/// `open_weight` is a *cap* that `Blink` writes into `eye.weight` on
+/// every open transition; in a static one-frame snapshot we apply it
+/// here ourselves to mirror Blink's at-rest behavior — otherwise
+/// Sleepy / Boring (which differ from Neutral primarily through
+/// dynamic-only fields) would read as identical.
+#[test]
+fn every_emotion_renders_distinguishable_frame() {
+    fn render(emotion: Emotion) -> Framebuffer {
+        let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = emotion;
+        let mut style = StyleFromEmotion::new();
+        let mut director = Director::new();
+        director
+            .add_modifier(&mut style)
+            .expect("Director registry has room for one modifier");
+        // Two ticks past the transition window so the style settles.
+        director.run(&mut entity, Instant::from_millis(0));
+        director.run(
+            &mut entity,
+            Instant::from_millis(StyleFromEmotion::TRANSITION_MS + 1),
+        );
+        // Apply Blink's open-state contract: at rest, eye.weight is
+        // pinned to open_weight. Without this, dynamic-only style
+        // differences (blink rate, breath depth, lid droop) would
+        // collapse onto identical static frames.
+        entity.face.left_eye.weight = entity.face.left_eye.open_weight;
+        entity.face.right_eye.weight = entity.face.right_eye.open_weight;
+        entity
+            .face
+            .draw(&mut fb)
+            .expect("Framebuffer DrawTarget is Infallible");
+        fb
+    }
+
+    let neutral_fb = render(Emotion::Neutral);
+
+    for &emotion in Emotion::ALL {
+        if emotion == Emotion::Neutral {
+            continue;
+        }
+        let fb = render(emotion);
+        assert_ne!(
+            fb.as_slice(),
+            neutral_fb.as_slice(),
+            "{emotion:?} rendered identically to Neutral — palette row may have collided"
+        );
+    }
 }
 
 #[test]

--- a/docs/http.md
+++ b/docs/http.md
@@ -86,7 +86,7 @@ $ curl -X POST http://stackchan.local/emotion \
 
 | Field    | Type   | Required | Notes                                             |
 |----------|--------|----------|---------------------------------------------------|
-| emotion  | string | yes      | `neutral` / `happy` / `sad` / `sleepy` / `surprised` / `angry` |
+| emotion  | string | yes      | One of the wire strings in [`Emotion::wire_str`](https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/emotion.rs) (e.g. `neutral`, `happy`, `sleepy`, …) |
 | hold_ms  | u32    | no       | Default 30 000. `0` is fire-and-forget.            |
 
 The hold blocks autonomous emotion drivers (touch, IR, ambient,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,9 @@ import { Speak } from "./components/Speak";
 import { TaskHealth } from "./components/TaskHealth";
 import { Toast } from "./components/Toast";
 
+// Keys 1-6 stay pinned to the original palette (muscle memory). The
+// expanded set fills the next contiguous keys: 7-9 + 0 cover four,
+// q/w/e cover the last three.
 const EMOTION_KEYS: Record<string, string> = {
   "1": "neutral",
   "2": "happy",
@@ -21,6 +24,13 @@ const EMOTION_KEYS: Record<string, string> = {
   "4": "sleepy",
   "5": "surprised",
   "6": "angry",
+  "7": "doubt",
+  "8": "boring",
+  "9": "hi",
+  "0": "loved",
+  q: "curious",
+  w: "confused",
+  e: "mad",
 };
 
 export function App() {
@@ -62,7 +72,9 @@ function onKeyDown(ev: KeyboardEvent) {
   if (ev.altKey || ev.ctrlKey || ev.metaKey) return;
 
   const k = ev.key.toLowerCase();
-  const emotion = EMOTION_KEYS[ev.key];
+  // Lowercase lookup so `q/w/e` work regardless of shift state, mirroring
+  // how R/M work below. Digits are unaffected by `.toLowerCase()`.
+  const emotion = EMOTION_KEYS[k];
   if (emotion) {
     const btn = document.querySelector<HTMLButtonElement>(`button[data-emotion="${emotion}"]`);
     btn?.click();

--- a/web/src/components/Emotion.tsx
+++ b/web/src/components/Emotion.tsx
@@ -2,7 +2,25 @@ import { For, createSignal } from "solid-js";
 import { postJson } from "../auth";
 import { showToast } from "../store";
 
-const EMOTIONS = ["neutral", "happy", "sad", "sleepy", "surprised", "angry"] as const;
+// Wire-string vocabulary mirrors `Emotion::wire_str` in
+// `crates/stackchan-core/src/emotion.rs`. Order is the reading order in
+// the dashboard, not the wire-byte order — keep originals first so
+// muscle memory on keys 1-6 holds.
+const EMOTIONS = [
+  "neutral",
+  "happy",
+  "sad",
+  "sleepy",
+  "surprised",
+  "angry",
+  "doubt",
+  "boring",
+  "hi",
+  "loved",
+  "curious",
+  "confused",
+  "mad",
+] as const;
 const HOLD_PRESETS_S = [5, 10, 30, 60, 120] as const;
 
 export function Emotion() {
@@ -57,7 +75,9 @@ export function Emotion() {
           </For>
         </div>
       </div>
-      <small>Keys 1-6 fire the emotion at the configured hold; R resets, M toggles mute.</small>
+      <small>
+        Keys 1-9 + 0 + Q/W/E fire the emotion at the configured hold; R resets, M toggles mute.
+      </small>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Adds **Doubt, Boring, Hi, Loved, Curious, Confused, Mad** to the `Emotion` enum, bringing the catalogue in line with the upstream m5stack-avatar expression set plus a few CoreS3-specific affects.
- Each variant gets a tuned `StyleFromEmotion` palette row, a unique `HeadFromEmotion` tilt offset, and an LED ring colour distinct from `LISTEN_PALETTE` and the existing six.
- Wire vocabulary covered everywhere: `wire_str`, `wire_byte` (forward-compatible append-only), HTTP `parse_emotion`, dashboard buttons, keyboard shortcuts (1–9 + 0 + Q/W/E).
- `Emotion::ALL` constant + `wire_byte_mapping_is_stable` / `wire_bytes_are_unique` / `wire_strs_are_unique_and_lowercase` tests pin the surface so a future variant surfaces in tests automatically.
- `emotion_from_touch::next_emotion` keeps the touch-cycle as-is — the new variants are reactive-only and exit holds back to `Neutral`, mirroring how `Angry` already behaves.

## Why these emotions

Picked to match what other Stack-chan repos surface (m5stack-avatar's canonical expressions: `Doubt`, `Hi`) plus the affects that the CoreS3 sensor surface meaningfully unlocks (`Loved`, `Curious`, `Confused`, `Boring`, `Mad`). Each one is distinguishable from every other along at least one axis (eye_curve, mouth_curve, blush, eye_scale, open_weight, mouth_weight) — pinned by `every_emotion_has_a_distinct_style_target`. Specific relationships pinned by tests:

- `Hi` is louder than `Happy` (wider eyes + faster blink)
- `Loved` carries the heaviest blush of the catalogue
- `Mad` is hotter than `Angry` (deeper frown, more blush, slower huff)
- `Doubt` and `Confused` mirror each other along valence (`Doubt` smiles faintly, `Confused` frowns)
- `Boring` and `Sleepy` differ on mouth + droop depth
- `Curious` widens less than `Surprised`

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features` (rustdoc CI gate)
- [x] `just clippy-firmware` — strict clippy on the firmware target
- [x] `every_emotion_renders_distinguishable_frame` (sim test) — each variant produces a non-Neutral pixel buffer
- [ ] Hardware verification — flash + cycle through every variant via `POST /emotion` and confirm visible distinctness on the LCD + LED ring

This is part 1a of a planned face / decorator / lip-sync stack; PR 1b adds a decorator overlay layer (Heart / Sweat / Dizzy) on top of the new palette.