### PR TITLE
feat(core): runtime palette swap with named presets

### DIFF
--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -11,7 +11,7 @@
 //! - Eyes: `Rgb565::BLACK`, either filled ellipses (when
 //!   [`Style::eye_curve`](crate::face::Style::eye_curve) is 0) or a
 //!   stroked polyline arc (otherwise).
-//! - Mouth: pink (`MOUTH_COLOR`), either the v0.1.0 line/ellipse (when
+//! - Mouth: from `palette.mouth`, either the v0.1.0 line/ellipse (when
 //!   [`Style::mouth_curve`](crate::face::Style::mouth_curve) is 0) or
 //!   a stroked polyline curve.
 //! - Cheeks: a weight-blended white→pink circle below each eye when
@@ -41,12 +41,11 @@ use embedded_graphics::{
 use crate::bubble::BubbleState;
 use crate::decorator::{Decorator, DecoratorState};
 use crate::face::{Eye, EyePhase, Face, Mouth, SCALE_DEFAULT};
+use crate::palette::PaletteColors;
 
-/// Pink mouth/cheek color — `#F58080` quantized into Rgb565's (5,6,5)-bit channels.
-const MOUTH_COLOR: Rgb565 = Rgb565::new(30, 32, 16);
-
-/// Heart decorator pink — slightly more saturated than `MOUTH_COLOR` so
-/// the heart reads as deliberate overlay rather than blush bleed-through.
+/// Heart decorator pink — slightly more saturated than the `Default`
+/// palette's mouth pink so the heart reads as a deliberate overlay
+/// rather than blush bleed-through.
 const HEART_COLOR: Rgb565 = Rgb565::new(31, 16, 12);
 
 /// Sweat decorator light blue — distinct from any other palette entry
@@ -102,7 +101,8 @@ impl Face {
     where
         D: DrawTarget<Color = Rgb565>,
     {
-        target.clear(Rgb565::WHITE)?;
+        let palette = self.palette.colors();
+        target.clear(palette.background)?;
         // Cheeks first: the eye sits on top of the cheek circle when the
         // two overlap at high `eye_scale` + `cheek_blush`.
         if self.style.cheek_blush > 0 {
@@ -110,12 +110,14 @@ impl Face {
                 &self.left_eye,
                 self.style.cheek_blush,
                 self.style.eye_scale,
+                palette,
                 target,
             )?;
             draw_cheek(
                 &self.right_eye,
                 self.style.cheek_blush,
                 self.style.eye_scale,
+                palette,
                 target,
             )?;
         }
@@ -123,15 +125,17 @@ impl Face {
             &self.left_eye,
             self.style.eye_curve,
             self.style.eye_scale,
+            palette.eye,
             target,
         )?;
         draw_eye(
             &self.right_eye,
             self.style.eye_curve,
             self.style.eye_scale,
+            palette.eye,
             target,
         )?;
-        draw_mouth(&self.mouth, self.style.mouth_curve, target)?;
+        draw_mouth(&self.mouth, self.style.mouth_curve, palette.mouth, target)?;
         if let Some(state) = self.decorator {
             draw_decorator(state, target)?;
         }
@@ -615,7 +619,13 @@ where
 /// 3. Otherwise: a stroked parabolic arc. `curve > 0` (Happy) arches
 ///    upward, `curve < 0` (Sad) dips downward.
 #[allow(clippy::similar_names)] // `scaled_rx` / `scaled_ry` is the intended x/y pair.
-fn draw_eye<D>(eye: &Eye, curve: i8, scale: u8, target: &mut D) -> Result<(), D::Error>
+fn draw_eye<D>(
+    eye: &Eye,
+    curve: i8,
+    scale: u8,
+    eye_color: Rgb565,
+    target: &mut D,
+) -> Result<(), D::Error>
 where
     D: DrawTarget<Color = Rgb565>,
 {
@@ -628,7 +638,7 @@ where
             eye.center.x,
             eye.center.y,
             scaled_rx,
-            stroke(Rgb565::BLACK, LINE_WIDTH),
+            stroke(eye_color, LINE_WIDTH),
             target,
         );
     }
@@ -640,7 +650,7 @@ where
         let top_left = EgPoint::new(eye.center.x - half_w, eye.center.y - half_h);
         let size = Size::new(u32::from(width), u32::from(height));
         return Ellipse::new(top_left, size)
-            .into_styled(fill(Rgb565::BLACK))
+            .into_styled(fill(eye_color))
             .draw(target);
     }
 
@@ -653,7 +663,7 @@ where
         eye.center.y,
         scaled_rx,
         sag,
-        stroke(Rgb565::BLACK, EYE_ARC_WIDTH),
+        stroke(eye_color, EYE_ARC_WIDTH),
         target,
     )
 }
