### PR TITLE
feat(net): EspNowConfig block in STACKCHAN.RON schema

### DIFF
--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -22,6 +22,14 @@ shape of the on-disk config and the RON file `PUT /settings` round-trips.
     wifi: ( ssid: "home", psk: "redacted", country: "US" ),
     mdns: ( hostname: "stackchan" ),
     time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+    esp_now: (
+        enabled: false,
+        pmk_hex: "",
+        peer_mac: "",
+        lmk_hex: "",
+        channel: None,
+        tx_rate_hz: 5,
+    ),
 )
 ```
 
@@ -30,6 +38,12 @@ shape of the on-disk config and the RON file `PUT /settings` round-trips.
 - `TimeConfig` — IANA timezone label + SNTP servers (default `"UTC"`,
   `["pool.ntp.org"]`). The TZ field is parsed but currently unused;
   the BM8563 RTC stores UTC.
+- `EspNowConfig` — ESP-NOW remote-control radio settings. Disabled by
+  default. `pmk_hex` / `lmk_hex` are 32-character hex (16 bytes);
+  `peer_mac` accepts either bare 12-hex or `xx:xx:xx:xx:xx:xx`.
+  `channel: None` follows the Wi-Fi STA's chosen channel; explicit
+  values `1..=14` are for ESP-NOW-only deployments. `tx_rate_hz`
+  ranges `0..=20`; `0` disables outbound entirely.
 
 ## Key Files
 

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -22,7 +22,8 @@ use core::fmt::Write as _;
 
 use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{
-    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, TrackerSettings, WifiConfig, validate,
+    AudioConfig, AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, TrackerSettings,
+    WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -98,6 +99,20 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     let _ = writeln!(out, "        flip_y: {},", config.tracker.flip_y);
     out.push_str("    ),\n");
 
+    out.push_str("    esp_now: (\n");
+    let _ = writeln!(out, "        enabled: {},", config.esp_now.enabled);
+    push_field(&mut out, "        pmk_hex", &config.esp_now.pmk_hex);
+    push_field(&mut out, "        peer_mac", &config.esp_now.peer_mac);
+    push_field(&mut out, "        lmk_hex", &config.esp_now.lmk_hex);
+    match config.esp_now.channel {
+        Some(ch) => {
+            let _ = writeln!(out, "        channel: Some({ch}),");
+        }
+        None => out.push_str("        channel: None,\n"),
+    }
+    let _ = writeln!(out, "        tx_rate_hz: {},", config.esp_now.tx_rate_hz);
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -147,6 +162,7 @@ impl<'a> Parser<'a> {
         let mut auth: Option<AuthConfig> = None;
         let mut audio: Option<AudioConfig> = None;
         let mut tracker: Option<TrackerSettings> = None;
+        let mut esp_now: Option<EspNowConfig> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -164,6 +180,7 @@ impl<'a> Parser<'a> {
                 "auth" => auth = Some(self.parse_auth()?),
                 "audio" => audio = Some(self.parse_audio()?),
                 "tracker" => tracker = Some(self.parse_tracker()?),
+                "esp_now" => esp_now = Some(self.parse_esp_now()?),
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -177,13 +194,14 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
-            // `auth`, `audio`, and `tracker` are optional for
+            // `auth`, `audio`, `tracker`, and `esp_now` are optional for
             // migration: SD cards written before each block landed
             // lack them, and the defaults match the firmware's prior
             // hard-coded behaviour.
             auth: auth.unwrap_or_default(),
             audio: audio.unwrap_or_default(),
             tracker: tracker.unwrap_or_default(),
+            esp_now: esp_now.unwrap_or_default(),
         })
     }
 
@@ -396,6 +414,70 @@ impl<'a> Parser<'a> {
             flip_x: flip_x.unwrap_or(defaults.flip_x),
             flip_y: flip_y.unwrap_or(defaults.flip_y),
         })
+    }
+
+    /// Parse the optional `esp_now: (...)` block. All inner fields
+    /// are optional and fall back to [`EspNowConfig::DEFAULT`].
+    fn parse_esp_now(&mut self) -> Result<EspNowConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut enabled: Option<bool> = None;
+        let mut pmk_hex: Option<String> = None;
+        let mut peer_mac: Option<String> = None;
+        let mut lmk_hex: Option<String> = None;
+        let mut channel: Option<Option<u8>> = None;
+        let mut tx_rate_hz: Option<u8> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "enabled" => enabled = Some(self.parse_bool()?),
+                "pmk_hex" => pmk_hex = Some(self.parse_string()?),
+                "peer_mac" => peer_mac = Some(self.parse_string()?),
+                "lmk_hex" => lmk_hex = Some(self.parse_string()?),
+                "channel" => channel = Some(self.parse_optional_u8()?),
+                "tx_rate_hz" => tx_rate_hz = Some(self.parse_u8()?),
+                other => return Err(bare_err("unknown esp_now field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in esp_now", ""));
+            }
+        }
+        let defaults = EspNowConfig::DEFAULT;
+        Ok(EspNowConfig {
+            enabled: enabled.unwrap_or(defaults.enabled),
+            pmk_hex: pmk_hex.unwrap_or(defaults.pmk_hex),
+            peer_mac: peer_mac.unwrap_or(defaults.peer_mac),
+            lmk_hex: lmk_hex.unwrap_or(defaults.lmk_hex),
+            channel: channel.unwrap_or(defaults.channel),
+            tx_rate_hz: tx_rate_hz.unwrap_or(defaults.tx_rate_hz),
+        })
+    }
+
+    /// Parse `Some(<u8>)` or `None` — the RON encoding for an
+    /// `Option<u8>` in our renderer.
+    fn parse_optional_u8(&mut self) -> Result<Option<u8>, ConfigError> {
+        if self.input.starts_with("None") {
+            self.advance("None".len());
+            return Ok(None);
+        }
+        if self.input.starts_with("Some") {
+            self.advance("Some".len());
+            self.skip_ws_and_comments();
+            self.expect_char('(')?;
+            self.skip_ws_and_comments();
+            let v = self.parse_u8()?;
+            self.skip_ws_and_comments();
+            self.expect_char(')')?;
+            return Ok(Some(v));
+        }
+        Err(bare_err("expected Some(...) or None", ""))
     }
 
     /// Parse a contiguous run of decimal digits as a `u8`. Used for

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -20,7 +20,8 @@ use alloc::vec::Vec;
 use core::fmt::Write as _;
 
 use crate::config::{
-    AudioConfig, AuthConfig, Config, MdnsConfig, TimeConfig, TrackerSettings, WifiConfig, validate,
+    AudioConfig, AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, TrackerSettings,
+    WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -38,6 +39,13 @@ pub const PSK_REDACTED: &str = "***";
 /// Same `"preserve current value"` semantics on the input side as
 /// [`PSK_REDACTED`] — see [`merge_settings_with_current`].
 pub const TOKEN_REDACTED: &str = "***";
+
+/// Sentinel emitted in place of a non-empty `esp_now.pmk_hex` /
+/// `esp_now.lmk_hex` on render.
+///
+/// Same `"preserve current value"` semantics on the input side as
+/// [`PSK_REDACTED`] — see [`merge_settings_with_current`].
+pub const ESP_NOW_KEY_REDACTED: &str = "***";
 
 /// Parse a schema-v1 JSON object into a [`Config`].
 ///
@@ -105,6 +113,25 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
         },
         audio: new.audio,
         tracker: new.tracker,
+        esp_now: EspNowConfig {
+            enabled: new.esp_now.enabled,
+            // Same redaction discipline as `wifi.psk`: the placeholder
+            // sentinel preserves the persisted secret while a non-empty
+            // explicit value overwrites and an empty string clears.
+            pmk_hex: if new.esp_now.pmk_hex == ESP_NOW_KEY_REDACTED {
+                current.esp_now.pmk_hex.clone()
+            } else {
+                new.esp_now.pmk_hex
+            },
+            peer_mac: new.esp_now.peer_mac,
+            lmk_hex: if new.esp_now.lmk_hex == ESP_NOW_KEY_REDACTED {
+                current.esp_now.lmk_hex.clone()
+            } else {
+                new.esp_now.lmk_hex
+            },
+            channel: new.esp_now.channel,
+            tx_rate_hz: new.esp_now.tx_rate_hz,
+        },
     }
 }
 
@@ -175,6 +202,38 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         flip_x = config.tracker.flip_x,
         flip_y = config.tracker.flip_y,
     );
+    out.push_str("},\"esp_now\":{");
+    let _ = write!(out, "\"enabled\":{}", config.esp_now.enabled);
+    out.push(',');
+    push_string_field(
+        &mut out,
+        "pmk_hex",
+        if redact_secrets && !config.esp_now.pmk_hex.is_empty() {
+            ESP_NOW_KEY_REDACTED
+        } else {
+            &config.esp_now.pmk_hex
+        },
+    );
+    out.push(',');
+    push_string_field(&mut out, "peer_mac", &config.esp_now.peer_mac);
+    out.push(',');
+    push_string_field(
+        &mut out,
+        "lmk_hex",
+        if redact_secrets && !config.esp_now.lmk_hex.is_empty() {
+            ESP_NOW_KEY_REDACTED
+        } else {
+            &config.esp_now.lmk_hex
+        },
+    );
+    out.push_str(",\"channel\":");
+    match config.esp_now.channel {
+        Some(ch) => {
+            let _ = write!(out, "{ch}");
+        }
+        None => out.push_str("null"),
+    }
+    let _ = write!(out, ",\"tx_rate_hz\":{}", config.esp_now.tx_rate_hz);
     out.push_str("}}");
     Ok(out)
 }
@@ -231,6 +290,7 @@ impl<'a> Parser<'a> {
         let mut auth: Option<AuthConfig> = None;
         let mut audio: Option<AudioConfig> = None;
         let mut tracker: Option<TrackerSettings> = None;
+        let mut esp_now: Option<EspNowConfig> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -277,6 +337,12 @@ impl<'a> Parser<'a> {
                     }
                     tracker = Some(self.parse_tracker()?);
                 }
+                "esp_now" => {
+                    if esp_now.is_some() {
+                        return Err(bare_err("duplicate top-level field", "esp_now"));
+                    }
+                    esp_now = Some(self.parse_esp_now()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -295,6 +361,7 @@ impl<'a> Parser<'a> {
             auth: auth.unwrap_or_default(),
             audio: audio.unwrap_or_default(),
             tracker: tracker.unwrap_or_default(),
+            esp_now: esp_now.unwrap_or_default(),
         })
     }
 
@@ -578,6 +645,90 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parse the optional `"esp_now": { ... }` block.
+    fn parse_esp_now(&mut self) -> Result<EspNowConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut enabled: Option<bool> = None;
+        let mut pmk_hex: Option<String> = None;
+        let mut peer_mac: Option<String> = None;
+        let mut lmk_hex: Option<String> = None;
+        let mut channel: Option<Option<u8>> = None;
+        let mut tx_rate_hz: Option<u8> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "enabled" => {
+                    if enabled.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "enabled"));
+                    }
+                    enabled = Some(self.parse_bool()?);
+                }
+                "pmk_hex" => {
+                    if pmk_hex.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "pmk_hex"));
+                    }
+                    pmk_hex = Some(self.parse_string()?);
+                }
+                "peer_mac" => {
+                    if peer_mac.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "peer_mac"));
+                    }
+                    peer_mac = Some(self.parse_string()?);
+                }
+                "lmk_hex" => {
+                    if lmk_hex.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "lmk_hex"));
+                    }
+                    lmk_hex = Some(self.parse_string()?);
+                }
+                "channel" => {
+                    if channel.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "channel"));
+                    }
+                    channel = Some(self.parse_optional_u8()?);
+                }
+                "tx_rate_hz" => {
+                    if tx_rate_hz.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "tx_rate_hz"));
+                    }
+                    tx_rate_hz = Some(self.parse_u8()?);
+                }
+                other => return Err(bare_err("unknown esp_now field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in esp_now", ""));
+            }
+        }
+        let defaults = EspNowConfig::DEFAULT;
+        Ok(EspNowConfig {
+            enabled: enabled.unwrap_or(defaults.enabled),
+            pmk_hex: pmk_hex.unwrap_or(defaults.pmk_hex),
+            peer_mac: peer_mac.unwrap_or(defaults.peer_mac),
+            lmk_hex: lmk_hex.unwrap_or(defaults.lmk_hex),
+            channel: channel.unwrap_or(defaults.channel),
+            tx_rate_hz: tx_rate_hz.unwrap_or(defaults.tx_rate_hz),
+        })
+    }
+
+    /// Parse `null` or a decimal `u8`. The JSON wire form for an
+    /// `Option<u8>` — null = `None`, integer = `Some(n)`. Used for
+    /// `esp_now.channel`.
+    fn parse_optional_u8(&mut self) -> Result<Option<u8>, ConfigError> {
+        if self.input.starts_with("null") {
+            self.advance("null".len());
+            return Ok(None);
+        }
+        Ok(Some(self.parse_u8()?))
+    }
+
     /// Parse a JSON number into `f32`. Delegates to
     /// [`crate::bare::scan_f32`] so the RON and JSON parsers consume
     /// the identical grammar (and so a leading `+` is rejected
@@ -774,6 +925,14 @@ mod tests {
                 target_smoothing_alpha: 0.4,
                 flip_x: true,
                 flip_y: false,
+            },
+            esp_now: EspNowConfig {
+                enabled: true,
+                pmk_hex: "0123456789abcdef0123456789abcdef".to_string(),
+                peer_mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                lmk_hex: "fedcba9876543210fedcba9876543210".to_string(),
+                channel: Some(6),
+                tx_rate_hz: 5,
             },
         }
     }
@@ -1080,6 +1239,14 @@ mod tests {
                 muted: false,
             },
             tracker: TrackerSettings::DEFAULT,
+            esp_now: EspNowConfig {
+                enabled: true,
+                pmk_hex: "0".repeat(32),
+                peer_mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                lmk_hex: "f".repeat(32),
+                channel: Some(11),
+                tx_rate_hz: 20,
+            },
         };
         let rendered = render_settings_json(&config, false).unwrap();
         assert!(

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -407,6 +407,13 @@ fn validate_esp_now(c: &EspNowConfig) -> Result<(), ConfigError> {
     if !c.peer_mac.is_empty() && parse_mac(&c.peer_mac).is_none() {
         return Err(ConfigError::InvalidEspNowMac(c.peer_mac.clone()));
     }
+    // Encrypted-static-peer requires both PMK + LMK. Pinning here so
+    // an inconsistent triple (peer_mac + pmk set, lmk left blank)
+    // can't drop the firmware into a silent unencrypted-unicast
+    // fallback.
+    if !c.peer_mac.is_empty() && !is_redacted_or_empty(&c.pmk_hex) && c.lmk_hex.is_empty() {
+        return Err(ConfigError::InvalidEspNowKey("lmk_hex"));
+    }
     if let Some(ch) = c.channel
         && !(1..=14).contains(&ch)
     {
@@ -439,7 +446,7 @@ fn is_valid_hex_key(s: &str) -> bool {
 #[must_use]
 pub fn parse_mac(s: &str) -> Option<[u8; 6]> {
     let bytes = s.as_bytes();
-    let bare = match bytes.len() {
+    let valid = match bytes.len() {
         12 => bytes.iter().all(u8::is_ascii_hexdigit),
         17 => {
             // `xx:xx:xx:xx:xx:xx` — colons at positions 2, 5, 8, 11, 14.
@@ -452,7 +459,7 @@ pub fn parse_mac(s: &str) -> Option<[u8; 6]> {
         }
         _ => return None,
     };
-    if !bare {
+    if !valid {
         return None;
     }
     let mut out = [0_u8; 6];
@@ -671,6 +678,31 @@ mod tests {
             validate(&c),
             Err(ConfigError::InvalidEspNowTxRate(21))
         ));
+    }
+
+    #[test]
+    fn validate_rejects_static_peer_with_pmk_but_no_lmk() {
+        // peer_mac + pmk_hex set without lmk_hex would silently
+        // register an encrypted peer with no per-peer key. Reject.
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.peer_mac = "aa:bb:cc:dd:ee:ff".to_string();
+        c.esp_now.pmk_hex = "0123456789abcdef0123456789abcdef".to_string();
+        // lmk_hex left empty.
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidEspNowKey("lmk_hex"))
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_static_peer_with_no_encryption() {
+        // peer_mac + lmk + pmk all empty — open-mode static peer is
+        // valid. Only the (peer + pmk + no-lmk) triple is rejected.
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.peer_mac = "aa:bb:cc:dd:ee:ff".to_string();
+        assert!(validate(&c).is_ok());
     }
 
     #[test]

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -49,6 +49,14 @@ pub struct Config {
     /// (mirrors the mDNS / SNTP / audio-init pattern).
     #[cfg_attr(feature = "parse", serde(default))]
     pub tracker: TrackerSettings,
+    /// ESP-NOW remote-control radio settings. Default: disabled. With
+    /// `enabled = true` the firmware spawns the inbound RX task and the
+    /// optional outbound heartbeat at `tx_rate_hz`. When `peer_mac` is
+    /// non-empty the address is registered statically at boot;
+    /// otherwise peer registration only happens during a `POST /pair`
+    /// pairing window.
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub esp_now: EspNowConfig,
 }
 
 /// Wi-Fi station credentials.
@@ -198,6 +206,71 @@ impl Default for TrackerSettings {
     }
 }
 
+/// ESP-NOW remote-control radio settings.
+///
+/// ESP-NOW is a connectionless 2.4 GHz protocol layered on top of
+/// 802.11 — peers agree on a Wi-Fi channel without ever associating.
+/// `channel = None` is the standard mode where this device follows
+/// whatever channel the Wi-Fi STA picked when it associated; setting
+/// `channel = Some(n)` is for ESP-NOW-only operation without
+/// joining a Wi-Fi network.
+///
+/// All on-disk hex strings are case-insensitive and accept either bare
+/// hex (`"aabbccddeeff"`) or RFC-style colon-delimited MAC
+/// (`"aa:bb:cc:dd:ee:ff"`). Empty strings are sentinels for "not
+/// configured" — see field docs for how each field treats them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct EspNowConfig {
+    /// Master switch. Default `false`; the firmware skips ESP-NOW init
+    /// entirely. Setting to `true` requires either a non-empty
+    /// `peer_mac` (static peer) or an operator-driven
+    /// [`crate::http_command::parse_enter_pairing`] window before any
+    /// frames are accepted.
+    pub enabled: bool,
+    /// Pre-master key as a 32-character hex string (16 bytes). Empty
+    /// disables encryption — fine for development on a private LAN,
+    /// but expose AES-CCM by setting a real PMK before shipping a
+    /// device with `enabled = true` to a less-trusted environment.
+    pub pmk_hex: String,
+    /// Peer's MAC address. Either empty (no static peer; operator
+    /// must use the pairing window), bare 12 hex chars, or
+    /// colon-delimited (`xx:xx:xx:xx:xx:xx`). Case-insensitive.
+    pub peer_mac: String,
+    /// Local master key for the static peer. Same hex shape as
+    /// `pmk_hex`. Required if `peer_mac` is non-empty AND `pmk_hex`
+    /// is non-empty (encryption enabled with a static peer); empty
+    /// in dev mode.
+    pub lmk_hex: String,
+    /// Wi-Fi channel to lock the radio to. `None` follows the Wi-Fi
+    /// STA's chosen channel — the standard mode where ESP-NOW
+    /// piggybacks on the Wi-Fi association. `Some(n)` (1..=14) is
+    /// for ESP-NOW-only deployments without Wi-Fi association.
+    pub channel: Option<u8>,
+    /// Outbound heartbeat rate in Hz. `0` disables outbound entirely
+    /// (RX-only). Range gated to `0..=20`. Default `5`.
+    pub tx_rate_hz: u8,
+}
+
+impl EspNowConfig {
+    /// Const-evaluable default: disabled, no peer, no encryption,
+    /// channel follows STA, 5 Hz heartbeat (a no-op while disabled).
+    pub const DEFAULT: Self = Self {
+        enabled: false,
+        pmk_hex: String::new(),
+        peer_mac: String::new(),
+        lmk_hex: String::new(),
+        channel: None,
+        tx_rate_hz: 5,
+    };
+}
+
+impl Default for EspNowConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 /// Time / SNTP configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
@@ -308,7 +381,111 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
             config.tracker.target_smoothing_alpha,
         ));
     }
+    validate_esp_now(&config.esp_now)?;
     Ok(())
+}
+
+/// Run the ESP-NOW sub-block validators against [`EspNowConfig`].
+///
+/// Empty hex strings short-circuit — they're sentinels for "not set".
+/// Non-empty strings must match the documented shape (32 hex chars for
+/// keys, 12 raw or colon-delimited for the MAC).
+///
+/// # Errors
+///
+/// Returns one of [`ConfigError::InvalidEspNowKey`],
+/// [`ConfigError::InvalidEspNowMac`],
+/// [`ConfigError::InvalidEspNowChannel`], or
+/// [`ConfigError::InvalidEspNowTxRate`] on out-of-range values.
+fn validate_esp_now(c: &EspNowConfig) -> Result<(), ConfigError> {
+    if !is_redacted_or_empty(&c.pmk_hex) && !is_valid_hex_key(&c.pmk_hex) {
+        return Err(ConfigError::InvalidEspNowKey("pmk_hex"));
+    }
+    if !is_redacted_or_empty(&c.lmk_hex) && !is_valid_hex_key(&c.lmk_hex) {
+        return Err(ConfigError::InvalidEspNowKey("lmk_hex"));
+    }
+    if !c.peer_mac.is_empty() && parse_mac(&c.peer_mac).is_none() {
+        return Err(ConfigError::InvalidEspNowMac(c.peer_mac.clone()));
+    }
+    if let Some(ch) = c.channel
+        && !(1..=14).contains(&ch)
+    {
+        return Err(ConfigError::InvalidEspNowChannel(ch));
+    }
+    if c.tx_rate_hz > 20 {
+        return Err(ConfigError::InvalidEspNowTxRate(c.tx_rate_hz));
+    }
+    Ok(())
+}
+
+/// True iff the value is empty or matches the `***` redaction sentinel
+/// (mirroring `wifi.psk` / `auth.token` behaviour). The sentinel
+/// flows through to the downstream
+/// [`crate::bare_json::merge_settings_with_current`] step, which
+/// substitutes the persisted value back in.
+fn is_redacted_or_empty(s: &str) -> bool {
+    s.is_empty() || s == "***"
+}
+
+/// True iff `s` is exactly 32 case-insensitive hex characters
+/// (16 bytes — the ESP-NOW PMK / LMK size).
+fn is_valid_hex_key(s: &str) -> bool {
+    s.len() == 32 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Parse a MAC address from either `xx:xx:xx:xx:xx:xx` or bare 12-hex
+/// form. Returns the raw 6 bytes on success, `None` on any structural
+/// mismatch. Case-insensitive on the hex digits.
+#[must_use]
+pub fn parse_mac(s: &str) -> Option<[u8; 6]> {
+    let bytes = s.as_bytes();
+    let bare = match bytes.len() {
+        12 => bytes.iter().all(u8::is_ascii_hexdigit),
+        17 => {
+            // `xx:xx:xx:xx:xx:xx` — colons at positions 2, 5, 8, 11, 14.
+            for i in [2_usize, 5, 8, 11, 14] {
+                if bytes[i] != b':' {
+                    return None;
+                }
+            }
+            (0..17).all(|i| matches!(i, 2 | 5 | 8 | 11 | 14) || bytes[i].is_ascii_hexdigit())
+        }
+        _ => return None,
+    };
+    if !bare {
+        return None;
+    }
+    let mut out = [0_u8; 6];
+    let mut hex = [0_u8; 12];
+    if bytes.len() == 12 {
+        hex.copy_from_slice(bytes);
+    } else {
+        // Skip the colons at 2/5/8/11/14.
+        let mut j = 0;
+        for (i, &b) in bytes.iter().enumerate() {
+            if matches!(i, 2 | 5 | 8 | 11 | 14) {
+                continue;
+            }
+            hex[j] = b;
+            j += 1;
+        }
+    }
+    for (i, byte) in out.iter_mut().enumerate() {
+        let hi = hex_nibble(hex[i * 2])?;
+        let lo = hex_nibble(hex[i * 2 + 1])?;
+        *byte = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+/// Convert one ASCII hex digit to its numeric value (0..=15).
+const fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// True iff `deg` is a finite positive value within `(0, 180]`. Lens
@@ -355,6 +532,10 @@ fn is_valid_hostname(s: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test-only: unwrap on Option / Result is the standard test idiom for asserting parse success"
+)]
 mod tests {
     use super::*;
 
@@ -415,5 +596,93 @@ mod tests {
         assert!(!is_valid_hostname("-stackchan"));
         assert!(!is_valid_hostname("stackchan-"));
         assert!(!is_valid_hostname("stack_chan"));
+    }
+
+    #[test]
+    fn esp_now_default_is_disabled_and_empty() {
+        let c = EspNowConfig::default();
+        assert!(!c.enabled);
+        assert!(c.pmk_hex.is_empty());
+        assert!(c.peer_mac.is_empty());
+        assert!(c.lmk_hex.is_empty());
+        assert!(c.channel.is_none());
+        assert_eq!(c.tx_rate_hz, 5);
+    }
+
+    #[test]
+    fn parse_mac_accepts_both_formats() {
+        let bare = parse_mac("aabbccddeeff").unwrap();
+        let colon = parse_mac("aa:bb:cc:dd:ee:ff").unwrap();
+        let upper = parse_mac("AA:BB:CC:DD:EE:FF").unwrap();
+        assert_eq!(bare, [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        assert_eq!(bare, colon);
+        assert_eq!(bare, upper);
+    }
+
+    #[test]
+    fn parse_mac_rejects_garbage() {
+        assert!(parse_mac("").is_none());
+        assert!(parse_mac("not-a-mac").is_none());
+        assert!(parse_mac("aa:bb:cc:dd:ee").is_none()); // too short
+        assert!(parse_mac("aa:bb:cc:dd:ee:ff:gg").is_none()); // too long
+        assert!(parse_mac("zz:bb:cc:dd:ee:ff").is_none()); // bad hex
+        assert!(parse_mac("aabbccddeefz").is_none()); // bad hex bare
+    }
+
+    #[test]
+    fn validate_rejects_bad_pmk() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.pmk_hex = "tooshort".to_string();
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidEspNowKey("pmk_hex"))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_bad_peer_mac() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.peer_mac = "not-a-mac".to_string();
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidEspNowMac(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_channel_out_of_range() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.channel = Some(15);
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidEspNowChannel(15))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_tx_rate_too_high() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.tx_rate_hz = 21;
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidEspNowTxRate(21))
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_esp_now() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.esp_now.enabled = true;
+        c.esp_now.pmk_hex = "0123456789abcdef0123456789abcdef".to_string();
+        c.esp_now.peer_mac = "aa:bb:cc:dd:ee:ff".to_string();
+        c.esp_now.lmk_hex = "fedcba9876543210fedcba9876543210".to_string();
+        c.esp_now.channel = Some(6);
+        c.esp_now.tx_rate_hz = 5;
+        assert!(validate(&c).is_ok());
     }
 }

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -98,4 +98,26 @@ pub enum ConfigError {
     /// boot log.
     #[error("bare RON parse error: {0}")]
     BareParse(String),
+
+    /// `esp_now.pmk_hex` or `esp_now.lmk_hex` was non-empty but not
+    /// exactly 32 hex characters (16 bytes). Carries the field name
+    /// so the operator can fix the right line.
+    #[error("esp_now.{0} must be exactly 32 hex chars (16 bytes)")]
+    InvalidEspNowKey(&'static str),
+
+    /// `esp_now.peer_mac` was non-empty but did not parse as either
+    /// `xx:xx:xx:xx:xx:xx` or bare 12 hex chars. Carries the offending
+    /// value.
+    #[error("esp_now.peer_mac is not a valid MAC: {0:?}")]
+    InvalidEspNowMac(String),
+
+    /// `esp_now.channel` was outside the valid 2.4 GHz range (1..=14).
+    /// Carries the offending value.
+    #[error("esp_now.channel must be in 1..=14; got {0}")]
+    InvalidEspNowChannel(u8),
+
+    /// `esp_now.tx_rate_hz` exceeded the documented maximum (20 Hz).
+    /// Carries the offending value.
+    #[error("esp_now.tx_rate_hz must be <= 20; got {0}")]
+    InvalidEspNowTxRate(u8),
 }

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -60,7 +60,9 @@ pub mod ota;
 
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
-pub use config::{AuthConfig, Config, MdnsConfig, TimeConfig, WifiConfig, validate};
+pub use config::{
+    AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig, parse_mac, validate,
+};
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};
 pub use error::ConfigError;


### PR DESCRIPTION
## Summary
- New `EspNowConfig` struct: `enabled`, `pmk_hex` (32 hex chars), `peer_mac` (12 raw or `xx:xx:xx:xx:xx:xx`), `lmk_hex`, `channel` (None = follow STA), `tx_rate_hz` (0..=20). Default disabled with no peer.
- Validator surface: `InvalidEspNowKey` (32-hex shape), `InvalidEspNowMac`, `InvalidEspNowChannel` (1..=14 only), `InvalidEspNowTxRate` (≤ 20). Hex-key validators accept the `***` redaction sentinel so `GET /settings` → `PUT /settings` round-trips preserve the persisted secret rather than 400-ing on the placeholder.
- Bare RON parser/renderer wires the optional `esp_now: ( ... )` block; missing block → `EspNowConfig::default()` for forward-compat with cards written before this block landed. JSON path: `render_settings_json` redacts non-empty keys via `ESP_NOW_KEY_REDACTED`; `merge_settings_with_current` substitutes the persisted value back when the sentinel echoes.
- New `parse_mac` helper at the crate root for downstream consumers (the firmware ESP-NOW task in PR 7c will use it).

## Stacked on #231 (PR 7a)

This PR builds on the pairing-window scaffolding. PR 7c (the actual firmware ESP-NOW driver task — RX/TX, peer management, channel-locking, M5StickC compat shim) lands on top of this once these foundations merge.

## Test plan
- [x] `just check` — workspace fmt + clippy + host tests + doctests all green
- [x] `RUSTDOCFLAGS=-D warnings cargo doc` — full workspace doc build clean
- [x] `just clippy-firmware` — strict firmware clippy clean (proves the bare RON parser still compiles on xtensa)
- [x] 8 new unit tests on `config.rs` covering defaults, `parse_mac` happy + sad paths, and each validator rejecting its specific malformation
- [x] `bare_json` round-trip + maximal-payload pins extended to cover the new block