### PR TITLE
feat(net): MCP set_volume + set_mute tools

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -889,10 +889,11 @@ async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
 const fn audio_persist_detail(outcome: crate::audio::AudioPersistOutcome) -> &'static str {
     use crate::audio::AudioPersistOutcome;
     match outcome {
-        // The success path is already filtered out by the call site;
-        // the variant is unreachable here but const-match needs every
-        // arm covered.
-        AudioPersistOutcome::Persisted => "ok",
+        // The success path is filtered out at the call site before we
+        // get here. A distinct sentinel makes any accidental future
+        // call with `Persisted` self-describing inside a -32603
+        // response rather than a misleading "ok".
+        AudioPersistOutcome::Persisted => "audio persisted (unexpected for error path)",
         AudioPersistOutcome::NoSnapshot => "config snapshot unavailable",
         AudioPersistOutcome::NoStorage => "no SD card mounted",
         AudioPersistOutcome::WriteFailed => "config write failed",

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -742,7 +742,7 @@ async fn handle_post_mcp(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), H
                 .ok()
                 .flatten()
                 .unwrap_or("{}");
-            mcp_dispatch_tool(req.id, tool_name, arguments)
+            mcp_dispatch_tool(req.id, tool_name, arguments).await
         }
         _ => render_error(
             Some(req.id),
@@ -756,7 +756,17 @@ async fn handle_post_mcp(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), H
 /// Dispatch a `tools/call` request to the matching control-plane
 /// primitive. Returns a fully-rendered JSON-RPC response (success or
 /// error) string ready for `write_json`.
-fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
+///
+/// Async because `set_volume` and `set_mute` thread through the audio
+/// task's SD-write persistence path, mirroring `POST /volume` and
+/// `POST /mute`. Other tools resolve synchronously by signalling
+/// `REMOTE_COMMAND_SIGNAL` and rendering a fixed acknowledgement.
+#[allow(
+    clippy::too_many_lines,
+    reason = "single dispatch table that mirrors `TOOLS_LIST_RESULT_JSON`; \
+              splitting fragments the per-tool layout the catalogue depends on"
+)]
+async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
     use stackchan_net::mcp::{
         JsonRpcErrorCode, render_error, render_success, render_tool_text_result,
     };
@@ -831,11 +841,61 @@ fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
                 tool_parse_detail(&e),
             ),
         },
+        "set_volume" => match json::parse_volume(arguments) {
+            Ok(level) => match crate::audio::persist_volume(level).await {
+                crate::audio::AudioPersistOutcome::Persisted => {
+                    render_success(id, &render_tool_text_result("volume persisted"))
+                }
+                outcome => render_error(
+                    Some(id),
+                    JsonRpcErrorCode::InternalError,
+                    audio_persist_detail(outcome),
+                ),
+            },
+            Err(e) => render_error(
+                Some(id),
+                JsonRpcErrorCode::InvalidParams,
+                tool_parse_detail(&e),
+            ),
+        },
+        "set_mute" => match json::parse_mute(arguments) {
+            Ok(muted) => match crate::audio::persist_mute(muted).await {
+                crate::audio::AudioPersistOutcome::Persisted => {
+                    render_success(id, &render_tool_text_result("mute persisted"))
+                }
+                outcome => render_error(
+                    Some(id),
+                    JsonRpcErrorCode::InternalError,
+                    audio_persist_detail(outcome),
+                ),
+            },
+            Err(e) => render_error(
+                Some(id),
+                JsonRpcErrorCode::InvalidParams,
+                tool_parse_detail(&e),
+            ),
+        },
         "get_state" => {
             let snap = snapshot::read();
             render_success(id, &render_tool_text_result(&state_body(snap)))
         }
         _ => render_error(Some(id), JsonRpcErrorCode::MethodNotFound, "unknown tool"),
