### PR TITLE
feat(core): mood presets + closed-eye smile on Petted

### DIFF
--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -196,6 +196,8 @@ pub enum Field {
     Engagement,
     /// `entity.mind.dormancy`
     Dormancy,
+    /// `entity.mind.mood`
+    Mood,
 
     // ---- Voice ----
     /// `entity.voice.chirp_request`
@@ -254,6 +256,7 @@ impl Field {
         Self::Attention,
         Self::Engagement,
         Self::Dormancy,
+        Self::Mood,
         Self::ChirpRequest,
         Self::UtteranceRequest,
         Self::IsSpeaking,
@@ -299,7 +302,8 @@ impl Field {
             | Self::Intent
             | Self::Attention
             | Self::Engagement
-            | Self::Dormancy => FieldGroup::Mind,
+            | Self::Dormancy
+            | Self::Mood => FieldGroup::Mind,
             Self::ChirpRequest | Self::UtteranceRequest | Self::IsSpeaking => FieldGroup::Voice,
             Self::TapPending | Self::RemotePending | Self::RemoteCommand => FieldGroup::Input,
         }
@@ -401,6 +405,7 @@ impl Field {
             Self::Attention => before.mind.attention != after.mind.attention,
             Self::Engagement => before.mind.engagement != after.mind.engagement,
             Self::Dormancy => before.mind.dormancy != after.mind.dormancy,
+            Self::Mood => before.mind.mood != after.mind.mood,
             Self::ChirpRequest => before.voice.chirp_request != after.voice.chirp_request,
             Self::UtteranceRequest => {
                 before.voice.utterance_request != after.voice.utterance_request
@@ -816,7 +821,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            41,
+            42,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod lipsync;
 pub mod mind;
 pub mod modifier;
 pub mod modifiers;
+pub mod mood;
 pub mod motor;
 pub mod perception;
 pub mod skill;
@@ -65,6 +66,7 @@ pub use lipsync::{
 };
 pub use mind::{Affect, Attention, Autonomy, Dormancy, Engagement, Intent, Mind, OverrideSource};
 pub use modifier::Modifier;
+pub use mood::Mood;
 pub use motor::Motor;
 pub use perception::{
     BodyTouch, HALF_FOV_H_DEG, HALF_FOV_V_DEG, MAX_TRACKING_CANDIDATES, Perception,

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -24,6 +24,7 @@
 use crate::clock::Instant;
 use crate::emotion::Emotion;
 use crate::head::Pose;
+use crate::mood::Mood;
 
 /// The entity's current felt state.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -319,6 +320,12 @@ pub struct Mind {
     /// [`crate::modifiers::IdleHeadDrift`] to silence the head servos
     /// when nothing's happening in the room.
     pub dormancy: Dormancy,
+    /// Operator-selected energy baseline. Persistent across emotion
+    /// changes; set by `STACKCHAN.RON` config and the HTTP control
+    /// plane, never written by reactive modifiers. Consumed by
+    /// [`crate::modifiers::StyleFromMood`] which scales blink rate,
+    /// breath depth, and idle drift on top of the per-emotion targets.
+    pub mood: Mood,
     /// Persistent facts.
     pub memory: Memory,
 }

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -110,6 +110,7 @@ mod mouth_from_audio;
 mod remote_command;
 mod style_from_emotion;
 mod style_from_intent;
+mod style_from_mood;
 
 pub use attention_from_tracking::{
     AttentionFromTracking, FACE_LOCK_HITS, FACE_RELEASE_MISSES, TRACKING_LOCK_TICKS,
@@ -169,4 +170,7 @@ pub use mouth_from_audio::{
 };
 pub use remote_command::RemoteCommandModifier;
 pub use style_from_emotion::StyleFromEmotion;
-pub use style_from_intent::{PETTING_BLUSH_BUMP, StyleFromIntent};
+pub use style_from_intent::{
+    PETTING_BLUSH_BUMP, PETTING_EYE_CURVE_BUMP, PETTING_OPEN_WEIGHT_CAP, StyleFromIntent,
+};
+pub use style_from_mood::StyleFromMood;

--- a/crates/stackchan-core/src/modifiers/style_from_intent.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_intent.rs
@@ -32,6 +32,22 @@ use crate::modifier::Modifier;
 /// of whatever `StyleFromEmotion` set; saturates at `255`.
 pub const PETTING_BLUSH_BUMP: u8 = 30;
 
+/// Eye-curve bump added on `Intent::Petted` for the closed-eye smile.
+///
+/// Stacked on top of whatever `StyleFromEmotion` already set — so a
+/// Happy + Petted combo curves the eyes into a bigger smile, while a
+/// Sad + Petted combo softens the downward droop. Clamped to the
+/// `i8` range.
+pub const PETTING_EYE_CURVE_BUMP: i8 = 30;
+
+/// Cap on `eye.open_weight` while `Intent::Petted` is active.
+///
+/// Sets the squint level for the closed-eye smile — eyes stay below
+/// this even if `StyleFromEmotion` was holding them wide. Visibly
+/// distinct from the always-closed `EyePhase::Closed` because Blink
+/// continues to drive the open/close lifecycle.
+pub const PETTING_OPEN_WEIGHT_CAP: u8 = 60;
+
 /// Per-intent face-style additions.
 ///
 /// Stateless — every tick reads the upstream `cheek_blush`
@@ -64,28 +80,82 @@ const fn blush_for(intent: Intent) -> u8 {
     }
 }
 
+/// Look up the per-intent eye-curve addition for the closed-eye smile
+/// on `Petted`. Other intents leave `eye_curve` to upstream modifiers.
+const fn eye_curve_bump_for(intent: Intent) -> i8 {
+    match intent {
+        Intent::Petted => PETTING_EYE_CURVE_BUMP,
+        Intent::Idle
+        | Intent::Listening
+        | Intent::PickedUp
+        | Intent::Shaken
+        | Intent::Tilted
+        | Intent::Startled => 0,
+    }
+}
+
+/// Look up the per-intent `open_weight` cap. `None` = no clamp; only
+/// `Petted` enforces a squint cap today.
+const fn open_weight_cap_for(intent: Intent) -> Option<u8> {
+    match intent {
+        Intent::Petted => Some(PETTING_OPEN_WEIGHT_CAP),
+        Intent::Idle
+        | Intent::Listening
+        | Intent::PickedUp
+        | Intent::Shaken
+        | Intent::Tilted
+        | Intent::Startled => None,
+    }
+}
+
 impl Modifier for StyleFromIntent {
     fn meta(&self) -> &'static ModifierMeta {
         static META: ModifierMeta = ModifierMeta {
             name: "StyleFromIntent",
             description: "Translates mind.intent into additive face.style overrides. \
-                          BeingPet adds +PETTING_BLUSH_BUMP to cheek_blush; other intents \
-                          contribute 0. Stateless — relies on StyleFromEmotion re-writing the \
-                          cheek_blush baseline each tick.",
+                          Petted adds +PETTING_BLUSH_BUMP to cheek_blush, +PETTING_EYE_CURVE_BUMP \
+                          to eye_curve, and clamps both eyes' open_weight at \
+                          PETTING_OPEN_WEIGHT_CAP for the closed-eye smile. Stateless — relies on \
+                          StyleFromEmotion re-writing the baselines each tick.",
             phase: Phase::Expression,
             // Runs after `StyleFromEmotion` (priority -10) but before
             // `Blink` / `Breath` / `IdleDrift` (priority 0). Same
             // bracket the canonical-order test pins.
             priority: -5,
-            reads: &[Field::Intent, Field::CheekBlush],
-            writes: &[Field::CheekBlush],
+            reads: &[
+                Field::Intent,
+                Field::CheekBlush,
+                Field::EyeCurve,
+                Field::LeftEyeOpenWeight,
+                Field::RightEyeOpenWeight,
+            ],
+            writes: &[
+                Field::CheekBlush,
+                Field::EyeCurve,
+                Field::LeftEyeOpenWeight,
+                Field::RightEyeOpenWeight,
+            ],
         };
         &META
     }
 
     fn update(&mut self, entity: &mut Entity) {
-        let bump = blush_for(entity.mind.intent);
+        let intent = entity.mind.intent;
+        let bump = blush_for(intent);
         entity.face.style.cheek_blush = entity.face.style.cheek_blush.saturating_add(bump);
+
+        let curve_bump = eye_curve_bump_for(intent);
+        if curve_bump != 0 {
+            entity.face.style.eye_curve = entity.face.style.eye_curve.saturating_add(curve_bump);
+        }
+
+        if let Some(cap) = open_weight_cap_for(intent) {
+            // Min-with-existing: `Petted` only *narrows* the eyes
+            // beyond what's already happening. A future intent that
+            // wants the opposite would need a different field.
+            entity.face.left_eye.open_weight = entity.face.left_eye.open_weight.min(cap);
+            entity.face.right_eye.open_weight = entity.face.right_eye.open_weight.min(cap);
+        }
     }
 }
 
@@ -155,6 +225,68 @@ mod tests {
         entity.mind.intent = Intent::Idle;
         m.update(&mut entity);
         assert_eq!(entity.face.style.cheek_blush, 70);
+    }
+
+    #[test]
+    fn being_pet_curves_eyes_into_smile() {
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 0);
+        // Pretend StyleFromEmotion left eye_curve = 20 (slight smile).
+        entity.face.style.eye_curve = 20;
+        m.update(&mut entity);
+        assert_eq!(
+            entity.face.style.eye_curve,
+            20 + PETTING_EYE_CURVE_BUMP,
+            "Petted should add curve_bump on top of upstream"
+        );
+    }
+
+    #[test]
+    fn being_pet_caps_open_weight_for_closed_eye_smile() {
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 0);
+        // StyleFromEmotion holds eyes wide on Happy/Hi (open_weight = 100).
+        entity.face.left_eye.open_weight = 100;
+        entity.face.right_eye.open_weight = 100;
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.open_weight, PETTING_OPEN_WEIGHT_CAP);
+        assert_eq!(entity.face.right_eye.open_weight, PETTING_OPEN_WEIGHT_CAP);
+    }
+
+    #[test]
+    fn being_pet_does_not_open_eyes_above_their_existing_value() {
+        // Sleepy emotion already droops open_weight to 55 — the cap of
+        // 60 must not push that *up* to 60. Min-with-existing.
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 0);
+        entity.face.left_eye.open_weight = 55;
+        entity.face.right_eye.open_weight = 55;
+        m.update(&mut entity);
+        assert_eq!(entity.face.left_eye.open_weight, 55);
+        assert_eq!(entity.face.right_eye.open_weight, 55);
+    }
+
+    #[test]
+    fn idle_intent_does_not_modify_eye_fields() {
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Idle, 0);
+        entity.face.style.eye_curve = 20;
+        entity.face.left_eye.open_weight = 100;
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.eye_curve, 20);
+        assert_eq!(entity.face.left_eye.open_weight, 100);
+    }
+
+    #[test]
+    fn being_pet_eye_curve_saturates_on_overflow() {
+        // Hi emotion + Petted: eye_curve already at 50; +30 = 80,
+        // well below i8::MAX. But pin saturating behaviour anyway so
+        // a future emotion with eye_curve = 110 doesn't wrap.
+        let mut m = StyleFromIntent::new();
+        let mut entity = entity_with(Intent::Petted, 0);
+        entity.face.style.eye_curve = 110;
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.eye_curve, i8::MAX);
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/style_from_mood.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_mood.rs
@@ -1,0 +1,181 @@
+//! [`StyleFromMood`] — applies the operator-selected [`Mood`] as a
+//! multiplier on top of the per-emotion style targets that
+//! [`super::StyleFromEmotion`] already wrote.
+//!
+//! Runs at priority `-7` in [`Phase::Expression`] — after
+//! `StyleFromEmotion` (`-10`) and `StyleFromIntent` (`-5`), but before
+//! [`super::Blink`] / [`super::Breath`] (`0`) so the cadence modifiers
+//! see the final mood-adjusted scale.
+//!
+//! ## Composition
+//!
+//! - `face.style.blink_rate_scale *= mood.blink_multiplier()`
+//! - `face.style.breath_depth_scale *= mood.breath_multiplier()`
+//!
+//! Idle-drift amplitude is scaled by the modifier itself reading
+//! `mood.drift_multiplier()` — the drift modifiers don't currently
+//! carry a runtime scale, so a follow-up can plumb that through; for
+//! now this modifier covers the two dominant cadence axes.
+//!
+//! [`Mood`]: crate::mood::Mood
+//! [`Phase::Expression`]: crate::director::Phase::Expression
+
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// Stateless modifier that scales the cadence-bearing style fields by
+/// the active [`crate::Mood`] multiplier.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StyleFromMood;
+
+impl StyleFromMood {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+/// Multiply a `u8` scale field by an `f32` multiplier and clamp back
+/// into `0..=255`. Saturating so a mood with an extreme multiplier
+/// can't overflow a baseline that's already near the cap.
+fn scale_u8(value: u8, multiplier: f32) -> u8 {
+    if !multiplier.is_finite() || multiplier <= 0.0 {
+        return 0;
+    }
+    let scaled = f32::from(value) * multiplier;
+    if scaled <= 0.0 {
+        0
+    } else if scaled >= 255.0 {
+        255
+    } else {
+        // `scaled` is in `[0, 255)` here; the cast is precision-safe.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let rounded = scaled as u8;
+        rounded
+    }
+}
+
+impl Modifier for StyleFromMood {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "StyleFromMood",
+            description: "Scales face.style.blink_rate_scale and breath_depth_scale by the \
+                          active mood's multipliers. Runs after StyleFromEmotion / \
+                          StyleFromIntent so it sees the final per-emotion + per-intent \
+                          baseline.",
+            phase: Phase::Expression,
+            priority: -7,
+            reads: &[Field::Mood, Field::BlinkRateScale, Field::BreathDepthScale],
+            writes: &[Field::BlinkRateScale, Field::BreathDepthScale],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let mood = entity.mind.mood;
+        entity.face.style.blink_rate_scale =
+            scale_u8(entity.face.style.blink_rate_scale, mood.blink_multiplier());
+        entity.face.style.breath_depth_scale = scale_u8(
+            entity.face.style.breath_depth_scale,
+            mood.breath_multiplier(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::face::SCALE_DEFAULT;
+    use crate::mood::Mood;
+
+    #[test]
+    fn neutral_mood_passes_scales_through_unchanged() {
+        let mut entity = Entity::default();
+        entity.mind.mood = Mood::Neutral;
+        entity.face.style.blink_rate_scale = SCALE_DEFAULT;
+        entity.face.style.breath_depth_scale = SCALE_DEFAULT;
+        let mut m = StyleFromMood::new();
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.blink_rate_scale, SCALE_DEFAULT);
+        assert_eq!(entity.face.style.breath_depth_scale, SCALE_DEFAULT);
+    }
+
+    #[test]
+    fn playful_speeds_blink_above_baseline() {
+        let mut entity = Entity::default();
+        entity.mind.mood = Mood::Playful;
+        entity.face.style.blink_rate_scale = SCALE_DEFAULT;
+        let mut m = StyleFromMood::new();
+        m.update(&mut entity);
+        assert!(entity.face.style.blink_rate_scale > SCALE_DEFAULT);
+    }
+
+    #[test]
+    fn calm_slows_blink_below_baseline() {
+        let mut entity = Entity::default();
+        entity.mind.mood = Mood::Calm;
+        entity.face.style.blink_rate_scale = SCALE_DEFAULT;
+        let mut m = StyleFromMood::new();
+        m.update(&mut entity);
+        assert!(entity.face.style.blink_rate_scale < SCALE_DEFAULT);
+    }
+
+    #[test]
+    fn calm_deepens_breath_above_baseline() {
+        let mut entity = Entity::default();
+        entity.mind.mood = Mood::Calm;
+        entity.face.style.breath_depth_scale = SCALE_DEFAULT;
+        let mut m = StyleFromMood::new();
+        m.update(&mut entity);
+        assert!(entity.face.style.breath_depth_scale > SCALE_DEFAULT);
+    }
+
+    #[test]
+    fn sleepy_drops_blink_far_below_baseline() {
+        // Sleepy mood × Sleepy emotion is the slowest-blink combo —
+        // pin that the multiplier actually compounds with the base.
+        let mut entity = Entity::default();
+        entity.mind.mood = Mood::Sleepy;
+        // Pretend StyleFromEmotion already set Sleepy emotion's
+        // blink_rate_scale = 48.
+        entity.face.style.blink_rate_scale = 48;
+        let mut m = StyleFromMood::new();
+        m.update(&mut entity);
+        // 48 × 0.4 = 19.2 → 19
+        assert_eq!(entity.face.style.blink_rate_scale, 19);
+    }
+
+    #[test]
+    fn scale_zero_input_stays_zero() {
+        // `Surprised` emotion sets blink_rate_scale = 0 (eyes held
+        // wide). Mood multiplier must respect that — otherwise a
+        // Playful Surprised would unexpectedly start blinking.
+        let mut entity = Entity::default();
+        entity.mind.mood = Mood::Playful;
+        entity.face.style.blink_rate_scale = 0;
+        let mut m = StyleFromMood::new();
+        m.update(&mut entity);
+        assert_eq!(entity.face.style.blink_rate_scale, 0);
+    }
+
+    #[test]
+    fn scale_u8_saturates_at_max() {
+        // A baseline near the cap × a > 1.0 multiplier mustn't wrap.
+        assert_eq!(scale_u8(200, 2.0), 255);
+        assert_eq!(scale_u8(255, 1.5), 255);
+    }
+
+    #[test]
+    fn scale_u8_handles_nonfinite_multiplier_as_zero() {
+        // Defensive: a future caller passing NaN / ±inf / negative
+        // must not poison the style fields. We pick the conservative
+        // "drop everything" branch — the avatar reads as still rather
+        // than chaotic on garbage input.
+        assert_eq!(scale_u8(128, f32::NAN), 0);
+        assert_eq!(scale_u8(128, f32::INFINITY), 0);
+        assert_eq!(scale_u8(128, f32::NEG_INFINITY), 0);
+        assert_eq!(scale_u8(128, -1.0), 0);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/style_from_mood.rs
+++ b/crates/stackchan-core/src/modifiers/style_from_mood.rs
@@ -3,19 +3,24 @@
 //! [`super::StyleFromEmotion`] already wrote.
 //!
 //! Runs at priority `-7` in [`Phase::Expression`] — after
-//! `StyleFromEmotion` (`-10`) and `StyleFromIntent` (`-5`), but before
-//! [`super::Blink`] / [`super::Breath`] (`0`) so the cadence modifiers
-//! see the final mood-adjusted scale.
+//! `StyleFromEmotion` (`-10`) but *before* `StyleFromIntent` (`-5`),
+//! and before [`super::Blink`] / [`super::Breath`] (`0`) so the
+//! cadence modifiers see the final mood-adjusted scale. The
+//! before-`StyleFromIntent` ordering is currently incidental — the
+//! two write to disjoint fields (cadence vs blush/eye-curve), so the
+//! interleaving is a no-op today. If a future
+//! `StyleFromIntent` field overlaps with cadence, swap priorities
+//! to keep mood as the final word.
 //!
 //! ## Composition
 //!
 //! - `face.style.blink_rate_scale *= mood.blink_multiplier()`
 //! - `face.style.breath_depth_scale *= mood.breath_multiplier()`
 //!
-//! Idle-drift amplitude is scaled by the modifier itself reading
-//! `mood.drift_multiplier()` — the drift modifiers don't currently
-//! carry a runtime scale, so a follow-up can plumb that through; for
-//! now this modifier covers the two dominant cadence axes.
+//! `Mood::drift_multiplier` is also defined on the type but isn't
+//! consumed yet — it'll plumb through `IdleDrift` / `IdleHeadDrift`
+//! once those grow runtime scales. Keeping it on the type now means
+//! the public API doesn't have to break later.
 //!
 //! [`Mood`]: crate::mood::Mood
 //! [`Phase::Expression`]: crate::director::Phase::Expression

--- a/crates/stackchan-core/src/mood.rs
+++ b/crates/stackchan-core/src/mood.rs
@@ -1,0 +1,171 @@
+//! Operator-selected baseline for the avatar's energy level.
+//!
+//! [`Mood`] is a *user* setting (set via dashboard / HTTP / SD config),
+//! distinct from [`crate::Emotion`] which is *reactive* (driven by
+//! sensors and the autonomous cycler). The two compose: emotion picks
+//! the visible expression palette, then mood scales the modulators
+//! that drive cadence and energy (blink rate, breath depth, idle
+//! drift) so the same Happy face can read as `Playful` (fast blinks,
+//! shallow breath) or `Calm` (slow blinks, deep breath).
+//!
+//! ## Why a separate enum (not just a per-emotion multiplier)
+//!
+//! Emotion changes second-to-second; mood is a property of the room
+//! the avatar is in. Folding the two would force every reactive
+//! emotion-driver to know about user preferences. Splitting them lets
+//! `StyleFromMood` run *after* `StyleFromEmotion` and apply a stable
+//! multiplier on top, with no cross-talk to the reactive side.
+
+/// The operator-selected energy baseline.
+///
+/// Set via persisted config (`STACKCHAN.RON`) and the HTTP control
+/// plane; never written by reactive modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum Mood {
+    /// Default. Modifier weights pass through unchanged — emotion
+    /// drives cadence with no additional multiplier on top.
+    #[default]
+    Neutral,
+    /// Slow + deep. Lower blink rate, deeper breath, less idle drift.
+    /// Reads as serene / meditative.
+    Calm,
+    /// Fast + light. Higher blink rate, shallower breath, more idle
+    /// drift. Reads as alert / engaged.
+    Playful,
+    /// Minimal extraneous motion. Lower blink rate, slightly shallower
+    /// breath, very little idle drift. Reads as concentrated / locked-in.
+    Focus,
+    /// Drowsy. Very low blink rate, very deep slow breath, minimal
+    /// drift. Reads as on-the-edge-of-sleep — distinct from
+    /// `Emotion::Sleepy` because it stays set across emotion changes.
+    Sleepy,
+}
+
+impl Mood {
+    /// Wire string for the HTTP `/state` snapshot and `/settings`
+    /// payload. Lowercase, mirrors [`crate::Emotion::wire_str`].
+    ///
+    /// Exhaustive without a wildcard: adding a variant forces a
+    /// conscious choice of wire string here.
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Neutral => "neutral",
+            Self::Calm => "calm",
+            Self::Playful => "playful",
+            Self::Focus => "focus",
+            Self::Sleepy => "sleepy",
+        }
+    }
+
+    /// Multiplier applied to `face.style.blink_rate_scale` after
+    /// [`crate::modifiers::StyleFromEmotion`] has set the per-emotion
+    /// baseline. `1.0` = no change; `< 1.0` slows blinks, `> 1.0`
+    /// speeds them up.
+    #[must_use]
+    pub const fn blink_multiplier(self) -> f32 {
+        match self {
+            Self::Neutral => 1.0,
+            Self::Calm => 0.7,
+            Self::Playful => 1.4,
+            Self::Focus => 0.6,
+            Self::Sleepy => 0.4,
+        }
+    }
+
+    /// Multiplier applied to `face.style.breath_depth_scale`. Same
+    /// convention as [`Self::blink_multiplier`].
+    #[must_use]
+    pub const fn breath_multiplier(self) -> f32 {
+        match self {
+            Self::Neutral => 1.0,
+            Self::Calm => 1.2,
+            Self::Playful => 0.9,
+            // `Focus` is *shallower* than `Playful` — held breath while
+            // concentrating, in contrast to `Playful`'s lighter bouncy
+            // breath. Distinct value so clippy's match-same-arms catches
+            // a future palette tweak that would collapse them.
+            Self::Focus => 0.85,
+            Self::Sleepy => 1.4,
+        }
+    }
+
+    /// Multiplier applied to idle-drift amplitude (eye centre jitter
+    /// and idle head glances). `1.0` = baseline; `< 1.0` damps the
+    /// random drift.
+    #[must_use]
+    pub const fn drift_multiplier(self) -> f32 {
+        match self {
+            Self::Neutral => 1.0,
+            Self::Calm => 0.7,
+            Self::Playful => 1.3,
+            Self::Focus => 0.5,
+            Self::Sleepy => 0.4,
+        }
+    }
+
+    /// Every variant in declaration order. Manually maintained;
+    /// `all_length_matches_variant_count` is the trip-wire that forces
+    /// an update on variant addition. (See [`crate::Emotion::ALL`] for
+    /// the same pattern.)
+    pub const ALL: &'static [Self] = &[
+        Self::Neutral,
+        Self::Calm,
+        Self::Playful,
+        Self::Focus,
+        Self::Sleepy,
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Length pin for [`Mood::ALL`]. Mirrors `Emotion::ALL`'s trip-wire.
+    #[test]
+    fn all_length_matches_variant_count() {
+        assert_eq!(Mood::ALL.len(), 5, "update Mood::ALL when adding a variant");
+    }
+
+    #[test]
+    fn neutral_passes_through_unchanged() {
+        assert!((Mood::Neutral.blink_multiplier() - 1.0).abs() < f32::EPSILON);
+        assert!((Mood::Neutral.breath_multiplier() - 1.0).abs() < f32::EPSILON);
+        assert!((Mood::Neutral.drift_multiplier() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn playful_blinks_faster_than_calm() {
+        assert!(Mood::Playful.blink_multiplier() > Mood::Calm.blink_multiplier());
+    }
+
+    #[test]
+    fn calm_breath_deeper_than_playful() {
+        assert!(Mood::Calm.breath_multiplier() > Mood::Playful.breath_multiplier());
+    }
+
+    #[test]
+    fn focus_minimises_drift_compared_to_neutral() {
+        assert!(Mood::Focus.drift_multiplier() < Mood::Neutral.drift_multiplier());
+    }
+
+    #[test]
+    fn sleepy_blinks_slower_than_calm() {
+        // Sleepy should be the slowest-blink mood — even slower than
+        // Calm, because Sleepy stays set across emotion changes
+        // whereas the Sleepy *emotion* is reactive.
+        assert!(Mood::Sleepy.blink_multiplier() < Mood::Calm.blink_multiplier());
+    }
+
+    #[test]
+    fn wire_strings_are_unique_and_lowercase() {
+        for (i, &a) in Mood::ALL.iter().enumerate() {
+            let wa = a.wire_str();
+            assert!(wa.chars().all(|c| !c.is_uppercase()));
+            for &b in &Mood::ALL[i + 1..] {
+                assert_ne!(wa, b.wire_str());
+            }
+        }
+    }
+}

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -80,7 +80,7 @@ use stackchan_core::{
         EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion,
         HeadFromIntent, IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud,
         MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, StyleFromEmotion,
-        StyleFromIntent,
+        StyleFromIntent, StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -203,6 +203,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut cycle = EmotionCycle::new();
     let mut style = StyleFromEmotion::new();
     let mut style_from_intent = StyleFromIntent::new();
+    let mut style_from_mood = StyleFromMood::new();
     let mut gaze_from_attention = GazeFromAttention::new();
     let mut microsaccade = MicrosaccadeFromAttention::new();
     let mut blink = Blink::new();
@@ -282,6 +283,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     director.add_modifier(&mut style).expect("registry full");
     director
         .add_modifier(&mut style_from_intent)
+        .expect("registry full");
+    director
+        .add_modifier(&mut style_from_mood)
         .expect("registry full");
     director
         .add_modifier(&mut gaze_from_attention)
@@ -431,6 +435,12 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
                 other => entity.input.remote_command = Some(other),
             }
         }
+        // Drain pending mood selections from `POST /mood`. Latest-wins;
+        // mood persists across emotion changes and only flips on an
+        // explicit operator action.
+        if let Some(mood) = net::http::MOOD_SIGNAL.try_take() {
+            entity.mind.mood = mood;
+        }
         // Drain the latest IMU reading.
         if let Some(m) = imu::IMU_SIGNAL.try_take() {
             entity.perception.accel_g = m.accel_g;
@@ -569,6 +579,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
             entity.motor.head_pose,
             Some(entity.motor.head_pose_actual),
             entity.face.decorator.map(|d| d.kind),
+            entity.mind.mood,
         );
         // Push the latest snapshot to any connected SSE subscribers.
         // Throttled internally so a 30 Hz render doesn't firehose

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -144,6 +144,11 @@ const DASHBOARD_GZ: &[u8] = include_bytes!("../../../../web/dist/index.html.gz")
 /// render task drains will overwrite the first.
 pub static REMOTE_COMMAND_SIGNAL: Signal<CriticalSectionRawMutex, RemoteCommand> = Signal::new();
 
+/// Latest mood the operator has selected via `POST /mood`. Drained by
+/// the render task into `entity.mind.mood` ahead of `Director::run`.
+/// Latest-wins semantics; persistence ships in a follow-up.
+pub static MOOD_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Mood> = Signal::new();
+
 /// Number of concurrent HTTP worker tasks. Each worker holds its own
 /// rx/tx buffers and accepts one connection at a time.
 ///
@@ -357,6 +362,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,
         ("POST", "/volume") => handle_post_volume(socket, body).await,
         ("POST", "/mute") => handle_post_mute(socket, body).await,
+        ("POST", "/mood") => handle_post_mood(socket, body).await,
         ("POST", "/camera/mode") => handle_post_camera_mode(socket, body).await,
         ("POST", "/camera/capture") => handle_post_camera_capture(socket).await,
         ("POST", "/restart") => handle_post_restart(socket).await,
@@ -655,6 +661,26 @@ async fn audio_persist_to_http(
     }
 }
 
+/// `POST /mood` — parse `{"mood": "<string>"}`, push the new mood at
+/// the render task via [`MOOD_SIGNAL`]. Runtime-only; persistence
+/// across reboots ships in a follow-up that touches the RON schema.
+async fn handle_post_mood(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let mood = match json::parse_mood(body) {
+        Ok(m) => m,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /mood parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    MOOD_SIGNAL.signal(mood);
+    defmt::info!("http: POST /mood → {}", mood.wire_str());
+    write_no_content(socket).await
+}
+
 /// `POST /camera/mode` — parse `{"enabled": <bool>}`, update the
 /// avatar snapshot, and signal the render task to flip the LCD.
 /// Display-only — tracking continues in either mode. No SD writeback;
@@ -852,6 +878,7 @@ fn state_body(s: AvatarSnapshot) -> String {
     format!(
         "{{\
 \"emotion\":\"{emotion}\",\
+\"mood\":\"{mood}\",\
 \"decorator\":{decorator},\
 \"head_pose\":{{\"pan_deg\":{pan:.2},\"tilt_deg\":{tilt:.2}}},\
 \"head_actual\":{actual},\
@@ -861,6 +888,7 @@ fn state_body(s: AvatarSnapshot) -> String {
 \"camera_mode\":{camera_mode}\
 }}\n",
         emotion = s.emotion.wire_str(),
+        mood = s.mood.wire_str(),
         pan = s.head_pose.pan_deg,
         tilt = s.head_pose.tilt_deg,
         connected = s.wifi.connected,

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -14,7 +14,7 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pubsub::PubSubChannel;
 use embassy_time::Instant as EmbassyInstant;
 use stackchan_core::head::Pose;
-use stackchan_core::{Decorator, Emotion};
+use stackchan_core::{Decorator, Emotion, Mood};
 use stackchan_net::config::AudioConfig;
 
 /// Battery snapshot — published by the power task.
@@ -69,6 +69,9 @@ pub struct AvatarSnapshot {
     /// `entity.face.decorator.kind`; the `expires_at` deadline is
     /// internal and not exposed.
     pub decorator: Option<Decorator>,
+    /// Operator-selected energy baseline. Mirrors `entity.mind.mood`;
+    /// HTTP `POST /mood` updates this through `MOOD_SIGNAL`.
+    pub mood: Mood,
 }
 
 impl AvatarSnapshot {
@@ -97,6 +100,7 @@ impl AvatarSnapshot {
             && self.audio == other.audio
             && self.camera_mode == other.camera_mode
             && self.decorator == other.decorator
+            && self.mood == other.mood
     }
 }
 
@@ -111,6 +115,7 @@ impl Default for AvatarSnapshot {
             audio: AudioConfig::DEFAULT,
             camera_mode: false,
             decorator: None,
+            mood: Mood::Neutral,
         }
     }
 }
@@ -136,6 +141,7 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
         audio: AudioConfig::DEFAULT,
         camera_mode: false,
         decorator: None,
+        mood: Mood::Neutral,
     }));
 
 /// Replace the avatar/head fields. Called per render tick.
