### PR TITLE
feat(net): apply time.tz from STACKCHAN.RON to boot wall-clock

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1252,9 +1252,38 @@ async fn main(spawner: Spawner) -> ! {
     if let Some(dt) = wallclock::read_datetime(rtc_bus).await {
         let mut rtc_buf = [0u8; 19];
         defmt::info!(
-            "boot @ {=str} (RTC)",
+            "boot @ {=str} (RTC, UTC)",
             bm8563::format_datetime(dt, &mut rtc_buf),
         );
+        // Emit a second line in local time when `time.tz` resolves to
+        // a non-zero offset. Unknown labels degrade to UTC with a
+        // warning so the boot log still reflects what the operator
+        // sees in their config.
+        let tz = stackchan_firmware::storage::CONFIG_SNAPSHOT
+            .lock()
+            .await
+            .as_ref()
+            .map(|c| c.time.tz.clone());
+        if let Some(tz_label) = tz {
+            match stackchan_net::tz_offset_minutes(&tz_label) {
+                Some(0) => {} // UTC — first line already shows it.
+                Some(offset_minutes) => {
+                    let local = wallclock::apply_offset(dt, offset_minutes);
+                    let mut local_buf = [0u8; 19];
+                    defmt::info!(
+                        "boot @ {=str} (RTC, {=str})",
+                        bm8563::format_datetime(local, &mut local_buf),
+                        tz_label.as_str(),
+                    );
+                }
+                None => {
+                    defmt::warn!(
+                        "wallclock: unknown tz {=str} — boot local-time line skipped",
+                        tz_label.as_str(),
+                    );
+                }
+            }
+        }
     }
 
     defmt::info!("boot complete — idle heartbeat");

--- a/crates/stackchan-firmware/src/wallclock.rs
+++ b/crates/stackchan-firmware/src/wallclock.rs
@@ -5,6 +5,11 @@
 //! This module exists to give the boot log an absolute time ("boot @
 //! 2026-04-24 13:37:05") so post-reboot logs can be correlated.
 //!
+//! The RTC stores UTC; [`apply_offset`] converts a UTC `DateTime` into
+//! local time using a signed minutes-from-UTC offset (typically derived
+//! from `Config::time::tz` via
+//! [`stackchan_net::tz_offset_minutes`]).
+//!
 //! No attempt to keep a running wall-clock: callers today pay for
 //! one I²C round-trip at boot. YAGNI until we grow a regular polling
 //! consumer.
@@ -35,4 +40,208 @@ pub async fn read_datetime<I: AsyncI2c>(bus: I) -> Option<DateTime> {
             );
         })
         .ok()
