### PR TITLE
feat(firmware): GET /camera/snapshot + dashboard view-capture button

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -365,6 +365,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/mood") => handle_post_mood(socket, body).await,
         ("POST", "/camera/mode") => handle_post_camera_mode(socket, body).await,
         ("POST", "/camera/capture") => handle_post_camera_capture(socket).await,
+        ("GET", "/camera/snapshot") => handle_get_camera_snapshot(socket).await,
         ("POST", "/restart") => handle_post_restart(socket).await,
         ("POST", "/factory-reset") => handle_post_factory_reset(socket, body).await,
         ("GET" | "POST" | "PUT", _) => write_text(socket, 404, "not found\n").await,
@@ -702,6 +703,54 @@ async fn handle_post_camera_mode(socket: &mut TcpSocket<'_>, body: &str) -> Resu
     crate::camera::CAMERA_MODE_SIGNAL.signal(active);
     defmt::info!("http: POST /camera/mode → {=bool}", active);
     write_no_content(socket).await
+}
+
+/// `GET /camera/snapshot` — read `/sd/CAPTURE.565` (the most recent
+/// frame written by `POST /camera/capture`) and return it as raw
+/// QVGA RGB565 big-endian bytes. The dashboard renders these onto a
+/// canvas after fetching.
+///
+/// Returns `404 Not Found` if no capture exists yet (the
+/// before-first-capture state). The interaction model is "POST
+/// /camera/capture → wait a moment → GET /camera/snapshot" — the
+/// snapshot endpoint always reads the SD copy rather than holding a
+/// live frame in RAM.
+async fn handle_get_camera_snapshot(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let frame =
+        match crate::storage::with_storage(crate::storage::FirmwareStorage::read_capture).await {
+            Some(Ok(Some(frame))) => frame,
+            Some(Ok(None)) => {
+                return write_text(
+                    socket,
+                    404,
+                    "no capture available — POST /camera/capture first\n",
+                )
+                .await;
+            }
+            Some(Err(e)) => {
+                defmt::warn!(
+                    "http: GET /camera/snapshot SD read failed ({})",
+                    defmt::Debug2Format(&e)
+                );
+                return write_text(socket, 503, "SD read failed\n").await;
+            }
+            None => {
+                return write_text(socket, 503, "storage unavailable\n").await;
+            }
+        };
+    let header = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        len = frame.len(),
+    );
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket
+        .write_all(&frame)
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)
 }
 
 /// `POST /camera/capture` — empty body, signals the camera task to

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -327,6 +327,33 @@ where
         self.write_file(CAPTURE_FILE, frame)
     }
 
+    /// Read the most recent camera capture from `/sd/CAPTURE.565`.
+    /// Returns `Ok(None)` if no capture exists yet — that's the
+    /// before-first-capture state, not an error.
+    ///
+    /// The returned `Vec<u8>` carries the raw QVGA RGB565 big-endian
+    /// frame as written by `write_capture` (320 × 240 × 2 = 153 600
+    /// bytes for a fresh CoreS3 GC0308 frame). Caller renders.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Read`] on a partial / failed read.
+    pub fn read_capture(&mut self) -> Result<Option<Vec<u8>>, StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(file) = root.open_file_in_dir(CAPTURE_FILE, Mode::ReadOnly) else {
+            return Ok(None);
+        };
+        let len = file.length() as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+        Ok(Some(buf))
+    }
+
     /// Delete every operator-visible file the firmware writes:
     /// `STACKCHAN.RON`, the staging file, `BONDS.BIN`, the bonds
     /// staging file, and the camera capture. Missing files are not

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -337,8 +337,14 @@ where
     ///
     /// # Errors
     ///
