### PR TITLE
feat(firmware): register LostTargetSearch in render task director

### DIFF
--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -68,8 +68,8 @@ EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIn
 EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
 AttentionFromTracking → DormancyFromActivity → EmotionCycle → StyleFromEmotion →
 StyleFromIntent → GazeFromAttention → MicrosaccadeFromAttention → Blink → Breath →
-IdleDrift → IdleHeadDrift → HeadFromEmotion → HeadFromAttention → HeadFromIntent →
-LostTargetSearch → MouthFromAudio
+IdleDrift → IdleHeadDrift → HeadFromEmotion → HeadFromAttention →
+LostTargetSearch → HeadFromIntent → MouthFromAudio
 ```
 
 Inputs arrive through embassy `Signal` channels from the per-peripheral

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -79,8 +79,8 @@ use stackchan_core::{
         EmotionCycle, EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
         EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion,
         HeadFromIntent, IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud,
-        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, StyleFromEmotion,
-        StyleFromIntent, StyleFromMood,
+        LostTargetSearch, MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier,
+        StyleFromEmotion, StyleFromIntent, StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -161,13 +161,16 @@ type LcdDisplay = mipidsi::Display<
 /// Modifier order is the canonical stackchan-core stack:
 /// `EmotionFromTouch` → `EmotionCycle` → `StyleFromEmotion` → `Blink` →
 /// `Breath` → `IdleDrift` → `IdleHeadDrift` → `HeadFromEmotion` →
-/// `HeadFromAttention`. `EmotionFromTouch` runs first so a tap queued from the
-/// touch task becomes the active emotion before `EmotionCycle` checks
-/// the `manual_until` gate. `IdleHeadDrift` writes the base
-/// `entity.motor.head_pose` (slow wander); `HeadFromEmotion` adds an
-/// emotion-keyed bias on top; `HeadFromAttention` adds an upward listening
-/// tilt when the `Listening` skill (registered separately) sets
-/// `mind.attention = Listening`.
+/// `HeadFromAttention` → `LostTargetSearch`. `EmotionFromTouch` runs
+/// first so a tap queued from the touch task becomes the active emotion
+/// before `EmotionCycle` checks the `manual_until` gate. `IdleHeadDrift`
+/// writes the base `entity.motor.head_pose` (slow wander);
+/// `HeadFromEmotion` adds an emotion-keyed bias on top; `HeadFromAttention`
+/// adds an upward listening tilt when the `Listening` skill (registered
+/// separately) sets `mind.attention = Listening`. `LostTargetSearch`
+/// rides on top of those, animating a brief directional saccade after
+/// the engagement falling-edge so the avatar reads as "looking for
+/// where they went."
 /// The final pose is published to the 50 Hz head task via
 /// [`head::POSE_SIGNAL`]. `frame_eq` short-circuits blits when no
 /// pixel-affecting modifier changed anything — pose updates alone never
@@ -217,6 +220,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut head_drift = IdleHeadDrift::with_seed(head_drift_seed);
     let mut head_from_emotion = HeadFromEmotion::new();
     let mut head_from_attention = HeadFromAttention::new();
+    let mut lost_target_search = LostTargetSearch::new();
     let mut head_from_intent = HeadFromIntent::new();
     let mut mouth_from_audio = MouthFromAudio::new();
     let mut listening = Listening::new();
@@ -327,6 +331,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         .add_modifier(&mut head_from_attention)
         .expect("registry full");
     director
+        .add_modifier(&mut lost_target_search)
+        .expect("registry full");
+    director
         .add_modifier(&mut head_from_intent)
         .expect("registry full");
     director
@@ -359,7 +366,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -161,16 +161,19 @@ type LcdDisplay = mipidsi::Display<
 /// Modifier order is the canonical stackchan-core stack:
 /// `EmotionFromTouch` → `EmotionCycle` → `StyleFromEmotion` → `Blink` →
 /// `Breath` → `IdleDrift` → `IdleHeadDrift` → `HeadFromEmotion` →
-/// `HeadFromAttention` → `LostTargetSearch`. `EmotionFromTouch` runs
-/// first so a tap queued from the touch task becomes the active emotion
-/// before `EmotionCycle` checks the `manual_until` gate. `IdleHeadDrift`
-/// writes the base `entity.motor.head_pose` (slow wander);
-/// `HeadFromEmotion` adds an emotion-keyed bias on top; `HeadFromAttention`
-/// adds an upward listening tilt when the `Listening` skill (registered
-/// separately) sets `mind.attention = Listening`. `LostTargetSearch`
-/// rides on top of those, animating a brief directional saccade after
-/// the engagement falling-edge so the avatar reads as "looking for
-/// where they went."
+/// `HeadFromAttention` → `LostTargetSearch` → `HeadFromIntent`.
+/// `EmotionFromTouch` runs first so a tap queued from the touch task
+/// becomes the active emotion before `EmotionCycle` checks the
+/// `manual_until` gate. `IdleHeadDrift` writes the base
+/// `entity.motor.head_pose` (slow wander); `HeadFromEmotion` adds an
+/// emotion-keyed bias on top; `HeadFromAttention` adds an upward
+/// listening tilt when the `Listening` skill (registered separately)
+/// sets `mind.attention = Listening`. `LostTargetSearch` rides on top
+/// of those, animating a brief directional saccade after the
+/// engagement falling-edge so the avatar reads as "looking for where
+/// they went." `HeadFromIntent` (priority 30) runs last in the Motion
+/// phase so its asymmetric startle recoil composes additively over
+/// the rest of the stack.
 /// The final pose is published to the 50 Hz head task via
 /// [`head::POSE_SIGNAL`]. `frame_eq` short-circuits blits when no
 /// pixel-affecting modifier changed anything — pose updates alone never


### PR DESCRIPTION
## Summary

- Wires the existing `LostTargetSearch` modifier into the firmware
  render-task director at `Phase::Motion` priority 25 — between
  `HeadFromAttention` (20) and `HeadFromIntent` (30).
- The modifier already had full unit and sim coverage; only the
  firmware registration was missing.
- Fixes the firmware README's modifier-stack diagram, which had
  `LostTargetSearch` in the wrong slot.

## Why

After the engagement falling-edge (a tracked face leaves frame),
the avatar now animates a brief directional saccade — hold for
500 ms, saccade 1.3× past the last-seen centroid for 300 ms, linear
return for 1000 ms — that reads as "looking for where they went."
Composes additively on top of the upstream motion stack via
diff-and-undo.

This is the first PR in the v0.2.0 ecosystem-parity push.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests pass
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features` — rustdoc gate passes
- [x] `just check-firmware` — esp-toolchain check passes
- [x] `just clippy-firmware` — strict release clippy passes
- [x] Existing sim integration tests in `crates/stackchan-sim/tests/lost_target_search.rs` exercise the full pipeline (`AttentionFromTracking` → engagement edge → search beat → return)
- [ ] Manual on-device verification: flash the unit, look at it then walk away, observe the directional saccade after the lock drops