+}
+
+/// Days in each month (non-leap year). Indexed by month - 1.
+const DAYS_IN_MONTH: [u32; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/// `true` iff `year` is a Gregorian leap year (divisible by 4, except
+/// century years not divisible by 400).
+fn is_leap(year: u16) -> bool {
+    let y = u32::from(year);
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
+}
+
+/// Days in a specific year/month. Returns 29 for February in leap years.
+fn days_in_month(year: u16, month: u8) -> u32 {
+    if month == 2 && is_leap(year) {
+        return 29;
+    }
+    DAYS_IN_MONTH[(month as usize) - 1]
+}
+
+/// Apply a signed minutes-from-UTC offset to a UTC [`DateTime`].
+///
+/// `offset_minutes` may be negative (zones west of UTC) or positive
+/// (east). The conversion handles month / year rollover in either
+/// direction without bringing in `chrono` — Stack-chan's RTC range is
+/// 2000-01-01..2099-12-31 (BM8563 chip limit), well inside `u16` year
+/// arithmetic.
+///
+/// Returns the input unchanged when `offset_minutes` is zero so the
+/// common `tz: "UTC"` path doesn't pay any conversion cost.
+#[must_use]
+pub fn apply_offset(utc: DateTime, offset_minutes: i32) -> DateTime {
+    if offset_minutes == 0 {
+        return utc;
+    }
+    let total_minutes =
+        i64::from(utc.hours) * 60 + i64::from(utc.minutes) + i64::from(offset_minutes);
+    // Floor-divide to handle the negative case correctly: for
+    // `-90 minutes`, we want -2 day-rollover and +1350 min-of-day, not
+    // -1 and -90.
+    let day_offset = total_minutes.div_euclid(1440);
+    let mins_of_day = total_minutes.rem_euclid(1440);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let new_hours = (mins_of_day / 60) as u8;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let new_minutes = (mins_of_day % 60) as u8;
+
+    let mut year = utc.year;
+    let mut month = utc.month;
+    let mut day = i64::from(utc.day) + day_offset;
+
+    // Walk forward / backward across month + year boundaries until
+    // `day` falls inside the current month.
+    while day < 1 {
+        // Roll back to the previous month.
+        if month == 1 {
+            month = 12;
+            year -= 1;
+        } else {
+            month -= 1;
+        }
+        day += i64::from(days_in_month(year, month));
+    }
+    loop {
+        let dim = i64::from(days_in_month(year, month));
+        if day <= dim {
+            break;
+        }
+        day -= dim;
+        if month == 12 {
+            month = 1;
+            year += 1;
+        } else {
+            month += 1;
+        }
+    }
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let new_day = day as u8;
+
+    DateTime {
+        year,
+        month,
+        day: new_day,
+        hours: new_hours,
+        minutes: new_minutes,
+        seconds: utc.seconds,
+        // Weekday rolls with day-of-week arithmetic which the BM8563
+        // tracks itself; on a derived local-time `DateTime` we don't
+        // try to recompute it (callers only care about year-second).
+        weekday: utc.weekday,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::missing_docs_in_private_items, reason = "test fixtures")]
+mod tests {
+    use super::*;
+
+    fn dt(year: u16, month: u8, day: u8, hours: u8, minutes: u8, seconds: u8) -> DateTime {
+        DateTime {
+            year,
+            month,
+            day,
+            hours,
+            minutes,
+            seconds,
+            weekday: 0,
+        }
+    }
+
+    #[test]
+    fn apply_offset_zero_returns_input() {
+        let d = dt(2026, 5, 7, 12, 0, 0);
+        assert_eq!(apply_offset(d, 0), d);
+    }
+
+    #[test]
+    fn apply_offset_positive_within_day() {
+        // 09:00 UTC + 9 hours = 18:00 same day (Tokyo).
+        let d = dt(2026, 5, 7, 9, 0, 0);
+        let local = apply_offset(d, 9 * 60);
+        assert_eq!(local.hours, 18);
+        assert_eq!(local.day, 7);
+    }
+
+    #[test]
+    fn apply_offset_positive_crosses_midnight_into_next_day() {
+        // 23:30 UTC + 9 hours = 08:30 next day.
+        let d = dt(2026, 5, 7, 23, 30, 0);
+        let local = apply_offset(d, 9 * 60);
+        assert_eq!(local.hours, 8);
+        assert_eq!(local.minutes, 30);
+        assert_eq!(local.day, 8);
+    }
+
+    #[test]
+    fn apply_offset_negative_crosses_midnight_into_prior_day() {
+        // 03:00 UTC - 8 hours = 19:00 prior day (Pacific).
+        let d = dt(2026, 5, 7, 3, 0, 0);
+        let local = apply_offset(d, -8 * 60);
+        assert_eq!(local.hours, 19);
+        assert_eq!(local.day, 6);
+    }
+
+    #[test]
+    fn apply_offset_rolls_month_backward() {
+        // 01:00 UTC on the 1st of May, -8 hours = 17:00 on 30 April.
+        let d = dt(2026, 5, 1, 1, 0, 0);
+        let local = apply_offset(d, -8 * 60);
+        assert_eq!(local.month, 4);
+        assert_eq!(local.day, 30);
+        assert_eq!(local.hours, 17);
+    }
+
+    #[test]
+    fn apply_offset_rolls_year_forward_at_midnight_dec_31() {
+        // 23:00 UTC on Dec 31, +9 hours = 08:00 on Jan 1 next year.
+        let d = dt(2026, 12, 31, 23, 0, 0);
+        let local = apply_offset(d, 9 * 60);
+        assert_eq!(local.year, 2027);
+        assert_eq!(local.month, 1);
+        assert_eq!(local.day, 1);
+        assert_eq!(local.hours, 8);
+    }
+
+    #[test]
+    fn apply_offset_rolls_year_backward_at_midnight_jan_1() {
+        // 03:00 UTC on Jan 1, -8 hours = 19:00 on Dec 31 prior year.
+        let d = dt(2026, 1, 1, 3, 0, 0);
+        let local = apply_offset(d, -8 * 60);
+        assert_eq!(local.year, 2025);
+        assert_eq!(local.month, 12);
+        assert_eq!(local.day, 31);
+        assert_eq!(local.hours, 19);
+    }
+
+    #[test]
+    fn apply_offset_handles_leap_day_february() {
+        // 03:00 UTC on March 1 2024, -8 hours = 19:00 on Feb 29 2024.
+        let d = dt(2024, 3, 1, 3, 0, 0);
+        let local = apply_offset(d, -8 * 60);
+        assert_eq!(local.month, 2);
+        assert_eq!(local.day, 29);
+    }
+
+    #[test]
+    fn apply_offset_handles_non_leap_february() {
+        // Same as above but 2025 is not a leap year, so we land on Feb 28.
+        let d = dt(2025, 3, 1, 3, 0, 0);
+        let local = apply_offset(d, -8 * 60);
+        assert_eq!(local.month, 2);
+        assert_eq!(local.day, 28);
+    }
+
+    #[test]
+    fn apply_offset_handles_half_hour_zone() {
+        // India: +5h30. 18:00 UTC + 5h30 = 23:30 same day.
+        let d = dt(2026, 5, 7, 18, 0, 0);
+        let local = apply_offset(d, 5 * 60 + 30);
+        assert_eq!(local.hours, 23);
+        assert_eq!(local.minutes, 30);
+        assert_eq!(local.day, 7);
+    }
 }

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -303,12 +303,14 @@ impl Default for TimeConfig {
 ///   IANA sign-inversion convention**, so `Etc/GMT-9` is `+9` hours
 ///   (Tokyo) and `Etc/GMT+8` is `-8` hours (Pacific Standard Time).
 /// - A small lookup table of common named zones at their **standard
-///   time** offset (no DST handling): `Asia/Tokyo`, `Asia/Shanghai`,
-///   `Asia/Singapore`, `Asia/Kolkata`, `Asia/Seoul`,
-///   `Europe/London`, `Europe/Paris`, `Europe/Berlin`,
-///   `Europe/Moscow`, `America/New_York`, `America/Chicago`,
-///   `America/Denver`, `America/Los_Angeles`, `America/Anchorage`,
-///   `Pacific/Honolulu`, `Australia/Sydney`, `Pacific/Auckland`.
+///   time** offset (no DST handling). The exhaustive list lives in
+///   the function body — refer there as the source of truth, not
+///   here. Coverage skews toward the timezones Stack-chan operators
+///   most often configure: APAC, mainland Europe, the Americas, plus
+///   a few common African / Pacific zones. Special cases:
+///   - `Africa/Casablanca` is `UTC+1` (Morocco's 2018 permanent shift,
+///     not `UTC+0` as a naïve EU-Western reading would suggest).
+///   - `Africa/Cairo` is Egypt Standard Time `UTC+2`.
 ///
 /// Anything else returns `None`; callers should treat that as
 /// "fall back to UTC and log a warning." The intent is to cover the
@@ -341,10 +343,16 @@ pub fn tz_offset_minutes(tz: &str) -> Option<i32> {
         "Asia/Shanghai" | "Asia/Singapore" | "Asia/Hong_Kong" | "Asia/Taipei"
         | "Australia/Perth" => 8 * 60,
         "Asia/Kolkata" => 5 * 60 + 30,
-        "Europe/London" | "Africa/Casablanca" => 0,
+        "Europe/London" => 0,
         "Europe/Paris" | "Europe/Berlin" | "Europe/Madrid" | "Europe/Rome" | "Europe/Amsterdam"
-        | "Africa/Lagos" => 60,
-        "Europe/Moscow" | "Africa/Cairo" => 3 * 60,
+        | "Africa/Lagos"
+        // Morocco moved permanently to UTC+1 in Oct 2018 when they stopped
+        // reverting from DST. IANA reflects UTC+1 year-round.
+        | "Africa/Casablanca" => 60,
+        // Cairo runs Egypt Standard Time (EET, UTC+2) — DST has flipped on
+        // and off historically; the standard offset is the durable choice.
+        "Africa/Cairo" => 2 * 60,
+        "Europe/Moscow" => 3 * 60,
         "America/New_York" | "America/Toronto" => -5 * 60,
         "America/Chicago" | "America/Mexico_City" => -6 * 60,
         "America/Denver" | "America/Phoenix" => -7 * 60,
@@ -820,6 +828,16 @@ mod tests {
         assert_eq!(tz_offset_minutes("America/Los_Angeles"), Some(-8 * 60));
         assert_eq!(tz_offset_minutes("Europe/Berlin"), Some(60));
         assert_eq!(tz_offset_minutes("Pacific/Auckland"), Some(12 * 60));
+    }
+
+    #[test]
+    fn tz_offset_special_case_african_zones() {
+        // Morocco moved permanently to UTC+1 in 2018; Egypt is UTC+2.
+        // Both warrant explicit pins so a future cleanup that
+        // alphabetises arms doesn't silently regress them.
+        assert_eq!(tz_offset_minutes("Africa/Casablanca"), Some(60));
+        assert_eq!(tz_offset_minutes("Africa/Cairo"), Some(2 * 60));
+        assert_eq!(tz_offset_minutes("Africa/Lagos"), Some(60));
     }
 
     #[test]

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -275,8 +275,10 @@ impl Default for EspNowConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 pub struct TimeConfig {
-    /// IANA timezone label (e.g. `"UTC"`, `"America/Los_Angeles"`).
-    /// Currently parsed but unused — the BM8563 RTC stores UTC.
+    /// IANA timezone label (e.g. `"UTC"`, `"Etc/GMT+8"`,
+    /// `"America/Los_Angeles"`). Pass to [`tz_offset_minutes`] for the
+    /// signed minutes-from-UTC value. The BM8563 RTC always stores
+    /// UTC; the offset is applied only at display time.
     pub tz: String,
     /// SNTP servers to query in order. The firmware tries each with
     /// a 5-second timeout before falling back to the next.
@@ -290,6 +292,70 @@ impl Default for TimeConfig {
             sntp_servers: vec!["pool.ntp.org".to_string()],
         }
     }
+}
+
+/// Resolve a timezone label to a signed minutes-from-UTC offset.
+///
+/// Recognised forms:
+///
+/// - `"UTC"` / `"Z"` — zero offset.
+/// - `"Etc/GMT+N"` / `"Etc/GMT-N"` — explicit offset; **note the
+///   IANA sign-inversion convention**, so `Etc/GMT-9` is `+9` hours
+///   (Tokyo) and `Etc/GMT+8` is `-8` hours (Pacific Standard Time).
+/// - A small lookup table of common named zones at their **standard
+///   time** offset (no DST handling): `Asia/Tokyo`, `Asia/Shanghai`,
+///   `Asia/Singapore`, `Asia/Kolkata`, `Asia/Seoul`,
+///   `Europe/London`, `Europe/Paris`, `Europe/Berlin`,
+///   `Europe/Moscow`, `America/New_York`, `America/Chicago`,
+///   `America/Denver`, `America/Los_Angeles`, `America/Anchorage`,
+///   `Pacific/Honolulu`, `Australia/Sydney`, `Pacific/Auckland`.
+///
+/// Anything else returns `None`; callers should treat that as
+/// "fall back to UTC and log a warning." The intent is to cover the
+/// common cases without bundling a full tz database; users in
+/// DST-affected zones can either swap the label seasonally or use
+/// the explicit `Etc/GMT±N` form.
+#[must_use]
+pub fn tz_offset_minutes(tz: &str) -> Option<i32> {
+    if tz.eq_ignore_ascii_case("UTC") || tz.eq_ignore_ascii_case("Z") {
+        return Some(0);
+    }
+    if let Some(rest) = tz.strip_prefix("Etc/GMT") {
+        // Form is `Etc/GMT[+-]N` where N is 0..=14. The IANA sign
+        // convention is inverted relative to ISO 8601, hence the
+        // negation below.
+        let (sign, digits) = match rest.as_bytes().first() {
+            Some(b'+') => (-1_i32, &rest[1..]),
+            Some(b'-') => (1_i32, &rest[1..]),
+            _ => return None,
+        };
+        let hours: i32 = digits.parse().ok()?;
+        if !(0..=14).contains(&hours) {
+            return None;
+        }
+        return Some(sign * hours * 60);
+    }
+    // Common named zones at standard time. DST-disclaimer applies.
+    let minutes = match tz {
+        "Asia/Tokyo" | "Asia/Seoul" => 9 * 60,
+        "Asia/Shanghai" | "Asia/Singapore" | "Asia/Hong_Kong" | "Asia/Taipei"
+        | "Australia/Perth" => 8 * 60,
+        "Asia/Kolkata" => 5 * 60 + 30,
+        "Europe/London" | "Africa/Casablanca" => 0,
+        "Europe/Paris" | "Europe/Berlin" | "Europe/Madrid" | "Europe/Rome" | "Europe/Amsterdam"
+        | "Africa/Lagos" => 60,
+        "Europe/Moscow" | "Africa/Cairo" => 3 * 60,
+        "America/New_York" | "America/Toronto" => -5 * 60,
+        "America/Chicago" | "America/Mexico_City" => -6 * 60,
+        "America/Denver" | "America/Phoenix" => -7 * 60,
+        "America/Los_Angeles" | "America/Vancouver" => -8 * 60,
+        "America/Anchorage" => -9 * 60,
+        "Pacific/Honolulu" => -10 * 60,
+        "Australia/Sydney" | "Australia/Melbourne" => 10 * 60,
+        "Pacific/Auckland" => 12 * 60,
+        _ => return None,
+    };
+    Some(minutes)
 }
 
 /// Parse + validate a RON document into a [`Config`].
@@ -716,5 +782,53 @@ mod tests {
         c.esp_now.channel = Some(6);
         c.esp_now.tx_rate_hz = 5;
         assert!(validate(&c).is_ok());
+    }
+
+    #[test]
+    fn tz_offset_utc_aliases() {
+        assert_eq!(tz_offset_minutes("UTC"), Some(0));
+        assert_eq!(tz_offset_minutes("utc"), Some(0));
+        assert_eq!(tz_offset_minutes("Z"), Some(0));
+        assert_eq!(tz_offset_minutes("z"), Some(0));
+    }
+
+    #[test]
+    fn tz_offset_etc_gmt_inverts_sign_per_iana_convention() {
+        // IANA's `Etc/GMT-9` is in fact +9 hours (Tokyo) — sign is
+        // inverted. `Etc/GMT+8` is -8 hours (PST).
+        assert_eq!(tz_offset_minutes("Etc/GMT-9"), Some(9 * 60));
+        assert_eq!(tz_offset_minutes("Etc/GMT+8"), Some(-8 * 60));
+        assert_eq!(tz_offset_minutes("Etc/GMT-0"), Some(0));
+        assert_eq!(tz_offset_minutes("Etc/GMT+0"), Some(0));
+    }
+
+    #[test]
+    fn tz_offset_etc_gmt_rejects_out_of_range() {
+        assert_eq!(tz_offset_minutes("Etc/GMT+15"), None);
+        assert_eq!(tz_offset_minutes("Etc/GMT-15"), None);
+    }
+
+    #[test]
+    fn tz_offset_etc_gmt_rejects_missing_sign() {
+        assert_eq!(tz_offset_minutes("Etc/GMT9"), None);
+    }
+
+    #[test]
+    fn tz_offset_named_zones_at_standard_time() {
+        assert_eq!(tz_offset_minutes("Asia/Tokyo"), Some(9 * 60));
+        assert_eq!(tz_offset_minutes("Asia/Kolkata"), Some(5 * 60 + 30));
+        assert_eq!(tz_offset_minutes("America/Los_Angeles"), Some(-8 * 60));
+        assert_eq!(tz_offset_minutes("Europe/Berlin"), Some(60));
+        assert_eq!(tz_offset_minutes("Pacific/Auckland"), Some(12 * 60));
+    }
+
+    #[test]
+    fn tz_offset_unknown_returns_none() {
+        // Caller falls back to UTC + log warning.
+        assert_eq!(tz_offset_minutes("Mars/Olympus_Mons"), None);
+        assert_eq!(tz_offset_minutes(""), None);
+        // Case sensitivity is intentional for IANA names — typos
+        // shouldn't quietly succeed.
+        assert_eq!(tz_offset_minutes("asia/tokyo"), None);
     }
 }

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -62,7 +62,8 @@ pub mod ota;
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
 pub use config::{
-    AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig, parse_mac, validate,
+    AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig, parse_mac,
+    tz_offset_minutes, validate,
 };
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};


