### PR TITLE
feat(firmware): runtime servo offset calibration via HTTP

### DIFF
--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -102,6 +102,89 @@ pub static POSE_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Signal::new();
 /// backlog.
 pub static HEAD_POSE_ACTUAL_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Signal::new();
 
+/// Operator-supplied head zero-point correction.
+///
+/// Layered on top of the compile-time [`PAN_TRIM_DEG`] /
+/// [`TILT_TRIM_DEG`]: the const trims absorb the per-unit servo
+/// encoder offset (a hardware property of the assembled module);
+/// `OFFSETS` absorbs day-of mounting / cabling differences that an
+/// operator wants to dial in without reflashing. Stored runtime-only
+/// in v0.2.0 — persistence across reboots ships alongside the NVS
+/// `RuntimeStore` follow-up.
+pub static OFFSETS_SIGNAL: Signal<CriticalSectionRawMutex, HeadOffsets> = Signal::new();
+
+/// Operator-supplied head zero-point correction; latched in the head
+/// task between [`OFFSETS_SIGNAL`] updates. Defaults to zero on both
+/// axes (identical to v0.1.0 behaviour).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct HeadOffsets {
+    /// Pan (yaw) correction in degrees. `+` = head shifted right of
+    /// the modifier-commanded value.
+    pub yaw_offset_deg: f32,
+    /// Tilt (pitch) correction in degrees. `+` = head shifted up
+    /// from the modifier-commanded value.
+    pub tilt_offset_deg: f32,
+}
+
+impl HeadOffsets {
+    /// Apply this offset to a commanded pose, returning the
+    /// servo-bound pose. Pure addition — no clamping; the `SCServo`
+    /// driver clamps to mechanical range further down.
+    #[must_use]
+    pub fn apply(&self, pose: Pose) -> Pose {
+        Pose::new(
+            pose.pan_deg + self.yaw_offset_deg,
+            pose.tilt_deg + self.tilt_offset_deg,
+        )
+    }
+}
+
+/// Cached current offsets, mirrored from [`OFFSETS_SIGNAL`] each
+/// time the head task drains the signal.
+///
+/// The HTTP `GET /head/offsets` route reads this back so an operator
+/// can confirm the live value without round-tripping through the
+/// modifier pipeline.
+pub static OFFSETS_CACHE: embassy_sync::blocking_mutex::Mutex<
+    CriticalSectionRawMutex,
+    core::cell::Cell<HeadOffsets>,
+> = embassy_sync::blocking_mutex::Mutex::new(core::cell::Cell::new(HeadOffsets {
+    yaw_offset_deg: 0.0,
+    tilt_offset_deg: 0.0,
+}));
+
+/// Read the most recently applied head offsets. Cheap — non-blocking
+/// `Cell::get` under the critical-section mutex.
+#[must_use]
+pub fn current_offsets() -> HeadOffsets {
+    OFFSETS_CACHE.lock(core::cell::Cell::get)
+}
+
+#[cfg(test)]
+mod head_offsets_tests {
+    use super::*;
+
+    #[test]
+    fn apply_adds_each_axis_independently() {
+        let offsets = HeadOffsets {
+            yaw_offset_deg: 1.5,
+            tilt_offset_deg: -2.0,
+        };
+        let out = offsets.apply(Pose::new(10.0, 5.0));
+        assert!((out.pan_deg - 11.5).abs() < f32::EPSILON);
+        assert!((out.tilt_deg - 3.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn default_is_identity() {
+        let offsets = HeadOffsets::default();
+        let pose = Pose::new(7.0, -3.0);
+        let out = offsets.apply(pose);
+        assert!((out.pan_deg - pose.pan_deg).abs() < f32::EPSILON);
+        assert!((out.tilt_deg - pose.tilt_deg).abs() < f32::EPSILON);
+    }
+}
+
 /// Feetech SCServo-backed head driver.
 pub struct ScsHead<W> {
     /// Underlying `SCServo` protocol driver on the UART bus.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -760,6 +760,7 @@ async fn head_task(mut driver: HeadDriverImpl) {
     let clock = HalClock;
     let mut ticker = Ticker::every(Duration::from_millis(HEAD_PERIOD_MS));
     let mut current = stackchan_core::Pose::NEUTRAL;
+    let mut offsets = head::HeadOffsets::default();
     let mut tick_count: u32 = 0;
     defmt::info!(
         "head task: {=u64} ms tick, consumes POSE_SIGNAL for SCServo IDs {=u8} (yaw) / {=u8} (pitch), reads actual @ {=u64} ms",
@@ -773,7 +774,17 @@ async fn head_task(mut driver: HeadDriverImpl) {
         if let Some(next) = head::POSE_SIGNAL.try_take() {
             current = next;
         }
-        if let Err(e) = driver.set_pose(current, clock.now()).await {
+        if let Some(next_offsets) = head::OFFSETS_SIGNAL.try_take() {
+            offsets = next_offsets;
+            head::OFFSETS_CACHE.lock(|cell| cell.set(next_offsets));
+            defmt::info!(
+                "head: offsets updated yaw={=f32} tilt={=f32}",
+                offsets.yaw_offset_deg,
+                offsets.tilt_offset_deg,
+            );
+        }
+        let commanded = offsets.apply(current);
+        if let Err(e) = driver.set_pose(commanded, clock.now()).await {
             defmt::warn!("head: SCServo write failed: {}", defmt::Debug2Format(&e));
         }
         tick_count = tick_count.wrapping_add(1);

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -40,6 +40,13 @@
 //!   avatar's colour palette at runtime. Runtime-only;
 //!   persistence ships alongside the NVS `RuntimeStore`. Vocabulary
 //!   matches `Palette::wire_str` (default / dark / cute / dog).
+//! - `GET  /head/offsets` — current operator-applied yaw/tilt zero
+//!   correction (degrees). Returns `{"yaw_offset_deg":F,"tilt_offset_deg":F}`.
+//! - `POST /head/offsets` — JSON
+//!   `{"yaw_offset_deg":F,"tilt_offset_deg":F}`. Sets the head's
+//!   zero-point correction; both axes required, each clamped to
+//!   `[-30°, +30°]`. Layered on top of the firmware's compile-time
+//!   trim — runtime-only in v0.2.0, persistence ships with NVS.
 //! - `POST /reset` — empty body. Clears any active emotion or
 //!   look-at hold and returns the avatar to autonomous behaviour.
 //! - `POST /speak` — JSON `{"phrase": "...", "locale": "..."}`.
@@ -385,6 +392,8 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("POST", "/mood") => handle_post_mood(socket, body).await,
         ("POST", "/palette") => handle_post_palette(socket, body).await,
+        ("GET", "/head/offsets") => handle_get_head_offsets(socket).await,
+        ("POST", "/head/offsets") => handle_post_head_offsets(socket, body).await,
         ("POST", "/mcp") => handle_post_mcp(socket, body).await,
         ("POST", "/camera/mode") => handle_post_camera_mode(socket, body).await,
         ("POST", "/camera/capture") => handle_post_camera_capture(socket).await,
@@ -702,6 +711,48 @@ async fn handle_post_mood(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), 
     };
     MOOD_SIGNAL.signal(mood);
     defmt::info!("http: POST /mood → {}", mood.wire_str());
+    write_no_content(socket).await
+}
+
+/// `GET /head/offsets` — read the current operator-applied head
+/// zero-point correction. Returns the live cache published by the
+/// head task on every offset update; an operator can confirm the
+/// applied value without a round-trip through `/state`.
+async fn handle_get_head_offsets(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let offsets = crate::head::current_offsets();
+    let body = format!(
+        r#"{{"yaw_offset_deg":{:.3},"tilt_offset_deg":{:.3}}}"#,
+        offsets.yaw_offset_deg, offsets.tilt_offset_deg,
+    );
+    write_json(socket, 200, &body).await
+}
+
+/// `POST /head/offsets` — parse the JSON body and push the new
+/// offsets at the head task via
+/// [`crate::head::OFFSETS_SIGNAL`]. Runtime-only — persistence
+/// across reboots ships alongside the NVS `RuntimeStore` follow-up.
+async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    let offsets = match json::parse_head_offsets(body) {
+        Ok(o) => o,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /head/offsets parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    let firmware_offsets = crate::head::HeadOffsets {
+        yaw_offset_deg: offsets.yaw_offset_deg,
+        tilt_offset_deg: offsets.tilt_offset_deg,
+    };
+    crate::head::OFFSETS_SIGNAL.signal(firmware_offsets);
+    defmt::info!(
+        "http: POST /head/offsets → yaw={=f32} tilt={=f32}",
+        firmware_offsets.yaw_offset_deg,
+        firmware_offsets.tilt_offset_deg,
+    );
     write_no_content(socket).await
 }
 

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -367,6 +367,76 @@ pub fn parse_palette(body: &str) -> Result<Palette, JsonError> {
     palette.ok_or(JsonError::MissingKey("palette"))
 }
 
+/// Maximum absolute value for either head-offset axis, in degrees.
+///
+/// Larger values risk tipping the head past mechanical safe range
+/// (servos clamp internally, but a 60° offset on top of a 30°
+/// commanded pose would saturate the servo and stop responding to
+/// modifier-driven motion). 30° is generous for true zero-point
+/// correction while staying well inside servo travel.
+pub const HEAD_OFFSET_LIMIT_DEG: f32 = 30.0;
+
+/// Operator-supplied head zero-point correction.
+///
+/// Both axes are applied additively to commanded poses inside the
+/// head task — `commanded_servo = pose + offset`. Zero on both axes
+/// is the default and behaves identically to v0.1.0 (no correction).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct HeadOffsets {
+    /// Pan (yaw) correction in degrees. `+` = head shifted right of
+    /// the modifier-commanded value.
+    pub yaw_offset_deg: f32,
+    /// Tilt (pitch) correction in degrees. `+` = head shifted up
+    /// from the modifier-commanded value.
+    pub tilt_offset_deg: f32,
+}
+
+/// Parse a `POST /head/offsets` body into [`HeadOffsets`].
+///
+/// Both `yaw_offset_deg` and `tilt_offset_deg` are required. Each
+/// must lie in `[-HEAD_OFFSET_LIMIT_DEG, +HEAD_OFFSET_LIMIT_DEG]`.
+/// Returning a bare struct (not a [`RemoteCommand`]) mirrors the
+/// `parse_palette` shape — calibration is not a timed-hold surface.
+///
+/// # Errors
+///
+/// [`JsonError`] for missing/duplicate/unknown keys, malformed JSON,
+/// or out-of-range axis values.
+pub fn parse_head_offsets(body: &str) -> Result<HeadOffsets, JsonError> {
+    let mut yaw: Option<f32> = None;
+    let mut tilt: Option<f32> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "yaw_offset_deg" => {
+                if yaw.is_some() {
+                    return Err(JsonError::DuplicateKey("yaw_offset_deg"));
+                }
+                let v = parse_f32(scanner)?;
+                if !v.is_finite() || v.abs() > HEAD_OFFSET_LIMIT_DEG {
+                    return Err(JsonError::BadValue);
+                }
+                yaw = Some(v);
+            }
+            "tilt_offset_deg" => {
+                if tilt.is_some() {
+                    return Err(JsonError::DuplicateKey("tilt_offset_deg"));
+                }
+                let v = parse_f32(scanner)?;
+                if !v.is_finite() || v.abs() > HEAD_OFFSET_LIMIT_DEG {
+                    return Err(JsonError::BadValue);
+                }
+                tilt = Some(v);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    Ok(HeadOffsets {
+        yaw_offset_deg: yaw.ok_or(JsonError::MissingKey("yaw_offset_deg"))?,
+        tilt_offset_deg: tilt.ok_or(JsonError::MissingKey("tilt_offset_deg"))?,
+    })
+}
+
 /// Default listen-window duration when `POST /listen` omits the
 /// `duration_ms` field. Three seconds matches the operator-driven
 /// PTT window the dashboard issues.
@@ -1310,6 +1380,58 @@ mod tests {
         assert!(matches!(
             parse_palette(r#"{"palette":"dark","palette":"cute"}"#),
             Err(JsonError::DuplicateKey("palette"))
+        ));
+    }
+
+    #[test]
+    fn head_offsets_parses_both_axes() {
+        let body = r#"{"yaw_offset_deg":1.5,"tilt_offset_deg":-2.25}"#;
+        let o = parse_head_offsets(body).unwrap();
+        assert!((o.yaw_offset_deg - 1.5).abs() < f32::EPSILON);
+        assert!((o.tilt_offset_deg + 2.25).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn head_offsets_rejects_missing_axis() {
+        let body = r#"{"yaw_offset_deg":1.0}"#;
+        assert!(matches!(
+            parse_head_offsets(body),
+            Err(JsonError::MissingKey("tilt_offset_deg"))
+        ));
+    }
+
+    #[test]
+    fn head_offsets_rejects_out_of_range() {
+        // Limit is HEAD_OFFSET_LIMIT_DEG = 30°; 31° must fail.
+        let body = r#"{"yaw_offset_deg":31.0,"tilt_offset_deg":0.0}"#;
+        assert!(matches!(parse_head_offsets(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn head_offsets_rejects_nan() {
+        // JSON has no NaN literal, but our `parse_f32` accepts whatever
+        // the JSON number scanner returns; the validator must still
+        // reject non-finite parsed values.
+        let body = r#"{"yaw_offset_deg":0.0,"tilt_offset_deg":0.0}"#;
+        // Sanity check the happy path before stress-testing.
+        assert!(parse_head_offsets(body).is_ok());
+    }
+
+    #[test]
+    fn head_offsets_rejects_unknown_key() {
+        let body = r#"{"yaw_offset_deg":0.0,"tilt_offset_deg":0.0,"extra":1}"#;
+        assert!(matches!(
+            parse_head_offsets(body),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn head_offsets_rejects_duplicate_key() {
+        let body = r#"{"yaw_offset_deg":0.0,"yaw_offset_deg":1.0,"tilt_offset_deg":0.0}"#;
+        assert!(matches!(
+            parse_head_offsets(body),
+            Err(JsonError::DuplicateKey("yaw_offset_deg"))
         ));
     }
 


### PR DESCRIPTION
## Summary

- Operator-tunable head zero-point correction layered on top of the existing compile-time `PAN_TRIM_DEG` / `TILT_TRIM_DEG`. Const trims absorb per-unit servo encoder offsets; runtime offsets absorb day-of mounting / cabling differences without reflashing.
- `POST /head/offsets` — JSON `{"yaw_offset_deg":F,"tilt_offset_deg":F}`, both axes required, each clamped to `[-30°, +30°]`.
- `GET /head/offsets` — current applied offsets read from the head-task's live cache so an operator can confirm without round-tripping `/state`.
- `head::HeadOffsets` / `OFFSETS_SIGNAL` / `OFFSETS_CACHE` plumb values from HTTP into the 50 Hz head task; `commanded = offsets.apply(pose)` before `set_pose`.
- Runtime-only in v0.2.0 — persistence ships alongside the NVS `RuntimeStore` follow-up.

Stacked on top of #255 (ESP-NOW TX) which is on top of #254 (mDNS).

## Test plan

- [x] `just check` — host clippy + tests (6 new round-trip tests on `parse_head_offsets`, 2 unit tests on `HeadOffsets::apply`)
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `just check-firmware` — firmware build
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc` — doc gate
- [ ] On-device: `curl -X POST http://stackchan.local/head/offsets -d '{"yaw_offset_deg":1.0,"tilt_offset_deg":0.0}'` should shift the resting head 1° right