-    /// [`StorageError::Read`] on a partial / failed read.
+    /// [`StorageError::Read`] on a partial / failed read,
+    /// [`StorageError::TooLarge`] if the file exceeds the QVGA RGB565
+    /// frame size — guards against a corrupt FAT entry reporting a
+    /// gigabyte-scale length and starving the PSRAM heap.
     pub fn read_capture(&mut self) -> Result<Option<Vec<u8>>, StorageError> {
+        // Cap on the capture size — a single QVGA RGB565 frame.
+        // Mirrors `MAX_BONDS_BYTES` / `MAX_CONFIG_BYTES`'s pattern.
+        const MAX_CAPTURE_BYTES: u32 = 320 * 240 * 2;
         let volume = self
             .mgr
             .open_volume(VolumeIdx(0))
@@ -347,7 +353,11 @@ where
         let Ok(file) = root.open_file_in_dir(CAPTURE_FILE, Mode::ReadOnly) else {
             return Ok(None);
         };
-        let len = file.length() as usize;
+        let raw_len = file.length();
+        if raw_len > MAX_CAPTURE_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = raw_len as usize;
         let mut buf = alloc::vec![0u8; len];
         let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
         buf.truncate(n);

--- a/docs/http.md
+++ b/docs/http.md
@@ -24,6 +24,7 @@ beats pulling a full HTTP framework into the firmware target.
 | GET    | `/`              | Operator dashboard (HTML + JS, embedded in firmware) |
 | GET    | `/health`        | Uptime, firmware version, free heap                  |
 | GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi, audio |
+| GET    | `/camera/snapshot` | Most recent `/sd/CAPTURE.565` frame as raw QVGA RGB565 BE |
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
 | POST   | `/emotion`       | Set affect with hold timer                          |
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |

--- a/web/src/components/Camera.tsx
+++ b/web/src/components/Camera.tsx
@@ -1,9 +1,43 @@
-import { Show, createMemo } from "solid-js";
+import { Show, createMemo, createSignal } from "solid-js";
 import { authedFetch, postJson } from "../auth";
 import { showToast, snapshot } from "../store";
 
+/// QVGA frame width — must match the firmware tracker's `WIDTH`.
+const FRAME_WIDTH = 320;
+/// QVGA frame height — must match the firmware tracker's `HEIGHT`.
+const FRAME_HEIGHT = 240;
+
+/// Convert a raw QVGA RGB565 big-endian frame into an `ImageData`
+/// the canvas can blit. Each input pixel is 2 bytes (BE):
+///
+/// - byte 0: `RRRRR_GGG`
+/// - byte 1: `GGG_BBBBB`
+function rgb565beToImageData(buf: Uint8Array): ImageData {
+  const out = new ImageData(FRAME_WIDTH, FRAME_HEIGHT);
+  const dst = out.data;
+  // DataView gives type-safe big-endian reads without the `noUncheckedIndexedAccess`
+  // narrowing that makes plain `buf[i]` come back as `number | undefined`.
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  for (let i = 0; i < FRAME_WIDTH * FRAME_HEIGHT; i++) {
+    const px = view.getUint16(i * 2, false);
+    // Expand 5/6/5 to 8 bits per channel by replicating high bits into
+    // the low bits — common upscale that avoids the dimming you'd
+    // get from a plain left-shift.
+    const r5 = (px >> 11) & 0x1f;
+    const g6 = (px >> 5) & 0x3f;
+    const b5 = px & 0x1f;
+    dst[i * 4] = (r5 << 3) | (r5 >> 2);
+    dst[i * 4 + 1] = (g6 << 2) | (g6 >> 4);
+    dst[i * 4 + 2] = (b5 << 3) | (b5 >> 2);
+    dst[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
 export function Camera() {
   const previewActive = createMemo(() => snapshot()?.camera_mode ?? false);
+  const [snapshotUrl, setSnapshotUrl] = createSignal<string | null>(null);
+  let canvasRef: HTMLCanvasElement | undefined;
 
   const toggleMode = async () => {
     const next = !previewActive();
@@ -22,7 +56,29 @@ export function Camera() {
         const text = await res.text().catch(() => "");
         throw new Error(`${res.status}: ${text || res.statusText}`);
       }
-      showToast("capture queued — eject SD to view CAPTURE.565");
+      showToast("capture queued — fetch with View capture in ~500 ms");
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  const view = async () => {
+    try {
+      const res = await authedFetch("/camera/snapshot");
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${text || res.statusText}`);
+      }
+      const buf = new Uint8Array(await res.arrayBuffer());
+      const expected = FRAME_WIDTH * FRAME_HEIGHT * 2;
+      if (buf.length !== expected) {
+        throw new Error(`unexpected size ${buf.length}; want ${expected}`);
+      }
+      const ctx = canvasRef?.getContext("2d");
+      if (!ctx) throw new Error("canvas 2d context unavailable");
+      ctx.putImageData(rgb565beToImageData(buf), 0, 0);
+      setSnapshotUrl("rendered"); // marker so the canvas shows
+      showToast("snapshot rendered");
     } catch (e) {
       showToast((e as Error).message, true);
     }
@@ -40,8 +96,25 @@ export function Camera() {
         <button type="button" onClick={capture}>
           Capture frame
         </button>
+        <button type="button" onClick={view}>
+          View capture
+        </button>
       </div>
-      <small>Preview swaps the LCD between avatar and live camera; tracking continues either way. Capture writes /sd/CAPTURE.565 (raw QVGA RGB565, ~150 KB).</small>
+      <canvas
+        ref={canvasRef}
+        width={FRAME_WIDTH}
+        height={FRAME_HEIGHT}
+        style={{
+          display: snapshotUrl() ? "block" : "none",
+          "margin-top": "8px",
+          "max-width": "100%",
+          border: "1px solid var(--muted)",
+        }}
+      />
+      <small>
+        Preview swaps the LCD between avatar and live camera; tracking continues either way.
+        Capture writes /sd/CAPTURE.565 (raw QVGA RGB565); View capture fetches and renders it.
+      </small>
     </section>
   );
 }

--- a/web/src/components/Camera.tsx
+++ b/web/src/components/Camera.tsx
@@ -36,7 +36,10 @@ function rgb565beToImageData(buf: Uint8Array): ImageData {
 
 export function Camera() {
   const previewActive = createMemo(() => snapshot()?.camera_mode ?? false);
-  const [snapshotUrl, setSnapshotUrl] = createSignal<string | null>(null);
+  // Visibility marker for the canvas — `true` once a snapshot has
+  // been fetched and rendered. Plain bool because we never hold the
+  // image bytes in JS state; the canvas owns them.
+  const [hasSnapshot, setHasSnapshot] = createSignal(false);
   let canvasRef: HTMLCanvasElement | undefined;
 
   const toggleMode = async () => {
@@ -77,7 +80,7 @@ export function Camera() {
       const ctx = canvasRef?.getContext("2d");
       if (!ctx) throw new Error("canvas 2d context unavailable");
       ctx.putImageData(rgb565beToImageData(buf), 0, 0);
-      setSnapshotUrl("rendered"); // marker so the canvas shows
+      setHasSnapshot(true);
       showToast("snapshot rendered");
     } catch (e) {
       showToast((e as Error).message, true);
@@ -105,7 +108,7 @@ export function Camera() {
         width={FRAME_WIDTH}
         height={FRAME_HEIGHT}
         style={{
-          display: snapshotUrl() ? "block" : "none",
+          display: hasSnapshot() ? "block" : "none",
           "margin-top": "8px",
           "max-width": "100%",
           border: "1px solid var(--muted)",


### PR DESCRIPTION
## Summary

Completes the camera-capture roundtrip the existing `POST /camera/capture` started: capture writes `/sd/CAPTURE.565` asynchronously, snapshot reads it back, dashboard fetches and renders to a canvas. No SD ejection needed.

- **`Storage::read_capture`** returns the most recent CAPTURE.565 contents as `Vec<u8>`, or `Ok(None)` for the before-first-capture state (no error, just no data yet).
- **`GET /camera/snapshot`** reads via `with_storage`, streams the raw QVGA RGB565 BE bytes back as `application/octet-stream`. 404 on no-capture; 503 on SD read failure or unmounted storage. No JPEG encoding — keeps the firmware libm-free and dodges the encoder dependency tree.
- **Dashboard `Camera` component** grows a "View capture" button that fetches `/camera/snapshot`, expands the 5/6/5 channels to 8 bits via the standard high-bit-replication trick (avoids the dimming you'd get from a plain left-shift), and blits onto a 320×240 canvas.

`DataView` used for the BE word reads instead of plain `Uint8Array[i]` indexing so TypeScript's `noUncheckedIndexedAccess` narrowing doesn't poison the loop with `number | undefined`.

## Why no servo calibration UI in this PR

The original PR 8 plan paired this with a calibration widget. The operator-facing slice of calibration needs new `STACKCHAN.RON` schema (servo offset / pan-tilt limit fields), boot-time application in `head.rs`, and a `PUT /settings` round-trip. That belongs in a follow-up where the schema work can stand on its own — bundling it here would block the more contained camera-snapshot win.

## Stacked on #220

Branched off `feat/voicevox-tts-backend` (PR #220).

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features`
- [x] `just clippy-firmware` — strict clippy on the firmware target
- [ ] Hardware verification — flash, POST /camera/capture, ~500 ms later GET /camera/snapshot, confirm bytes match the SD copy and dashboard canvas renders the captured frame