### PR TITLE
feat(core): speech-bubble overlay primitive

### DIFF
--- a/crates/stackchan-core/src/bubble.rs
+++ b/crates/stackchan-core/src/bubble.rs
@@ -1,0 +1,97 @@
+//! Speech-bubble overlay — short text rendered above the face for
+//! soliloquy beats, voice-feedback hints, or operator-supplied notes.
+//!
+//! The bubble layer sits on top of the [`crate::face::Face`] base
+//! layer (eyes, mouth, blush, decorator), drawn last so its rounded
+//! rectangle and black text occlude the face geometry where they
+//! overlap. Only one bubble shows at a time; trigger modifiers in
+//! [`crate::director::Phase::Decoration`] (or short-circuit code paths
+//! in firmware tasks) populate the field; [`crate::modifiers::BubbleExpiry`]
+//! clears it on deadline.
+//!
+//! ## Storage shape
+//!
+//! [`BubbleState::text`] is `&'static str`. Embedded firmware avoids
+//! per-tick `String` allocations on the render path; phrase pools are
+//! the canonical content source. Dynamic text from external sources
+//! (e.g. an MCP `speak` tool with a runtime-supplied string) needs a
+//! separate mechanism — likely a small interning arena — rather than
+//! widening this surface.
+//!
+//! ## Lifecycle
+//!
+//! Same pattern as [`crate::decorator::DecoratorState`]: each bubble
+//! carries an `expires_at` `Instant` and the
+//! [`crate::modifiers::BubbleExpiry`] modifier clears the field when
+//! the deadline passes. A trigger that fires while one is already
+//! active just overwrites the field — there's no priority arbitration
+//! beyond modifier sort order.
+
+use crate::clock::Instant;
+
+/// Active speech-bubble overlay with its expiry deadline.
+///
+/// Stored as `Option<BubbleState>` on [`crate::face::Face`]; `None`
+/// is the steady state. Trigger modifiers fill it in; the expiry
+/// modifier clears it when `expires_at` passes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BubbleState {
+    /// Text content. `&'static str` so the render path stays
+    /// allocation-free; firmware feeds this from a phrase pool.
+    pub text: &'static str,
+    /// Wall-clock instant at which this bubble stops being drawn.
+    pub expires_at: Instant,
+}
+
+impl BubbleState {
+    /// Construct a state that holds `text` from `now` for `duration_ms`
+    /// milliseconds.
+    #[must_use]
+    pub const fn hold_for(text: &'static str, now: Instant, duration_ms: u64) -> Self {
+        Self {
+            text,
+            expires_at: Instant::from_millis(now.as_millis() + duration_ms),
+        }
+    }
+
+    /// `true` iff `now` has reached or passed [`Self::expires_at`].
+    #[must_use]
+    pub fn is_expired(&self, now: Instant) -> bool {
+        now >= self.expires_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hold_for_pins_expiry_at_now_plus_duration() {
+        let now = Instant::from_millis(1_000);
+        let s = BubbleState::hold_for("hi", now, 2_000);
+        assert_eq!(s.text, "hi");
+        assert_eq!(s.expires_at, Instant::from_millis(3_000));
+    }
+
+    #[test]
+    fn is_expired_at_or_after_deadline() {
+        let now = Instant::from_millis(1_000);
+        let s = BubbleState::hold_for("hi", now, 500);
+        assert!(!s.is_expired(Instant::from_millis(1_000)));
+        assert!(!s.is_expired(Instant::from_millis(1_499)));
+        assert!(s.is_expired(Instant::from_millis(1_500)));
+        assert!(s.is_expired(Instant::from_millis(2_000)));
+    }
+
+    #[test]
+    fn equality_compares_text_and_expiry() {
+        let now = Instant::from_millis(0);
+        let a = BubbleState::hold_for("a", now, 1_000);
+        let b = BubbleState::hold_for("a", now, 1_000);
+        let c = BubbleState::hold_for("b", now, 1_000);
+        let d = BubbleState::hold_for("a", now, 2_000);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, d);
+    }
+}

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -156,6 +156,8 @@ pub enum Field {
     BreathDepthScale,
     /// `entity.face.decorator`
     Decorator,
+    /// `entity.face.bubble`
+    Bubble,
 
     // ---- Motor ----
     /// `entity.motor.head_pose`
@@ -239,6 +241,7 @@ impl Field {
         Self::BlinkRateScale,
         Self::BreathDepthScale,
         Self::Decorator,
+        Self::Bubble,
         Self::HeadPose,
         Self::HeadPoseActual,
         Self::AccelG,
@@ -286,7 +289,8 @@ impl Field {
             | Self::EyeScale
             | Self::BlinkRateScale
             | Self::BreathDepthScale
-            | Self::Decorator => FieldGroup::Face,
+            | Self::Decorator
+            | Self::Bubble => FieldGroup::Face,
             Self::HeadPose | Self::HeadPoseActual => FieldGroup::Motor,
             Self::AccelG
             | Self::GyroDps
@@ -346,6 +350,7 @@ impl Field {
                 before.face.style.breath_depth_scale != after.face.style.breath_depth_scale
             }
             Self::Decorator => before.face.decorator != after.face.decorator,
+            Self::Bubble => before.face.bubble != after.face.bubble,
             Self::HeadPose => {
                 before.motor.head_pose.pan_deg.to_bits() != after.motor.head_pose.pan_deg.to_bits()
                     || before.motor.head_pose.tilt_deg.to_bits()
@@ -821,7 +826,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            42,
+            43,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -33,7 +33,7 @@ use crate::modifier::Modifier;
 use crate::skill::{Skill, SkillStatus};
 
 /// Maximum number of modifiers a [`Director`] can hold.
-pub const MODIFIER_CAP: usize = 32;
+pub const MODIFIER_CAP: usize = 48;
 
 /// Maximum number of skills a [`Director`] can hold.
 pub const SKILL_CAP: usize = 16;

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -29,13 +29,16 @@ use embedded_graphics::{
     Drawable,
     draw_target::DrawTarget,
     geometry::{Point as EgPoint, Size},
+    mono_font::{MonoTextStyle, ascii::FONT_10X20},
     pixelcolor::{Rgb565, RgbColor},
     primitives::{
         Circle, Ellipse, Line, Polyline, Primitive, PrimitiveStyle, PrimitiveStyleBuilder,
         Rectangle,
     },
+    text::{Alignment, Baseline, Text, TextStyleBuilder},
 };
 
+use crate::bubble::BubbleState;
 use crate::decorator::{Decorator, DecoratorState};
 use crate::face::{Eye, EyePhase, Face, Mouth, SCALE_DEFAULT};
 
@@ -131,6 +134,9 @@ impl Face {
         draw_mouth(&self.mouth, self.style.mouth_curve, target)?;
         if let Some(state) = self.decorator {
             draw_decorator(state, target)?;
+        }
+        if let Some(state) = self.bubble {
+            draw_bubble(state, target)?;
         }
         Ok(())
     }
@@ -469,6 +475,127 @@ where
                 .draw(target)?;
         }
     }
+    Ok(())
+}
+
+/// Speech-bubble outer-rect colour — black border around the
+/// white text background. Reads as a clean callout against the
+/// white face background.
+const BUBBLE_BORDER_COLOR: Rgb565 = Rgb565::BLACK;
+/// Speech-bubble fill colour — slightly off-white so the bubble
+/// reads as a separate layer, not a hole punched through the face.
+/// Light gray = `Rgb565::new(28, 56, 28)` (~#E0E0E0).
+const BUBBLE_FILL_COLOR: Rgb565 = Rgb565::new(28, 56, 28);
+/// Speech-bubble text colour.
+const BUBBLE_TEXT_COLOR: Rgb565 = Rgb565::BLACK;
+/// Speech-bubble border stroke width.
+const BUBBLE_BORDER_STROKE: u32 = 2;
+/// Vertical padding inside the bubble (top + bottom of text area).
+const BUBBLE_VERTICAL_PADDING: i32 = 6;
+/// Horizontal padding inside the bubble (left + right of text).
+const BUBBLE_HORIZONTAL_PADDING: i32 = 8;
+/// Speech-bubble anchor Y — top of the bubble, just below the
+/// frame's top edge. Anchors at the top so the bubble doesn't
+/// occlude the eyes (which sit at y≈110).
+const BUBBLE_ANCHOR_Y: i32 = 4;
+/// Frame-edge clearance — how close the bubble can come to the
+/// left / right edge of the framebuffer. Prevents the border from
+/// landing on the screen-edge pixel column.
+const BUBBLE_EDGE_CLEARANCE: i32 = 4;
+/// Maximum bubble width, in pixels. Inferred from the framebuffer
+/// width assumption (320 px); covers the full top of the frame
+/// minus the edge clearance on both sides.
+const BUBBLE_MAX_WIDTH: i32 = 320 - 2 * BUBBLE_EDGE_CLEARANCE;
+/// `FONT_10X20` glyph width — used to measure rendered text width
+/// without round-tripping through `embedded_graphics`'s text
+/// metrics API.
+const BUBBLE_GLYPH_WIDTH: i32 = 10;
+/// `FONT_10X20` glyph height — see [`BUBBLE_GLYPH_WIDTH`].
+const BUBBLE_GLYPH_HEIGHT: i32 = 20;
+
+/// Compute the bubble's drawn rectangle in framebuffer coordinates,
+/// given the text length in characters. Returns `(top_left, size)`.
+/// Width is text-derived but clamped to [`BUBBLE_MAX_WIDTH`] so a
+/// runaway-length text never overflows the frame; the renderer
+/// truncates the visible characters at the same boundary.
+const fn bubble_rect(char_count: usize) -> (EgPoint, Size) {
+    let chars = if char_count == 0 { 1 } else { char_count };
+    #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+    let raw_text_w = chars as i32 * BUBBLE_GLYPH_WIDTH;
+    let max_text_w = BUBBLE_MAX_WIDTH - 2 * BUBBLE_HORIZONTAL_PADDING;
+    let text_w = if raw_text_w > max_text_w {
+        max_text_w
+    } else {
+        raw_text_w
+    };
+    let total_w = text_w + 2 * BUBBLE_HORIZONTAL_PADDING;
+    let total_h = BUBBLE_GLYPH_HEIGHT + 2 * BUBBLE_VERTICAL_PADDING;
+    // Centred horizontally on the 320 px frame.
+    let top_left_x = (320 - total_w) / 2;
+    #[allow(clippy::cast_sign_loss)]
+    let size = Size::new(total_w as u32, total_h as u32);
+    (EgPoint::new(top_left_x, BUBBLE_ANCHOR_Y), size)
+}
+
+/// Draw the speech bubble: a bordered rounded-rect-style callout
+/// (rendered as a regular rectangle for `no_std`-friendly simplicity)
+/// with the bubble text rendered in `FONT_10X20` inside it.
+fn draw_bubble<D>(state: BubbleState, target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    // Truncate at the maximum visible character count for the bubble
+    // width. The bubble never word-wraps; firmware feeds short
+    // phrase-pool strings.
+    let max_visible_chars =
+        ((BUBBLE_MAX_WIDTH - 2 * BUBBLE_HORIZONTAL_PADDING) / BUBBLE_GLYPH_WIDTH).max(1);
+    #[allow(clippy::cast_sign_loss)]
+    let visible_char_cap = max_visible_chars as usize;
+    let visible_text = if state.text.chars().count() > visible_char_cap {
+        // Byte-truncate at a char boundary corresponding to the cap.
+        let mut byte_end = 0;
+        for (i, (idx, _)) in state.text.char_indices().enumerate() {
+            if i == visible_char_cap {
+                break;
+            }
+            byte_end = idx + state.text[idx..].chars().next().map_or(0, char::len_utf8);
+        }
+        &state.text[..byte_end]
+    } else {
+        state.text
+    };
+    let visible_chars = visible_text.chars().count();
+
+    let (top_left, size) = bubble_rect(visible_chars);
+
+    // Filled background.
+    Rectangle::new(top_left, size)
+        .into_styled(fill(BUBBLE_FILL_COLOR))
+        .draw(target)?;
+    // Border on top.
+    Rectangle::new(top_left, size)
+        .into_styled(stroke(BUBBLE_BORDER_COLOR, BUBBLE_BORDER_STROKE))
+        .draw(target)?;
+
+    // Text centre point: horizontal midpoint of the bubble, vertical
+    // midpoint of the inner area (which sits one glyph-height tall
+    // inside the padded rect).
+    #[allow(clippy::cast_possible_wrap)]
+    let center_x = top_left.x + (size.width / 2) as i32;
+    let baseline_y = top_left.y + BUBBLE_VERTICAL_PADDING + BUBBLE_GLYPH_HEIGHT / 2;
+
+    let character_style = MonoTextStyle::new(&FONT_10X20, BUBBLE_TEXT_COLOR);
+    let text_style = TextStyleBuilder::new()
+        .alignment(Alignment::Center)
+        .baseline(Baseline::Middle)
+        .build();
+    Text::with_text_style(
+        visible_text,
+        EgPoint::new(center_x, baseline_y),
+        character_style,
+        text_style,
+    )
+    .draw(target)?;
     Ok(())
 }
 

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -484,7 +484,9 @@ where
 const BUBBLE_BORDER_COLOR: Rgb565 = Rgb565::BLACK;
 /// Speech-bubble fill colour — slightly off-white so the bubble
 /// reads as a separate layer, not a hole punched through the face.
-/// Light gray = `Rgb565::new(28, 56, 28)` (~#E0E0E0).
+/// `Rgb565::new(28, 56, 28)` quantises to roughly `#E6E3E6` after the
+/// (5,6,5)-bit channel scaling — a barely perceptible lavender-tinged
+/// neutral that does not compete with the avatar palette.
 const BUBBLE_FILL_COLOR: Rgb565 = Rgb565::new(28, 56, 28);
 /// Speech-bubble text colour.
 const BUBBLE_TEXT_COLOR: Rgb565 = Rgb565::BLACK;
@@ -498,14 +500,17 @@ const BUBBLE_HORIZONTAL_PADDING: i32 = 8;
 /// frame's top edge. Anchors at the top so the bubble doesn't
 /// occlude the eyes (which sit at y≈110).
 const BUBBLE_ANCHOR_Y: i32 = 4;
+/// Framebuffer width assumption used for centring. The render target
+/// is the same 320×240 LCD canvas as the rest of the avatar
+/// (matches `crates/stackchan-firmware/src/framebuffer.rs::WIDTH`).
+const BUBBLE_FB_WIDTH: i32 = 320;
 /// Frame-edge clearance — how close the bubble can come to the
 /// left / right edge of the framebuffer. Prevents the border from
 /// landing on the screen-edge pixel column.
 const BUBBLE_EDGE_CLEARANCE: i32 = 4;
-/// Maximum bubble width, in pixels. Inferred from the framebuffer
-/// width assumption (320 px); covers the full top of the frame
+/// Maximum bubble width, in pixels. Covers the full top of the frame
 /// minus the edge clearance on both sides.
-const BUBBLE_MAX_WIDTH: i32 = 320 - 2 * BUBBLE_EDGE_CLEARANCE;
+const BUBBLE_MAX_WIDTH: i32 = BUBBLE_FB_WIDTH - 2 * BUBBLE_EDGE_CLEARANCE;
 /// `FONT_10X20` glyph width — used to measure rendered text width
 /// without round-tripping through `embedded_graphics`'s text
 /// metrics API.
@@ -530,8 +535,8 @@ const fn bubble_rect(char_count: usize) -> (EgPoint, Size) {
     };
     let total_w = text_w + 2 * BUBBLE_HORIZONTAL_PADDING;
     let total_h = BUBBLE_GLYPH_HEIGHT + 2 * BUBBLE_VERTICAL_PADDING;
-    // Centred horizontally on the 320 px frame.
-    let top_left_x = (320 - total_w) / 2;
+    // Centred horizontally on the framebuffer.
+    let top_left_x = (BUBBLE_FB_WIDTH - total_w) / 2;
     #[allow(clippy::cast_sign_loss)]
     let size = Size::new(total_w as u32, total_h as u32);
     (EgPoint::new(top_left_x, BUBBLE_ANCHOR_Y), size)
@@ -553,14 +558,17 @@ where
     let visible_char_cap = max_visible_chars as usize;
     let visible_text = if state.text.chars().count() > visible_char_cap {
         // Byte-truncate at a char boundary corresponding to the cap.
-        let mut byte_end = 0;
-        for (i, (idx, _)) in state.text.char_indices().enumerate() {
-            if i == visible_char_cap {
-                break;
-            }
-            byte_end = idx + state.text[idx..].chars().next().map_or(0, char::len_utf8);
-        }
-        &state.text[..byte_end]
+        // `char_indices().nth(cap)` yields the (byte, char) of the
+        // *next* char past the cap — its byte index is exactly where
+        // we slice. Falls back to the full string when `nth` is None,
+        // i.e. when the text has fewer chars than the cap (defensive;
+        // the outer length check already short-circuits this path).
+        let split = state
+            .text
+            .char_indices()
+            .nth(visible_char_cap)
+            .map_or(state.text.len(), |(idx, _)| idx);
+        &state.text[..split]
     } else {
         state.text
     };

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -179,6 +179,11 @@ pub struct Face {
     /// [`crate::director::Phase::Decoration`] populate this field;
     /// [`crate::modifiers::DecoratorExpiry`] clears it on deadline.
     pub decorator: Option<crate::decorator::DecoratorState>,
+    /// Active speech-bubble text overlay, drawn above the face. `None`
+    /// is the steady state. Trigger paths (e.g. soliloquy modifier,
+    /// firmware-side MCP `speak` short-circuit) populate this field;
+    /// [`crate::modifiers::BubbleExpiry`] clears it on deadline.
+    pub bubble: Option<crate::bubble::BubbleState>,
 }
 
 impl Default for Face {
@@ -212,6 +217,7 @@ impl Default for Face {
             },
             style: Style::default(),
             decorator: None,
+            bubble: None,
         }
     }
 }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -27,6 +27,7 @@
 #![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
 
