### PR TITLE
feat(core): Soliloquy modifier — opt-in autonomous bubble beats

### DIFF
--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -111,6 +111,7 @@ mod lost_target_search;
 mod microsaccade_from_attention;
 mod mouth_from_audio;
 mod remote_command;
+mod soliloquy;
 mod style_from_emotion;
 mod style_from_intent;
 mod style_from_mood;
@@ -175,6 +176,10 @@ pub use mouth_from_audio::{
     DEFAULT_ATTACK_MS, DEFAULT_FULL_DB, DEFAULT_RELEASE_MS, DEFAULT_SILENCE_DB, MouthFromAudio,
 };
 pub use remote_command::{PAIRING_DECORATOR_TAIL_MS, RemoteCommandModifier};
+pub use soliloquy::{
+    SOLILOQUY_BUBBLE_TTL_MS, SOLILOQUY_INTERVAL_MAX_MS, SOLILOQUY_INTERVAL_MIN_MS, SOLILOQUY_LINES,
+    Soliloquy,
+};
 pub use style_from_emotion::StyleFromEmotion;
 pub use style_from_intent::{
     PETTING_BLUSH_BUMP, PETTING_EYE_CURVE_BUMP, PETTING_OPEN_WEIGHT_CAP, StyleFromIntent,

--- a/crates/stackchan-core/src/modifiers/soliloquy.rs
+++ b/crates/stackchan-core/src/modifiers/soliloquy.rs
@@ -188,6 +188,19 @@ impl Modifier for Soliloquy {
             return;
         }
 
+        // Yield to a non-expired bubble already on screen. The
+        // soliloquy beat is the lowest-priority bubble producer:
+        // anything that drove the bubble field this tick (or earlier
+        // ticks within its TTL) is by definition more topical than a
+        // random ambient line. Re-roll the schedule as if we'd fired
+        // so the operator-driven bubble's TTL gets to play out before
+        // we try again.
+        if entity.face.bubble.is_some_and(|b| !b.is_expired(now)) {
+            let next = self.rand_interval(SOLILOQUY_INTERVAL_MIN_MS, SOLILOQUY_INTERVAL_MAX_MS);
+            self.next_fire_at = Some(now + next);
+            return;
+        }
+
         // Pick a phrase. Modulo over a small slice is fine — the
         // tiny bias toward early entries is invisible at 10
         // entries.
@@ -321,5 +334,35 @@ mod tests {
             fa, fb,
             "two distinct seeds produced identical first-fire instants",
         );
+    }
+
+    #[test]
+    fn yields_to_non_expired_bubble_from_other_source() {
+        // An MCP `speak` or operator-set bubble should NOT be
+        // clobbered by a soliloquy fire. Drive the modifier past its
+        // first scheduled fire while a non-soliloquy bubble is
+        // active; the modifier must leave the existing bubble alone.
+        let mut m = Soliloquy::with_enabled(true);
+        let mut entity = at(0);
+
+        // Plant a non-soliloquy bubble whose TTL extends past the
+        // soliloquy max-interval so we can be sure the active-bubble
+        // gate is what's preventing the fire.
+        let external_text = "external operator text";
+        entity.face.bubble = Some(BubbleState::hold_for(
+            external_text,
+            Instant::from_millis(0),
+            SOLILOQUY_INTERVAL_MAX_MS + 30_000,
+        ));
+
+        for t_ms in (0..SOLILOQUY_INTERVAL_MAX_MS + 1_000).step_by(500) {
+            entity.tick.now = Instant::from_millis(t_ms);
+            m.update(&mut entity);
+            let bubble = entity.face.bubble.expect("external bubble must persist");
+            assert_eq!(
+                bubble.text, external_text,
+                "soliloquy clobbered an active external bubble at {t_ms}ms",
+            );
+        }
     }
 }

