### PR TITLE
feat(net): ESP-NOW TX path — pose-mirror + heartbeat broadcast

### DIFF
--- a/crates/stackchan-firmware/src/net/esp_now.rs
+++ b/crates/stackchan-firmware/src/net/esp_now.rs
@@ -1,36 +1,61 @@
-//! ESP-NOW RX task — drives [`REMOTE_COMMAND_SIGNAL`] from inbound
-//! ESP-NOW frames.
+//! ESP-NOW task — RX (drives [`REMOTE_COMMAND_SIGNAL`] from inbound
+//! frames) plus TX (broadcasts pose-mirror + heartbeat frames so other
+//! Stack-chan units can choreograph against this device).
 //!
 //! ## Responsibilities
 //!
 //! 1. Configure the radio from `STACKCHAN.RON`'s `esp_now` block:
 //!    install the PMK, register a static peer if `peer_mac` is set,
 //!    optionally lock the channel.
-//! 2. Loop on `EspNow::receive_async`, drop anything that doesn't
-//!    parse as a valid Stack-chan frame, route the rest into the
-//!    same `RemoteCommand` plumbing the HTTP control plane uses.
-//! 3. Honour the pairing window — when [`PAIR_WINDOW`] is signalled
+//! 2. RX: receive frames, drop anything that doesn't parse as a valid
+//!    Stack-chan frame, route commands into the same
+//!    `RemoteCommand` plumbing the HTTP control plane uses.
+//! 3. RX: honour the pairing window — when [`PAIR_WINDOW`] is signalled
 //!    (by `POST /pair`), accept frames from senders that aren't on
 //!    the static-peer allowlist; outside the window, drop them.
+//! 4. TX: every [`TX_TICK_MS`] poll the avatar snapshot; emit a
+//!    `PoseMirror` frame when the pose moved by more than
+//!    [`POSE_TX_EPSILON_DEG`], and a `Heartbeat` frame at
+//!    [`HEARTBEAT_INTERVAL_MS`] cadence (skipped when a pose-mirror
+//!    went out in the same tick — they double as liveness).
 //!
-//! ## Why not split RX/TX yet
-//!
-//! TX (the 5 Hz heartbeat) is the natural follow-up; this PR ships
-//! the RX path so an external `M5StickC` remote can drive the avatar.
-//! The split keeps the diff focused — TX is its own task, its own
-//! lifecycle, its own failure modes.
+//! TX targets the broadcast MAC. ESP-NOW broadcast can't be encrypted,
+//! which matches the choreography use case: any unit on the same
+//! channel can listen without pre-shared keys. The asymmetric
+//! configured-peer encryption stays on the RX side.
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
+use embassy_futures::select::{Either, select};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
-use embassy_time::{Duration, Instant};
+use embassy_time::{Duration, Instant, Timer};
 use esp_radio::esp_now::{BROADCAST_ADDRESS, EspNow, EspNowWifiInterface, PeerInfo, ReceivedData};
+use stackchan_core::Pose;
 use stackchan_net::EspNowConfig;
 use stackchan_net::config::parse_mac;
-use stackchan_net::esp_now::{InboundFrame, decode};
+use stackchan_net::esp_now::{
+    InboundFrame, MAX_FRAME_LEN, decode, encode_heartbeat, encode_pose_mirror,
+};
 
 use crate::net::http::REMOTE_COMMAND_SIGNAL;
+use crate::net::snapshot::read as read_avatar_snapshot;
+
+/// TX cadence — how often the loop checks the snapshot for a new
+/// pose. 200 ms (5 Hz) keeps mirroring smooth without flooding the
+/// 2.4 GHz band with sub-perceptible deltas.
+const TX_TICK_MS: u64 = 200;
+
+/// Pose change threshold for emitting a `PoseMirror`. Below this the
+/// pose is treated as held — quantising avoids broadcasting servo
+/// jitter or sub-degree noise that wouldn't be perceptible on a
+/// receiver's avatar.
+const POSE_TX_EPSILON_DEG: f32 = 0.5;
+
+/// How often a `Heartbeat` frame is sent independent of pose changes.
+/// 1 Hz is plenty of liveness signal — receivers that need faster
+/// disconnect detection can subscribe to other Stack-chan TX traffic.
+const HEARTBEAT_INTERVAL_MS: u64 = 1_000;
 
 /// Pairing-window deadline.
 ///
