### PR TITLE
feat(core): pairing-window scaffolding + Decorator::Pairing

### DIFF
--- a/crates/stackchan-core/src/decorator.rs
+++ b/crates/stackchan-core/src/decorator.rs
@@ -35,6 +35,10 @@ pub enum Decorator {
     /// [`crate::Intent::Listening`] holds (operator-triggered or
     /// wake-word triggered).
     Ear,
+    /// Concentric blue rings — ESP-NOW pairing window active. Set by
+    /// [`crate::modifiers::RemoteCommandModifier`] for the duration of
+    /// an [`crate::RemoteCommand::EnterPairing`] hold.
+    Pairing,
 }
 
 impl Decorator {
@@ -52,6 +56,7 @@ impl Decorator {
             Self::Sweat => "sweat",
             Self::Dizzy => "dizzy",
             Self::Ear => "ear",
+            Self::Pairing => "pairing",
         }
     }
 
@@ -64,6 +69,7 @@ impl Decorator {
             Self::Sweat => 1,
             Self::Dizzy => 2,
             Self::Ear => 3,
+            Self::Pairing => 4,
         }
     }
 
@@ -72,7 +78,13 @@ impl Decorator {
     /// are the compile-time guard; this slice has no compile-time
     /// completeness check, so the `all_length_matches_variant_count`
     /// test is the trip-wire that forces an update on variant addition.
-    pub const ALL: &'static [Self] = &[Self::Heart, Self::Sweat, Self::Dizzy, Self::Ear];
+    pub const ALL: &'static [Self] = &[
+        Self::Heart,
+        Self::Sweat,
+        Self::Dizzy,
+        Self::Ear,
+        Self::Pairing,
+    ];
 }
 
 /// Active decorator overlay with its expiry deadline.
@@ -117,7 +129,7 @@ mod tests {
     fn all_length_matches_variant_count() {
         assert_eq!(
             Decorator::ALL.len(),
-            4,
+            5,
             "update Decorator::ALL when adding a variant"
         );
     }
@@ -128,6 +140,7 @@ mod tests {
         assert_eq!(Decorator::Sweat.wire_byte(), 1);
         assert_eq!(Decorator::Dizzy.wire_byte(), 2);
         assert_eq!(Decorator::Ear.wire_byte(), 3);
+        assert_eq!(Decorator::Pairing.wire_byte(), 4);
     }
 
     #[test]

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -54,6 +54,10 @@ const SWEAT_COLOR: Rgb565 = Rgb565::new(8, 32, 28);
 /// background even at small sizes.
 const DIZZY_COLOR: Rgb565 = Rgb565::BLACK;
 
+/// Pairing decorator color — saturated blue, the universal "transmitting"
+/// cue. Distinct from sweat-blue so the two never read as the same overlay.
+const PAIRING_COLOR: Rgb565 = Rgb565::new(4, 18, 31);
+
 /// Stroke width for closed-eye line, resting mouth line, and curved arcs.
 const LINE_WIDTH: u32 = 3;
 
@@ -132,6 +136,7 @@ where
         Decorator::Sweat => draw_sweat(target),
         Decorator::Dizzy => draw_dizzy(target),
         Decorator::Ear => draw_ear(target),
+        Decorator::Pairing => draw_pairing(target),
     }
 }
 
@@ -300,6 +305,59 @@ where
     Circle::new(inner_top_left, EAR_INNER_DIAMETER)
         .into_styled(fill(Rgb565::WHITE))
         .draw(target)?;
