### PR TITLE
feat(core): decorator overlay layer + 3 trigger modifiers

### DIFF
--- a/crates/stackchan-core/src/decorator.rs
+++ b/crates/stackchan-core/src/decorator.rs
@@ -1,0 +1,153 @@
+//! Decorator overlays — small symbolic shapes drawn on top of the face
+//! to amplify whatever emotion is showing.
+//!
+//! The face renders the emotion-driven base layer (eyes, mouth, blush);
+//! the decorator layer paints one symbolic overlay on top — Heart for
+//! affection, Sweat for distress, Dizzy stars for confusion — anchored
+//! at fixed positions above the eyes. Only one decorator shows at a
+//! time; per-tick trigger modifiers in [`crate::director::Phase::Decoration`]
+//! decide which (if any) is active.
+//!
+//! ## Lifecycle
+//!
+//! Decorators are time-bounded: each carries an `expires_at` `Instant`
+//! and the [`crate::modifiers::DecoratorExpiry`] modifier clears the
+//! field when the deadline passes. A trigger modifier that fires while
+//! one is already active just overwrites the field — there's no
+//! priority arbitration beyond the modifier sort order.
+
+use crate::clock::Instant;
+
+/// Decorator overlay kind. Picked by trigger modifiers in
+/// [`crate::director::Phase::Decoration`]; rendered by the draw code on
+/// top of the emotion base layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Decorator {
+    /// Pink heart cluster — affection / love overlay.
+    Heart,
+    /// Light-blue tear drop — distress / surprise overlay.
+    Sweat,
+    /// Three-dot arc — dizzy / shaken overlay.
+    Dizzy,
+}
+
+impl Decorator {
+    /// Lowercase wire name for the HTTP `/state` snapshot. Mirrors
+    /// [`crate::Emotion::wire_str`]'s convention so a consumer can
+    /// lift a decorator string off `/state` and post it back without
+    /// case translation (when a future write route ships).
+    ///
+    /// Exhaustive without a wildcard — adding a variant forces a
+    /// conscious choice of wire string.
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Heart => "heart",
+            Self::Sweat => "sweat",
+            Self::Dizzy => "dizzy",
+        }
+    }
+
+    /// Single-byte wire encoding for any future BLE GATT exposure.
+    /// Append-only, mirroring [`crate::Emotion::wire_byte`].
+    #[must_use]
+    pub const fn wire_byte(self) -> u8 {
+        match self {
+            Self::Heart => 0,
+            Self::Sweat => 1,
+            Self::Dizzy => 2,
+        }
+    }
+
+    /// Every variant in declaration order. Manually maintained — the
+    /// exhaustive match arms in [`Self::wire_byte`] / [`Self::wire_str`]
+    /// are the compile-time guard; this slice has no compile-time
+    /// completeness check, so the `all_length_matches_variant_count`
+    /// test is the trip-wire that forces an update on variant addition.
+    pub const ALL: &'static [Self] = &[Self::Heart, Self::Sweat, Self::Dizzy];
+}
+
+/// Active decorator overlay with its expiry deadline.
+///
+/// The field is `Option<DecoratorState>` on [`crate::face::Face`];
+/// `None` is the steady state. Trigger modifiers fill it in; the
+/// expiry modifier clears it when `expires_at` passes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecoratorState {
+    /// Which decorator is showing.
+    pub kind: Decorator,
+    /// Wall-clock instant at which this decorator stops being drawn.
+    pub expires_at: Instant,
+}
+
+impl DecoratorState {
+    /// Construct a state that holds `kind` from `now` for `duration_ms`
+    /// milliseconds.
+    #[must_use]
+    pub const fn hold_for(kind: Decorator, now: Instant, duration_ms: u64) -> Self {
+        Self {
+            kind,
+            expires_at: Instant::from_millis(now.as_millis() + duration_ms),
+        }
+    }
+
+    /// `true` iff `now` has reached or passed [`Self::expires_at`].
+    #[must_use]
+    pub fn is_expired(&self, now: Instant) -> bool {
+        now >= self.expires_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Length pin for [`Decorator::ALL`]. Mirrors
+    /// `Emotion::all_length_matches_variant_count` — the slice has no
+    /// compile-time exhaustiveness check, so the count is the trip-wire.
+    #[test]
+    fn all_length_matches_variant_count() {
+        assert_eq!(
+            Decorator::ALL.len(),
+            3,
+            "update Decorator::ALL when adding a variant"
+        );
+    }
+
+    #[test]
+    fn wire_byte_mapping_is_stable() {
+        assert_eq!(Decorator::Heart.wire_byte(), 0);
+        assert_eq!(Decorator::Sweat.wire_byte(), 1);
+        assert_eq!(Decorator::Dizzy.wire_byte(), 2);
+    }
+
+    #[test]
+    fn wire_strings_are_unique_and_lowercase() {
+        for (i, &a) in Decorator::ALL.iter().enumerate() {
+            let wa = a.wire_str();
+            assert!(wa.chars().all(|c| !c.is_uppercase()));
+            for &b in &Decorator::ALL[i + 1..] {
+                assert_ne!(wa, b.wire_str());
+            }
+        }
+    }
+
+    #[test]
+    fn hold_for_pins_expiry_at_now_plus_duration() {
+        let now = Instant::from_millis(1_000);
+        let s = DecoratorState::hold_for(Decorator::Heart, now, 2_000);
+        assert_eq!(s.kind, Decorator::Heart);
+        assert_eq!(s.expires_at, Instant::from_millis(3_000));
+    }
+
+    #[test]
+    fn is_expired_at_or_after_deadline() {
+        let now = Instant::from_millis(1_000);
+        let s = DecoratorState::hold_for(Decorator::Sweat, now, 500);
+        assert!(!s.is_expired(Instant::from_millis(1_000)));
+        assert!(!s.is_expired(Instant::from_millis(1_499)));
+        assert!(s.is_expired(Instant::from_millis(1_500)));
+        assert!(s.is_expired(Instant::from_millis(2_000)));
+    }
+}

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -70,6 +70,12 @@ pub enum Phase {
     /// Emotion → face style. `StyleFromEmotion` picks curve / scale /
     /// blush; Blink / Breath / `IdleDrift` add per-frame deltas.
     Expression = 50,
+    /// Symbolic overlay layer. `DecoratorExpiry` clears stale state at
+    /// the head of the phase; trigger modifiers (body-touch → Heart,
+    /// loud → Sweat, shake → Dizzy) write `face.decorator` after.
+    /// Sits between Expression and Motion so decorators read final
+    /// emotion / style state but don't influence pose.
+    Decoration = 55,
     /// Intent + emotion → pose. `IdleHeadDrift` writes a baseline;
     /// `HeadFromEmotion` adds an emotion-keyed bias on top.
     Motion = 60,
@@ -148,6 +154,8 @@ pub enum Field {
     BlinkRateScale,
     /// `entity.face.style.breath_depth_scale`
     BreathDepthScale,
+    /// `entity.face.decorator`
+    Decorator,
 
     // ---- Motor ----
     /// `entity.motor.head_pose`
@@ -228,6 +236,7 @@ impl Field {
         Self::EyeScale,
         Self::BlinkRateScale,
         Self::BreathDepthScale,
+        Self::Decorator,
         Self::HeadPose,
         Self::HeadPoseActual,
         Self::AccelG,
@@ -273,7 +282,8 @@ impl Field {
             | Self::CheekBlush
             | Self::EyeScale
             | Self::BlinkRateScale
-            | Self::BreathDepthScale => FieldGroup::Face,
+            | Self::BreathDepthScale
+            | Self::Decorator => FieldGroup::Face,
             Self::HeadPose | Self::HeadPoseActual => FieldGroup::Motor,
             Self::AccelG
             | Self::GyroDps
@@ -331,6 +341,7 @@ impl Field {
             Self::BreathDepthScale => {
                 before.face.style.breath_depth_scale != after.face.style.breath_depth_scale
             }
+            Self::Decorator => before.face.decorator != after.face.decorator,
             Self::HeadPose => {
                 before.motor.head_pose.pan_deg.to_bits() != after.motor.head_pose.pan_deg.to_bits()
                     || before.motor.head_pose.tilt_deg.to_bits()
@@ -805,7 +816,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            40,
+            41,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -35,10 +35,24 @@ use embedded_graphics::{
     },
 };
 
+use crate::decorator::{Decorator, DecoratorState};
 use crate::face::{Eye, EyePhase, Face, Mouth, SCALE_DEFAULT};
 
 /// Pink mouth/cheek color — `#F58080` quantized into Rgb565's (5,6,5)-bit channels.
 const MOUTH_COLOR: Rgb565 = Rgb565::new(30, 32, 16);
+
+/// Heart decorator pink — slightly more saturated than `MOUTH_COLOR` so
+/// the heart reads as deliberate overlay rather than blush bleed-through.
+const HEART_COLOR: Rgb565 = Rgb565::new(31, 16, 12);
+
+/// Sweat decorator light blue — distinct from any other palette entry
+/// so it doesn't cross-talk with the LCD background or the angry/sad
+/// face rendering.
+const SWEAT_COLOR: Rgb565 = Rgb565::new(8, 32, 28);
+
+/// Dizzy decorator dot color — black so it reads against the white
+/// background even at small sizes.
+const DIZZY_COLOR: Rgb565 = Rgb565::BLACK;
 
 /// Stroke width for closed-eye line, resting mouth line, and curved arcs.
 const LINE_WIDTH: u32 = 3;
@@ -99,8 +113,141 @@ impl Face {
             target,
         )?;
         draw_mouth(&self.mouth, self.style.mouth_curve, target)?;
+        if let Some(state) = self.decorator {
+            draw_decorator(state, target)?;
+        }
         Ok(())
     }
+}
+
+/// Dispatch on [`Decorator`] kind to the per-shape draw routine. Only
+/// runs when `face.decorator` is `Some` — `None` is the steady state
+/// and short-circuits in `Face::draw`.
+fn draw_decorator<D>(state: DecoratorState, target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    match state.kind {
+        Decorator::Heart => draw_heart(target),
+        Decorator::Sweat => draw_sweat(target),
+        Decorator::Dizzy => draw_dizzy(target),
+    }
+}
+
+/// Heart decorator anchor — upper-right of the face. Two overlapping
+/// pink circles form the lobes; a small filled triangle fills the
+/// bottom point. Anchored at fixed coordinates rather than relative to
+/// the eyes because all three decorators share an anchor convention.
+const HEART_ANCHOR_X: i32 = 270;
+/// Heart decorator anchor Y — see [`HEART_ANCHOR_X`].
+const HEART_ANCHOR_Y: i32 = 50;
+/// Lobe radius for the heart — small enough to read as overlay rather
+/// than competing with the eyes (`radius_y = 25`).
+const HEART_LOBE_RADIUS: u32 = 9;
+
+/// Draw a small pink heart in the upper-right corner of the face.
+///
+/// The heart is two overlapping circles (left and right lobes) plus a
+/// downward-pointing triangle for the bottom point. Integer math; no
+/// floats; non-allocating.
+fn draw_heart<D>(target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    use embedded_graphics::primitives::Triangle;
+
+    #[allow(clippy::cast_possible_wrap)]
+    let lobe_offset = (HEART_LOBE_RADIUS / 2) as i32;
+    let left_top = EgPoint::new(
+        HEART_ANCHOR_X - lobe_offset - i32::try_from(HEART_LOBE_RADIUS).unwrap_or(0),
+        HEART_ANCHOR_Y,
+    );
+    let right_top = EgPoint::new(HEART_ANCHOR_X + lobe_offset, HEART_ANCHOR_Y);
+    Circle::new(left_top, HEART_LOBE_RADIUS)
+        .into_styled(fill(HEART_COLOR))
+        .draw(target)?;
+    Circle::new(right_top, HEART_LOBE_RADIUS)
+        .into_styled(fill(HEART_COLOR))
+        .draw(target)?;
+    // Triangle filling the bottom point. Top corners sit at the
+    // bottom-inside of each lobe; bottom point sits below by ~lobe
+    // radius for a balanced heart silhouette.
+    #[allow(clippy::cast_possible_wrap)]
+    let r = HEART_LOBE_RADIUS as i32;
+    let lobe_bottom_y = HEART_ANCHOR_Y + r;
+    Triangle::new(
+        EgPoint::new(HEART_ANCHOR_X - r, lobe_bottom_y),
+        EgPoint::new(HEART_ANCHOR_X + r, lobe_bottom_y),
+        EgPoint::new(HEART_ANCHOR_X, lobe_bottom_y + r + 2),
+    )
+    .into_styled(fill(HEART_COLOR))
+    .draw(target)
+}
+
+/// Sweat decorator anchor — same upper-right region as Heart since
+/// only one decorator shows at a time.
+const SWEAT_ANCHOR_X: i32 = 270;
+/// Sweat decorator anchor Y — see [`SWEAT_ANCHOR_X`].
+const SWEAT_ANCHOR_Y: i32 = 40;
+
+/// Draw a small light-blue sweat drop. Approximated as a vertical
+/// ellipse with a small triangle on top (the drop's pointed end).
+fn draw_sweat<D>(target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    use embedded_graphics::primitives::Triangle;
+
+    // Body: vertical ellipse, 12 px wide × 18 px tall.
+    let body_width: u32 = 12;
+    let body_height: u32 = 18;
+    #[allow(clippy::cast_possible_wrap)]
+    let half_w = (body_width / 2) as i32;
+    let body_top = EgPoint::new(SWEAT_ANCHOR_X - half_w, SWEAT_ANCHOR_Y + 6);
+    Ellipse::new(body_top, Size::new(body_width, body_height))
+        .into_styled(fill(SWEAT_COLOR))
+        .draw(target)?;
+    // Pointed tip: triangle above the ellipse, ~6 px tall.
+    Triangle::new(
+        EgPoint::new(SWEAT_ANCHOR_X - 4, SWEAT_ANCHOR_Y + 6),
+        EgPoint::new(SWEAT_ANCHOR_X + 4, SWEAT_ANCHOR_Y + 6),
+        EgPoint::new(SWEAT_ANCHOR_X, SWEAT_ANCHOR_Y),
+    )
+    .into_styled(fill(SWEAT_COLOR))
+    .draw(target)
+}
+
+/// Dizzy decorator: three black dots in an arc above the centre of the
+/// face. Centred at x=160 (frame midpoint).
+const DIZZY_CENTER_X: i32 = 160;
+/// Dizzy decorator anchor Y — above the eyes (eye centres are at y=110).
+const DIZZY_CENTER_Y: i32 = 30;
+/// Diameter of one dizzy dot.
+const DIZZY_DOT_DIAMETER: u32 = 8;
+
+/// Draw three small black dots in an arc above the eyes — the
+/// stylised "I'm seeing stars" overlay.
+fn draw_dizzy<D>(target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    #[allow(clippy::cast_possible_wrap)]
+    let half = (DIZZY_DOT_DIAMETER / 2) as i32;
+    // Dots at x = -30, 0, +30 from centre. Arc curvature: middle dot
+    // sits 4 px lower than the side dots so the trio reads as an
+    // arc rather than a straight line.
+    let positions: [(i32, i32); 3] = [
+        (DIZZY_CENTER_X - 30, DIZZY_CENTER_Y),
+        (DIZZY_CENTER_X, DIZZY_CENTER_Y + 4),
+        (DIZZY_CENTER_X + 30, DIZZY_CENTER_Y),
+    ];
+    for (cx, cy) in positions {
+        let top_left = EgPoint::new(cx - half, cy - half);
+        Circle::new(top_left, DIZZY_DOT_DIAMETER)
+            .into_styled(fill(DIZZY_COLOR))
+            .draw(target)?;
+    }
+    Ok(())
 }
 
 /// Draw one eye. Decision tree:

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -141,9 +141,15 @@ where
 const HEART_ANCHOR_X: i32 = 270;
 /// Heart decorator anchor Y — see [`HEART_ANCHOR_X`].
 const HEART_ANCHOR_Y: i32 = 50;
-/// Lobe radius for the heart — small enough to read as overlay rather
-/// than competing with the eyes (`radius_y = 25`).
-const HEART_LOBE_RADIUS: u32 = 9;
+/// Lobe diameter (passed directly to `Circle::new`). Sized so lobe
+/// centres sit `HEART_LOBE_CENTER_OFFSET` apart and the right edge of
+/// the left lobe overlaps the left edge of the right lobe by a few
+/// pixels — the classic double-bump silhouette.
+const HEART_LOBE_DIAMETER: u32 = 12;
+/// Horizontal distance from the anchor to each lobe's centre. Picked
+/// so the two lobes overlap (centre offset < diameter) for the heart
+/// silhouette rather than reading as two isolated dots.
+const HEART_LOBE_CENTER_OFFSET: i32 = 4;
 
 /// Draw a small pink heart in the upper-right corner of the face.
 ///
@@ -156,29 +162,32 @@ where
 {
     use embedded_graphics::primitives::Triangle;
 
+    // `Circle::new(top_left, diameter)` — the corner of the bounding
+    // box, not the centre. Convert from each lobe's centre to its
+    // bounding-box top-left.
     #[allow(clippy::cast_possible_wrap)]
-    let lobe_offset = (HEART_LOBE_RADIUS / 2) as i32;
-    let left_top = EgPoint::new(
-        HEART_ANCHOR_X - lobe_offset - i32::try_from(HEART_LOBE_RADIUS).unwrap_or(0),
-        HEART_ANCHOR_Y,
-    );
-    let right_top = EgPoint::new(HEART_ANCHOR_X + lobe_offset, HEART_ANCHOR_Y);
-    Circle::new(left_top, HEART_LOBE_RADIUS)
+    let half_d = (HEART_LOBE_DIAMETER / 2) as i32;
+    let left_center_x = HEART_ANCHOR_X - HEART_LOBE_CENTER_OFFSET;
+    let right_center_x = HEART_ANCHOR_X + HEART_LOBE_CENTER_OFFSET;
+    let lobe_top_y = HEART_ANCHOR_Y;
+    let left_top = EgPoint::new(left_center_x - half_d, lobe_top_y);
+    let right_top = EgPoint::new(right_center_x - half_d, lobe_top_y);
+    Circle::new(left_top, HEART_LOBE_DIAMETER)
         .into_styled(fill(HEART_COLOR))
         .draw(target)?;
-    Circle::new(right_top, HEART_LOBE_RADIUS)
+    Circle::new(right_top, HEART_LOBE_DIAMETER)
         .into_styled(fill(HEART_COLOR))
         .draw(target)?;
-    // Triangle filling the bottom point. Top corners sit at the
-    // bottom-inside of each lobe; bottom point sits below by ~lobe
-    // radius for a balanced heart silhouette.
+    // Triangle filling the bottom point. Top corners sit on the lobe
+    // bottoms (diameter px below the lobe top); bottom apex sits a
+    // further ~diameter below for a balanced heart silhouette.
     #[allow(clippy::cast_possible_wrap)]
-    let r = HEART_LOBE_RADIUS as i32;
-    let lobe_bottom_y = HEART_ANCHOR_Y + r;
+    let d = HEART_LOBE_DIAMETER as i32;
+    let lobe_bottom_y = lobe_top_y + d;
     Triangle::new(
-        EgPoint::new(HEART_ANCHOR_X - r, lobe_bottom_y),
-        EgPoint::new(HEART_ANCHOR_X + r, lobe_bottom_y),
-        EgPoint::new(HEART_ANCHOR_X, lobe_bottom_y + r + 2),
+        EgPoint::new(left_center_x - half_d, lobe_bottom_y - 1),
+        EgPoint::new(right_center_x + half_d, lobe_bottom_y - 1),
+        EgPoint::new(HEART_ANCHOR_X, lobe_bottom_y + d),
     )
     .into_styled(fill(HEART_COLOR))
     .draw(target)

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -174,6 +174,11 @@ pub struct Face {
     pub mouth: Mouth,
     /// Emotion-driven appearance modulators.
     pub style: Style,
+    /// Active decorator overlay, drawn on top of the base face. `None`
+    /// is the steady state. Trigger modifiers in
+    /// [`crate::director::Phase::Decoration`] populate this field;
+    /// [`crate::modifiers::DecoratorExpiry`] clears it on deadline.
+    pub decorator: Option<crate::decorator::DecoratorState>,
 }
 
 impl Default for Face {
@@ -206,6 +211,7 @@ impl Default for Face {
                 mouth_open: 0.0,
             },
             style: Style::default(),
+            decorator: None,
         }
     }
 }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -28,6 +28,7 @@
 #![deny(unsafe_code)]
 
 pub mod clock;
+pub mod decorator;
 pub mod director;
 pub mod draw;
 pub mod emotion;
@@ -48,6 +49,7 @@ pub mod skills;
 pub mod voice;
 
 pub use clock::{Clock, Instant};
+pub use decorator::{Decorator, DecoratorState};
 pub use director::{
     Director, Field, FieldGroup, MODIFIER_CAP, ModifierMeta, Phase, SKILL_CAP, SkillMeta,
 };

--- a/crates/stackchan-core/src/modifiers/decorator_expiry.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_expiry.rs
@@ -1,0 +1,90 @@
+//! [`DecoratorExpiry`] — runs first in [`Phase::Decoration`] and clears
+//! `face.decorator` once its `expires_at` deadline passes.
+//!
+//! Splitting expiry into its own modifier keeps the trigger modifiers
+//! stateless on the time axis: each trigger only writes a fresh
+//! [`crate::decorator::DecoratorState`] when its condition fires, and
+//! never has to know whether the current decorator is "still alive."
+//!
+//! [`Phase::Decoration`]: crate::director::Phase::Decoration
+
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// Stateless modifier that clears expired decorators.
+///
+/// Runs at priority `-10` in [`Phase::Decoration`] so trigger
+/// modifiers (priority `0+`) see a clean slate before deciding whether
+/// to re-arm a decorator.
+///
+/// [`Phase::Decoration`]: crate::director::Phase::Decoration
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DecoratorExpiry;
+
+impl DecoratorExpiry {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Modifier for DecoratorExpiry {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DecoratorExpiry",
+            description: "Clears face.decorator once expires_at passes; runs first in \
+                          Phase::Decoration so trigger modifiers see a clean slate.",
+            phase: Phase::Decoration,
+            priority: -10,
+            reads: &[Field::Decorator],
+            writes: &[Field::Decorator],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        if let Some(state) = entity.face.decorator
+            && state.is_expired(entity.tick.now)
+        {
+            entity.face.decorator = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::Instant;
+    use crate::decorator::{Decorator, DecoratorState};
+
+    #[test]
+    fn clears_decorator_on_or_after_deadline() {
+        let mut entity = Entity::default();
+        entity.face.decorator = Some(DecoratorState {
+            kind: Decorator::Heart,
+            expires_at: Instant::from_millis(1_000),
+        });
+        let mut m = DecoratorExpiry::new();
+
+        // Before deadline — held.
+        entity.tick.now = Instant::from_millis(999);
+        m.update(&mut entity);
+        assert!(entity.face.decorator.is_some());
+
+        // At deadline — cleared.
+        entity.tick.now = Instant::from_millis(1_000);
+        m.update(&mut entity);
+        assert!(entity.face.decorator.is_none());
+    }
+
+    #[test]
+    fn noop_on_empty_decorator() {
+        let mut entity = Entity::default();
+        let mut m = DecoratorExpiry::new();
+        entity.tick.now = Instant::from_millis(99_999);
+        m.update(&mut entity);
+        assert!(entity.face.decorator.is_none());
+    }
+}

--- a/crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs
@@ -7,7 +7,6 @@
 //! we want is "anyone who pats Stack-chan gets a heart back," and
 //! `Petting`'s sustain-counter is too slow for that interaction.
 
-use crate::clock::Instant;
 use crate::decorator::{Decorator, DecoratorState};
 use crate::director::{Field, ModifierMeta, Phase};
 use crate::emotion::Emotion;
@@ -22,10 +21,11 @@ pub const HEART_HOLD_MS: u64 = 2_000;
 pub struct DecoratorFromBodyTouch {
     /// Hold duration in milliseconds. Configurable for tests.
     hold_ms: u64,
-    /// Last `now` we observed `body_touch.any() == true`. Used so we
-    /// only re-arm the heart on a rising edge, not on every frame the
-    /// hand is still resting on the head.
-    last_touched_at: Option<Instant>,
+    /// `true` if the previous frame observed `body_touch.any()`. Used
+    /// so we only re-arm the heart on a rising edge, not on every
+    /// frame the hand is still resting on the head — a `bool` is
+    /// enough; we don't need the timestamp.
+    was_touched_last_frame: bool,
 }
 
 impl DecoratorFromBodyTouch {
@@ -34,7 +34,7 @@ impl DecoratorFromBodyTouch {
     pub const fn new() -> Self {
         Self {
             hold_ms: HEART_HOLD_MS,
-            last_touched_at: None,
+            was_touched_last_frame: false,
         }
     }
 
@@ -44,7 +44,7 @@ impl DecoratorFromBodyTouch {
     pub const fn with_hold_ms(hold_ms: u64) -> Self {
         Self {
             hold_ms,
-            last_touched_at: None,
+            was_touched_last_frame: false,
         }
     }
 }
@@ -84,12 +84,8 @@ impl Modifier for DecoratorFromBodyTouch {
         // Detect rising edge: was untouched (or first frame), now is.
         // Without the rising-edge gate we'd refresh the expiry every
         // frame the hand is held, masking the natural fade-out.
-        let rose = touched && self.last_touched_at.is_none();
-        if touched {
-            self.last_touched_at = Some(now);
-        } else {
-            self.last_touched_at = None;
-        }
+        let rose = touched && !self.was_touched_last_frame;
+        self.was_touched_last_frame = touched;
 
         if rose && emotion_invites_heart(entity.mind.affect.emotion) {
             entity.face.decorator = Some(DecoratorState::hold_for(
@@ -110,6 +106,7 @@ impl Modifier for DecoratorFromBodyTouch {
 )]
 mod tests {
     use super::*;
+    use crate::clock::Instant;
     use crate::perception::BodyTouch;
 
     fn step(m: &mut DecoratorFromBodyTouch, entity: &mut Entity, ms: u64) {

--- a/crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs
@@ -1,0 +1,205 @@
+//! [`DecoratorFromBodyTouch`] — fires the [`Decorator::Heart`] overlay
+//! when a positive emotion meets a back-of-head touch.
+//!
+//! Reads `entity.perception.body_touch` directly rather than depending
+//! on the `Petting` skill's `Intent::BeingPet` so a brief tap (rather
+//! than sustained petting) still earns the heart — the user reaction
+//! we want is "anyone who pats Stack-chan gets a heart back," and
+//! `Petting`'s sustain-counter is too slow for that interaction.
+
+use crate::clock::Instant;
+use crate::decorator::{Decorator, DecoratorState};
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::emotion::Emotion;
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// How long the Heart decorator is held after a triggering tap.
+pub const HEART_HOLD_MS: u64 = 2_000;
+
+/// Modifier that arms [`Decorator::Heart`] on body-touch + positive emotion.
+#[derive(Debug, Clone, Copy)]
+pub struct DecoratorFromBodyTouch {
+    /// Hold duration in milliseconds. Configurable for tests.
+    hold_ms: u64,
+    /// Last `now` we observed `body_touch.any() == true`. Used so we
+    /// only re-arm the heart on a rising edge, not on every frame the
+    /// hand is still resting on the head.
+    last_touched_at: Option<Instant>,
+}
+
+impl DecoratorFromBodyTouch {
+    /// Construct with the default hold of [`HEART_HOLD_MS`].
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            hold_ms: HEART_HOLD_MS,
+            last_touched_at: None,
+        }
+    }
+
+    /// Construct with a custom hold duration. Test helper; firmware
+    /// uses [`Self::new`].
+    #[must_use]
+    pub const fn with_hold_ms(hold_ms: u64) -> Self {
+        Self {
+            hold_ms,
+            last_touched_at: None,
+        }
+    }
+}
+
+impl Default for DecoratorFromBodyTouch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Emotions that earn a heart on touch. Reactive variants
+/// (`Sad`, `Surprised`, `Angry`, `Confused`, `Mad`, …) explicitly
+/// exclude the heart so a hostile pat doesn't paint a contradicting
+/// affection overlay.
+const fn emotion_invites_heart(e: Emotion) -> bool {
+    matches!(e, Emotion::Happy | Emotion::Loved | Emotion::Hi)
+}
+
+impl Modifier for DecoratorFromBodyTouch {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DecoratorFromBodyTouch",
+            description: "Arms face.decorator = Heart when body_touch.any() rises and the \
+                          current emotion invites affection (Happy / Loved / Hi).",
+            phase: Phase::Decoration,
+            priority: 0,
+            reads: &[Field::BodyTouch, Field::Emotion],
+            writes: &[Field::Decorator],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        let touched = entity.perception.body_touch.is_some_and(|t| t.any());
+
+        // Detect rising edge: was untouched (or first frame), now is.
+        // Without the rising-edge gate we'd refresh the expiry every
+        // frame the hand is held, masking the natural fade-out.
+        let rose = touched && self.last_touched_at.is_none();
+        if touched {
+            self.last_touched_at = Some(now);
+        } else {
+            self.last_touched_at = None;
+        }
+
+        if rose && emotion_invites_heart(entity.mind.affect.emotion) {
+            entity.face.decorator = Some(DecoratorState::hold_for(
+                Decorator::Heart,
+                now,
+                self.hold_ms,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: Option::unwrap on values just written by the \
+              modifier-under-test"
+)]
+mod tests {
+    use super::*;
+    use crate::perception::BodyTouch;
+
+    fn step(m: &mut DecoratorFromBodyTouch, entity: &mut Entity, ms: u64) {
+        entity.tick.now = Instant::from_millis(ms);
+        m.update(entity);
+    }
+
+    #[test]
+    fn touch_on_happy_arms_heart() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Happy;
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 0,
+            centre: 2,
+            right: 0,
+        });
+        let mut m = DecoratorFromBodyTouch::new();
+        step(&mut m, &mut entity, 0);
+        let state = entity.face.decorator.expect("heart should be armed");
+        assert_eq!(state.kind, Decorator::Heart);
+        assert_eq!(state.expires_at, Instant::from_millis(HEART_HOLD_MS));
+    }
+
+    #[test]
+    fn touch_on_neutral_does_not_arm_heart() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Neutral;
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 0,
+            centre: 3,
+            right: 0,
+        });
+        let mut m = DecoratorFromBodyTouch::new();
+        step(&mut m, &mut entity, 0);
+        assert!(entity.face.decorator.is_none());
+    }
+
+    #[test]
+    fn sustained_touch_does_not_refresh_expiry() {
+        // Without the rising-edge gate, a hand resting on the head
+        // for 4 seconds would extend the heart indefinitely.
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Happy;
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 0,
+            centre: 2,
+            right: 0,
+        });
+        let mut m = DecoratorFromBodyTouch::with_hold_ms(2_000);
+
+        step(&mut m, &mut entity, 0);
+        let first_expiry = entity.face.decorator.unwrap().expires_at;
+
+        // Continued touch on subsequent frames must not re-arm.
+        step(&mut m, &mut entity, 500);
+        step(&mut m, &mut entity, 1_000);
+        let still_first = entity.face.decorator.unwrap().expires_at;
+        assert_eq!(first_expiry, still_first);
+    }
+
+    #[test]
+    fn release_then_re_touch_re_arms() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Loved;
+        let mut m = DecoratorFromBodyTouch::with_hold_ms(2_000);
+
+        // Touch at t=0
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 0,
+            centre: 2,
+            right: 0,
+        });
+        step(&mut m, &mut entity, 0);
+        let first = entity.face.decorator.unwrap().expires_at;
+
+        // Release at t=500
+        entity.perception.body_touch = Some(BodyTouch::default());
+        step(&mut m, &mut entity, 500);
+
+        // Re-touch at t=1000 — fresh edge → fresh expiry.
+        entity.perception.body_touch = Some(BodyTouch {
+            left: 1,
+            centre: 1,
+            right: 0,
+        });
+        step(&mut m, &mut entity, 1_000);
+        let second = entity.face.decorator.unwrap().expires_at;
+        assert!(
+            second > first,
+            "re-armed expiry should be later than the original ({second:?} vs {first:?})"
+        );
+    }
+}

--- a/crates/stackchan-core/src/modifiers/decorator_from_loud.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_loud.rs
@@ -1,0 +1,190 @@
+//! [`DecoratorFromLoud`] — fires the [`Decorator::Sweat`] overlay when
+//! a sudden loud sound coincides with a non-positive emotion.
+//!
+//! The trigger reuses the same RMS that [`crate::modifiers::IntentFromLoud`]
+//! reads; the difference is that this modifier paints a decorator
+//! rather than writing intent. Both can fire on the same frame
+//! without conflict.
+
+use crate::decorator::{Decorator, DecoratorState};
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::emotion::Emotion;
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// How long the Sweat decorator is held after a triggering loud spike.
+pub const SWEAT_HOLD_MS: u64 = 3_000;
+
+/// Default rising-edge RMS threshold that fires the sweat overlay.
+/// Matches `IntentFromLoud`'s startle threshold so the two reactions
+/// are visually correlated.
+pub const SWEAT_RMS_THRESHOLD: f32 = 0.4;
+
+/// Modifier that arms [`Decorator::Sweat`] on a loud rising edge while
+/// the current emotion is non-positive (Sad / Surprised / Angry / Mad
+/// / Confused).
+#[derive(Debug, Clone, Copy)]
+pub struct DecoratorFromLoud {
+    /// Hold duration in ms.
+    hold_ms: u64,
+    /// Threshold RMS — sweat arms only on the rising edge across this.
+    threshold: f32,
+    /// `true` once we've seen a sample above [`Self::threshold`]; the
+    /// next dip back below resets it. This keeps a sustained loud
+    /// noise from re-arming on every frame.
+    armed_above: bool,
+}
+
+impl DecoratorFromLoud {
+    /// Construct with default hold + threshold.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            hold_ms: SWEAT_HOLD_MS,
+            threshold: SWEAT_RMS_THRESHOLD,
+            armed_above: false,
+        }
+    }
+
+    /// Construct with a custom hold + threshold. Test helper.
+    #[must_use]
+    pub const fn with_params(hold_ms: u64, threshold: f32) -> Self {
+        Self {
+            hold_ms,
+            threshold,
+            armed_above: false,
+        }
+    }
+}
+
+impl Default for DecoratorFromLoud {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Emotions that justify a sweat overlay. Positive emotions (Happy /
+/// Loved / Hi / Curious) should *not* paint sweat even on a loud spike
+/// — those reactions belong to `IntentFromLoud`'s startle path, which
+/// would have flipped the emotion away from positive territory if the
+/// spike was genuinely jarring.
+const fn emotion_admits_sweat(e: Emotion) -> bool {
+    matches!(
+        e,
+        Emotion::Sad | Emotion::Surprised | Emotion::Angry | Emotion::Mad | Emotion::Confused
+    )
+}
+
+impl Modifier for DecoratorFromLoud {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DecoratorFromLoud",
+            description: "Arms face.decorator = Sweat on the rising edge of audio_rms across \
+                          the threshold while emotion is non-positive (Sad / Surprised / \
+                          Angry / Mad / Confused).",
+            phase: Phase::Decoration,
+            priority: 10,
+            reads: &[Field::AudioRms, Field::Emotion],
+            writes: &[Field::Decorator],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        let rms = entity.perception.audio_rms.unwrap_or(0.0);
+        let above = rms.is_finite() && rms > self.threshold;
+
+        // Rising edge across the threshold.
+        let rose = above && !self.armed_above;
+        self.armed_above = above;
+
+        if rose && emotion_admits_sweat(entity.mind.affect.emotion) {
+            entity.face.decorator = Some(DecoratorState::hold_for(
+                Decorator::Sweat,
+                now,
+                self.hold_ms,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: Option::unwrap and Option::expect on values just \
+              assigned by the modifier-under-test"
+)]
+mod tests {
+    use super::*;
+    use crate::clock::Instant;
+
+    fn step(m: &mut DecoratorFromLoud, entity: &mut Entity, rms: f32, ms: u64) {
+        entity.perception.audio_rms = Some(rms);
+        entity.tick.now = Instant::from_millis(ms);
+        m.update(entity);
+    }
+
+    #[test]
+    fn loud_on_sad_arms_sweat() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Sad;
+        let mut m = DecoratorFromLoud::with_params(3_000, 0.4);
+        step(&mut m, &mut entity, 0.5, 0);
+        let state = entity.face.decorator.expect("sweat should arm");
+        assert_eq!(state.kind, Decorator::Sweat);
+        assert_eq!(state.expires_at, Instant::from_millis(3_000));
+    }
+
+    #[test]
+    fn loud_on_happy_does_not_arm_sweat() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Happy;
+        let mut m = DecoratorFromLoud::new();
+        step(&mut m, &mut entity, 0.6, 0);
+        assert!(entity.face.decorator.is_none());
+    }
+
+    #[test]
+    fn sustained_loud_does_not_re_arm() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Surprised;
+        let mut m = DecoratorFromLoud::with_params(3_000, 0.4);
+        step(&mut m, &mut entity, 0.5, 0);
+        let first = entity.face.decorator.unwrap().expires_at;
+
+        // Continued loud audio — must not re-arm.
+        step(&mut m, &mut entity, 0.7, 100);
+        step(&mut m, &mut entity, 0.6, 200);
+        let still_first = entity.face.decorator.unwrap().expires_at;
+        assert_eq!(first, still_first);
+    }
+
+    #[test]
+    fn quiet_then_loud_re_arms_sweat() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Angry;
+        let mut m = DecoratorFromLoud::with_params(3_000, 0.4);
+        step(&mut m, &mut entity, 0.5, 0);
+        let first = entity.face.decorator.unwrap().expires_at;
+        step(&mut m, &mut entity, 0.05, 500); // quiet — resets the edge
+        step(&mut m, &mut entity, 0.7, 1_000); // loud again
+        let second = entity.face.decorator.unwrap().expires_at;
+        assert!(
+            second > first,
+            "fresh edge should produce later expiry ({second:?} vs {first:?})"
+        );
+    }
+
+    #[test]
+    fn nonfinite_rms_is_silent() {
+        let mut entity = Entity::default();
+        entity.mind.affect.emotion = Emotion::Sad;
+        let mut m = DecoratorFromLoud::new();
+        step(&mut m, &mut entity, f32::NAN, 0);
+        assert!(entity.face.decorator.is_none());
+        step(&mut m, &mut entity, f32::INFINITY, 100);
+        assert!(entity.face.decorator.is_none());
+    }
+}