@@ -679,7 +689,12 @@ const MOUTH_OPEN_MAX_HEIGHT_PX: f32 = 40.0;
 ///    uses this) and the `mouth_open`-derived audio height. When both
 ///    are zero, falls back to a horizontal resting line (v0.1.0
 ///    neutral mouth).
-fn draw_mouth<D>(mouth: &Mouth, curve: i8, target: &mut D) -> Result<(), D::Error>
+fn draw_mouth<D>(
+    mouth: &Mouth,
+    curve: i8,
+    mouth_color: Rgb565,
+    target: &mut D,
+) -> Result<(), D::Error>
 where
     D: DrawTarget<Color = Rgb565>,
 {
@@ -692,7 +707,7 @@ where
             mouth.center.y,
             mouth.radius_x,
             sag,
-            stroke(MOUTH_COLOR, LINE_WIDTH),
+            stroke(mouth_color, LINE_WIDTH),
             target,
         );
     }
@@ -705,7 +720,7 @@ where
             mouth.center.x,
             mouth.center.y,
             mouth.radius_x,
-            stroke(MOUTH_COLOR, LINE_WIDTH),
+            stroke(mouth_color, LINE_WIDTH),
             target,
         );
     }
@@ -717,7 +732,7 @@ where
     let size = Size::new(u32::from(width), u32::from(height));
 
     Ellipse::new(top_left, size)
-        .into_styled(fill(MOUTH_COLOR))
+        .into_styled(fill(mouth_color))
         .draw(target)
 }
 
@@ -745,9 +760,18 @@ fn audio_open_height(mouth_open: f32) -> u16 {
     rounded
 }
 
-/// Draw a cheek circle below `eye` with color blended between white and
-/// `MOUTH_COLOR` by `blush` (0..=255).
-fn draw_cheek<D>(eye: &Eye, blush: u8, eye_scale: u8, target: &mut D) -> Result<(), D::Error>
+/// Draw a cheek circle below `eye` with color blended between the
+/// palette background and the palette cheek colour by `blush`
+/// (0..=255). The blend lives in the palette's colour space rather
+/// than always-against-white so a `Dark` palette's cheek reads
+/// correctly against the black background.
+fn draw_cheek<D>(
+    eye: &Eye,
+    blush: u8,
+    eye_scale: u8,
+    palette: PaletteColors,
+    target: &mut D,
+) -> Result<(), D::Error>
 where
     D: DrawTarget<Color = Rgb565>,
 {
@@ -758,32 +782,32 @@ where
     let half = (CHEEK_DIAMETER / 2) as i32;
     let top_left = EgPoint::new(eye.center.x - half, cheek_top);
     Circle::new(top_left, CHEEK_DIAMETER)
-        .into_styled(fill(blend_blush(blush)))
+        .into_styled(fill(blend_blush(blush, palette.background, palette.cheek)))
         .draw(target)
 }
 