--- a/crates/stackchan-core/src/modifiers/soliloquy.rs
+++ b/crates/stackchan-core/src/modifiers/soliloquy.rs
@@ -1,0 +1,325 @@
+//! [`Soliloquy`] — opt-in autonomous bubble beat.
+//!
+//! Writes a randomly picked phrase to [`crate::bubble::BubbleState`]
+//! at random intervals when nothing else is engaging the avatar.
+//!
+//! Disabled by default. Operators flip
+//! `stackchan_net::BehaviorConfig::soliloquy_enabled` to opt in;
+//! the firmware passes that flag to [`Soliloquy::with_enabled`] at
+//! construction.
+//!
+//! ## Why a modifier (not a skill)
+//!
+//! Skills require a `should_fire` boolean that the director polls. The
+//! soliloquy beat is purely time-driven: every tick the modifier
+//! checks `now >= next_fire_at` and either fires (write bubble +
+//! re-roll the next deadline) or no-ops. That fits the modifier
+//! contract more naturally than a skill — and lets us reuse the
+//! same xorshift PRNG / random-interval shape as
+//! [`super::IdleHeadDrift`].
+//!
+//! ## Bubble-only for v0.2.0
+//!
+//! Audio playback is intentionally not wired here. The baked phrase
+//! catalog ([`crate::voice::PhraseId`]) doesn't yet carry general
+//! soliloquy lines — adding the audio path means generating PCM
+//! assets, deciding on TX priority, etc. The bubble line alone gets
+//! the visible feature in front of operators while the audio
+//! follow-up matures.
+//!
+//! ## Phase + priority
+//!
+//! Runs in [`Phase::Decoration`] at priority `0` (between
+//! [`super::BubbleExpiry`] at `-10` and the decorator triggers at
+//! `0+`). The director sorts ties by registration order, so as long as
+//! [`super::BubbleExpiry`] is registered first the expired bubble is
+//! cleared before this modifier checks the field — meaning a stale
+//! expired bubble doesn't suppress a fresh fire.
+
+use core::num::NonZeroU32;
+
+use crate::bubble::BubbleState;
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// Phrase pool — short observational lines the avatar mumbles.
+///
+/// Kept short (≤ 28 ASCII chars to fit in the bubble at
+/// `FONT_10X20`) and non-prescriptive — the avatar mumbling these is
+/// the joke; the audience shouldn't read them as instructions.
+pub const SOLILOQUY_LINES: &[&str] = &[
+    "hmm...",
+    "I wonder...",
+    "interesting.",
+    "what was that?",
+    "...",
+    "hello?",
+    "let's see.",
+    "oh!",
+    "huh.",
+    "okay.",
+];
+
+/// Minimum interval between soliloquy fires, in ms. `30_000` reads as
+/// "occasional ambient mumble" rather than "narrating constantly."
+pub const SOLILOQUY_INTERVAL_MIN_MS: u64 = 30_000;
+/// Maximum interval between soliloquy fires, in ms.
+pub const SOLILOQUY_INTERVAL_MAX_MS: u64 = 90_000;
+/// How long each soliloquy bubble stays on screen, in ms. Long enough
+/// for the audience to read 1–2 short words; short enough that the
+/// face isn't occluded for any meaningful interaction window.
+pub const SOLILOQUY_BUBBLE_TTL_MS: u64 = 4_000;
+
+/// Default xorshift32 seed. Different from the seeds in
+/// [`super::IdleDrift`] / [`super::IdleHeadDrift`] so the schedules
+/// don't synchronise out of the box.
+#[allow(
+    clippy::unwrap_used,
+    reason = "const-evaluated against a non-zero literal: unwrap can't fire at runtime"
+)]
+const DEFAULT_SEED: NonZeroU32 = NonZeroU32::new(0xDEAD_BEEF).unwrap();
+
+/// Modifier that fires soliloquy bubbles at random intervals.
+#[derive(Debug, Clone, Copy)]
+pub struct Soliloquy {
+    /// `true` iff the firmware-side config has soliloquy turned on.
+    /// `false` short-circuits `update` to a no-op.
+    enabled: bool,
+    /// xorshift32 PRNG state. Same algorithm as
+    /// [`super::IdleHeadDrift::next_u32`].
+    rng_state: u32,
+    /// Wall-clock instant at which the next soliloquy fires. `None`
+    /// until the first tick anchors the schedule.
+    next_fire_at: Option<Instant>,
+}
+
+impl Soliloquy {
+    /// Construct enabled with a custom seed. Test helper.
+    #[must_use]
+    pub const fn with_seed(enabled: bool, seed: NonZeroU32) -> Self {
+        Self {
+            enabled,
+            rng_state: seed.get(),
+            next_fire_at: None,
+        }
+    }
+
+    /// Construct with the default seed. Pass the operator's
+    /// `behavior.soliloquy_enabled` flag from
+    /// `stackchan_net::BehaviorConfig`.
+    #[must_use]
+    pub const fn with_enabled(enabled: bool) -> Self {
+        Self::with_seed(enabled, DEFAULT_SEED)
+    }
+
+    /// Construct disabled. Equivalent to `with_enabled(false)` —
+    /// makes the no-op intent explicit when the firmware always
+    /// constructs the modifier and only flips the flag at runtime.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::with_enabled(false)
+    }
+
+    /// Advance the xorshift32 state and return the next pseudo-random
+    /// `u32`.
+    const fn next_u32(&mut self) -> u32 {
+        let mut x = self.rng_state;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.rng_state = x;
+        x
+    }
+
+    /// Pick a uniform `u64` in `[lo, hi]` from the next PRNG draw.
+    fn rand_interval(&mut self, lo: u64, hi: u64) -> u64 {
+        if hi <= lo {
+            return lo;
+        }
+        let span = hi - lo + 1;
+        let draw = u64::from(self.next_u32()) % span;
+        lo + draw
+    }
+}
+
+impl Default for Soliloquy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for Soliloquy {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "Soliloquy",
+            description: "Writes a random short phrase from SOLILOQUY_LINES to face.bubble \
+                          at randomised 30-90 s intervals when enabled. Bubble-only for \
+                          this iteration; audio integration ships later. No-op when \
+                          BehaviorConfig::soliloquy_enabled is false.",
+            phase: Phase::Decoration,
+            priority: 0,
+            reads: &[Field::Bubble],
+            writes: &[Field::Bubble],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        if !self.enabled {
+            return;
+        }
+        let now = entity.tick.now;
+
+        // Anchor the schedule on the first wakeful tick. Done in two
+        // steps because the closure form clashes with the second
+        // `&mut self` access for `rand_interval`.
+        let due_at = if let Some(t) = self.next_fire_at {
+            t
+        } else {
+            let dwell = self.rand_interval(SOLILOQUY_INTERVAL_MIN_MS, SOLILOQUY_INTERVAL_MAX_MS);
+            let t = now + dwell;
+            self.next_fire_at = Some(t);
+            t
+        };
+
+        if now < due_at {
+            return;
+        }
+
+        // Pick a phrase. Modulo over a small slice is fine — the
+        // tiny bias toward early entries is invisible at 10
+        // entries.
+        let idx = (self.next_u32() as usize) % SOLILOQUY_LINES.len();
+        let text = SOLILOQUY_LINES[idx];
+        entity.face.bubble = Some(BubbleState::hold_for(text, now, SOLILOQUY_BUBBLE_TTL_MS));
+
+        // Schedule the next fire from `now`, not from the stale due
+        // time, so a long stall (e.g. flash erase) doesn't queue a
+        // burst of catch-up fires.
+        let next = self.rand_interval(SOLILOQUY_INTERVAL_MIN_MS, SOLILOQUY_INTERVAL_MAX_MS);
+        self.next_fire_at = Some(now + next);
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used,
+    reason = "test-only: fixture-derived non-zero seeds and bubble unwraps"
+)]
+mod tests {
+    use super::*;
+
+    fn at(now_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.tick.now = Instant::from_millis(now_ms);
+        e
+    }
+
+    #[test]
+    fn disabled_never_writes_bubble() {
+        let mut m = Soliloquy::new();
+        let mut entity = at(0);
+        for t_ms in (0..200_000).step_by(1_000) {
+            entity.tick.now = Instant::from_millis(t_ms);
+            m.update(&mut entity);
+            assert!(
+                entity.face.bubble.is_none(),
+                "disabled soliloquy must never set bubble; saw it at {t_ms}ms",
+            );
+        }
+    }
+
+    #[test]
+    fn enabled_holds_until_first_interval() {
+        let mut m = Soliloquy::with_enabled(true);
+        let mut entity = at(0);
+        // Sample for a window strictly less than the minimum interval.
+        for t_ms in (0..SOLILOQUY_INTERVAL_MIN_MS - 100).step_by(500) {
+            entity.tick.now = Instant::from_millis(t_ms);
+            m.update(&mut entity);
+            assert!(
+                entity.face.bubble.is_none(),
+                "soliloquy fired before SOLILOQUY_INTERVAL_MIN_MS at {t_ms}ms",
+            );
+        }
+    }
+
+    #[test]
+    fn enabled_fires_within_max_interval() {
+        // Within the upper bound + one bubble TTL we must observe at
+        // least one bubble write.
+        let mut m = Soliloquy::with_enabled(true);
+        let mut entity = at(0);
+        let mut saw_bubble = false;
+        for t_ms in (0..SOLILOQUY_INTERVAL_MAX_MS + SOLILOQUY_BUBBLE_TTL_MS).step_by(1_000) {
+            entity.tick.now = Instant::from_millis(t_ms);
+            m.update(&mut entity);
+            if entity.face.bubble.is_some() {
+                saw_bubble = true;
+                break;
+            }
+        }
+        assert!(
+            saw_bubble,
+            "no soliloquy fired within the max-interval window"
+        );
+    }
+
+    #[test]
+    fn fired_bubble_carries_a_known_phrase_with_correct_ttl() {
+        // Drive past the first fire deadline, then verify the bubble
+        // text is a member of SOLILOQUY_LINES and the expiry matches
+        // SOLILOQUY_BUBBLE_TTL_MS from the fire instant.
+        let mut m = Soliloquy::with_enabled(true);
+        let mut entity = at(0);
+        let mut fire_at: Option<u64> = None;
+        for t_ms in (0..SOLILOQUY_INTERVAL_MAX_MS + 100).step_by(500) {
+            entity.tick.now = Instant::from_millis(t_ms);
+            m.update(&mut entity);
+            if entity.face.bubble.is_some() {
+                fire_at = Some(t_ms);
+                break;
+            }
+        }
+        let fire_ms = fire_at.expect("soliloquy must fire within max-interval window");
+        let bubble = entity.face.bubble.expect("bubble set on fire");
+        assert!(
+            SOLILOQUY_LINES.contains(&bubble.text),
+            "bubble text {:?} not in SOLILOQUY_LINES",
+            bubble.text,
+        );
+        assert_eq!(
+            bubble.expires_at,
+            Instant::from_millis(fire_ms + SOLILOQUY_BUBBLE_TTL_MS),
+        );
+    }
+
+    #[test]
+    fn distinct_seeds_produce_distinct_first_fire_instants() {
+        let mut a = Soliloquy::with_seed(true, NonZeroU32::new(0x1234_5678).expect("non-zero"));
+        let mut b = Soliloquy::with_seed(true, NonZeroU32::new(0xCAFE_BABE).expect("non-zero"));
+
+        // Drive both, record the first `t_ms` that produced a bubble.
+        let first_fire = |m: &mut Soliloquy| -> u64 {
+            let mut e = at(0);
+            for t_ms in (0..SOLILOQUY_INTERVAL_MAX_MS + 100).step_by(500) {
+                e.tick.now = Instant::from_millis(t_ms);
+                m.update(&mut e);
+                if e.face.bubble.is_some() {
+                    return t_ms;
+                }
+            }
+            panic!("soliloquy never fired");
+        };
+        let fa = first_fire(&mut a);
+        let fb = first_fire(&mut b);
+        assert_ne!(
+            fa, fb,
+            "two distinct seeds produced identical first-fire instants",
+        );
+    }
+}

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -80,8 +80,8 @@ use stackchan_core::{
         EmotionFromBattery, EmotionFromIntent, EmotionFromRemote, EmotionFromTouch,
         EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent,
         IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud, LostTargetSearch,
-        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, StyleFromEmotion,
-        StyleFromIntent, StyleFromMood,
+        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, Soliloquy,
+        StyleFromEmotion, StyleFromIntent, StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -232,6 +232,19 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut handling = Handling::new();
     let mut intent_from_body_touch = IntentFromBodyTouch::new();
     let mut bubble_expiry = BubbleExpiry::new();
+    // `behavior.soliloquy_enabled` flips at boot via STACKCHAN.RON; if
+    // the operator later toggles it via PUT /settings, the change
+    // takes effect on the next reboot. The modifier is always
+    // constructed; `enabled = false` short-circuits its `update` to a
+    // no-op so there's no cost when disabled.
+    let mut soliloquy = {
+        let enabled = stackchan_firmware::storage::CONFIG_SNAPSHOT
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|c| c.behavior.soliloquy_enabled);
+        Soliloquy::with_enabled(enabled)
+    };
     let mut decorator_expiry = DecoratorExpiry::new();
     let mut decorator_from_emotion = DecoratorFromEmotion::new();
     let mut decorator_from_body_touch = DecoratorFromBodyTouch::new();