@@ -87,7 +112,7 @@ pub async fn esp_now_task(esp_now: EspNow<'static>, cfg: EspNowConfig) {
         defmt::info!("esp-now: disabled in config — task exiting");
         return;
     }
-    let (manager, _sender, mut receiver) = esp_now.split();
+    let (manager, mut sender, mut receiver) = esp_now.split();
 
     // Install PMK if configured. Empty string = no encryption (dev mode).
     if !cfg.pmk_hex.is_empty() {
@@ -142,40 +167,197 @@ pub async fn esp_now_task(esp_now: EspNow<'static>, cfg: EspNowConfig) {
         );
     }
 
+    // Register the broadcast peer so `sender.send_async` to
+    // BROADCAST_ADDRESS doesn't return PeerNotFound. ESP-NOW broadcast
+    // is unencrypted by spec — no LMK, encrypt=false.
+    let broadcast_peer = PeerInfo {
+        interface: EspNowWifiInterface::Sta,
+        peer_address: BROADCAST_ADDRESS,
+        lmk: None,
+        channel: cfg.channel,
+        encrypt: false,
+    };
+    if let Err(e) = manager.add_peer(broadcast_peer) {
+        // PeerExists is fine — esp-radio may auto-add the broadcast
+        // peer on first use. Other errors block TX but not RX.
+        defmt::info!("esp-now: broadcast peer add: {}", defmt::Debug2Format(&e));
+    }
+
     ESP_NOW_ACTIVE.store(true, Ordering::Release);
     defmt::info!(
-        "esp-now: RX task ready (peer={=str:?})",
-        cfg.peer_mac.as_str()
+        "esp-now: task ready (peer={=str:?}, tx tick {=u64} ms, heartbeat {=u64} ms)",
+        cfg.peer_mac.as_str(),
+        TX_TICK_MS,
+        HEARTBEAT_INTERVAL_MS,
     );
 
     let static_peer = parse_mac(&cfg.peer_mac);
     let mut window = PairWindowCache::new();