-/// Linearly blend between white and `MOUTH_COLOR` by `blush` (0 = white,
-/// 255 = full pink). Stays in Rgb565 channel space (5/6/5 bits) to keep
-/// the result directly renderable.
-fn blend_blush(blush: u8) -> Rgb565 {
+/// Linearly blend between `from` and `to` colours by `blush` (0 =
+/// pure `from`, 255 = pure `to`). Stays in Rgb565 channel space
+/// (5/6/5 bits) so the result is directly renderable.
+fn blend_blush(blush: u8, from: Rgb565, to: Rgb565) -> Rgb565 {
     let t = u32::from(blush);
-    let lerp = |from: u32, to: u32| -> u8 {
-        let delta = from.abs_diff(to);
+    let lerp = |from_ch: u32, to_ch: u32| -> u8 {
+        let delta = from_ch.abs_diff(to_ch);
         let shift = delta * t / 255;
         #[allow(clippy::cast_possible_truncation)]
         let shifted = shift as u8;
         #[allow(clippy::cast_possible_truncation)]
-        let base = from as u8;
-        if to >= from {
+        let base = from_ch as u8;
+        if to_ch >= from_ch {
             base.saturating_add(shifted)
         } else {
             base.saturating_sub(shifted)
         }
     };
     Rgb565::new(
-        lerp(31, u32::from(MOUTH_COLOR.r())),
-        lerp(63, u32::from(MOUTH_COLOR.g())),
-        lerp(31, u32::from(MOUTH_COLOR.b())),
+        lerp(u32::from(from.r()), u32::from(to.r())),
+        lerp(u32::from(from.g()), u32::from(to.g())),
+        lerp(u32::from(from.b()), u32::from(to.b())),
     )
 }
 
@@ -904,9 +928,15 @@ mod tests {
 
     #[test]
     fn blend_blush_endpoints_match_palette() {
-        let at_zero = blend_blush(0);
-        assert_eq!(at_zero, Rgb565::WHITE, "blush=0 is pure white");
-        let at_max = blend_blush(255);
-        assert_eq!(at_max, MOUTH_COLOR, "blush=255 matches palette pink");
+        // Default palette: blush 0 → background (white),
+        // blush 255 → cheek (pink).
+        let default_palette = crate::palette::Palette::Default.colors();
+        let at_zero = blend_blush(0, default_palette.background, default_palette.cheek);
+        assert_eq!(
+            at_zero, default_palette.background,
+            "blush=0 stays at background"
+        );
+        let at_max = blend_blush(255, default_palette.background, default_palette.cheek);
+        assert_eq!(at_max, default_palette.cheek, "blush=255 stays at cheek");
     }
 }

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -184,6 +184,11 @@ pub struct Face {
     /// firmware-side MCP `speak` short-circuit) populate this field;
     /// [`crate::modifiers::BubbleExpiry`] clears it on deadline.
     pub bubble: Option<crate::bubble::BubbleState>,
+    /// Active colour palette. Picks the background / eye / mouth /
+    /// cheek colours used by the renderer. Decorator and bubble
+    /// overlays keep their own dedicated colours so a palette swap
+    /// doesn't desaturate the symbolic-overlay layer's distinctness.
+    pub palette: crate::palette::Palette,
 }
 
 impl Default for Face {
@@ -218,6 +223,7 @@ impl Default for Face {
             style: Style::default(),
             decorator: None,
             bubble: None,
+            palette: crate::palette::Palette::Default,
         }
     }
 }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod modifier;
 pub mod modifiers;
 pub mod mood;
 pub mod motor;
+pub mod palette;
 pub mod perception;
 pub mod skill;
 pub mod skills;
@@ -70,6 +71,7 @@ pub use mind::{Affect, Attention, Autonomy, Dormancy, Engagement, Intent, Mind, 
 pub use modifier::Modifier;
 pub use mood::Mood;
 pub use motor::Motor;
+pub use palette::{Palette, PaletteColors};
 pub use perception::{
     BodyTouch, HALF_FOV_H_DEG, HALF_FOV_V_DEG, MAX_TRACKING_CANDIDATES, Perception,
     TargetCandidate, TrackingMotion, TrackingObservation,

--- a/crates/stackchan-core/src/palette.rs
+++ b/crates/stackchan-core/src/palette.rs
@@ -1,0 +1,215 @@
+//! Color palette — named presets that swap the avatar's base colours
+//! at runtime.
+//!
+//! The palette layer affects the four "skin" colours of the avatar:
+//! background, eye, mouth, and cheek. Decorator and bubble overlays
+//! keep their own dedicated colours so a palette swap doesn't
+//! desaturate or mute the symbolic-overlay layer's distinctness.
+//!
+//! Schema is intentionally a small enum of named presets rather than
+//! free-form RGB565 fields. Named presets keep the operator surface
+//! bounded (no need to validate arbitrary colour combinations against
+//! "is the eye still readable?") and let future revisions grow the
+//! palette set without breaking back-compat.
+//!
+//! ## Lifecycle
+//!
+//! `Face::palette` is populated at boot from the firmware's runtime
+//! state, and updated on `POST /palette` / future MCP `set_palette`.
+//! No expiry — the palette persists until the next operator change
+//! (or the next reboot, since v0.2.0 doesn't yet persist the choice).
+
+use embedded_graphics::pixelcolor::Rgb565;
+
+/// Named palette preset. Picks one of the curated four-colour
+/// combinations bundled with the firmware. Default `Default` matches
+/// the original v0.x palette so a missing field on disk renders
+/// identically.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Palette {
+    /// Original Stack-chan palette: white background, black eyes,
+    /// pink mouth + cheeks.
+    #[default]
+    Default,
+    /// Dark mode: black background, white eyes, light pink for
+    /// mouth + cheeks. Easier on the eyes in a dark room.
+    Dark,
+    /// "Cute" / uwu palette: light pink background, dark pink eyes,
+    /// white mouth + cheeks. The avatar reads as a single
+    /// blush-coloured blob with eyes.
+    Cute,
+    /// Dog-mode palette: tan background, brown eyes, pink mouth +
+    /// cheeks. Pairs with the `m5stack-avatar` "dog face" geometry
+    /// stylistically though kai retains the canonical face shape.
+    Dog,
+}
+
+impl Palette {
+    /// Lowercase wire name for the HTTP `/state` snapshot and the
+    /// `POST /palette` body. Mirrors [`crate::Emotion::wire_str`]'s
+    /// convention so a value lifted off `/state` can be posted back
+    /// without case translation.
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Dark => "dark",
+            Self::Cute => "cute",
+            Self::Dog => "dog",
+        }
+    }
+
+    /// Single-byte wire encoding for any future BLE GATT exposure.
+    /// Append-only; new variants get the next free integer.
+    #[must_use]
+    pub const fn wire_byte(self) -> u8 {
+        match self {
+            Self::Default => 0,
+            Self::Dark => 1,
+            Self::Cute => 2,
+            Self::Dog => 3,
+        }
+    }
+
+    /// Parse a lowercase wire string back into a [`Palette`].
+    #[must_use]
+    pub fn from_wire_str(s: &str) -> Option<Self> {
+        match s {
+            "default" => Some(Self::Default),
+            "dark" => Some(Self::Dark),
+            "cute" => Some(Self::Cute),
+            "dog" => Some(Self::Dog),
+            _ => None,
+        }
+    }
+
+    /// Every variant in declaration order. Manually maintained — the
+    /// exhaustive match arms in [`Self::wire_str`] / [`Self::wire_byte`]
+    /// guard the encoding side, but this slice has no compile-time
+    /// completeness check, so the `all_length_matches_variant_count`
+    /// test is the trip-wire that forces an update on variant addition.
+    pub const ALL: &'static [Self] = &[Self::Default, Self::Dark, Self::Cute, Self::Dog];
+
+    /// Resolve to the four-colour palette for the renderer.
+    #[must_use]
+    pub const fn colors(self) -> PaletteColors {
+        match self {
+            Self::Default => PaletteColors {
+                // White background, black eyes, the existing
+                // `MOUTH_COLOR` (`#F58080` quantised) for both mouth
+                // and cheeks.
+                background: Rgb565::new(31, 63, 31),
+                eye: Rgb565::new(0, 0, 0),
+                mouth: Rgb565::new(30, 32, 16),
+                cheek: Rgb565::new(30, 32, 16),
+            },
+            Self::Dark => PaletteColors {
+                background: Rgb565::new(0, 0, 0),
+                // High-contrast off-white for the eye so the
+                // ellipse / arc reads as a single solid feature
+                // against the black background.
+                eye: Rgb565::new(28, 56, 28),
+                mouth: Rgb565::new(31, 32, 20),
+                cheek: Rgb565::new(31, 32, 20),
+            },
+            Self::Cute => PaletteColors {
+                // Light pink background — the avatar is a single
+                // soft-pink blob.
+                background: Rgb565::new(31, 50, 22),
+                // Saturated pink for the eyes, contrasting against
+                // the lighter background.
+                eye: Rgb565::new(28, 16, 14),
+                mouth: Rgb565::new(31, 63, 31),
+                cheek: Rgb565::new(31, 63, 31),
+            },
+            Self::Dog => PaletteColors {
+                // Warm tan background.
+                background: Rgb565::new(28, 48, 14),
+                // Brown eyes.
+                eye: Rgb565::new(10, 14, 4),
+                mouth: Rgb565::new(30, 32, 16),
+                cheek: Rgb565::new(30, 32, 16),
+            },
+        }
+    }
+}
+
+/// Resolved palette — the four colours the renderer uses for the
+/// avatar's skin. Returned by [`Palette::colors`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PaletteColors {
+    /// Background-clear colour (the canvas is filled with this before
+    /// drawing eyes / mouth / cheeks / overlays).
+    pub background: Rgb565,
+    /// Eye colour — the filled ellipse for `eye_curve == 0` or the
+    /// stroked polyline arc for non-zero curve.
+    pub eye: Rgb565,
+    /// Mouth colour — line / ellipse / arc, all the same colour.
+    pub mouth: Rgb565,
+    /// Cheek-blush circle colour. Often the same as `mouth`.
+    pub cheek: Rgb565,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_length_matches_variant_count() {
+        assert_eq!(
+            Palette::ALL.len(),
+            4,
+            "update Palette::ALL when adding a variant"
+        );
+    }
+
+    #[test]
+    fn wire_byte_mapping_is_stable() {
+        assert_eq!(Palette::Default.wire_byte(), 0);
+        assert_eq!(Palette::Dark.wire_byte(), 1);
+        assert_eq!(Palette::Cute.wire_byte(), 2);
+        assert_eq!(Palette::Dog.wire_byte(), 3);
+    }
+
+    #[test]
+    fn wire_str_round_trip_for_all_variants() {
+        for &p in Palette::ALL {
+            let s = p.wire_str();
+            assert_eq!(Palette::from_wire_str(s), Some(p));
+        }
+    }
+
+    #[test]
+    fn from_wire_str_rejects_unknown() {
+        assert_eq!(Palette::from_wire_str(""), None);
+        assert_eq!(Palette::from_wire_str("DEFAULT"), None); // case sensitive
+        assert_eq!(Palette::from_wire_str("rainbow"), None);
+    }
+
+    #[test]
+    fn each_palette_renders_distinct_background() {
+        // Sanity guard against two palettes silently sharing the
+        // background colour and reading as the same theme on screen.
+        for (i, &a) in Palette::ALL.iter().enumerate() {
+            for &b in &Palette::ALL[i + 1..] {
+                assert_ne!(
+                    a.colors().background,
+                    b.colors().background,
+                    "{a:?} and {b:?} share a background colour",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn default_palette_matches_original_constants() {
+        // Pin the Default palette to the legacy hardcoded values so
+        // the avatar's pre-PR-#8 look survives the refactor exactly.
+        let c = Palette::Default.colors();
+        assert_eq!(c.background, Rgb565::new(31, 63, 31)); // white
+        assert_eq!(c.eye, Rgb565::new(0, 0, 0)); // black
+        assert_eq!(c.mouth, Rgb565::new(30, 32, 16)); // legacy MOUTH_COLOR
+        assert_eq!(c.cheek, Rgb565::new(30, 32, 16));
+    }
+}

--- a/crates/stackchan-core/src/palette.rs
+++ b/crates/stackchan-core/src/palette.rs
@@ -114,14 +114,20 @@ impl Palette {
                 cheek: Rgb565::new(31, 32, 20),
             },
             Self::Cute => PaletteColors {
-                // Light pink background — the avatar is a single
+                // Very light pink background — the avatar is a single
                 // soft-pink blob.
                 background: Rgb565::new(31, 50, 22),
                 // Saturated pink for the eyes, contrasting against
                 // the lighter background.
                 eye: Rgb565::new(28, 16, 14),
+                // Mouth stays white for the high-contrast smile.
                 mouth: Rgb565::new(31, 63, 31),
-                cheek: Rgb565::new(31, 63, 31),
+                // Cheek is a medium pink between the background's
+                // light tint and the eye's saturated pink — without
+                // this the blush blends into the background at any
+                // realistic `cheek_blush` weight and the cheek
+                // disappears.
+                cheek: Rgb565::new(30, 32, 16),
             },
             Self::Dog => PaletteColors {
                 // Warm tan background.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -480,6 +480,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         if let Some(mood) = net::http::MOOD_SIGNAL.try_take() {
             entity.mind.mood = mood;
         }
+        // Drain the latest palette selection from `POST /palette`.
+        // Same latest-wins semantics as MOOD_SIGNAL — the palette
+        // persists across operator-driven changes and emotion swings,
+        // and only flips on explicit re-selection (or reboot, since
+        // palette persistence is a follow-up).
+        if let Some(palette) = net::http::PALETTE_SIGNAL.try_take() {
+            entity.face.palette = palette;
+        }
         // Drain the latest IMU reading.
         if let Some(m) = imu::IMU_SIGNAL.try_take() {
             entity.perception.accel_g = m.accel_g;

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -36,6 +36,10 @@
 //!   and routes through the same `RemoteCommand::LookAt` path as
 //!   `/look-at` so cognition modifiers don't have to distinguish the
 //!   command source.
+//! - `POST /palette` — JSON `{"palette": "<name>"}`. Switches the
+//!   avatar's colour palette at runtime. Runtime-only;
+//!   persistence ships alongside the NVS `RuntimeStore`. Vocabulary
+//!   matches `Palette::wire_str` (default / dark / cute / dog).
 //! - `POST /reset` — empty body. Clears any active emotion or
 //!   look-at hold and returns the avatar to autonomous behaviour.
 //! - `POST /speak` — JSON `{"phrase": "...", "locale": "..."}`.
@@ -155,6 +159,13 @@ pub static REMOTE_COMMAND_SIGNAL: Signal<CriticalSectionRawMutex, RemoteCommand>
 /// the render task into `entity.mind.mood` ahead of `Director::run`.
 /// Latest-wins semantics; persistence ships in a follow-up.
 pub static MOOD_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Mood> = Signal::new();
+
+/// Latest palette the operator has selected via `POST /palette`.
+///
+/// Drained by the render task into `entity.face.palette` ahead of
+/// `Director::run`. Latest-wins semantics; persistence ships in a
+/// follow-up alongside the NVS `RuntimeStore`.
+pub static PALETTE_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Palette> = Signal::new();
 
 /// Number of concurrent HTTP worker tasks. Each worker holds its own
 /// rx/tx buffers and accepts one connection at a time.
@@ -373,6 +384,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/volume") => handle_post_volume(socket, body).await,
         ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("POST", "/mood") => handle_post_mood(socket, body).await,
+        ("POST", "/palette") => handle_post_palette(socket, body).await,
         ("POST", "/mcp") => handle_post_mcp(socket, body).await,
         ("POST", "/camera/mode") => handle_post_camera_mode(socket, body).await,
         ("POST", "/camera/capture") => handle_post_camera_capture(socket).await,
@@ -693,6 +705,27 @@ async fn handle_post_mood(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), 
     write_no_content(socket).await
 }
 
+/// `POST /palette` — parse `{"palette": "<string>"}`, push the
+/// selected palette at the render task via [`PALETTE_SIGNAL`].
+/// Runtime-only; persistence across reboots ships in a follow-up
+/// alongside the NVS `RuntimeStore`.
+async fn handle_post_palette(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let palette = match json::parse_palette(body) {
+        Ok(p) => p,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /palette parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    PALETTE_SIGNAL.signal(palette);
+    defmt::info!("http: POST /palette → {}", palette.wire_str());
+    write_no_content(socket).await
+}
+
 /// `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP.
 ///
 /// Reads a JSON-RPC request, dispatches to one of `initialize` /
@@ -925,6 +958,7 @@ const fn tool_parse_detail(e: &JsonError) -> &'static str {
         E::UnknownPhrase => "unknown phrase",
         E::UnknownLocale => "unknown locale",
         E::UnknownMood => "unknown mood",
+        E::UnknownPalette => "unknown palette",
         E::VolumeOutOfRange(_) => "volume out of range",
     }
 }

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -1270,6 +1270,50 @@ mod tests {
     }
 
     #[test]
+    fn palette_accepts_each_known_name() {
+        for &p in stackchan_core::Palette::ALL {
+            let body = format!("{{\"palette\":\"{}\"}}", p.wire_str());
+            assert_eq!(
+                parse_palette(&body).unwrap(),
+                p,
+                "round-trip failed for {p:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn palette_rejects_missing_key() {
+        assert!(matches!(
+            parse_palette("{}"),
+            Err(JsonError::MissingKey("palette"))
+        ));
+    }
+
+    #[test]
+    fn palette_rejects_unknown_palette_name() {
+        assert!(matches!(
+            parse_palette(r#"{"palette":"rainbow"}"#),
+            Err(JsonError::UnknownPalette)
+        ));
+    }
+
+    #[test]
+    fn palette_rejects_unknown_top_level_key() {
+        assert!(matches!(
+            parse_palette(r#"{"theme":"dark"}"#),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn palette_rejects_duplicate_key() {
+        assert!(matches!(
+            parse_palette(r#"{"palette":"dark","palette":"cute"}"#),
+            Err(JsonError::DuplicateKey("palette"))
+        ));
+    }
+
+    #[test]
     fn face_target_lower_edges_pan_left_and_tilt_up() {
         // Mirror of the right-edge / down test — covers the negative
         // half of the FOV mapping.

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -20,7 +20,7 @@
 //! parsed in their entirety with [`core::str::FromStr`].
 
 use stackchan_core::voice::{Locale, PhraseId, Priority};
-use stackchan_core::{Emotion, Mood, Pose, RemoteCommand};
+use stackchan_core::{Emotion, Mood, Palette, Pose, RemoteCommand};
 
 /// Default hold window when the request body omits `hold_ms`.
 pub const DEFAULT_HOLD_MS: u32 = 30_000;
@@ -53,6 +53,8 @@ pub enum JsonError {
     UnknownLocale,
     /// Mood string didn't match any [`Mood`] variant.
     UnknownMood,
+    /// Palette string didn't match any [`Palette`] variant.
+    UnknownPalette,
     /// `audio.volume_pct` value outside the documented `0..=100`
     /// range. Carries the offending value so the firmware's `400`
     /// response body is self-describing.
@@ -327,6 +329,42 @@ pub fn parse_mood(body: &str) -> Result<Mood, JsonError> {
         Ok(())
     })?;
     mood.ok_or(JsonError::MissingKey("mood"))
+}
+
+/// Parse a `POST /palette` body into a [`Palette`].
+///
+/// Required: `palette` (string, lowercase wire form). No optional
+/// fields. Vocabulary is whatever [`Palette::from_wire_str`] knows;
+/// anything else returns [`JsonError::UnknownPalette`].
+///
+/// Returns the bare [`Palette`] rather than wrapping in a
+/// [`RemoteCommand`] — palette is not a hold-with-timer surface
+/// (operator selects a theme; theme persists until they pick another),
+/// so the dispatch path is direct: HTTP signals the render task with
+/// the new palette, render task writes `face.palette`.
+///
+/// # Errors
+///
+/// [`JsonError`] for missing/unknown keys, malformed JSON, or
+/// unrecognised palette strings.
+pub fn parse_palette(body: &str) -> Result<Palette, JsonError> {
+    let mut palette: Option<Palette> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "palette" => {
+                if palette.is_some() {
+                    return Err(JsonError::DuplicateKey("palette"));
+                }
+                let raw = scanner.read_string()?;
+                palette = Palette::from_wire_str(raw)
+                    .ok_or(JsonError::UnknownPalette)
+                    .map(Some)?;
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    palette.ok_or(JsonError::MissingKey("palette"))
 }
 
 /// Default listen-window duration when `POST /listen` omits the


### PR DESCRIPTION
## Summary

- Adds `Palette` enum (`Default` / `Dark` / `Cute` / `Dog`) + `PaletteColors` struct in `stackchan-core::palette`.
- Threads palette colours through `Face::draw`; renderer reads from `palette.{background,eye,mouth,cheek}` instead of hardcoded constants. `blend_blush` is palette-aware: lerps between `palette.background` and `palette.cheek`.
- New `POST /palette` HTTP route + `PALETTE_SIGNAL` drained into `face.palette` by the render task. Runtime-only; persistence ships with the NVS RuntimeStore follow-up.
- New `parse_palette` parser + `JsonError::UnknownPalette` for closed-vocabulary validation.

## Why

Closes the v0.2.0 colour-palette parity gap. Matches the upstream `m5stack-avatar` named-theme pattern (Round 3 decision: presets only, not free-form RGB565).

`Default` is pinned to the v0.x hardcoded values so the avatar's pre-refactor look is byte-identical (regression test enforces this).

## Test plan

- [x] `cargo test -p stackchan-core` — 399 pass (+5 new palette tests, +1 updated blend_blush test)
- [x] `just ci` clean
- [x] `just check-firmware` and `just clippy-firmware` clean
- [ ] Manual on-device verification: `curl -X POST http://stackchan.local/palette -d '{"palette":"dark"}'` and observe black background + white eyes; cycle through cute/dog/default