+    Ok(())
+}
+
+/// Pairing decorator anchor X — top-centre, mirrors `DIZZY_CENTER_X`.
+const PAIRING_CENTER_X: i32 = 160;
+/// Pairing decorator anchor Y — same band as the dizzy/listening cues.
+const PAIRING_CENTER_Y: i32 = 30;
+/// Centre dot diameter.
+const PAIRING_CORE_DIAMETER: u32 = 6;
+/// Inner ring diameter.
+const PAIRING_RING_INNER_DIAMETER: u32 = 16;
+/// Outer ring diameter.
+const PAIRING_RING_OUTER_DIAMETER: u32 = 26;
+/// Stroke width on the rings — thick enough to read at 320×240.
+const PAIRING_RING_STROKE: u32 = 2;
+
+/// Draw a wireless-signal radiating-from-point glyph: a filled centre
+/// dot with two concentric ring outlines. Reads as "transmitting" /
+/// "pairing window open" — pulse animation belongs to the LED ring,
+/// not the LCD overlay (the avatar's own attention should stay readable
+/// during pairing).
+fn draw_pairing<D>(target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let core_top_left = EgPoint::new(
+        #[allow(clippy::cast_possible_wrap)]
+        {
+            PAIRING_CENTER_X - (PAIRING_CORE_DIAMETER / 2) as i32
+        },
+        #[allow(clippy::cast_possible_wrap)]
+        {
+            PAIRING_CENTER_Y - (PAIRING_CORE_DIAMETER / 2) as i32
+        },
+    );
+    Circle::new(core_top_left, PAIRING_CORE_DIAMETER)
+        .into_styled(fill(PAIRING_COLOR))
+        .draw(target)?;
+    for diameter in [PAIRING_RING_INNER_DIAMETER, PAIRING_RING_OUTER_DIAMETER] {
+        let top_left = EgPoint::new(
+            #[allow(clippy::cast_possible_wrap)]
+            {
+                PAIRING_CENTER_X - (diameter / 2) as i32
+            },
+            #[allow(clippy::cast_possible_wrap)]
+            {
+                PAIRING_CENTER_Y - (diameter / 2) as i32
+            },
+        );
+        Circle::new(top_left, diameter)
+            .into_styled(stroke(PAIRING_COLOR, PAIRING_RING_STROKE))
+            .draw(target)?;
+    }
     Ok(())
 }
 

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -79,6 +79,19 @@ pub enum RemoteCommand {
         /// playing audio; the default is [`Priority::Normal`].
         priority: Priority,
     },