+    }
+}
+
+/// Map a non-`Persisted` [`crate::audio::AudioPersistOutcome`] to a
+/// `&'static str` MCP error detail. Mirrors [`audio_persist_to_http`]
+/// but in JSON-RPC error-detail form rather than HTTP status codes.
+const fn audio_persist_detail(outcome: crate::audio::AudioPersistOutcome) -> &'static str {
+    use crate::audio::AudioPersistOutcome;
+    match outcome {
+        // The success path is already filtered out by the call site;
+        // the variant is unreachable here but const-match needs every
+        // arm covered.
+        AudioPersistOutcome::Persisted => "ok",
+        AudioPersistOutcome::NoSnapshot => "config snapshot unavailable",
+        AudioPersistOutcome::NoStorage => "no SD card mounted",
+        AudioPersistOutcome::WriteFailed => "config write failed",
     }
 }
 

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -607,13 +607,17 @@ pub const INITIALIZE_RESULT_JSON: &str = concat!(
     "}",
 );
 
-/// Static MCP `tools/list` result JSON. Five tools that map onto the
-/// existing HTTP control plane:
+/// Static MCP `tools/list` result JSON. Tools map onto the existing
+/// HTTP control plane:
 ///
 /// - `set_emotion(emotion: string, hold_ms?: integer)`
 /// - `set_mood(mood: string)`
 /// - `look_at(pan_deg: number, tilt_deg: number, hold_ms?: integer)`
 /// - `speak(phrase: string, locale?: string)`
+/// - `start_listen(duration_ms?: integer)`
+/// - `enter_pairing(duration_ms?: integer)`
+/// - `set_volume(level: integer)`
+/// - `set_mute(muted: bool)`
 /// - `get_state()`
 ///
 /// Schemas are minimal — no enum constraints on emotion / mood /
@@ -627,6 +631,8 @@ pub const TOOLS_LIST_RESULT_JSON: &str = concat!(
     r#"{"name":"speak","description":"Play a baked phrase or chirp through the speaker.","inputSchema":{"type":"object","properties":{"phrase":{"type":"string"},"locale":{"type":"string"}},"required":["phrase"]}},"#,
     r#"{"name":"start_listen","description":"Open a listen window: queue an acknowledge chirp, set Attention::Listening, arm the Ear decorator. Default 3000 ms.","inputSchema":{"type":"object","properties":{"duration_ms":{"type":"integer"}}}},"#,
     r#"{"name":"enter_pairing","description":"Open an ESP-NOW pairing window for the configured duration so an external remote can register.","inputSchema":{"type":"object","properties":{"duration_ms":{"type":"integer"}}}},"#,
+    r#"{"name":"set_volume","description":"Set the speaker volume in percent (0..=100). Persists to STACKCHAN.RON; survives reboot.","inputSchema":{"type":"object","properties":{"level":{"type":"integer","minimum":0,"maximum":100}},"required":["level"]}},"#,
+    r#"{"name":"set_mute","description":"Mute or unmute the speaker without losing the persisted volume level. Persists to STACKCHAN.RON.","inputSchema":{"type":"object","properties":{"muted":{"type":"boolean"}},"required":["muted"]}},"#,
     r#"{"name":"get_state","description":"Return the current avatar snapshot (emotion, mood, head pose, decorator, battery, Wi-Fi, audio).","inputSchema":{"type":"object","properties":{}}}"#,
     "]}",
 );


### PR DESCRIPTION
## Summary

- Adds `set_volume(level: 0..=100)` and `set_mute(muted: bool)` to the MCP `tools/list` catalog.
- Dispatcher in `crates/stackchan-firmware/src/net/http.rs` becomes async so it can thread through the existing `crate::audio::persist_*` SD-writeback path.
- Adds `audio_persist_detail` helper mirroring `audio_persist_to_http` but for JSON-RPC error details.

## Why

m5stack official's MCP server ships analogous tools so any MCP client can drive speaker volume + brightness without HTTP credentials. Wrapping `POST /volume` + `POST /mute` keeps the persistence semantics identical and avoids duplicating the SD-snapshot mutex hygiene.

## Test plan

- [x] `just ci` clean
- [x] `just check-firmware` and `just clippy-firmware` clean
- [x] Existing `parse_volume` / `parse_mute` test coverage in `stackchan-net::http_command` already exercises the parser surface
- [ ] Manual verification: `curl -X POST http://stackchan.local/mcp -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"set_volume","arguments":{"level":50}}}'` → confirm SD write + speaker level change