@@ -317,6 +330,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         .expect("registry full");
     director
         .add_modifier(&mut bubble_expiry)
+        .expect("registry full");
+    director
+        .add_modifier(&mut soliloquy)
         .expect("registry full");
     director
         .add_modifier(&mut decorator_from_emotion)

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -22,8 +22,8 @@ use core::fmt::Write as _;
 
 use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{
-    AudioConfig, AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, TrackerSettings,
-    WifiConfig, validate,
+    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
+    TrackerSettings, WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -113,6 +113,14 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     let _ = writeln!(out, "        tx_rate_hz: {},", config.esp_now.tx_rate_hz);
     out.push_str("    ),\n");
 
+    out.push_str("    behavior: (\n");
+    let _ = writeln!(
+        out,
+        "        soliloquy_enabled: {},",
+        config.behavior.soliloquy_enabled
+    );
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -163,6 +171,7 @@ impl<'a> Parser<'a> {
         let mut audio: Option<AudioConfig> = None;
         let mut tracker: Option<TrackerSettings> = None;
         let mut esp_now: Option<EspNowConfig> = None;
+        let mut behavior: Option<BehaviorConfig> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -181,6 +190,7 @@ impl<'a> Parser<'a> {
                 "audio" => audio = Some(self.parse_audio()?),
                 "tracker" => tracker = Some(self.parse_tracker()?),
                 "esp_now" => esp_now = Some(self.parse_esp_now()?),
+                "behavior" => behavior = Some(self.parse_behavior()?),
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -202,6 +212,7 @@ impl<'a> Parser<'a> {
             audio: audio.unwrap_or_default(),
             tracker: tracker.unwrap_or_default(),
             esp_now: esp_now.unwrap_or_default(),
+            behavior: behavior.unwrap_or_default(),
         })
     }
 
@@ -457,6 +468,33 @@ impl<'a> Parser<'a> {
             lmk_hex: lmk_hex.unwrap_or(defaults.lmk_hex),
             channel: channel.unwrap_or(defaults.channel),
             tx_rate_hz: tx_rate_hz.unwrap_or(defaults.tx_rate_hz),
+        })
+    }
+
+    /// Parse the `behavior: (soliloquy_enabled)` block.
+    fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut soliloquy_enabled: Option<bool> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "soliloquy_enabled" => soliloquy_enabled = Some(self.parse_bool()?),
+                other => return Err(bare_err("unknown behavior field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in behavior", ""));
+            }
+        }
+        Ok(BehaviorConfig {
+            soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -20,8 +20,8 @@ use alloc::vec::Vec;
 use core::fmt::Write as _;
 
 use crate::config::{
-    AudioConfig, AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, TrackerSettings,
-    WifiConfig, validate,
+    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
+    TrackerSettings, WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -132,6 +132,7 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
             channel: new.esp_now.channel,
             tx_rate_hz: new.esp_now.tx_rate_hz,
         },
+        behavior: new.behavior,
     }
 }
 