+    /// Open an ESP-NOW pairing window for `duration_ms` milliseconds.
+    /// While the window is active,
+    /// [`crate::modifiers::RemoteCommandModifier`] arms the
+    /// [`crate::Decorator::Pairing`] overlay (refreshing expiry each
+    /// tick) so the operator gets visible confirmation, and the
+    /// firmware-side ESP-NOW receiver accepts new peer registrations.
+    /// Fire-and-forget on autonomy — pairing does not gate emotion or
+    /// attention.
+    EnterPairing {
+        /// Window length in milliseconds. The decorator refreshes its
+        /// 500 ms tail each tick and fades on release.
+        duration_ms: u32,
+    },
 }
 
 /// Pending inputs the modifier graph consumes.

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -170,7 +170,7 @@ pub use microsaccade_from_attention::{
 pub use mouth_from_audio::{
     DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthFromAudio,
 };
-pub use remote_command::RemoteCommandModifier;
+pub use remote_command::{PAIRING_DECORATOR_TAIL_MS, RemoteCommandModifier};
 pub use style_from_emotion::StyleFromEmotion;
 pub use style_from_intent::{
     PETTING_BLUSH_BUMP, PETTING_EYE_CURVE_BUMP, PETTING_OPEN_WEIGHT_CAP, StyleFromIntent,

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -34,6 +34,7 @@
 //! same way [`super::AttentionFromTracking`] holds its lock counter.
 
 use crate::clock::Instant;
+use crate::decorator::{Decorator, DecoratorState};
 use crate::director::{Field, ModifierMeta, Phase};
 use crate::emotion::Emotion;
 use crate::entity::Entity;
@@ -43,13 +44,18 @@ use crate::mind::{Attention, OverrideSource};
 use crate::modifier::Modifier;
 use crate::voice::ChirpKind;
 
+/// Tail length re-applied each tick a pairing window is active. Once
+/// the window closes the standard
+/// [`super::DecoratorExpiry`] sweep clears the overlay after this
+/// many milliseconds.
+pub const PAIRING_DECORATOR_TAIL_MS: u64 = 500;
+
 /// External control-plane modifier — see module docs for trigger shape.
-#[derive(Debug, Default, Clone, Copy)]
 #[allow(
     clippy::struct_field_names,
-    reason = "the `_hold` postfix is the load-bearing distinction across the three slots; \
-              renaming to drop it would erase the 'this is a hold-timer slot' meaning"
+    reason = "the `_hold` postfix is the load-bearing distinction across the hold slots"
 )]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct RemoteCommandModifier {
     /// Active emotion hold, if any. `(emotion, hold_until)`.
     emotion_hold: Option<(Emotion, Instant)>,
@@ -61,6 +67,10 @@ pub struct RemoteCommandModifier {
     /// pins to the entry frame so listening-pose ease-in animations
     /// don't restart per tick (same idiom as [`Self::lookat_hold`]).
     listen_hold: Option<(Instant, Instant)>,
+    /// Active pairing-window hold, if any. `(entered_at, hold_until)`.
+    /// While the timer is live, [`Self::update`] re-arms
+    /// [`Decorator::Pairing`] on `entity.face.decorator` each tick.
+    pairing_hold: Option<(Instant, Instant)>,
 }
 
 impl RemoteCommandModifier {
@@ -71,6 +81,7 @@ impl RemoteCommandModifier {
             emotion_hold: None,
             lookat_hold: None,
             listen_hold: None,
+            pairing_hold: None,
         }
     }
 
@@ -98,6 +109,7 @@ impl RemoteCommandModifier {
                 self.emotion_hold = None;
                 self.lookat_hold = None;
                 self.listen_hold = None;
+                self.pairing_hold = None;
             }
             RemoteCommand::Speak { .. } => {
                 // Audio dispatch is firmware-only; the producer drains
@@ -115,6 +127,15 @@ impl RemoteCommandModifier {
                 // tick.
                 entity.voice.chirp_request = Some(ChirpKind::Wake);
                 self.listen_hold = Some((now, until));
+            }
+            RemoteCommand::EnterPairing { duration_ms } => {
+                let until = now + u64::from(duration_ms);
+                entity.face.decorator = Some(DecoratorState::hold_for(
+                    Decorator::Pairing,
+                    now,
+                    PAIRING_DECORATOR_TAIL_MS,
+                ));
+                self.pairing_hold = Some((now, until));
             }
         }
     }
@@ -139,6 +160,7 @@ impl Modifier for RemoteCommandModifier {
                 Field::Attention,
                 Field::RemoteCommand,
                 Field::ChirpRequest,
+                Field::Decorator,
             ],
         };
         &META
@@ -191,16 +213,29 @@ impl Modifier for RemoteCommandModifier {
                 }
             }
         }
+
+        if let Some((_entered, until)) = self.pairing_hold {
+            if now < until {
+                entity.face.decorator = Some(DecoratorState::hold_for(
+                    Decorator::Pairing,
+                    now,
+                    PAIRING_DECORATOR_TAIL_MS,
+                ));
+            } else {
+                self.pairing_hold = None;
+            }
+        }
     }
 }
 
 #[cfg(test)]
 #[allow(
