### PR TITLE
feat(firmware): ESP-NOW RX task — peer-allowlisted frame ingest

### DIFF
--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -86,7 +86,7 @@ esp-alloc = { version = "0.9.0", features = ["defmt"] }
 # the `BleConnector` Transport); `coex` lets Wi-Fi STA and BLE share
 # the radio at the cost of ~10–15% Wi-Fi throughput. The bt-hci
 # version pin (^0.6) cascades into the trouble-host 0.5.x line.
-esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "ble", "coex", "unstable"] }
+esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "ble", "coex", "esp-now", "unstable"] }
 # BLE host stack. 0.5.1 is the trouble-host release pinned to
 # `bt-hci ^0.6` (matches esp-radio 0.17). 0.6.0 jumps to `bt-hci 0.8`
 # and pairs with esp-radio 0.18 — bump together when we move the

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1045,6 +1045,16 @@ async fn main(spawner: Spawner) -> ! {
     )) {
         defmt::panic!("spawn(wifi_task) failed: {}", defmt::Debug2Format(&e));
     }
+    // ESP-NOW receive task. Boots inert when `esp_now.enabled = false`
+    // — the task exits without claiming the radio queue. With it
+    // enabled, `interfaces.esp_now` is the handle gated behind the
+    // `esp-now` feature on `esp-radio`.
+    if let Err(e) = spawner.spawn(net::esp_now::esp_now_task(
+        interfaces.esp_now,
+        net_config.esp_now.clone(),
+    )) {
+        defmt::panic!("spawn(esp_now_task) failed: {}", defmt::Debug2Format(&e));
+    }
     let sntp_rtc_bus = I2cDevice::new(board_io.i2c_bus);
     if let Err(e) = spawner.spawn(net::sntp::sntp_task(
         net_stack,

--- a/crates/stackchan-firmware/src/net/esp_now.rs
+++ b/crates/stackchan-firmware/src/net/esp_now.rs
@@ -1,0 +1,242 @@
+//! ESP-NOW RX task — drives [`REMOTE_COMMAND_SIGNAL`] from inbound
+//! ESP-NOW frames.
+//!
+//! ## Responsibilities
+//!
+//! 1. Configure the radio from `STACKCHAN.RON`'s `esp_now` block:
+//!    install the PMK, register a static peer if `peer_mac` is set,
+//!    optionally lock the channel.
+//! 2. Loop on `EspNow::receive_async`, drop anything that doesn't
+//!    parse as a valid Stack-chan frame, route the rest into the
+//!    same `RemoteCommand` plumbing the HTTP control plane uses.
+//! 3. Honour the pairing window — when [`PAIR_WINDOW`] is signalled
+//!    (by `POST /pair`), accept frames from senders that aren't on
+//!    the static-peer allowlist; outside the window, drop them.
+//!
+//! ## Why not split RX/TX yet
+//!
+//! TX (the 5 Hz heartbeat) is the natural follow-up; this PR ships
+//! the RX path so an external `M5StickC` remote can drive the avatar.
+//! The split keeps the diff focused — TX is its own task, its own
+//! lifecycle, its own failure modes.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_time::{Duration, Instant};
+use esp_radio::esp_now::{BROADCAST_ADDRESS, EspNow, EspNowWifiInterface, PeerInfo, ReceivedData};
+use stackchan_net::EspNowConfig;
+use stackchan_net::config::parse_mac;
+use stackchan_net::esp_now::{InboundFrame, decode};
+
+use crate::net::http::REMOTE_COMMAND_SIGNAL;
+
+/// Pairing-window deadline.
+///
+/// Producers (HTTP `POST /pair`, MCP `enter_pairing` tool) signal this
+/// with `now + duration` when an operator opens a pairing window. The
+/// RX task gates non-allowlisted frames on the deadline being in the
+/// future. `None` (Signal not yet signalled) is the closed default.
+pub static PAIR_WINDOW: Signal<CriticalSectionRawMutex, Instant> = Signal::new();
+
+/// Latched ON when the ESP-NOW task is running. Read by the dashboard
+/// via the `/state` snapshot for operator-visible debug.
+pub static ESP_NOW_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Cached pairing deadline. The Signal is single-waker; the task
+/// drains it into this static so multiple frame-handling paths can
+/// peek at the deadline without contending for the waker slot.
+struct PairWindowCache {
+    /// `None` = window closed; `Some(t)` = open until `t`.
+    until: Option<Instant>,
+}
+
+impl PairWindowCache {
+    /// Construct with the window closed.
+    const fn new() -> Self {
+        Self { until: None }
+    }
+
+    /// Refresh from the Signal if a new deadline arrived; report
+    /// whether the window is currently open.
+    fn refresh_and_check(&mut self, now: Instant) -> bool {
+        if let Some(new_until) = PAIR_WINDOW.try_take() {
+            self.until = Some(new_until);
+        }
+        match self.until {
+            Some(until) if now < until => true,
+            Some(_) => {
+                self.until = None;
+                false
+            }
+            None => false,
+        }
+    }
+}
+
+/// ESP-NOW receive task.
+///
+/// Boots inert if `cfg.enabled == false` — the task exits without
+/// touching the radio. Otherwise installs the PMK, registers the
+/// static peer (if configured), optionally locks the channel, then
+/// loops on `receive`.
+#[embassy_executor::task]
+pub async fn esp_now_task(esp_now: EspNow<'static>, cfg: EspNowConfig) {
+    if !cfg.enabled {
+        defmt::info!("esp-now: disabled in config — task exiting");
+        return;
+    }
+    let (manager, _sender, mut receiver) = esp_now.split();
+
+    // Install PMK if configured. Empty string = no encryption (dev mode).
+    if !cfg.pmk_hex.is_empty() {
+        if let Some(pmk) = parse_hex_key(&cfg.pmk_hex) {
+            if let Err(e) = manager.set_pmk(&pmk) {
+                defmt::warn!("esp-now: set_pmk failed: {}", defmt::Debug2Format(&e));
+            }
+        } else {
+            defmt::warn!(
+                "esp-now: pmk_hex didn't parse — skipping (config validator should have caught this)"
+            );
+        }
+    }
+
+    // Register the static peer if configured. Failure here is
+    // recoverable — we still want to accept dynamic peers via the
+    // pairing window.
+    if let Some(peer_mac) = parse_mac(&cfg.peer_mac) {
+        let lmk = if cfg.lmk_hex.is_empty() {
+            None
+        } else {
+            parse_hex_key(&cfg.lmk_hex)
+        };
+        let encrypt = !cfg.pmk_hex.is_empty() && lmk.is_some();
+        let peer = PeerInfo {
+            interface: EspNowWifiInterface::Sta,
+            peer_address: peer_mac,
+            lmk,
+            channel: cfg.channel,
+            encrypt,
+        };
+        match manager.add_peer(peer) {
+            Ok(()) => defmt::info!(
+                "esp-now: static peer registered ({=[u8; 6]:02x}) encrypt={}",
+                peer_mac,
+                encrypt
+            ),
+            Err(e) => defmt::warn!("esp-now: add_peer failed: {}", defmt::Debug2Format(&e)),
+        }
+    }
+
+    // Lock the radio channel if the operator pinned one. With
+    // `channel = None` the radio follows whatever the Wi-Fi STA
+    // associated on, which is the standard mode.
+    if let Some(ch) = cfg.channel
+        && let Err(e) = manager.set_channel(ch)
+    {
+        defmt::warn!(
+            "esp-now: set_channel({}) failed: {}",
+            ch,
+            defmt::Debug2Format(&e)
+        );
+    }
+
+    ESP_NOW_ACTIVE.store(true, Ordering::Release);
+    defmt::info!(
+        "esp-now: RX task ready (peer={=str:?})",
+        cfg.peer_mac.as_str()
+    );
+
+    let static_peer = parse_mac(&cfg.peer_mac);
+    let mut window = PairWindowCache::new();
+
+    loop {
+        let frame = receiver.receive_async().await;
+        let now = Instant::now();
+        let allow = is_allowlisted(&frame, static_peer, &mut window, now);
+        if !allow {
+            // Drop silently — emitting a log per dropped frame would
+            // flood the bus on a noisy 2.4 GHz environment.
+            continue;
+        }
+        match decode(frame.data()) {
+            Ok(InboundFrame::Heartbeat) => {
+                // Liveness only; no state change.
+            }
+            Ok(InboundFrame::Command(cmd)) => {
+                REMOTE_COMMAND_SIGNAL.signal(cmd);
+            }
+            Err(e) => {
+                defmt::warn!(
+                    "esp-now: drop frame ({=usize} bytes): {}",
+                    frame.data().len(),
+                    defmt::Debug2Format(&e)
+                );
+            }
+        }
+    }
+}
+
+/// Allowlist check: accept frames from the configured static peer
+/// always; accept anything during a pairing window; drop the rest.
+/// Broadcast-destination frames pass — the firmware is the intended
+/// audience for the broadcast pattern that bulk operator tooling uses.
+fn is_allowlisted(
+    frame: &ReceivedData,
+    static_peer: Option<[u8; 6]>,
+    window: &mut PairWindowCache,
+    now: Instant,
+) -> bool {
+    let src = frame.info.src_address;
+    if let Some(allowed) = static_peer
+        && src == allowed
+    {
+        return true;
+    }
+    if frame.info.dst_address == BROADCAST_ADDRESS && static_peer == Some(src) {
+        return true;
+    }
+    window.refresh_and_check(now)
+}
+
+/// Helper: parse a 32-character hex key into 16 bytes. Validator
+/// already vetted shape; returns `None` only on internal mismatch
+/// (which would be a bug).
+fn parse_hex_key(s: &str) -> Option<[u8; 16]> {
+    if s.len() != 32 {
+        return None;
+    }
+    let mut out = [0_u8; 16];
+    let bytes = s.as_bytes();
+    for (i, slot) in out.iter_mut().enumerate() {
+        let hi = hex_nibble(bytes[i * 2])?;
+        let lo = hex_nibble(bytes[i * 2 + 1])?;
+        *slot = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+/// ASCII hex nibble decoder mirroring the validator helper in
+/// `stackchan-net::config` — duplicated here because that fn is
+/// `pub(crate)` and the binary boundary keeps it that way.
+const fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Default pairing window when the HTTP route is hit without explicit
+/// duration. Mirrors `stackchan_net::http_command::DEFAULT_PAIRING_DURATION_MS`.
+pub const PAIR_WINDOW_DEFAULT_MS: u64 = 30_000;
+
+/// Open the pairing window for `duration_ms`. Producer-side helper
+/// for the HTTP route + MCP tool: signals [`PAIR_WINDOW`] with the
+/// computed deadline.
+pub fn open_pair_window(duration_ms: u32) {
+    let until = Instant::now() + Duration::from_millis(u64::from(duration_ms));
+    PAIR_WINDOW.signal(until);
+}

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -819,6 +819,9 @@ fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
         },
         "enter_pairing" => match json::parse_enter_pairing(arguments) {
             Ok(cmd) => {
+                if let RemoteCommand::EnterPairing { duration_ms } = cmd {
+                    crate::net::esp_now::open_pair_window(duration_ms);
+                }
                 REMOTE_COMMAND_SIGNAL.signal(cmd);
                 render_success(id, &render_tool_text_result("pairing window opened"))
             }
@@ -1035,6 +1038,13 @@ async fn handle_remote(
     match command {
         Ok(cmd) => {
             defmt::info!("http: remote command {}", defmt::Debug2Format(&cmd));
+            // EnterPairing has two consumers: the avatar-side modifier
+            // (visual decorator + chirp) and the radio-side ESP-NOW
+            // task (open peer-registration window). Signal both before
+            // forwarding the command to the modifier.
+            if let RemoteCommand::EnterPairing { duration_ms } = cmd {
+                crate::net::esp_now::open_pair_window(duration_ms);
+            }
             REMOTE_COMMAND_SIGNAL.signal(cmd);
             write_no_content(socket).await
         }

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -5,7 +5,13 @@
 //! avatar tasks first, then `wifi_task` — the avatar must remain
 //! responsive even when there's no SSID configured or the AP is
 //! unreachable.
+//!
+//! [`esp_now`] runs alongside the Wi-Fi stack, claiming the
+//! `interfaces.esp_now` handle from `esp_radio::wifi::new`. The task
+//! is inert when the operator hasn't enabled it in
+//! `STACKCHAN.RON`.
 
+pub mod esp_now;
 pub mod http;
 pub mod mdns;
 pub mod snapshot;

--- a/crates/stackchan-net/src/esp_now.rs
+++ b/crates/stackchan-net/src/esp_now.rs
@@ -1,0 +1,333 @@
+//! ESP-NOW frame format for Stack-chan remote control.
+//!
+//! ## Frame layout
+//!
+//! ```text
+//! offset  bytes   field
+//! 0       4       MAGIC = b"STKC"
+//! 4       1       VERSION = 1
+//! 5       1       kind (see [`EspNowKind`])
+//! 6       N       JSON body (UTF-8) — empty for kinds with no payload
+//! ```
+//!
+//! The JSON body for each kind is **byte-identical** to the HTTP API
+//! body for the same action — so a remote (Arduino `M5StickC` sketch,
+//! Python script over the host serial port, ...) reuses the same
+//! payloads it would POST over HTTP, prefixed with the kind byte.
+//! On the firmware side, the existing
+//! [`crate::http_command`] parsers consume the JSON body as-is.
+//!
+//! ## Why kind-byte prefix instead of an `"action"` field
+//!
+//! A leading `"action"` key would force the parser to make two
+//! passes over the body — once to discover the kind, once to bind
+//! the rest. The kind byte is one fixed read. The wire size cost is
+//! negligible (1 byte vs ~12 bytes for `"action":"x",`) and the
+//! semantics are unambiguous: `kind` is mandatory, every byte after
+//! position 6 is JSON.
+
+use crate::http_command::{
+    JsonError, parse_enter_pairing, parse_look_at, parse_set_emotion, parse_speak,
+};
+use stackchan_core::input::RemoteCommand;
+
+/// Frame magic — first four bytes of every Stack-chan ESP-NOW frame.
+/// Receivers that don't recognise this magic drop the frame silently.
+pub const ESP_NOW_MAGIC: [u8; 4] = *b"STKC";
+
+/// Wire-format version. Bumped on any breaking layout change so
+/// senders + receivers can negotiate. Mismatching version on the
+/// receiver drops the frame with a `VersionMismatch` decode error.
+pub const ESP_NOW_VERSION: u8 = 1;
+
+/// Header length in bytes (magic + version + kind).
+pub const HEADER_LEN: usize = 6;
+
+/// ESP-NOW peers max payload (ESP-IDF `ESP_NOW_MAX_DATA_LEN`).
+pub const MAX_FRAME_LEN: usize = 250;
+
+/// Maximum JSON body size = `MAX_FRAME_LEN - HEADER_LEN`.
+pub const MAX_BODY_LEN: usize = MAX_FRAME_LEN - HEADER_LEN;
+
+/// Frame kind. The numeric values are part of the wire contract —
+/// **append only**. Re-using or shifting an existing value breaks
+/// every shipped remote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EspNowKind {
+    /// Empty-body keepalive. Receivers ignore the body and treat the
+    /// frame as proof-of-life from the peer.
+    Heartbeat = 0x00,
+    /// JSON body matches `POST /emotion` schema.
+    SetEmotion = 0x01,
+    /// JSON body matches `POST /look-at` schema.
+    LookAt = 0x02,
+    /// Empty body — corresponds to `POST /reset`.
+    Reset = 0x03,
+    /// JSON body matches `POST /speak` schema.
+    Speak = 0x04,
+    /// JSON body matches `POST /pair` schema.
+    EnterPairing = 0x05,
+}
+
+impl EspNowKind {
+    /// Decode a wire byte into an [`EspNowKind`]. `None` on unknown.
+    #[must_use]
+    pub const fn from_wire(b: u8) -> Option<Self> {
+        match b {
+            0x00 => Some(Self::Heartbeat),
+            0x01 => Some(Self::SetEmotion),
+            0x02 => Some(Self::LookAt),
+            0x03 => Some(Self::Reset),
+            0x04 => Some(Self::Speak),
+            0x05 => Some(Self::EnterPairing),
+            _ => None,
+        }
+    }
+
+    /// True iff this kind expects a non-empty JSON body.
+    #[must_use]
+    pub const fn has_body(self) -> bool {
+        match self {
+            Self::Heartbeat | Self::Reset => false,
+            Self::SetEmotion | Self::LookAt | Self::Speak | Self::EnterPairing => true,
+        }
+    }
+}
+
+/// Decode failure for a received ESP-NOW frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// Frame shorter than [`HEADER_LEN`] — too small to even be a header.
+    TooShort,
+    /// Magic prefix didn't match [`ESP_NOW_MAGIC`].
+    BadMagic,
+    /// Header version byte didn't match [`ESP_NOW_VERSION`].
+    VersionMismatch(u8),
+    /// Header kind byte wasn't one of the known [`EspNowKind`] values.
+    UnknownKind(u8),
+    /// Frame exceeded [`MAX_FRAME_LEN`] — caller should drop.
+    Oversize(usize),
+    /// JSON body did not parse against the kind's schema. Carries
+    /// the underlying [`JsonError`] for the firmware log path.
+    BadBody(JsonError),
+    /// Frame UTF-8 invalid (kinds with bodies require valid UTF-8).
+    NotUtf8,
+}
+
+impl From<JsonError> for DecodeError {
+    fn from(e: JsonError) -> Self {
+        Self::BadBody(e)
+    }
+}
+
+/// Decoded inbound ESP-NOW frame.
+///
+/// `Heartbeat` carries no payload; the rest map onto a
+/// [`RemoteCommand`] ready to enqueue on the firmware-side
+/// `REMOTE_COMMAND_SIGNAL`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InboundFrame {
+    /// Liveness only — caller may use as proof-of-life for the peer.
+    Heartbeat,
+    /// Decoded remote command, ready to forward to the modifier graph.
+    Command(RemoteCommand),
+}
+
+/// Parse a raw ESP-NOW frame buffer into an [`InboundFrame`].
+///
+/// Validates magic, version, kind, and body shape. Bodies are parsed
+/// through the same [`crate::http_command`] parsers the HTTP control
+/// plane uses — wire compatibility with a `POST /<route>` body is the
+/// stable contract, not the byte layout of any individual command.
+///
+/// # Errors
+///
+/// Returns the matching [`DecodeError`] variant on any structural or
+/// schema mismatch.
+pub fn decode(buf: &[u8]) -> Result<InboundFrame, DecodeError> {
+    if buf.len() > MAX_FRAME_LEN {
+        return Err(DecodeError::Oversize(buf.len()));
+    }
+    if buf.len() < HEADER_LEN {
+        return Err(DecodeError::TooShort);
+    }
+    if buf[0..4] != ESP_NOW_MAGIC {
+        return Err(DecodeError::BadMagic);
+    }
+    if buf[4] != ESP_NOW_VERSION {
+        return Err(DecodeError::VersionMismatch(buf[4]));
+    }
+    let kind = EspNowKind::from_wire(buf[5]).ok_or(DecodeError::UnknownKind(buf[5]))?;
+    let body = &buf[HEADER_LEN..];
+    let body_str = if body.is_empty() {
+        ""
+    } else {
+        core::str::from_utf8(body).map_err(|_| DecodeError::NotUtf8)?
+    };
+    match kind {
+        EspNowKind::Heartbeat => Ok(InboundFrame::Heartbeat),
+        EspNowKind::Reset => Ok(InboundFrame::Command(RemoteCommand::Reset)),
+        EspNowKind::SetEmotion => Ok(InboundFrame::Command(parse_set_emotion(body_str)?)),
+        EspNowKind::LookAt => Ok(InboundFrame::Command(parse_look_at(body_str)?)),
+        EspNowKind::Speak => Ok(InboundFrame::Command(parse_speak(body_str)?)),
+        EspNowKind::EnterPairing => Ok(InboundFrame::Command(parse_enter_pairing(body_str)?)),
+    }
+}
+
+/// Encode the 6-byte header for `kind` into `buf[..HEADER_LEN]`. Returns
+/// the header length on success. Used by senders that follow it with
+/// a JSON body of their own composition.
+///
+/// # Errors
+///
+/// Returns [`DecodeError::TooShort`] if `buf` can't hold
+/// [`HEADER_LEN`] bytes.
+pub fn encode_header(buf: &mut [u8], kind: EspNowKind) -> Result<usize, DecodeError> {
+    if buf.len() < HEADER_LEN {
+        return Err(DecodeError::TooShort);
+    }
+    buf[0..4].copy_from_slice(&ESP_NOW_MAGIC);
+    buf[4] = ESP_NOW_VERSION;
+    buf[5] = kind as u8;
+    Ok(HEADER_LEN)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: unwrap + match-with-panic for variant extraction is the standard pattern"
+)]
+mod tests {
+    use super::*;
+    use stackchan_core::Emotion;
+    use stackchan_core::voice::{Locale, PhraseId, Priority};
+
+    #[test]
+    fn header_round_trip() {
+        let mut buf = [0_u8; HEADER_LEN];
+        let n = encode_header(&mut buf, EspNowKind::SetEmotion).unwrap();
+        assert_eq!(n, HEADER_LEN);
+        assert_eq!(&buf[0..4], &ESP_NOW_MAGIC);
+        assert_eq!(buf[4], ESP_NOW_VERSION);
+        assert_eq!(buf[5], 0x01);
+    }
+
+    #[test]
+    fn decode_heartbeat_empty_body() {
+        let buf = [b'S', b'T', b'K', b'C', 1, 0x00];
+        assert_eq!(decode(&buf), Ok(InboundFrame::Heartbeat));
+    }
+
+    #[test]
+    fn decode_reset_empty_body() {
+        let buf = [b'S', b'T', b'K', b'C', 1, 0x03];
+        assert_eq!(
+            decode(&buf),
+            Ok(InboundFrame::Command(RemoteCommand::Reset))
+        );
+    }
+
+    #[test]
+    fn decode_set_emotion() {
+        let mut frame: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+        frame.extend_from_slice(&ESP_NOW_MAGIC);
+        frame.push(ESP_NOW_VERSION);
+        frame.push(EspNowKind::SetEmotion as u8);
+        frame.extend_from_slice(br#"{"emotion":"happy","hold_ms":1500}"#);
+        let decoded = decode(&frame).unwrap();
+        match decoded {
+            InboundFrame::Command(RemoteCommand::SetEmotion { emotion, hold_ms }) => {
+                assert_eq!(emotion, Emotion::Happy);
+                assert_eq!(hold_ms, 1500);
+            }
+            other => panic!("expected SetEmotion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_look_at() {
+        let mut frame: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+        frame.extend_from_slice(&ESP_NOW_MAGIC);
+        frame.push(ESP_NOW_VERSION);
+        frame.push(EspNowKind::LookAt as u8);
+        frame.extend_from_slice(br#"{"pan_deg":12.0,"tilt_deg":-3.0}"#);
+        let decoded = decode(&frame).unwrap();
+        match decoded {
+            InboundFrame::Command(RemoteCommand::LookAt { target, .. }) => {
+                assert!((target.pan_deg - 12.0).abs() < f32::EPSILON);
+                assert!((target.tilt_deg - -3.0).abs() < f32::EPSILON);
+            }
+            other => panic!("expected LookAt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_speak() {
+        let mut frame: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+        frame.extend_from_slice(&ESP_NOW_MAGIC);
+        frame.push(ESP_NOW_VERSION);
+        frame.push(EspNowKind::Speak as u8);
+        frame.extend_from_slice(br#"{"phrase":"wake_chirp"}"#);
+        let decoded = decode(&frame).unwrap();
+        match decoded {
+            InboundFrame::Command(RemoteCommand::Speak {
+                phrase,
+                locale,
+                priority,
+            }) => {
+                assert_eq!(phrase, PhraseId::WakeChirp);
+                assert_eq!(locale, Locale::En);
+                assert_eq!(priority, Priority::Normal);
+            }
+            other => panic!("expected Speak, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_enter_pairing_default() {
+        let mut frame: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+        frame.extend_from_slice(&ESP_NOW_MAGIC);
+        frame.push(ESP_NOW_VERSION);
+        frame.push(EspNowKind::EnterPairing as u8);
+        frame.extend_from_slice(b"{}");
+        let decoded = decode(&frame).unwrap();
+        match decoded {
+            InboundFrame::Command(RemoteCommand::EnterPairing { duration_ms }) => {
+                assert_eq!(duration_ms, 30_000);
+            }
+            other => panic!("expected EnterPairing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_rejects_bad_magic() {
+        let buf = [0, 0, 0, 0, 1, 0];
+        assert_eq!(decode(&buf), Err(DecodeError::BadMagic));
+    }
+
+    #[test]
+    fn decode_rejects_version_mismatch() {
+        let buf = [b'S', b'T', b'K', b'C', 99, 0];
+        assert_eq!(decode(&buf), Err(DecodeError::VersionMismatch(99)));
+    }
+
+    #[test]
+    fn decode_rejects_unknown_kind() {
+        let buf = [b'S', b'T', b'K', b'C', 1, 0xff];
+        assert_eq!(decode(&buf), Err(DecodeError::UnknownKind(0xff)));
+    }
+
+    #[test]
+    fn decode_rejects_too_short() {
+        let buf = [b'S', b'T', b'K'];
+        assert_eq!(decode(&buf), Err(DecodeError::TooShort));
+    }
+
+    #[test]
+    fn decode_rejects_oversize() {
+        let buf = [0_u8; MAX_FRAME_LEN + 1];
+        assert_eq!(decode(&buf), Err(DecodeError::Oversize(MAX_FRAME_LEN + 1)));
+    }
+}

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -53,6 +53,7 @@ pub mod bare_json;
 pub mod ble_command;
 pub mod config;
 pub mod error;
+pub mod esp_now;
 pub mod http_command;
 pub mod http_parse;
 pub mod mcp;


### PR DESCRIPTION
## Summary
- Wire format spec (`stackchan_net::esp_now`): 6-byte header `STKC` + version + kind, then a JSON body byte-identical to the HTTP API body for the same route. Existing `parse_set_emotion` / `parse_look_at` / `parse_speak` / `parse_enter_pairing` parsers consume the body unchanged — the "M5StickC compat shim" is a published spec, not a special protocol.
- Firmware module (`crates/stackchan-firmware/src/net/esp_now.rs`): `esp_now_task` boots inert when `cfg.enabled == false`. Otherwise installs the PMK, registers a static peer, optionally channel-locks, and loops on `receive_async`. Allowlist: static peer always passes; non-allowlisted frames gate on the `PAIR_WINDOW` Signal. Frames outside the window are dropped silently.
- `PAIR_WINDOW` Signal is driven by `POST /pair` and the `enter_pairing` MCP tool — both producers call `open_pair_window` alongside their existing `REMOTE_COMMAND_SIGNAL.signal(cmd)` so the avatar visual + radio peer-registration open in lockstep.
- Cargo: `esp-now` feature added to `esp-radio`.

## Stacked on #232 (PR 7b)

This is the third (and final operator-required) PR in the ESP-NOW stack. After this lands, an external device on the right channel can drive emotion / look-at / speak / reset commands without the operator at the dashboard.

## Test plan
- [x] `just check` — workspace fmt + clippy + host tests + doctests all green
- [x] `RUSTDOCFLAGS=-D warnings cargo doc` — full workspace doc build clean
- [x] `just clippy-firmware` — strict firmware clippy clean (proves the new `esp-now` feature links cleanly)
- [x] 11 new unit tests on `stackchan_net::esp_now` covering header round-trip, every kind's decode happy path, plus structural rejections (bad magic, version mismatch, unknown kind, too-short, oversize)
- [x] Bench: device boots clean, `esp_now: disabled in config — task exiting` log line confirms the new task spawns + exits cleanly when SD-card config is missing
- [ ] Bench: full RX path exercise with a second device emitting ESP-NOW frames + Wi-Fi up for the `/pair` window trigger — deferred until that bench setup is available

## Follow-ups (not in this PR)
- TX heartbeat task (5 Hz outbound on `tx_rate_hz`)
- M5StickC reference Arduino sketch in a docs/sketches/ directory
- LED-ring pulse during the pairing window