--- a/crates/stackchan-core/src/modifiers/decorator_from_shake.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_shake.rs
@@ -1,0 +1,147 @@
+//! [`DecoratorFromShake`] — fires the [`Decorator::Dizzy`] overlay
+//! whenever [`crate::skills::Handling`] flips intent into
+//! [`crate::mind::Intent::Shaken`].
+//!
+//! Hooks the existing shake detection rather than rolling its own
+//! accel-window analysis: `Handling` already does the heavy lifting,
+//! and reusing its intent surface keeps the trigger correlated with
+//! the rest of the shake reaction (Angry emotion via
+//! `EmotionFromIntent`, head recoil via `HeadFromIntent`, etc.).
+
+use crate::decorator::{Decorator, DecoratorState};
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::Intent;
+use crate::modifier::Modifier;
+
+/// How long the Dizzy decorator is held after a shake event.
+pub const DIZZY_HOLD_MS: u64 = 4_000;
+
+/// Modifier that arms [`Decorator::Dizzy`] on the rising edge into
+/// [`Intent::Shaken`].
+#[derive(Debug, Clone, Copy)]
+pub struct DecoratorFromShake {
+    /// Hold duration in ms.
+    hold_ms: u64,
+    /// Last frame's intent — needed to detect the edge into
+    /// [`Intent::Shaken`] so we don't refresh the dizzy hold every
+    /// frame the shake intent persists.
+    last_intent: Option<Intent>,
+}
+
+impl DecoratorFromShake {
+    /// Construct with default hold ([`DIZZY_HOLD_MS`]).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            hold_ms: DIZZY_HOLD_MS,
+            last_intent: None,
+        }
+    }
+
+    /// Construct with a custom hold duration. Test helper.
+    #[must_use]
+    pub const fn with_hold_ms(hold_ms: u64) -> Self {
+        Self {
+            hold_ms,
+            last_intent: None,
+        }
+    }
+}
+
+impl Default for DecoratorFromShake {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for DecoratorFromShake {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DecoratorFromShake",
+            description: "Arms face.decorator = Dizzy on the rising edge into Intent::Shaken.",
+            phase: Phase::Decoration,
+            priority: 20,
+            reads: &[Field::Intent],
+            writes: &[Field::Decorator],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        let intent = entity.mind.intent;
+        let was_shaken = matches!(self.last_intent, Some(Intent::Shaken));
+        let is_shaken = matches!(intent, Intent::Shaken);
+        self.last_intent = Some(intent);
+
+        if is_shaken && !was_shaken {
+            entity.face.decorator = Some(DecoratorState::hold_for(
+                Decorator::Dizzy,
+                now,
+                self.hold_ms,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: Option::unwrap on values just written by the \
+              modifier-under-test"
+)]
+mod tests {
+    use super::*;
+    use crate::clock::Instant;
+
+    fn step(m: &mut DecoratorFromShake, entity: &mut Entity, intent: Intent, ms: u64) {
+        entity.mind.intent = intent;
+        entity.tick.now = Instant::from_millis(ms);
+        m.update(entity);
+    }
+
+    #[test]
+    fn shake_edge_arms_dizzy() {
+        let mut entity = Entity::default();
+        let mut m = DecoratorFromShake::new();
+        step(&mut m, &mut entity, Intent::Idle, 0);
+        assert!(entity.face.decorator.is_none());
+        step(&mut m, &mut entity, Intent::Shaken, 33);
+        let state = entity.face.decorator.expect("dizzy should arm");
+        assert_eq!(state.kind, Decorator::Dizzy);
+        assert_eq!(state.expires_at, Instant::from_millis(33 + DIZZY_HOLD_MS));
+    }
+
+    #[test]
+    fn sustained_shaken_does_not_refresh_expiry() {
+        let mut entity = Entity::default();
+        let mut m = DecoratorFromShake::with_hold_ms(4_000);
+        step(&mut m, &mut entity, Intent::Idle, 0);
+        step(&mut m, &mut entity, Intent::Shaken, 33);
+        let first = entity.face.decorator.unwrap().expires_at;
+        // Shaken intent persists across multiple frames — must not re-arm.
+        step(&mut m, &mut entity, Intent::Shaken, 66);
+        step(&mut m, &mut entity, Intent::Shaken, 99);
+        let still_first = entity.face.decorator.unwrap().expires_at;
+        assert_eq!(first, still_first);
+    }
+
+    #[test]
+    fn intent_other_than_shaken_does_nothing() {
+        let mut entity = Entity::default();
+        let mut m = DecoratorFromShake::new();
+        for intent in [
+            Intent::Idle,
+            Intent::Listening,
+            Intent::Tilted,
+            Intent::PickedUp,
+            Intent::Petted,
+            Intent::Startled,
+        ] {
+            step(&mut m, &mut entity, intent, 0);
+        }
+        assert!(entity.face.decorator.is_none());
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -84,6 +84,10 @@
 mod attention_from_tracking;
 mod blink;
 mod breath;
+mod decorator_expiry;
+mod decorator_from_body_touch;
+mod decorator_from_loud;
+mod decorator_from_shake;
 mod dormancy_from_activity;
 mod emotion_cycle;
 mod emotion_from_ambient;
@@ -113,6 +117,10 @@ pub use attention_from_tracking::{
 };
 pub use blink::Blink;
 pub use breath::Breath;
+pub use decorator_expiry::DecoratorExpiry;
+pub use decorator_from_body_touch::{DecoratorFromBodyTouch, HEART_HOLD_MS};
+pub use decorator_from_loud::{DecoratorFromLoud, SWEAT_HOLD_MS, SWEAT_RMS_THRESHOLD};
+pub use decorator_from_shake::{DIZZY_HOLD_MS, DecoratorFromShake};
 pub use dormancy_from_activity::{DORMANCY_TIMEOUT_MS, DormancyFromActivity};
 pub use emotion_cycle::EmotionCycle;
 pub use emotion_from_ambient::{

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -74,7 +74,8 @@ use mipidsi::{
 use stackchan_core::{
     Attention, Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
     modifiers::{
-        AttentionFromTracking, Blink, Breath, DormancyFromActivity, EmotionCycle,
+        AttentionFromTracking, Blink, Breath, DecoratorExpiry, DecoratorFromBodyTouch,
+        DecoratorFromLoud, DecoratorFromShake, DormancyFromActivity, EmotionCycle,
         EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
         EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion,
         HeadFromIntent, IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud,
@@ -221,6 +222,10 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut petting = Petting::new();
     let mut handling = Handling::new();
     let mut intent_from_body_touch = IntentFromBodyTouch::new();
+    let mut decorator_expiry = DecoratorExpiry::new();
+    let mut decorator_from_body_touch = DecoratorFromBodyTouch::new();
+    let mut decorator_from_loud = DecoratorFromLoud::new();
+    let mut decorator_from_shake = DecoratorFromShake::new();
     let mut last_rendered: Option<Face> = None;
     // Last on-screen pairing passkey. Tracked separately from
     // `last_rendered` so a passkey transition forces a redraw even
@@ -287,6 +292,23 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     director.add_modifier(&mut blink).expect("registry full");
     director.add_modifier(&mut breath).expect("registry full");
     director.add_modifier(&mut drift).expect("registry full");
+    // Phase::Decoration — expiry first (priority -10), then trigger
+    // modifiers in priority order. Sits between Expression and Motion
+    // so decorators read final emotion / style state but don't influence
+    // pose. Registration order doesn't matter; the Director sorts by
+    // (phase, priority, registration_order).
+    director
+        .add_modifier(&mut decorator_expiry)
+        .expect("registry full");
+    director
+        .add_modifier(&mut decorator_from_body_touch)
+        .expect("registry full");
+    director
+        .add_modifier(&mut decorator_from_loud)
+        .expect("registry full");
+    director
+        .add_modifier(&mut decorator_from_shake)
+        .expect("registry full");
     director
         .add_modifier(&mut head_drift)
         .expect("registry full");
@@ -546,6 +568,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
             entity.mind.affect.emotion,
             entity.motor.head_pose,
             Some(entity.motor.head_pose_actual),
+            entity.face.decorator.map(|d| d.kind),
         );
         // Push the latest snapshot to any connected SSE subscribers.
         // Throttled internally so a 30 Hz render doesn't firehose

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -846,9 +846,13 @@ fn state_body(s: AvatarSnapshot) -> String {
         .wifi
         .ip
         .map_or_else(|| String::from("null"), |a| format!("\"{a}\""));
+    let decorator = s
+        .decorator
+        .map_or_else(|| String::from("null"), |d| format!("\"{}\"", d.wire_str()));
     format!(
         "{{\
 \"emotion\":\"{emotion}\",\
+\"decorator\":{decorator},\
 \"head_pose\":{{\"pan_deg\":{pan:.2},\"tilt_deg\":{tilt:.2}}},\
 \"head_actual\":{actual},\
 \"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -13,8 +13,8 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pubsub::PubSubChannel;
 use embassy_time::Instant as EmbassyInstant;
-use stackchan_core::Emotion;
 use stackchan_core::head::Pose;
+use stackchan_core::{Decorator, Emotion};
 use stackchan_net::config::AudioConfig;
 
 /// Battery snapshot — published by the power task.
@@ -65,6 +65,10 @@ pub struct AvatarSnapshot {
     /// HTTP `POST /camera/mode`, BLE view-service write) before the
     /// signal fires, so the snapshot stays canonical.
     pub camera_mode: bool,
+    /// Active decorator overlay, if any. Mirrors
+    /// `entity.face.decorator.kind`; the `expires_at` deadline is
+    /// internal and not exposed.
+    pub decorator: Option<Decorator>,
 }
 
 impl AvatarSnapshot {
@@ -92,6 +96,7 @@ impl AvatarSnapshot {
             && self.wifi == other.wifi
             && self.audio == other.audio
             && self.camera_mode == other.camera_mode
+            && self.decorator == other.decorator
     }
 }
 
@@ -105,6 +110,7 @@ impl Default for AvatarSnapshot {
             wifi: WifiSnapshot::default(),
             audio: AudioConfig::DEFAULT,
             camera_mode: false,
+            decorator: None,
         }
     }
 }
@@ -129,15 +135,22 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
         },
         audio: AudioConfig::DEFAULT,
         camera_mode: false,
+        decorator: None,
     }));
 
 /// Replace the avatar/head fields. Called per render tick.
-pub fn update_avatar(emotion: Emotion, head_pose: Pose, head_actual: Option<Pose>) {
+pub fn update_avatar(
+    emotion: Emotion,
+    head_pose: Pose,
+    head_actual: Option<Pose>,
+    decorator: Option<Decorator>,
+) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
         s.emotion = emotion;
         s.head_pose = head_pose;
         s.head_actual = head_actual;
+        s.decorator = decorator;
         cell.set(s);
     });
 }

--- a/crates/stackchan-sim/tests/render_snapshot.rs
+++ b/crates/stackchan-sim/tests/render_snapshot.rs
@@ -15,7 +15,7 @@
 
 use embedded_graphics::pixelcolor::{Rgb565, RgbColor};
 use stackchan_core::modifiers::StyleFromEmotion;
-use stackchan_core::{Director, Emotion, Entity, Instant};
+use stackchan_core::{Decorator, DecoratorState, Director, Emotion, Entity, Instant};
 use stackchan_sim::Framebuffer;
 
 /// LCD canvas width the firmware targets.
@@ -169,6 +169,70 @@ fn every_emotion_renders_distinguishable_frame() {
             neutral_fb.as_slice(),
             "{emotion:?} rendered identically to Neutral — palette row may have collided"
         );
+    }
+}
+
+/// Each [`Decorator`] variant must render visibly distinct from the
+/// no-decorator baseline. The base face is identical across runs;
+/// only the overlay layer differs.
+#[test]
+fn every_decorator_renders_distinguishable_overlay() {
+    let mut baseline = Framebuffer::new(WIDTH, HEIGHT);
+    Entity::default()
+        .face
+        .draw(&mut baseline)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    for &kind in Decorator::ALL {
+        let mut entity = Entity::default();
+        entity.face.decorator = Some(DecoratorState {
+            kind,
+            // Far in the future — we draw the overlay regardless of
+            // expiry; expiry is the modifier's job, not the renderer's.
+            expires_at: Instant::from_millis(u64::MAX / 2),
+        });
+        let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+        entity
+            .face
+            .draw(&mut fb)
+            .expect("Framebuffer DrawTarget is Infallible");
+        assert_ne!(
+            fb.as_slice(),
+            baseline.as_slice(),
+            "{kind:?} should paint pixels outside the no-decorator baseline"
+        );
+    }
+}
+
+/// Two distinct decorators must produce visibly distinct frames. Catches
+/// a draw-routine collision (e.g. Heart and Sweat anchored at the same
+/// pixel range with the same colour palette).
+#[test]
+fn distinct_decorators_render_distinct_frames() {
+    fn render(kind: Decorator) -> Framebuffer {
+        let mut entity = Entity::default();
+        entity.face.decorator = Some(DecoratorState {
+            kind,
+            expires_at: Instant::from_millis(u64::MAX / 2),
+        });
+        let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+        entity
+            .face
+            .draw(&mut fb)
+            .expect("Framebuffer DrawTarget is Infallible");
+        fb
+    }
+
+    for (i, &a) in Decorator::ALL.iter().enumerate() {
+        let fb_a = render(a);
+        for &b in &Decorator::ALL[i + 1..] {
+            let fb_b = render(b);
+            assert_ne!(
+                fb_a.as_slice(),
+                fb_b.as_slice(),
+                "{a:?} and {b:?} render identically — overlay anchors / colours have collided"
+            );
+        }
     }
 }
 