@@ -234,6 +235,12 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         None => out.push_str("null"),
     }
     let _ = write!(out, ",\"tx_rate_hz\":{}", config.esp_now.tx_rate_hz);
+    out.push_str("},\"behavior\":{");
+    let _ = write!(
+        out,
+        "\"soliloquy_enabled\":{}",
+        config.behavior.soliloquy_enabled
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -291,6 +298,7 @@ impl<'a> Parser<'a> {
         let mut audio: Option<AudioConfig> = None;
         let mut tracker: Option<TrackerSettings> = None;
         let mut esp_now: Option<EspNowConfig> = None;
+        let mut behavior: Option<BehaviorConfig> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -343,6 +351,12 @@ impl<'a> Parser<'a> {
                     }
                     esp_now = Some(self.parse_esp_now()?);
                 }
+                "behavior" => {
+                    if behavior.is_some() {
+                        return Err(bare_err("duplicate top-level field", "behavior"));
+                    }
+                    behavior = Some(self.parse_behavior()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -362,6 +376,7 @@ impl<'a> Parser<'a> {
             audio: audio.unwrap_or_default(),
             tracker: tracker.unwrap_or_default(),
             esp_now: esp_now.unwrap_or_default(),
+            behavior: behavior.unwrap_or_default(),
         })
     }
 
@@ -718,6 +733,38 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parse the optional `"behavior": { "soliloquy_enabled": <bool> }` block.
+    fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut soliloquy_enabled: Option<bool> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "soliloquy_enabled" => {
+                    if soliloquy_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "soliloquy_enabled"));
+                    }
+                    soliloquy_enabled = Some(self.parse_bool()?);
+                }
+                other => return Err(bare_err("unknown behavior field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in behavior", ""));
+            }
+        }
+        Ok(BehaviorConfig {
+            soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
+        })
+    }
+
     /// Parse `null` or a decimal `u8`. The JSON wire form for an
     /// `Option<u8>` — null = `None`, integer = `Some(n)`. Used for
     /// `esp_now.channel`.