+pub mod bubble;
 pub mod clock;
 pub mod decorator;
 pub mod director;
@@ -49,6 +50,7 @@ pub mod skill;
 pub mod skills;
 pub mod voice;
 
+pub use bubble::BubbleState;
 pub use clock::{Clock, Instant};
 pub use decorator::{Decorator, DecoratorState};
 pub use director::{

--- a/crates/stackchan-core/src/modifiers/bubble_expiry.rs
+++ b/crates/stackchan-core/src/modifiers/bubble_expiry.rs
@@ -1,0 +1,90 @@
+//! [`BubbleExpiry`] — runs first in [`Phase::Decoration`] and clears
+//! `face.bubble` once its `expires_at` deadline passes.
+//!
+//! Mirrors [`super::DecoratorExpiry`] for the speech-bubble layer:
+//! splitting expiry into its own modifier keeps trigger paths
+//! stateless on the time axis. Each trigger only writes a fresh
+//! [`crate::bubble::BubbleState`] when its condition fires.
+//!
+//! [`Phase::Decoration`]: crate::director::Phase::Decoration
+
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// Stateless modifier that clears expired bubbles.
+///
+/// Runs at priority `-10` in [`Phase::Decoration`] alongside
+/// [`super::DecoratorExpiry`] so future trigger modifiers see a
+/// clean slate before re-arming.
+///
+/// [`Phase::Decoration`]: crate::director::Phase::Decoration
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BubbleExpiry;
+
+impl BubbleExpiry {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Modifier for BubbleExpiry {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "BubbleExpiry",
+            description: "Clears face.bubble once expires_at passes; runs first in \
+                          Phase::Decoration so trigger paths see a clean slate.",
+            phase: Phase::Decoration,
+            priority: -10,
+            reads: &[Field::Bubble],
+            writes: &[Field::Bubble],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        if let Some(state) = entity.face.bubble
+            && state.is_expired(entity.tick.now)
+        {
+            entity.face.bubble = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bubble::BubbleState;
+    use crate::clock::Instant;
+
+    #[test]
+    fn clears_bubble_on_or_after_deadline() {
+        let mut entity = Entity::default();
+        entity.face.bubble = Some(BubbleState {
+            text: "hi",
+            expires_at: Instant::from_millis(1_000),
+        });
+        let mut m = BubbleExpiry::new();
+
+        // Before deadline — held.
+        entity.tick.now = Instant::from_millis(999);
+        m.update(&mut entity);
+        assert!(entity.face.bubble.is_some());
+
+        // At deadline — cleared.
+        entity.tick.now = Instant::from_millis(1_000);
+        m.update(&mut entity);
+        assert!(entity.face.bubble.is_none());
+    }
+
+    #[test]
+    fn noop_on_empty_bubble() {
+        let mut entity = Entity::default();
+        let mut m = BubbleExpiry::new();
+        entity.tick.now = Instant::from_millis(99_999);
+        m.update(&mut entity);
+        assert!(entity.face.bubble.is_none());
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -84,6 +84,7 @@
 mod attention_from_tracking;
 mod blink;
 mod breath;
+mod bubble_expiry;
 mod decorator_expiry;
 mod decorator_from_body_touch;
 mod decorator_from_emotion;
@@ -120,6 +121,7 @@ pub use attention_from_tracking::{
 };
 pub use blink::Blink;
 pub use breath::Breath;
+pub use bubble_expiry::BubbleExpiry;
 pub use decorator_expiry::DecoratorExpiry;
 pub use decorator_from_body_touch::{DecoratorFromBodyTouch, HEART_HOLD_MS};
 pub use decorator_from_emotion::{DECORATOR_EMOTION_HOLD_MS, DecoratorFromEmotion};

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -74,12 +74,12 @@ use mipidsi::{
 use stackchan_core::{
     Attention, Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
     modifiers::{
-        AttentionFromTracking, Blink, Breath, DecoratorExpiry, DecoratorFromBodyTouch,
-        DecoratorFromEmotion, DecoratorFromListening, DecoratorFromLoud, DecoratorFromShake,
-        DormancyFromActivity, EmotionCycle, EmotionFromAmbient, EmotionFromBattery,
-        EmotionFromIntent, EmotionFromRemote, EmotionFromTouch, EmotionFromVoice,
-        GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent, IdleDrift,
-        IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud, LostTargetSearch,
+        AttentionFromTracking, Blink, Breath, BubbleExpiry, DecoratorExpiry,
+        DecoratorFromBodyTouch, DecoratorFromEmotion, DecoratorFromListening, DecoratorFromLoud,
+        DecoratorFromShake, DormancyFromActivity, EmotionCycle, EmotionFromAmbient,
+        EmotionFromBattery, EmotionFromIntent, EmotionFromRemote, EmotionFromTouch,
+        EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent,
+        IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud, LostTargetSearch,
         MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, StyleFromEmotion,
         StyleFromIntent, StyleFromMood,
     },
@@ -231,6 +231,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut petting = Petting::new();
     let mut handling = Handling::new();
     let mut intent_from_body_touch = IntentFromBodyTouch::new();
+    let mut bubble_expiry = BubbleExpiry::new();
     let mut decorator_expiry = DecoratorExpiry::new();
     let mut decorator_from_emotion = DecoratorFromEmotion::new();
     let mut decorator_from_body_touch = DecoratorFromBodyTouch::new();
@@ -313,6 +314,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     // (phase, priority, registration_order).
     director
         .add_modifier(&mut decorator_expiry)
+        .expect("registry full");
+    director
+        .add_modifier(&mut bubble_expiry)
         .expect("registry full");
     director
         .add_modifier(&mut decorator_from_emotion)

--- a/crates/stackchan-sim/tests/render_snapshot.rs
+++ b/crates/stackchan-sim/tests/render_snapshot.rs
@@ -15,7 +15,7 @@
 
 use embedded_graphics::pixelcolor::{Rgb565, RgbColor};
 use stackchan_core::modifiers::StyleFromEmotion;
-use stackchan_core::{Decorator, DecoratorState, Director, Emotion, Entity, Instant};
+use stackchan_core::{BubbleState, Decorator, DecoratorState, Director, Emotion, Entity, Instant};
 use stackchan_sim::Framebuffer;
 
 /// LCD canvas width the firmware targets.
@@ -234,6 +234,62 @@ fn distinct_decorators_render_distinct_frames() {
             );
         }
     }
+}
+
+/// A populated speech bubble must render visibly different from the
+/// no-bubble baseline, regardless of which face is showing underneath.
+#[test]
+fn bubble_overlay_paints_pixels_outside_baseline() {
+    let mut baseline = Framebuffer::new(WIDTH, HEIGHT);
+    Entity::default()
+        .face
+        .draw(&mut baseline)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    let mut entity = Entity::default();
+    entity.face.bubble = Some(BubbleState {
+        text: "hi",
+        // Far in the future — the renderer draws regardless of expiry.
+        expires_at: Instant::from_millis(u64::MAX / 2),
+    });
+    let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+    entity
+        .face
+        .draw(&mut fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+    assert_ne!(
+        fb.as_slice(),
+        baseline.as_slice(),
+        "bubble overlay should paint pixels outside the no-bubble baseline"
+    );
+}
+
+/// A bubble with text long enough to overflow the maximum frame width
+/// must still render — the draw code truncates rather than panicking
+/// or overflowing the framebuffer.
+#[test]
+fn bubble_overlay_handles_oversized_text() {
+    let mut entity = Entity::default();
+    entity.face.bubble = Some(BubbleState {
+        // Far longer than the bubble can hold (~28 chars at FONT_10X20
+        // on a 320 px frame minus padding); the draw code truncates.
+        text: "this is a deliberately very long speech bubble text that overflows",
+        expires_at: Instant::from_millis(u64::MAX / 2),
+    });
+    let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+    entity
+        .face
+        .draw(&mut fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+    // No assertion on pixels beyond "draw didn't panic and produced
+    // something different from baseline" — visual truncation is
+    // covered by the no-overflow guarantee inside `draw_bubble`.
+    let mut baseline = Framebuffer::new(WIDTH, HEIGHT);
+    Entity::default()
+        .face
+        .draw(&mut baseline)
+        .expect("Framebuffer DrawTarget is Infallible");
+    assert_ne!(fb.as_slice(), baseline.as_slice());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds a `BubbleState { text: &'static str, expires_at }` overlay layer on `Face`, drawn after the decorator layer at the top of the frame.
- Includes `BubbleExpiry` modifier (Phase::Decoration priority -10, mirroring `DecoratorExpiry`) and `Field::Bubble` for director write-enforcement.
- Sim render-snapshot tests cover overlay-paints-pixels and oversized-text-truncates.

## Why

This is the foundational primitive for several Tier-1 features in the v0.2.0 push:
- Soliloquy / monologue mode (random idle phrases)
- MCP `speak` text feedback (acknowledge what was said)
- Operator-supplied notes / debug callouts

Storage shape is `&'static str` so the render path stays allocation-free; firmware feeds it from phrase pools. Dynamic external strings (runtime-supplied text from MCP) need a separate interning mechanism rather than widening this surface.

## Test plan

- [x] `cargo test -p stackchan-core` — 380 pass (incl. new `BubbleState` and `BubbleExpiry` tests; field-count pin updated 42→43)
- [x] `cargo test -p stackchan-sim` — passes including new bubble snapshot tests
- [x] `just ci` clean (fmt + clippy + cargo-deny + workspace doc gate)
- [x] `just clippy-firmware` strict release clippy passes
- [ ] Manual on-device verification: trigger a bubble via firmware path, observe the rounded callout