+    clippy::expect_used,
     clippy::float_cmp,
     clippy::panic,
     reason = "test-only: f32 fields compared exactly against the literal we wrote; \
               let-else / match-with-panic is the cleanest pattern for value extraction \
-              on enum variants in tests"
+              on enum variants in tests; expect on Option is fine in test setup"
 )]
 mod tests {
     use super::*;
@@ -493,5 +528,68 @@ mod tests {
         step(&mut m, &mut entity, 0);
         assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
         assert!(entity.mind.autonomy.manual_until.is_none());
+    }
+
+    #[test]
+    fn enter_pairing_arms_decorator_and_refreshes_each_tick() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterPairing { duration_ms: 1_000 });
+        step(&mut m, &mut entity, 0);
+        let s = entity
+            .face
+            .decorator
+            .expect("Pairing should be armed after EnterPairing");
+        assert_eq!(s.kind, Decorator::Pairing);
+        assert_eq!(
+            s.expires_at,
+            Instant::from_millis(PAIRING_DECORATOR_TAIL_MS)
+        );
+
+        // Advance mid-window: expiry refreshes to `now + tail`.
+        step(&mut m, &mut entity, 500);
+        let s = entity.face.decorator.expect("still armed mid-window");
+        assert_eq!(s.kind, Decorator::Pairing);
+        assert_eq!(
+            s.expires_at,
+            Instant::from_millis(500 + PAIRING_DECORATOR_TAIL_MS)
+        );
+    }
+
+    #[test]
+    fn enter_pairing_stops_refreshing_after_window_expires() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterPairing { duration_ms: 100 });
+        step(&mut m, &mut entity, 0);
+        // After the 100 ms window the modifier stops re-arming. The
+        // overlay clears via DecoratorExpiry once the 500 ms tail elapses;
+        // the modifier itself just stops touching the field.
+        let pre_expiry = entity.face.decorator;
+        step(&mut m, &mut entity, 1_000);
+        // The previous DecoratorState may still sit in the field if no
+        // expiry sweep has run; the assertion that matters is that the
+        // pairing_hold is released.
+        assert_eq!(entity.face.decorator, pre_expiry);
+    }
+
+    #[test]
+    fn reset_clears_pairing_hold() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterPairing {
+            duration_ms: 30_000,
+        });
+        step(&mut m, &mut entity, 0);
+        assert!(entity.face.decorator.is_some());
+
+        entity.input.remote_command = Some(RemoteCommand::Reset);
+        step(&mut m, &mut entity, 100);
+        // Reset clears the timer; the decorator field is left alone
+        // (DecoratorExpiry handles the visual fade) — what we pin here
+        // is that subsequent ticks no longer refresh the overlay.
+        let after_reset = entity.face.decorator;
+        step(&mut m, &mut entity, 200);
+        assert_eq!(entity.face.decorator, after_reset);
     }
 }

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -67,10 +67,10 @@ pub struct RemoteCommandModifier {
     /// pins to the entry frame so listening-pose ease-in animations
     /// don't restart per tick (same idiom as [`Self::lookat_hold`]).
     listen_hold: Option<(Instant, Instant)>,
-    /// Active pairing-window hold, if any. `(entered_at, hold_until)`.
-    /// While the timer is live, [`Self::update`] re-arms
-    /// [`Decorator::Pairing`] on `entity.face.decorator` each tick.
-    pairing_hold: Option<(Instant, Instant)>,
+    /// Active pairing-window deadline, if any. While the timer is
+    /// live, [`Self::update`] re-arms [`Decorator::Pairing`] on
+    /// `entity.face.decorator` each tick.
+    pairing_hold: Option<Instant>,
 }
 
 impl RemoteCommandModifier {
@@ -135,7 +135,7 @@ impl RemoteCommandModifier {
                     now,
                     PAIRING_DECORATOR_TAIL_MS,
                 ));
-                self.pairing_hold = Some((now, until));
+                self.pairing_hold = Some(until);
             }
         }
     }
@@ -214,7 +214,7 @@ impl Modifier for RemoteCommandModifier {
             }
         }
 