@@ -933,6 +980,9 @@ mod tests {
                 lmk_hex: "fedcba9876543210fedcba9876543210".to_string(),
                 channel: Some(6),
                 tx_rate_hz: 5,
+            },
+            behavior: BehaviorConfig {
+                soliloquy_enabled: true,
             },
         }
     }
@@ -1246,6 +1296,9 @@ mod tests {
                 lmk_hex: "f".repeat(32),
                 channel: Some(11),
                 tx_rate_hz: 20,
+            },
+            behavior: BehaviorConfig {
+                soliloquy_enabled: true,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -57,6 +57,11 @@ pub struct Config {
     /// pairing window.
     #[cfg_attr(feature = "parse", serde(default))]
     pub esp_now: EspNowConfig,
+    /// Behavioural toggles — opt-in autonomous beats that aren't
+    /// part of the always-on reactive surface (which is driven by
+    /// the canonical modifier stack at all times).
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub behavior: BehaviorConfig,
 }
 
 /// Wi-Fi station credentials.
@@ -269,6 +274,24 @@ impl Default for EspNowConfig {
     fn default() -> Self {
         Self::DEFAULT
     }
+}
+
+/// Behavioural toggles. Opt-in autonomous beats that aren't part of
+/// the always-on reactive surface.
+///
+/// Default: every flag `false`. The boot config doesn't need a
+/// `behavior:` block at all — `serde(default)` on the parent populates
+/// it. Operators opt in by adding the block via `PUT /settings` or
+/// editing `STACKCHAN.RON` directly.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct BehaviorConfig {
+    /// When `true`, the firmware writes a randomly-picked
+    /// soliloquy line to `face.bubble` at random intervals
+    /// (no audio playback in this iteration; audio rides on a
+    /// follow-up that adds the corresponding phrase pool to the
+    /// baked TTS catalog).
+    pub soliloquy_enabled: bool,
 }
 
 /// Time / SNTP configuration.

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -62,8 +62,8 @@ pub mod ota;
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
 pub use config::{
-    AuthConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig, parse_mac,
-    tz_offset_minutes, validate,
+    AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig,
+    parse_mac, tz_offset_minutes, validate,
 };
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};