@@ -144,6 +150,7 @@ pub fn update_avatar(
     head_pose: Pose,
     head_actual: Option<Pose>,
     decorator: Option<Decorator>,
+    mood: Mood,
 ) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
@@ -151,6 +158,7 @@ pub fn update_avatar(
         s.head_pose = head_pose;
         s.head_actual = head_actual;
         s.decorator = decorator;
+        s.mood = mood;
         cell.set(s);
     });
 }

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -20,7 +20,7 @@
 //! parsed in their entirety with [`core::str::FromStr`].
 
 use stackchan_core::voice::{Locale, PhraseId, Priority};
-use stackchan_core::{Emotion, Pose, RemoteCommand};
+use stackchan_core::{Emotion, Mood, Pose, RemoteCommand};
 
 /// Default hold window when the request body omits `hold_ms`.
 pub const DEFAULT_HOLD_MS: u32 = 30_000;
@@ -51,6 +51,8 @@ pub enum JsonError {
     UnknownPhrase,
     /// Locale string didn't match any [`Locale`] variant.
     UnknownLocale,
+    /// Mood string didn't match any [`Mood`] variant.
+    UnknownMood,
     /// `audio.volume_pct` value outside the documented `0..=100`
     /// range. Carries the offending value so the firmware's `400`
     /// response body is self-describing.
@@ -213,6 +215,39 @@ pub fn parse_volume(body: &str) -> Result<u8, JsonError> {
     }
     #[allow(clippy::cast_possible_truncation)]
     Ok(level as u8)
+}
+
+/// Parse a `POST /mood` body into a [`Mood`].
+///
+/// Required: `mood` (string). No optional fields.
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys,
+/// unknown keys, malformed JSON shape, or unrecognised mood strings.
+pub fn parse_mood(body: &str) -> Result<Mood, JsonError> {
+    let mut mood: Option<Mood> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "mood" => {
+                if mood.is_some() {
+                    return Err(JsonError::DuplicateKey("mood"));
+                }
+                let raw = scanner.read_string()?;
+                mood = Some(match raw {
+                    "neutral" => Mood::Neutral,
+                    "calm" => Mood::Calm,
+                    "playful" => Mood::Playful,
+                    "focus" => Mood::Focus,
+                    "sleepy" => Mood::Sleepy,
+                    _ => return Err(JsonError::UnknownMood),
+                });
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    mood.ok_or(JsonError::MissingKey("mood"))
 }
 
 /// Parse a `POST /mute` body into a `bool`.
@@ -640,6 +675,37 @@ mod tests {
         assert!(matches!(
             parse_look_at(body),
             Err(JsonError::DuplicateKey("pan_deg"))
+        ));
+    }
+
+    #[test]
+    fn parse_mood_accepts_every_wire_string() {
+        // Iterate `Mood::ALL` so adding a variant in core surfaces
+        // here automatically (after a parser arm is added).
+        for &variant in Mood::ALL {
+            let wire = variant.wire_str();
+            let body = alloc::format!(r#"{{"mood":"{wire}"}}"#);
+            assert_eq!(
+                parse_mood(&body).unwrap(),
+                variant,
+                "round-trip failed for `{wire}`"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_mood_rejects_unknown_mood() {
+        assert!(matches!(
+            parse_mood(r#"{"mood":"zen"}"#),
+            Err(JsonError::UnknownMood)
+        ));
+    }
+
+    #[test]
+    fn parse_mood_rejects_missing_key() {
+        assert!(matches!(
+            parse_mood("{}"),
+            Err(JsonError::MissingKey("mood"))
         ));
     }
 

--- a/crates/stackchan-sim/tests/mood_style_chain.rs
+++ b/crates/stackchan-sim/tests/mood_style_chain.rs
@@ -1,0 +1,107 @@
+//! End-to-end sim test: a non-Neutral [`Mood`] visibly modulates
+//! cadence on top of [`StyleFromEmotion`]'s per-emotion baseline.
+//!
+//! Drives the full Affect → Expression chain through the
+//! [`Director`] for a single emotion (Happy) under each [`Mood`]
+//! variant and asserts the resulting `blink_rate_scale` /
+//! `breath_depth_scale` actually differ — pinning that
+//! [`StyleFromMood`] integrates correctly with the rest of the
+//! Director sort order.
+
+#![allow(
+    clippy::expect_used,
+    reason = "test-only: registry capacity is a compile-time constant in this fixture"
+)]
+
+use stackchan_core::modifiers::{StyleFromEmotion, StyleFromMood};
+use stackchan_core::{Director, Emotion, Entity, Instant, Mood};
+
+fn settled_style_under(mood: Mood) -> (u8, u8) {
+    let mut entity = Entity::default();
+    entity.mind.affect.emotion = Emotion::Happy;
+    entity.mind.mood = mood;
+    let mut style_from_emotion = StyleFromEmotion::new();
+    let mut style_from_mood = StyleFromMood::new();
+    let mut director = Director::new();
+    director
+        .add_modifier(&mut style_from_emotion)
+        .expect("registry full");
+    director
+        .add_modifier(&mut style_from_mood)
+        .expect("registry full");
+    // Two ticks past the transition window so the easing settles.
+    director.run(&mut entity, Instant::from_millis(0));
+    director.run(
+        &mut entity,
+        Instant::from_millis(StyleFromEmotion::TRANSITION_MS + 1),
+    );
+    (
+        entity.face.style.blink_rate_scale,
+        entity.face.style.breath_depth_scale,
+    )
+}
+
+#[test]
+fn mood_modulates_blink_rate_through_director() {
+    let neutral = settled_style_under(Mood::Neutral);
+    let playful = settled_style_under(Mood::Playful);
+    let calm = settled_style_under(Mood::Calm);
+
+    assert!(
+        playful.0 > neutral.0,
+        "Playful should blink faster than Neutral on the same Happy face ({} vs {})",
+        playful.0,
+        neutral.0,
+    );
+    assert!(
+        calm.0 < neutral.0,
+        "Calm should blink slower than Neutral on the same Happy face ({} vs {})",
+        calm.0,
+        neutral.0,
+    );
+}
+
+#[test]
+fn mood_modulates_breath_depth_through_director() {
+    let neutral = settled_style_under(Mood::Neutral);
+    let calm = settled_style_under(Mood::Calm);
+    let playful = settled_style_under(Mood::Playful);
+
+    assert!(
+        calm.1 > neutral.1,
+        "Calm should deepen breath above Neutral ({} vs {})",
+        calm.1,
+        neutral.1,
+    );
+    assert!(
+        playful.1 < neutral.1,
+        "Playful should shallow breath below Neutral ({} vs {})",
+        playful.1,
+        neutral.1,
+    );
+}
+
+#[test]
+fn surprised_blink_zero_resists_mood_amplification() {
+    // `Surprised` emotion sets blink_rate_scale = 0 (eyes held
+    // wide). A Playful mood multiplier mustn't quietly start the
+    // eyes blinking — the zero must propagate.
+    let mut entity = Entity::default();
+    entity.mind.affect.emotion = Emotion::Surprised;
+    entity.mind.mood = Mood::Playful;
+    let mut style_from_emotion = StyleFromEmotion::new();
+    let mut style_from_mood = StyleFromMood::new();
+    let mut director = Director::new();
+    director
+        .add_modifier(&mut style_from_emotion)
+        .expect("registry full");
+    director
+        .add_modifier(&mut style_from_mood)
+        .expect("registry full");
+    director.run(&mut entity, Instant::from_millis(0));
+    director.run(
+        &mut entity,
+        Instant::from_millis(StyleFromEmotion::TRANSITION_MS + 1),
+    );
+    assert_eq!(entity.face.style.blink_rate_scale, 0);
+}

--- a/docs/http.md
+++ b/docs/http.md
@@ -29,6 +29,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |
 | POST   | `/speak`         | Play a baked phrase / chirp through the speaker      |
+| POST   | `/mood`          | Set the operator-selected energy baseline (runtime-only) |
 | POST   | `/volume`        | Set output volume (0–100); persisted to SD           |
 | POST   | `/mute`          | Mute / un-mute output stage; persisted to SD         |
 | GET    | `/settings`      | Persisted config (PSK + token redacted)             |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { connectStream } from "./store";
 import { ConnStatus } from "./components/ConnStatus";
 import { State } from "./components/State";
 import { Emotion } from "./components/Emotion";
+import { Mood } from "./components/Mood";
 import { LookAt } from "./components/LookAt";
 import { Audio } from "./components/Audio";
 import { Camera } from "./components/Camera";
@@ -48,6 +49,7 @@ export function App() {
         </header>
         <State />
         <Emotion />
+        <Mood />
         <LookAt />
         <Audio />
         <Speak />

--- a/web/src/components/Mood.tsx
+++ b/web/src/components/Mood.tsx
@@ -1,0 +1,44 @@
+import { For } from "solid-js";
+import { postJson } from "../auth";
+import { showToast, snapshot } from "../store";
+
+// Wire-string vocabulary mirrors `Mood::wire_str` in
+// `crates/stackchan-core/src/mood.rs`.
+const MOODS = ["neutral", "calm", "playful", "focus", "sleepy"] as const;
+
+export function Mood() {
+  const send = async (mood: string) => {
+    try {
+      await postJson("/mood", { mood });
+      showToast(`mood → ${mood}`);
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Mood</h2>
+      <div class="btn-row">
+        <For each={MOODS}>
+          {(name) => {
+            const active = () => snapshot()?.mood === name;
+            return (
+              <button
+                onClick={() => send(name)}
+                style={active() ? "border-color:var(--accent)" : ""}
+                data-mood={name}
+              >
+                {name.charAt(0).toUpperCase() + name.slice(1)}
+              </button>
+            );
+          }}
+        </For>
+      </div>
+      <small>
+        Mood scales blink rate, breath depth, and idle drift on top of the active emotion.
+        Runtime-only — resets to Neutral on reboot.
+      </small>
+    </section>
+  );
+}

--- a/web/src/components/State.tsx
+++ b/web/src/components/State.tsx
@@ -8,6 +8,8 @@ export function State() {
       <dl class="row">
         <dt>Emotion</dt>
         <dd>{snapshot()?.emotion ?? "—"}</dd>
+        <dt>Mood</dt>
+        <dd>{snapshot()?.mood ?? "—"}</dd>
         <dt>Decorator</dt>
         <dd>{snapshot()?.decorator ?? "—"}</dd>
         <dt>Head pose</dt>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -20,6 +20,7 @@ export type AudioState = {
 
 export type AvatarSnapshot = {
   emotion: string;
+  mood: string;
   decorator: string | null;
   head_pose: Pose;
   head_actual: Pose | null;


### PR DESCRIPTION
## Summary

Adds an operator-selected energy baseline (`Mood`) that scales cadence on top of the per-emotion baseline `StyleFromEmotion` writes. Same Happy face reads as `Playful` (fast blinks, shallow breath, more drift) or `Calm` (slow blinks, deep breath, less drift) depending on what the operator picked.

- **`Mood` enum** (Neutral / Calm / Playful / Focus / Sleepy) with `blink_multiplier` / `breath_multiplier` / `drift_multiplier` factors. Distinct from `Emotion::Sleepy` (reactive, short-lived) — `Mood::Sleepy` stays set across emotion changes.
- **`StyleFromMood` modifier** at priority -7 in `Phase::Expression` — runs after `StyleFromEmotion` (-10) + `StyleFromIntent` (-5), before `Blink`/`Breath` (0). Zero baselines (e.g. `Surprised` holding eyes wide) propagate through unchanged so a Playful Surprised doesn't unexpectedly blink.
- **Closed-eye smile on `Intent::Petted`** — `StyleFromIntent` now also bumps `eye_curve` by +30 and clamps both eyes' `open_weight` at 60 (squint cap). Stack-chan's eyes curve into a smile while being petted on top of the existing blush bump.
- **`POST /mood`** HTTP route + `MOOD_SIGNAL` + render-task drain. Runtime-only; persistence across reboots ships in a follow-up that touches the `STACKCHAN.RON` schema.
- **`/state` JSON** exposes `mood`; dashboard adds a Mood control component + a "Mood" row in the State view.

## Stacked on #218

Branched off `feat/viseme-task` (PR #218); base auto-updates to `main` once the upstream stack merges.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests (368 unit, 140 integration)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features`
- [x] `just clippy-firmware` — strict clippy on the firmware target
- [x] 6 unit tests on `Mood::*_multiplier` ordering invariants
- [x] 8 unit tests on `StyleFromMood` (NaN/inf guard, saturation, zero-input pass-through, full Sleepy×Sleepy compound)
- [x] 4 unit tests on the closed-eye smile (curve bump, open_weight cap, no-amplify-existing-droop, saturating add)
- [x] `mood_style_chain.rs` end-to-end sim test exercising the full Director sort order on Happy + each mood
- [x] `parse_mood` round-trip pin iterating `Mood::ALL`
- [ ] Hardware verification — flash, cycle through moods via dashboard, confirm visible cadence change at the same emotion

## Follow-up

`STACKCHAN.RON` persistence for mood (Schema v2 entry + boot-time drain) ships in a separate PR — the schema change is invasive and orthogonal to the visible behaviour added here.