+    let mut tx_state = TxState::new();
 
     loop {
-        let frame = receiver.receive_async().await;
-        let now = Instant::now();
-        let allow = is_allowlisted(&frame, static_peer, &mut window, now);
-        if !allow {
-            // Drop silently — emitting a log per dropped frame would
-            // flood the bus on a noisy 2.4 GHz environment.
-            continue;
-        }
-        match decode(frame.data()) {
-            Ok(InboundFrame::Heartbeat) => {
-                // Liveness only; no state change.
+        // Bias is implicit in `select`: whichever future resolves
+        // first wins. Heartbeat / pose-mirror cadence is 200 ms, so
+        // a steady RX stream still gets serviced — frames just queue
+        // in the radio buffer between TX ticks.
+        match select(
+            receiver.receive_async(),
+            Timer::after(Duration::from_millis(TX_TICK_MS)),
+        )
+        .await
+        {
+            Either::First(frame) => {
+                handle_inbound_frame(&frame, static_peer, &mut window);
             }
-            Ok(InboundFrame::Command(cmd)) => {
-                REMOTE_COMMAND_SIGNAL.signal(cmd);
-            }
-            Err(e) => {
-                defmt::warn!(
-                    "esp-now: drop frame ({=usize} bytes): {}",
-                    frame.data().len(),
-                    defmt::Debug2Format(&e)
-                );
+            Either::Second(()) => {
+                tx_state.tick(&mut sender).await;
             }
         }
     }
+}
+
+/// Per-frame inbound handling — allowlist gate + decode + dispatch.
+/// Pulled out so the receive arm of the `select!` stays a single
+/// statement and the loop body reads top-down.
+fn handle_inbound_frame(
+    frame: &ReceivedData,
+    static_peer: Option<[u8; 6]>,
+    window: &mut PairWindowCache,
+) {
+    let now = Instant::now();
+    if !is_allowlisted(frame, static_peer, window, now) {
+        // Drop silently — emitting a log per dropped frame would
+        // flood the bus on a noisy 2.4 GHz environment.
+        return;
+    }
+    match decode(frame.data()) {
+        // Heartbeat = liveness only. Pose-mirror frames from peer
+        // Stack-chans are advisory only — this firmware doesn't
+        // slave its head to peer poses (would invite multi-unit
+        // feedback loops). A future choreography modifier can
+        // subscribe via a separate signal if that policy changes.
+        Ok(InboundFrame::Heartbeat | InboundFrame::Pose { .. }) => {}
+        Ok(InboundFrame::Command(cmd)) => {
+            REMOTE_COMMAND_SIGNAL.signal(cmd);
+        }
+        Err(e) => {
+            defmt::warn!(
+                "esp-now: drop frame ({=usize} bytes): {}",
+                frame.data().len(),
+                defmt::Debug2Format(&e)
+            );
+        }
+    }
+}
+
+/// TX-side state machine: tracks the last broadcast pose so we only
+/// emit `PoseMirror` when the avatar's head has actually moved, plus
+/// a heartbeat deadline so liveness frames go out at a steady cadence
+/// regardless of pose activity.
+struct TxState {
+    /// Last pose actually emitted on the wire. `None` until the
+    /// first send so the very first non-zero pose is always
+    /// announced.
+    last_sent: Option<Pose>,
+    /// Wall-clock time at which the next heartbeat is due. Reset
+    /// after every successful heartbeat send.
+    next_heartbeat_at: Instant,
+}
+
+impl TxState {
+    /// Construct with no prior pose recorded and the first heartbeat
+    /// scheduled one full interval out — the very first tick should
+    /// announce the boot pose without doubling up with a heartbeat.
+    fn new() -> Self {
+        Self {
+            last_sent: None,
+            next_heartbeat_at: Instant::now() + Duration::from_millis(HEARTBEAT_INTERVAL_MS),
+        }
+    }
+
+    /// Emit pose-mirror + heartbeat as appropriate. The heartbeat is
+    /// suppressed for the current tick if a pose-mirror went out
+    /// (the receiver gets liveness for free from the pose frame).
+    async fn tick(&mut self, sender: &mut esp_radio::esp_now::EspNowSender<'_>) {
+        let snapshot = read_avatar_snapshot();
+        let pose = snapshot.head_pose;
+        let pose_changed = self
+            .last_sent
+            .is_none_or(|prev| pose_delta_exceeds(prev, pose, POSE_TX_EPSILON_DEG));
+        let now = Instant::now();
+
+        let sent_anything = if pose_changed && send_pose_mirror(sender, pose).await {
+            self.last_sent = Some(pose);
+            true
+        } else {
+            false
+        };
+
+        // Pose-mirror counts as liveness; heartbeat fires only when
+        // the deadline passed and no pose-mirror went out this tick.
+        // Either path advances the heartbeat deadline by one full
+        // interval so we don't double up.
+        let heartbeat_sent =
+            !sent_anything && now >= self.next_heartbeat_at && send_heartbeat(sender).await;
+        if sent_anything || heartbeat_sent {
+            self.next_heartbeat_at = now + Duration::from_millis(HEARTBEAT_INTERVAL_MS);
+        }
+    }
+}
+
+/// True iff the angular delta between `a` and `b` exceeds
+/// `epsilon_deg` on either axis.
+fn pose_delta_exceeds(a: Pose, b: Pose, epsilon_deg: f32) -> bool {
+    (a.pan_deg - b.pan_deg).abs() > epsilon_deg || (a.tilt_deg - b.tilt_deg).abs() > epsilon_deg
+}
+
+/// Encode + transmit a `PoseMirror` frame. Returns `true` on a
+/// successful send; logs and returns `false` on encode / send errors
+/// so the caller doesn't update `last_sent` on a dropped frame.
+async fn send_pose_mirror(sender: &mut esp_radio::esp_now::EspNowSender<'_>, pose: Pose) -> bool {
+    let mut buf = [0_u8; MAX_FRAME_LEN];
+    let len = match encode_pose_mirror(&mut buf, pose.pan_deg, pose.tilt_deg) {
+        Ok(n) => n,
+        Err(e) => {
+            defmt::warn!(
+                "esp-now tx: encode pose-mirror failed: {}",
+                defmt::Debug2Format(&e)
+            );
+            return false;
+        }
+    };
+    if let Err(e) = sender.send_async(&BROADCAST_ADDRESS, &buf[..len]).await {
+        defmt::warn!(
+            "esp-now tx: pose-mirror send failed: {}",
+            defmt::Debug2Format(&e)
+        );
+        return false;
+    }
+    true
+}
+
+/// Encode + transmit a `Heartbeat` frame. Same error-swallowing
+/// shape as [`send_pose_mirror`].
+async fn send_heartbeat(sender: &mut esp_radio::esp_now::EspNowSender<'_>) -> bool {
+    let mut buf = [0_u8; 8];
+    let len = match encode_heartbeat(&mut buf) {
+        Ok(n) => n,
+        Err(e) => {
+            defmt::warn!(
+                "esp-now tx: encode heartbeat failed: {}",
+                defmt::Debug2Format(&e)
+            );
+            return false;
+        }
+    };
+    if let Err(e) = sender.send_async(&BROADCAST_ADDRESS, &buf[..len]).await {
+        defmt::warn!(
+            "esp-now tx: heartbeat send failed: {}",
+            defmt::Debug2Format(&e)
+        );
+        return false;
+    }
+    true
 }
 
 /// Allowlist check: accept frames from the configured static peer

--- a/crates/stackchan-net/src/esp_now.rs
+++ b/crates/stackchan-net/src/esp_now.rs
@@ -68,6 +68,12 @@ pub enum EspNowKind {
     Speak = 0x04,
     /// JSON body matches `POST /pair` schema.
     EnterPairing = 0x05,
+    /// Outbound pose-mirror broadcast. JSON body is the same shape as
+    /// `POST /look-at` (`{"pan_deg":F,"tilt_deg":F}`) — receivers
+    /// that want to slave their head to this device's pose can map
+    /// the body straight to a `LookAt` command, while receivers that
+    /// don't care decode it as [`InboundFrame::Pose`] and discard.
+    PoseMirror = 0x06,
 }
 
 impl EspNowKind {
@@ -81,6 +87,7 @@ impl EspNowKind {
             0x03 => Some(Self::Reset),
             0x04 => Some(Self::Speak),
             0x05 => Some(Self::EnterPairing),
+            0x06 => Some(Self::PoseMirror),
             _ => None,
         }
     }
@@ -90,7 +97,11 @@ impl EspNowKind {
     pub const fn has_body(self) -> bool {
         match self {
             Self::Heartbeat | Self::Reset => false,
-            Self::SetEmotion | Self::LookAt | Self::Speak | Self::EnterPairing => true,
+            Self::SetEmotion
+            | Self::LookAt
+            | Self::Speak
+            | Self::EnterPairing
+            | Self::PoseMirror => true,
         }
     }
 }
@@ -123,15 +134,27 @@ impl From<JsonError> for DecodeError {
 
 /// Decoded inbound ESP-NOW frame.
 ///
-/// `Heartbeat` carries no payload; the rest map onto a
-/// [`RemoteCommand`] ready to enqueue on the firmware-side
-/// `REMOTE_COMMAND_SIGNAL`.
+/// `Heartbeat` carries no payload; `Pose` carries an advisory mirror
+/// of another device's head pose (the receiver decides whether to
+/// follow it); the rest map onto a [`RemoteCommand`] ready to enqueue
+/// on the firmware-side `REMOTE_COMMAND_SIGNAL`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum InboundFrame {
     /// Liveness only — caller may use as proof-of-life for the peer.
     Heartbeat,
     /// Decoded remote command, ready to forward to the modifier graph.
     Command(RemoteCommand),
+    /// Pose-mirror frame from another Stack-chan unit. Carrying the
+    /// same shape as a `LookAt` command but kept distinct so the
+    /// receiver decides whether to slave to the sender's head — a
+    /// blanket mirror of inbound `LookAt`s would create a feedback
+    /// loop in any multi-unit choreography.
+    Pose {
+        /// Sender's head pan in degrees, +CCW from straight ahead.
+        pan_deg: f32,
+        /// Sender's head tilt in degrees, + up.
+        tilt_deg: f32,
+    },
 }
 
 /// Parse a raw ESP-NOW frame buffer into an [`InboundFrame`].
@@ -172,6 +195,20 @@ pub fn decode(buf: &[u8]) -> Result<InboundFrame, DecodeError> {
         EspNowKind::LookAt => Ok(InboundFrame::Command(parse_look_at(body_str)?)),
         EspNowKind::Speak => Ok(InboundFrame::Command(parse_speak(body_str)?)),
         EspNowKind::EnterPairing => Ok(InboundFrame::Command(parse_enter_pairing(body_str)?)),
+        EspNowKind::PoseMirror => {
+            // Reuse `parse_look_at` for the body shape — same JSON
+            // schema — then unwrap to bare degrees so a `Pose` variant
+            // can't be mistaken for a `LookAt` command downstream.
+            match parse_look_at(body_str)? {
+                RemoteCommand::LookAt { target, .. } => Ok(InboundFrame::Pose {
+                    pan_deg: target.pan_deg,
+                    tilt_deg: target.tilt_deg,
+                }),
+                // `parse_look_at` only ever returns `LookAt`, but the
+                // exhaustive arm keeps the types honest.
+                _ => Err(DecodeError::BadBody(JsonError::BadValue)),
+            }
+        }
     }
 }
 
@@ -191,6 +228,105 @@ pub fn encode_header(buf: &mut [u8], kind: EspNowKind) -> Result<usize, DecodeEr
     buf[4] = ESP_NOW_VERSION;
     buf[5] = kind as u8;
     Ok(HEADER_LEN)
+}
+
+/// Encode an empty-body [`EspNowKind::Heartbeat`] frame into `buf`,
+/// returning the total frame length. Liveness signal — receivers
+/// treat it as proof-of-life from the sender's MAC.
+///
+/// # Errors
+///
+/// Returns [`DecodeError::TooShort`] if `buf` can't hold the 6-byte
+/// header.
+pub fn encode_heartbeat(buf: &mut [u8]) -> Result<usize, DecodeError> {
+    encode_header(buf, EspNowKind::Heartbeat)
+}
+
+/// Encode a [`EspNowKind::PoseMirror`] frame carrying the sender's
+/// current head pose.
+///
+/// Body is JSON-shape-identical to a `LookAt` command
+/// (`{"pan_deg":F,"tilt_deg":F}`) so cross-decoders that want to
+/// slave on the pose can reuse the existing parser. Returns the
+/// total frame length on success.
+///
+/// # Errors
+///
+/// - [`DecodeError::TooShort`] if `buf` can't hold the header + body.
+/// - [`DecodeError::Oversize`] if the rendered body would itself
+///   exceed [`MAX_BODY_LEN`] (only possible for pathological f32
+///   formatting, but the bound keeps the wire contract honest).
+pub fn encode_pose_mirror(
+    buf: &mut [u8],
+    pan_deg: f32,
+    tilt_deg: f32,
+) -> Result<usize, DecodeError> {
+    if buf.len() < HEADER_LEN {
+        return Err(DecodeError::TooShort);
+    }
+    encode_header(buf, EspNowKind::PoseMirror)?;
+    let body_buf = &mut buf[HEADER_LEN..];
+    let body_len = render_pose_body(body_buf, pan_deg, tilt_deg)?;
+    Ok(HEADER_LEN + body_len)
+}
+
+/// Render `{"pan_deg":F,"tilt_deg":F}` into `out` without touching
+/// `alloc`. Each angle is formatted to one decimal place — pose
+/// values live in `[-90.0, +90.0]` degrees and 0.1° resolution is
+/// well below the servo's mechanical noise floor.
+///
+/// Non-finite inputs (NaN / inf) render as `0`; the firmware-side
+/// pose source already clamps to finite values, so the fallback
+/// only protects against future callers passing raw IMU data.
+fn render_pose_body(out: &mut [u8], pan_deg: f32, tilt_deg: f32) -> Result<usize, DecodeError> {
+    use core::fmt::Write as _;
+    let mut cursor = ByteCursor::new(out);
+    let pan = if pan_deg.is_finite() { pan_deg } else { 0.0 };
+    let tilt = if tilt_deg.is_finite() { tilt_deg } else { 0.0 };
+    write!(
+        &mut cursor,
+        r#"{{"pan_deg":{pan:.1},"tilt_deg":{tilt:.1}}}"#
+    )
+    .map_err(|_| DecodeError::TooShort)?;
+    let len = cursor.len();
+    if len > MAX_BODY_LEN {
+        return Err(DecodeError::Oversize(len));
+    }
+    Ok(len)
+}
+
+/// `core::fmt::Write` adapter over a `&mut [u8]`. Keeps the wire
+/// rendering allocation-free without pulling in `heapless` for a
+/// 32-byte transient buffer.
+struct ByteCursor<'a> {
+    /// Backing slice the cursor writes into.
+    buf: &'a mut [u8],
+    /// Bytes written so far — also the next-free offset.
+    written: usize,
+}
+
+impl<'a> ByteCursor<'a> {
+    /// Wrap `buf` with the cursor positioned at offset 0.
+    const fn new(buf: &'a mut [u8]) -> Self {
+        Self { buf, written: 0 }
+    }
+
+    /// Total bytes the cursor has emitted into `buf`.
+    const fn len(&self) -> usize {
+        self.written
+    }
+}
+
+impl core::fmt::Write for ByteCursor<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let end = self.written.checked_add(s.len()).ok_or(core::fmt::Error)?;
+        if end > self.buf.len() {
+            return Err(core::fmt::Error);
+        }
+        self.buf[self.written..end].copy_from_slice(s.as_bytes());
+        self.written = end;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -329,5 +465,47 @@ mod tests {
     fn decode_rejects_oversize() {
         let buf = [0_u8; MAX_FRAME_LEN + 1];
         assert_eq!(decode(&buf), Err(DecodeError::Oversize(MAX_FRAME_LEN + 1)));
+    }
+
+    #[test]
+    fn encode_heartbeat_round_trips() {
+        let mut buf = [0_u8; HEADER_LEN];
+        let n = encode_heartbeat(&mut buf).unwrap();
+        assert_eq!(n, HEADER_LEN);
+        assert_eq!(decode(&buf[..n]), Ok(InboundFrame::Heartbeat));
+    }
+
+    #[test]
+    fn encode_pose_mirror_round_trips() {
+        let mut buf = [0_u8; MAX_FRAME_LEN];
+        let n = encode_pose_mirror(&mut buf, 12.5, -3.4).unwrap();
+        match decode(&buf[..n]).unwrap() {
+            InboundFrame::Pose { pan_deg, tilt_deg } => {
+                assert!((pan_deg - 12.5).abs() < 0.05, "pan_deg={pan_deg}");
+                assert!((tilt_deg - -3.4).abs() < 0.05, "tilt_deg={tilt_deg}");
+            }
+            other => panic!("expected Pose, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_pose_mirror_handles_non_finite_inputs() {
+        let mut buf = [0_u8; MAX_FRAME_LEN];
+        let n = encode_pose_mirror(&mut buf, f32::NAN, f32::INFINITY).unwrap();
+        // NaN/inf collapse to 0 so the body stays valid JSON.
+        match decode(&buf[..n]).unwrap() {
+            InboundFrame::Pose { pan_deg, tilt_deg } => {
+                assert!(pan_deg.abs() < f32::EPSILON, "pan_deg={pan_deg}");
+                assert!(tilt_deg.abs() < f32::EPSILON, "tilt_deg={tilt_deg}");
+            }
+            other => panic!("expected Pose, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pose_mirror_kind_is_append_only() {
+        // Wire byte for PoseMirror must stay 0x06 — every shipped
+        // remote depends on this value being stable.
+        assert_eq!(EspNowKind::PoseMirror as u8, 0x06);
     }
 }


### PR DESCRIPTION
## Summary

- Round out the ESP-NOW task with TX: every 200 ms it polls `AVATAR_SNAPSHOT.head_pose` and broadcasts a `PoseMirror` frame when the pose moved by > 0.5°. A 1 Hz heartbeat fires when no pose-mirror went out — pose frames double as liveness for receivers.
- New wire kind `EspNowKind::PoseMirror = 0x06` (append-only). Body shape is identical to `LookAt` so cross-decoders can reuse `parse_look_at`. `InboundFrame::Pose` is a non-`RemoteCommand` variant — this firmware ignores peer poses to avoid multi-unit feedback loops; a future choreography modifier can opt in.
- TX targets `BROADCAST_ADDRESS`. The broadcast peer is registered at task boot; encryption stays asymmetric (PMK/LMK is RX-side per ESP-NOW broadcast semantics).
- New `encode_heartbeat` / `encode_pose_mirror` helpers in `stackchan-net::esp_now` render bodies via a no-alloc `core::fmt::Write` byte cursor.

Stacked on top of #254 (mDNS service records).

## Test plan

- [x] `just check` — host clippy + tests (5 new round-trip tests for the wire encoders)
- [x] `just clippy-firmware` — strict firmware clippy (the new `select!` + TxState path)
- [x] `just check-firmware` — firmware build
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc` — doc gate
- [ ] On-device: with two CoreS3 units on the same Wi-Fi channel, head-driven choreography should be observable as the second unit logs `Pose` frames at 5 Hz when the first moves