-        if let Some((_entered, until)) = self.pairing_hold {
+        if let Some(until) = self.pairing_hold {
             if now < until {
                 entity.face.decorator = Some(DecoratorState::hold_for(
                     Decorator::Pairing,

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -361,6 +361,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
         ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,
         ("POST", "/listen") => handle_remote(socket, json::parse_start_listen(body)).await,
+        ("POST", "/pair") => handle_remote(socket, json::parse_enter_pairing(body)).await,
         ("POST", "/volume") => handle_post_volume(socket, body).await,
         ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("POST", "/mood") => handle_post_mood(socket, body).await,
@@ -809,6 +810,17 @@ fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
             Ok(cmd) => {
                 REMOTE_COMMAND_SIGNAL.signal(cmd);
                 render_success(id, &render_tool_text_result("listen window opened"))
+            }
+            Err(e) => render_error(
+                Some(id),
+                JsonRpcErrorCode::InvalidParams,
+                tool_parse_detail(&e),
+            ),
+        },
+        "enter_pairing" => match json::parse_enter_pairing(arguments) {
+            Ok(cmd) => {
+                REMOTE_COMMAND_SIGNAL.signal(cmd);
+                render_success(id, &render_tool_text_result("pairing window opened"))
             }
             Err(e) => render_error(
                 Some(id),

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -337,6 +337,40 @@ pub fn parse_camera_mode(body: &str) -> Result<bool, JsonError> {
     enabled.ok_or(JsonError::MissingKey("enabled"))
 }
 
+/// Default ESP-NOW pairing window. 30 seconds is the rough span needed
+/// to power up an `M5StickC` remote, navigate its menu, and trigger the
+/// pairing handshake. Operators can override per request.
+pub const DEFAULT_PAIRING_DURATION_MS: u32 = 30_000;
+
+/// Parse a `POST /pair` body into a [`RemoteCommand::EnterPairing`].
+///
+/// All keys are optional. Missing body or empty `{}` defaults to
+/// [`DEFAULT_PAIRING_DURATION_MS`]; the only key recognised is
+/// `duration_ms` (u32).
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for unknown keys or malformed JSON
+/// shape.
+pub fn parse_enter_pairing(body: &str) -> Result<RemoteCommand, JsonError> {
+    let mut duration_ms: Option<u32> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "duration_ms" => {
+                if duration_ms.is_some() {
+                    return Err(JsonError::DuplicateKey("duration_ms"));
+                }
+                duration_ms = Some(parse_u32(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    Ok(RemoteCommand::EnterPairing {
+        duration_ms: duration_ms.unwrap_or(DEFAULT_PAIRING_DURATION_MS),
+    })
+}
+
 /// Single-pass byte cursor over the body. Each parse helper advances
 /// past the value it consumes (without consuming the trailing comma
 /// or `}` — those belong to [`visit_object`]).
@@ -974,6 +1008,39 @@ mod tests {
         assert!(matches!(
             parse_camera_mode(r#"{"enabled":true,"hold_ms":1000}"#),
             Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn enter_pairing_defaults_to_30s_window() {
+        let cmd = parse_enter_pairing(r"{}").unwrap();
+        assert_eq!(
+            cmd,
+            RemoteCommand::EnterPairing {
+                duration_ms: DEFAULT_PAIRING_DURATION_MS
+            }
+        );
+    }
+
+    #[test]
+    fn enter_pairing_accepts_explicit_duration() {
+        let cmd = parse_enter_pairing(r#"{"duration_ms":5000}"#).unwrap();
+        assert_eq!(cmd, RemoteCommand::EnterPairing { duration_ms: 5_000 });
+    }
+
+    #[test]
+    fn enter_pairing_rejects_unknown_key() {
+        assert!(matches!(
+            parse_enter_pairing(r#"{"hold_ms":1000}"#),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn enter_pairing_rejects_duplicate_key() {
+        assert!(matches!(
+            parse_enter_pairing(r#"{"duration_ms":1,"duration_ms":2}"#),
+            Err(JsonError::DuplicateKey("duration_ms"))
         ));
     }
 }

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -626,6 +626,7 @@ pub const TOOLS_LIST_RESULT_JSON: &str = concat!(
     r#"{"name":"look_at","description":"Aim the avatar's head at a pan/tilt target in degrees, with an optional hold timer.","inputSchema":{"type":"object","properties":{"pan_deg":{"type":"number"},"tilt_deg":{"type":"number"},"hold_ms":{"type":"integer"}},"required":["pan_deg","tilt_deg"]}},"#,
     r#"{"name":"speak","description":"Play a baked phrase or chirp through the speaker.","inputSchema":{"type":"object","properties":{"phrase":{"type":"string"},"locale":{"type":"string"}},"required":["phrase"]}},"#,
     r#"{"name":"start_listen","description":"Open a listen window: queue an acknowledge chirp, set Attention::Listening, arm the Ear decorator. Default 3000 ms.","inputSchema":{"type":"object","properties":{"duration_ms":{"type":"integer"}}}},"#,
+    r#"{"name":"enter_pairing","description":"Open an ESP-NOW pairing window for the configured duration so an external remote can register.","inputSchema":{"type":"object","properties":{"duration_ms":{"type":"integer"}}}},"#,
     r#"{"name":"get_state","description":"Return the current avatar snapshot (emotion, mood, head pose, decorator, battery, Wi-Fi, audio).","inputSchema":{"type":"object","properties":{}}}"#,
     "]}",
 );

--- a/docs/http.md
+++ b/docs/http.md
@@ -31,6 +31,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |
 | POST   | `/speak`         | Play a baked phrase / chirp through the speaker      |
 | POST   | `/listen`        | Open a 3-second listen window — Ear decorator + ack chirp |
+| POST   | `/pair`          | Open ESP-NOW pairing window with hold timer         |
 | POST   | `/mood`          | Set the operator-selected energy baseline (runtime-only) |
 | POST   | `/mcp`           | JSON-RPC 2.0 / MCP endpoint (initialize, tools/list, tools/call) |
 | POST   | `/volume`        | Set output volume (0–100); persisted to SD           |
@@ -160,6 +161,26 @@ firmware's `audio::try_dispatch_utterance` directly and can preempt
 or evict an in-flight operator request.
 
 `POST /speak` is gated by [auth](#auth) when a token is configured.
+
+### `POST /pair`
+
+```
+$ curl -X POST http://stackchan.local/pair \
+       -H 'Content-Type: application/json' \
+       -d '{"duration_ms":30000}'
+```
+
+| Field        | Type    | Required | Notes                                                |
+|--------------|---------|----------|------------------------------------------------------|
+| duration_ms  | integer | no       | Pairing window length in ms; default 30 000          |
+
+Opens an ESP-NOW pairing window for the given duration. While the
+window is open, the avatar shows the `Decorator::Pairing` overlay
+(concentric blue rings) and the firmware-side ESP-NOW receiver
+accepts new peer registrations. The window times out automatically;
+`POST /reset` closes it early.
+
+`POST /pair` is gated by [auth](#auth) when a token is configured.
 
 ### `POST /volume`
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { Events } from "./components/Events";
 import { Recovery } from "./components/Recovery";
 import { Sensors } from "./components/Sensors";
 import { Settings } from "./components/Settings";
+import { Pair } from "./components/Pair";
 import { Speak } from "./components/Speak";
 import { TaskHealth } from "./components/TaskHealth";
 import { Toast } from "./components/Toast";
@@ -55,6 +56,7 @@ export function App() {
         <Audio />
         <Speak />
         <Listen />
+        <Pair />
         <Camera />
         <Sensors />
         <TaskHealth />

--- a/web/src/components/Pair.tsx
+++ b/web/src/components/Pair.tsx
@@ -1,0 +1,50 @@
+import { Show, createSignal, onCleanup } from "solid-js";
+import { postJson } from "../auth";
+import { showToast } from "../store";
+
+const DEFAULT_DURATION_MS = 30_000;
+const TICK_MS = 250;
+
+export function Pair() {
+  const [endsAt, setEndsAt] = createSignal<number | null>(null);
+  const [now, setNow] = createSignal(Date.now());
+  const remainingMs = () => {
+    const e = endsAt();
+    return e === null ? 0 : Math.max(0, e - now());
+  };
+  const isOpen = () => remainingMs() > 0;
+
+  const timer = setInterval(() => {
+    setNow(Date.now());
+    if (endsAt() !== null && Date.now() >= (endsAt() ?? 0)) setEndsAt(null);
+  }, TICK_MS);
+  onCleanup(() => clearInterval(timer));
+
+  const openWindow = async () => {
+    try {
+      await postJson("/pair", { duration_ms: DEFAULT_DURATION_MS });
+      setEndsAt(Date.now() + DEFAULT_DURATION_MS);
+      showToast(`pairing window open for ${DEFAULT_DURATION_MS / 1000}s`);
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Pair</h2>
+      <div class="btn-row">
+        <button type="button" onClick={openWindow} disabled={isOpen()}>
+          Open pairing window (30s)
+        </button>
+        <Show when={isOpen()}>
+          <span>{Math.ceil(remainingMs() / 1000)}s remaining</span>
+        </Show>
+      </div>
+      <small>
+        While open, the avatar shows the pairing decorator and accepts new
+        ESP-NOW peer registrations.
+      </small>
+    </section>
+  );
+}

--- a/web/src/components/Pair.tsx
+++ b/web/src/components/Pair.tsx
@@ -8,6 +8,7 @@ const TICK_MS = 250;
 export function Pair() {
   const [endsAt, setEndsAt] = createSignal<number | null>(null);
   const [now, setNow] = createSignal(Date.now());
+  const [isPending, setIsPending] = createSignal(false);
   const remainingMs = () => {
     const e = endsAt();
     return e === null ? 0 : Math.max(0, e - now());
@@ -21,12 +22,16 @@ export function Pair() {
   onCleanup(() => clearInterval(timer));
 
   const openWindow = async () => {
+    if (isPending() || isOpen()) return;
+    setIsPending(true);
     try {
       await postJson("/pair", { duration_ms: DEFAULT_DURATION_MS });
       setEndsAt(Date.now() + DEFAULT_DURATION_MS);
       showToast(`pairing window open for ${DEFAULT_DURATION_MS / 1000}s`);
     } catch (e) {
       showToast((e as Error).message, true);
+    } finally {
+      setIsPending(false);
     }
   };
 
@@ -34,8 +39,12 @@ export function Pair() {
     <section>
       <h2>Pair</h2>
       <div class="btn-row">
-        <button type="button" onClick={openWindow} disabled={isOpen()}>
-          Open pairing window (30s)
+        <button
+          type="button"
+          onClick={openWindow}
+          disabled={isPending() || isOpen()}
+        >
+          Open pairing window ({DEFAULT_DURATION_MS / 1000}s)
         </button>
         <Show when={isOpen()}>
           <span>{Math.ceil(remainingMs() / 1000)}s remaining</span>


### PR DESCRIPTION
## Summary
- New `Decorator::Pairing` overlay (concentric blue rings with a filled centre dot — wireless-signal glyph anchored top-centre). `Decorator::ALL` length-pin trip-wire bumps to 4.
- New `RemoteCommand::EnterPairing { duration_ms }`. `RemoteCommandModifier` stashes a `pairing_hold` timer; while live, refreshes `Decorator::Pairing` each tick and lets `DecoratorExpiry`'s 500 ms tail handle the fade-out cleanly. `Reset` clears the hold.
- `POST /pair` HTTP route (default 30 000 ms, optional `duration_ms` override), `enter_pairing(duration_ms?)` MCP tool, and dashboard `Pair` component with live countdown — all three call into the same `parse_enter_pairing` primitive in `stackchan-net::http_command`.

This is the operator-facing pairing UX layer. The firmware-side ESP-NOW driver (peer registration during the open window, AES-CCM encryption, channel-locked send/receive tasks, M5StickC compat shim) lands in PR 7b — splitting the visual surface from the radio implementation lets us QA each independently and keeps either PR reviewable.

## Test plan
- [x] `just check` — workspace fmt + clippy + host tests + doctests all green
- [x] `RUSTDOCFLAGS=-D warnings cargo doc` — full workspace doc build clean
- [x] `just clippy-firmware` — strict firmware clippy clean
- [x] 3 new unit tests on `RemoteCommandModifier` covering arm / mid-window refresh, post-expiry release, and `Reset` clearing the pairing hold
- [x] 4 new tests on `parse_enter_pairing` for default, explicit duration, unknown key, duplicate key
- [ ] Bench on hardware: `POST /pair`, watch concentric-ring overlay appear top-centre, dashboard countdown decrements, lapses silently after the window