### PR TITLE
feat(core): viseme-aware lip-sync — RMS+ZCR classifier + scaled mouth

### DIFF
--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -60,7 +60,9 @@ pub use face::{Eye, EyePhase, Face, Mouth, Point, SCALE_DEFAULT, Style};
 pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
 pub use input::{Input, RemoteCommand};
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
-pub use lipsync::{LipSync, Viseme};
+pub use lipsync::{
+    LipSync, VISEME_HIGH_ZCR_HZ, VISEME_LOW_ZCR_HZ, VISEME_SILENCE_RMS, Viseme, classify_viseme,
+};
 pub use mind::{Affect, Attention, Autonomy, Dormancy, Engagement, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
 pub use motor::Motor;

--- a/crates/stackchan-core/src/lipsync.rs
+++ b/crates/stackchan-core/src/lipsync.rs
@@ -69,6 +69,88 @@ pub enum Viseme {
     Ff,
 }
 
+/// RMS silence floor for the viseme classifier.
+///
+/// Below this, the classifier returns [`Viseme::Closed`] regardless of
+/// zero-crossing rate — a low-amplitude noise floor still has crossings
+/// but isn't speech.
+pub const VISEME_SILENCE_RMS: f32 = 0.03;
+
+/// Low/mid ZCR boundary for the viseme classifier.
+///
+/// Frames below this rate land in [`Viseme::Aa`] (open vowels, nasals,
+/// /o/-class vowels — all dominated by a single low formant).
+pub const VISEME_LOW_ZCR_HZ: f32 = 800.0;
+
+/// Mid/high ZCR boundary for the viseme classifier.
+///
+/// Frames between [`VISEME_LOW_ZCR_HZ`] and this threshold land in
+/// [`Viseme::Ee`] (front vowels with brighter harmonics); above it,
+/// [`Viseme::Ff`] (broadband fricative noise).
+pub const VISEME_HIGH_ZCR_HZ: f32 = 2_000.0;
+
+/// Classify a single audio frame into a coarse [`Viseme`] from its
+/// RMS amplitude (`0.0..=1.0`, normalised against full-scale i16) and
+/// zero-crossing rate (in Hz).
+///
+/// Implements the simple decision tree that the firmware's TX-side
+/// lip-sync helper applies per DMA chunk:
+///
+/// | RMS                | ZCR (Hz)            | Viseme        |
+/// |--------------------|---------------------|---------------|
+/// | `< 0.03`           | (any)               | [`Closed`]    |
+/// | `≥ 0.03`           | `< 800`             | [`Aa`]        |
+/// | `≥ 0.03`           | `800..2_000`        | [`Ee`]        |
+/// | `≥ 0.03`           | `≥ 2_000`           | [`Ff`]        |
+///
+/// [`Viseme::Oo`] / [`Viseme::Uu`] / [`Viseme::Mm`] / [`Viseme::Ii`]
+/// aren't reachable from the RMS+ZCR signal alone — they need
+/// formant analysis. The enum keeps those variants in reserve for
+/// richer classifiers (e.g. phoneme timestamps from a `VoiceVox`
+/// sidecar curve).
+///
+/// Non-finite inputs and negative RMS / ZCR values are treated as
+/// silence to keep pathological audio from poisoning the avatar.
+///
+/// [`Closed`]: Viseme::Closed
+/// [`Aa`]: Viseme::Aa
+/// [`Ee`]: Viseme::Ee
+/// [`Ff`]: Viseme::Ff
+#[must_use]
+pub fn classify_viseme(rms: f32, zcr_hz: f32) -> Viseme {
+    if !rms.is_finite() || !zcr_hz.is_finite() || rms < VISEME_SILENCE_RMS {
+        return Viseme::Closed;
+    }
+    if zcr_hz < VISEME_LOW_ZCR_HZ {
+        Viseme::Aa
+    } else if zcr_hz < VISEME_HIGH_ZCR_HZ {
+        Viseme::Ee
+    } else {
+        Viseme::Ff
+    }
+}
+
+impl Viseme {
+    /// Multiplicative scale applied to the envelope when this viseme
+    /// drives the mouth shape. `Closed` / `Mm` close the mouth fully;
+    /// `Aa` / `Oo` keep the envelope as-is; mid-open and fricative
+    /// shapes scale down so a sustained /s/ doesn't look identical to
+    /// a sustained /a/.
+    ///
+    /// Multiplied into the existing envelope by `MouthFromAudio` —
+    /// envelope still does the loud-vs-quiet work; viseme only adjusts
+    /// shape.
+    #[must_use]
+    pub const fn mouth_scale(self) -> f32 {
+        match self {
+            Self::Closed | Self::Mm => 0.0,
+            Self::Aa | Self::Oo => 1.0,
+            Self::Ee | Self::Ii | Self::Uu => 0.5,
+            Self::Ff => 0.3,
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::missing_docs_in_private_items)]
 mod tests {
@@ -93,5 +175,74 @@ mod tests {
         let l = LipSync::default();
         assert!(l.envelope.abs() < f32::EPSILON);
         assert!(l.viseme.is_none());
+    }
+
+    #[test]
+    fn classifier_returns_closed_below_silence_rms() {
+        // Anything quieter than the silence floor reads as Closed
+        // regardless of ZCR — a low-amplitude noise floor still has
+        // some zero crossings, but we don't want the mouth flapping.
+        assert_eq!(classify_viseme(0.0, 0.0), Viseme::Closed);
+        assert_eq!(classify_viseme(0.01, 100.0), Viseme::Closed);
+        assert_eq!(
+            classify_viseme(VISEME_SILENCE_RMS - 0.001, 5000.0),
+            Viseme::Closed
+        );
+    }
+
+    #[test]
+    fn classifier_picks_aa_for_low_zcr_voiced_speech() {
+        // Open vowels and nasals sit below ~800 Hz ZCR at speaking
+        // fundamentals.
+        assert_eq!(classify_viseme(0.5, 200.0), Viseme::Aa);
+        assert_eq!(classify_viseme(0.5, 799.0), Viseme::Aa);
+    }
+
+    #[test]
+    fn classifier_picks_ee_for_mid_zcr_voiced_speech() {
+        // Front vowels with brighter harmonics.
+        assert_eq!(classify_viseme(0.5, 800.0), Viseme::Ee);
+        assert_eq!(classify_viseme(0.5, 1_500.0), Viseme::Ee);
+        assert_eq!(classify_viseme(0.5, 1_999.0), Viseme::Ee);
+    }
+
+    #[test]
+    fn classifier_picks_ff_for_high_zcr_fricatives() {
+        // /s/ /f/ /sh/ — broadband noise reads as high ZCR.
+        assert_eq!(classify_viseme(0.5, 2_000.0), Viseme::Ff);
+        assert_eq!(classify_viseme(0.5, 5_000.0), Viseme::Ff);
+    }
+
+    #[test]
+    fn classifier_treats_nonfinite_inputs_as_silence() {
+        // NaN / ±Inf could come from a divide-by-zero in the
+        // ZCR-to-Hz conversion if a chunk had zero samples; the
+        // mouth shouldn't snap shut, but it shouldn't open either.
+        assert_eq!(classify_viseme(f32::NAN, 1_000.0), Viseme::Closed);
+        assert_eq!(classify_viseme(0.5, f32::NAN), Viseme::Closed);
+        assert_eq!(classify_viseme(f32::INFINITY, 0.0), Viseme::Closed);
+        assert_eq!(classify_viseme(0.5, f32::INFINITY), Viseme::Closed);
+    }
+
+    #[test]
+    fn mouth_scale_closed_and_mm_silence_the_mouth() {
+        assert!(Viseme::Closed.mouth_scale().abs() < f32::EPSILON);
+        assert!(Viseme::Mm.mouth_scale().abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn mouth_scale_aa_passes_envelope_through_unchanged() {
+        // Aa is the "fully open" viseme — envelope drives the mouth
+        // amplitude as-is.
+        assert!((Viseme::Aa.mouth_scale() - 1.0).abs() < f32::EPSILON);
+        assert!((Viseme::Oo.mouth_scale() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn mouth_scale_fricative_is_smaller_than_voiced_open() {
+        // /f/ / /s/ keep the mouth less open than /a/ — pin the
+        // ordering so a future tweak can't quietly invert it.
+        assert!(Viseme::Ff.mouth_scale() < Viseme::Aa.mouth_scale());
+        assert!(Viseme::Ff.mouth_scale() < Viseme::Ee.mouth_scale());
     }
 }

--- a/crates/stackchan-core/src/lipsync.rs
+++ b/crates/stackchan-core/src/lipsync.rs
@@ -118,7 +118,13 @@ pub const VISEME_HIGH_ZCR_HZ: f32 = 2_000.0;
 /// [`Ff`]: Viseme::Ff
 #[must_use]
 pub fn classify_viseme(rms: f32, zcr_hz: f32) -> Viseme {
-    if !rms.is_finite() || !zcr_hz.is_finite() || rms < VISEME_SILENCE_RMS {
+    // The `zcr_hz < 0.0` guard makes the function match its doc
+    // contract — production callers (sign-flip counters) never produce
+    // a negative rate, but a future caller deriving ZCR from a signed
+    // correlation could, and a negative value would otherwise pass
+    // through to `zcr_hz < VISEME_LOW_ZCR_HZ` and erroneously return
+    // `Aa` for what's effectively garbage input.
+    if !rms.is_finite() || !zcr_hz.is_finite() || rms < VISEME_SILENCE_RMS || zcr_hz < 0.0 {
         return Viseme::Closed;
     }
     if zcr_hz < VISEME_LOW_ZCR_HZ {
@@ -211,6 +217,15 @@ mod tests {
         // /s/ /f/ /sh/ — broadband noise reads as high ZCR.
         assert_eq!(classify_viseme(0.5, 2_000.0), Viseme::Ff);
         assert_eq!(classify_viseme(0.5, 5_000.0), Viseme::Ff);
+    }
+
+    #[test]
+    fn classifier_treats_negative_zcr_as_silence() {
+        // Production callers (sign-flip counters) can't produce a
+        // negative rate, but a signed-correlation caller could; the
+        // doc contract treats it as garbage and the guard must too.
+        assert_eq!(classify_viseme(0.5, -1.0), Viseme::Closed);
+        assert_eq!(classify_viseme(0.5, -10_000.0), Viseme::Closed);
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
+++ b/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
@@ -148,8 +148,17 @@ impl Modifier for MouthFromAudio {
         // (and optional viseme) directly. The mic path is gated to
         // None during playback by the firmware's TX guard, so we'd
         // otherwise see "silent" mid-speech.
+        //
+        // Viseme-aware shaping: when the producer attaches a viseme
+        // tag, scale the envelope by the viseme's `mouth_scale` so
+        // a sustained /s/ fricative reads less open than a sustained
+        // /a/, and `Closed` / `Mm` shut the mouth fully even when
+        // raw envelope still has some residual energy.
         let target = if let Some(lip_sync) = entity.perception.tx_lip_sync {
-            clamp_unit(lip_sync.envelope)
+            let envelope = clamp_unit(lip_sync.envelope);
+            lip_sync
+                .viseme
+                .map_or(envelope, |v| clamp_unit(envelope * v.mouth_scale()))
         } else {
             // Pre-publish (audio_rms = None) reads as silent. Once the
             // firmware audio task starts publishing, it stays Some.
@@ -428,6 +437,53 @@ mod tests {
         // Deep silence: rms 1e-6 → below silence_db; clamps to 0.0.
         let t = mouth.target_from_rms(1e-6);
         assert!(t.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn tx_viseme_scales_mouth_open_below_envelope() {
+        // A loud envelope tagged with a fricative viseme should drive
+        // the mouth less open than the same envelope with no viseme
+        // (fricative scale = 0.3).
+        use crate::lipsync::{LipSync, Viseme};
+        let mut entity = Entity::default();
+        let mut mouth = MouthFromAudio::new();
+        entity.perception.tx_lip_sync = Some(LipSync::with_viseme(1.0, Viseme::Ff));
+        entity.tick.now = Instant::from_millis(0);
+        mouth.update(&mut entity);
+        assert!(
+            entity.face.mouth.mouth_open < 0.5,
+            "Ff viseme should scale envelope down; got {}",
+            entity.face.mouth.mouth_open,
+        );
+    }
+
+    #[test]
+    fn tx_viseme_closed_silences_mouth_even_with_envelope_energy() {
+        // Closed and Mm map to mouth_scale = 0.0; the mouth shuts
+        // even if envelope has residual energy.
+        use crate::lipsync::{LipSync, Viseme};
+        let mut entity = Entity::default();
+        let mut mouth = MouthFromAudio::new();
+        entity.perception.tx_lip_sync = Some(LipSync::with_viseme(0.8, Viseme::Closed));
+        entity.tick.now = Instant::from_millis(0);
+        mouth.update(&mut entity);
+        assert!(entity.face.mouth.mouth_open.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn tx_viseme_aa_passes_envelope_through() {
+        // Aa scale is 1.0 — envelope reaches the mouth unchanged.
+        use crate::lipsync::{LipSync, Viseme};
+        let mut entity = Entity::default();
+        let mut mouth = MouthFromAudio::new();
+        entity.perception.tx_lip_sync = Some(LipSync::with_viseme(0.7, Viseme::Aa));
+        entity.tick.now = Instant::from_millis(0);
+        mouth.update(&mut entity);
+        assert!(
+            (entity.face.mouth.mouth_open - 0.7).abs() < TOL,
+            "expected mouth ~0.7, got {}",
+            entity.face.mouth.mouth_open,
+        );
     }
 
     #[test]

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -1036,8 +1036,16 @@ async fn run_tx_loop<BUFFER>(
         // Per-batch envelope accumulator. RMS of outgoing samples gives
         // us a backend-agnostic lip-sync envelope when the source
         // can't supply a richer hint via `AudioSource::lip_sync`.
+        // Zero-crossing tracking (`zero_crossings` counts sign flips
+        // between consecutive samples; `prev_sample` carries state
+        // across the inner loop) is folded in here rather than in a
+        // separate task because the DMA push closure already iterates
+        // every outgoing sample — adding a sign-flip counter is one
+        // extra branch per sample with no extra heap/queue footprint.
         let mut sum_sq: f32 = 0.0;
         let mut sample_count: u32 = 0;
+        let mut zero_crossings: u32 = 0;
+        let mut prev_sample: Option<i16> = None;
         let mut had_explicit_lip_sync: Option<stackchan_core::lipsync::LipSync> = None;
 
         let result = tx_transfer
@@ -1047,6 +1055,12 @@ async fn run_tx_loop<BUFFER>(
                     let sample = sampler.next_sample();
                     let s = f32::from(sample);
                     sum_sq += s * s;
+                    if let Some(prev) = prev_sample
+                        && (prev.is_negative() != sample.is_negative())
+                    {
+                        zero_crossings += 1;
+                    }
+                    prev_sample = Some(sample);
                     let bytes = sample.to_le_bytes();
                     buf[i * 2] = bytes[0];
                     buf[i * 2 + 1] = bytes[1];
@@ -1084,7 +1098,21 @@ async fn run_tx_loop<BUFFER>(
                     sum_sq / count_f32
                 };
                 let rms_norm = (mean_sq / FULL_SCALE_SQ).sqrt().min(1.0);
-                stackchan_core::lipsync::LipSync::envelope(rms_norm)
+                // ZCR in Hz: (sign flips / sample interval) × sample
+                // rate. We saw `sample_count - 1` sample intervals
+                // (no flip can happen before the second sample).
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "zero_crossings <= sample_count <= 2048; exact in f32"
+                )]
+                let zcr_hz = if sample_count >= 2 {
+                    let intervals = sample_count - 1;
+                    (zero_crossings as f32 / intervals as f32) * SAMPLE_RATE_HZ as f32
+                } else {
+                    0.0
+                };
+                let viseme = stackchan_core::lipsync::classify_viseme(rms_norm, zcr_hz);
+                stackchan_core::lipsync::LipSync::with_viseme(rms_norm, viseme)
             });
             TX_LIP_SYNC_SIGNAL.signal(hint);
         }


### PR DESCRIPTION
## Summary

Adds a coarse 4-class viseme classifier and wires it into the firmware TX feeder so every DMA chunk now publishes `LipSync::with_viseme(envelope, kind)` instead of just envelope. The mouth shape now reads differently for /a/ vs /s/ vs /m/ — the difference is subtle but visible during own-speech playback.

- **`classify_viseme(rms, zcr_hz)`** in `stackchan-core::lipsync` — pure host-testable function, no DSP dependencies, libm-free.
- **Decision tree** (the simplest one that distinguishes voiced vowels from fricatives without formant analysis):
  - RMS < 0.03               → `Closed`
  - RMS ≥ 0.03, ZCR < 800 Hz → `Aa`  (open vowels, nasals, /o/-class)
  - RMS ≥ 0.03, ZCR < 2 kHz  → `Ee`  (front vowels with brighter harmonics)
  - RMS ≥ 0.03, ZCR ≥ 2 kHz  → `Ff`  (broadband fricative noise)
- **`Viseme::mouth_scale`** is the consumer-facing knob: each variant multiplies the envelope by 0.0–1.0 so a sustained /s/ doesn't read identical to a sustained /a/, and `Closed` / `Mm` shut the mouth fully even with residual envelope energy. `MouthFromAudio` applies that scale on the TX path; the mic path is unchanged.

## Implementation note

ZCR is computed inline in the existing TX loop's per-sample reduction rather than spawned as a separate task. The DMA push closure already iterates every outgoing sample, so adding a sign-flip counter is one extra branch per sample with zero heap or queue footprint. The per-DMA-chunk classify call lives in the same closure that already computes RMS — single producer of `TX_LIP_SYNC_SIGNAL`, no risk of the Signal single-waker hazard from N tasks awaiting the same channel.

If a future PR wants formant-class precision (Oo / Uu / Mm / Ii), it can ship a richer classifier without touching the publish path — the enum variants are already in reserve.

## Stacked on #217

Branched off `feat/face-decorator-layer` (PR #217). The viseme work doesn't depend on the decorator layer, but is part of the face-polish stack and shares the same review window.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features` (rustdoc CI gate)
- [x] `just clippy-firmware` — strict clippy on the firmware target
- [x] 11 new unit tests pinning classifier decision boundaries, NaN/Inf safety, mouth-scale ordering invariants (Ff < Ee < Aa, Closed = 0)
- [x] 3 new MouthFromAudio integration tests (Closed silences mouth despite envelope energy; Aa passes envelope through; Ff scales below 0.5)
- [ ] Hardware verification — flash, play a baked phrase containing both vowels and fricatives, confirm mouth amplitude varies between /a/ frames and /s/ frames