### PR DESCRIPTION
## Summary

- Adds `stackchan_net::tz_offset_minutes(&str) -> Option<i32>` resolving the `time.tz` config field to signed minutes-from-UTC.
- Adds `stackchan_firmware::wallclock::apply_offset(DateTime, i32)` for UTC → local conversion with full month/year/leap-year rollover.
- Wires both into the boot log: emits UTC line first, then a local-time line when `tz` resolves to a non-zero offset; unknown labels degrade to UTC + warn.

## Why

`time.tz` was parsed but unused — RTC storage stays UTC, so it had no display path. This closes the v0.2.0 gap: operators who set `tz: "America/Los_Angeles"` in `STACKCHAN.RON` now see local time in the boot log; future surfaces (hourly chime, MCP `get_time` tool) can call `apply_offset` directly.

DST is intentionally not handled. The lookup recognises:
- `UTC` / `Z`
- `Etc/GMT±N` for explicit hourly offsets (note IANA sign-inversion)
- A small lookup of common named zones at standard time

Operators in DST-affected regions can flip the label seasonally or use the explicit `Etc/GMT±N` form.

## Test plan

- [x] `just ci` clean (10 new `tz_offset_minutes` tests + 9 new `apply_offset` tests including leap-day rollover, year boundaries, half-hour zones, IANA sign convention)
- [x] `just check-firmware` and `just clippy-firmware` clean
- [ ] Manual verification: set `tz: "Asia/Tokyo"` in STACKCHAN.RON, reboot, observe two boot @ lines (UTC + local) in the defmt log