### PR DESCRIPTION
## Summary

- Adds `Soliloquy` Phase::Decoration modifier that writes randomly picked phrases from `SOLILOQUY_LINES` to `face.bubble` at randomised 30-90 s intervals when enabled.
- New `behavior:` config block (RON + JSON wire forms) carrying `soliloquy_enabled: bool` (default `false`). Round-trip clean.
- Reuses xorshift32 / random-interval shape from `IdleHeadDrift` with a distinct seed so schedules don't synchronise.

## Why

This is the v0.2.0 Tier-1 soliloquy parity item. Default-off (per Round 2 decision) — operators opt in. Audio playback is intentionally bubble-only for now; once the baked phrase catalog grows soliloquy lines, the audio path can hook in via the same modifier.

## Test plan

- [x] `just ci` clean
- [x] `just check-firmware` and `just clippy-firmware` clean
- [x] 5 new modifier tests (disabled-no-op, holds-until-first-interval, fires-within-max-interval, phrase-and-TTL correctness, distinct-seeds-distinct-fires)
- [x] Bare-RON + bare-JSON parser/render round-trip tests cover the new `behavior` block
- [ ] Manual verification: set `behavior: ( soliloquy_enabled: true )` in STACKCHAN.RON, reboot, leave the avatar idle, observe periodic bubble fires