--- a/web/src/components/State.tsx
+++ b/web/src/components/State.tsx
@@ -8,6 +8,8 @@ export function State() {
       <dl class="row">
         <dt>Emotion</dt>
         <dd>{snapshot()?.emotion ?? "—"}</dd>
+        <dt>Decorator</dt>
+        <dd>{snapshot()?.decorator ?? "—"}</dd>
         <dt>Head pose</dt>
         <dd>
           <Show when={snapshot()} fallback="—">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -20,6 +20,7 @@ export type AudioState = {
 
 export type AvatarSnapshot = {
   emotion: string;
+  decorator: string | null;
   head_pose: Pose;
   head_actual: Pose | null;
   battery: BatterySnapshot;


### PR DESCRIPTION
Restacked from #217 onto fresh main after PR #216 merged.

## Summary

Adds a dedicated **`Phase::Decoration`** (= 55) between Expression and Motion for symbolic overlays painted on top of the emotion-driven base face, plus four modifiers in the new phase that drive it.

- **`Decorator` enum** (Heart, Sweat, Dizzy) + `DecoratorState` struct with an `expires_at` deadline; `Face::decorator: Option<DecoratorState>` carries the active overlay.
- **Drawing primitives** in `draw.rs` — Heart (two overlapping pink lobes + filled triangle), Sweat (vertical ellipse + pointed tip), Dizzy (three black dots in arc). Stack-allocated, integer-only, libm-free.
- **Four modifiers in `Phase::Decoration`**:
  - `DecoratorExpiry` (priority -10) — clears stale state at the head of the phase
  - `DecoratorFromBodyTouch` (priority 0) — body-touch rising edge + Happy/Loved/Hi → Heart, 2 s
  - `DecoratorFromLoud` (priority 10) — RMS rising edge across 0.4 + non-positive emotion → Sweat, 3 s
  - `DecoratorFromShake` (priority 20) — `Intent::Shaken` rising edge → Dizzy, 4 s
- **`/state` JSON** surfaces the active decorator's wire string (or `null`); dashboard adds a Decorator row.
- **`Field::Decorator`** joins the write-tracking surface; `Field::ALL.len()` trip-wire bumps to 41.

Each trigger gates on a *rising edge*, not steady state — pinned by sim tests (`sustained_touch_does_not_refresh_expiry`, etc.).

`DecoratorFromShake` reuses `Intent::Shaken` (set by the existing `Handling` skill) so the dizzy overlay correlates naturally with the rest of the shake reaction.

Greptile review previously cleared at 5/5 confidence on PR #217 (closed when its base branch was deleted on 216 merge — recreated here against main).

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features`
- [x] `just clippy-firmware`
- [x] 19 unit tests (decorator types + 4 modifiers covering edge detection, expiry, emotion gating, NaN guards)
- [x] `every_decorator_renders_distinguishable_overlay` + `distinct_decorators_render_distinct_frames` sim tests