### PR TITLE
feat(firmware): hourly chime — config-gated top-of-hour chirp

### DIFF
--- a/crates/stackchan-firmware/src/chime.rs
+++ b/crates/stackchan-firmware/src/chime.rs
@@ -1,0 +1,181 @@
+//! Hourly chime task — a short chirp at every wall-clock top-of-hour.
+//!
+//! Off by default. Enabled via `behavior.hourly_chime_enabled` in
+//! `STACKCHAN.RON` or `PUT /settings`. The task waits for an
+//! SNTP-synced wall clock before scheduling, then loops:
+//!
+//! 1. Read the current wall time from the BM8563 RTC.
+//! 2. Compute milliseconds remaining until the next top-of-hour.
+//! 3. Sleep that long.
+//! 4. Re-read the clock to handle skew across the sleep, and emit a
+//!    [`stackchan_core::PhraseId::WakeChirp`] (~100 ms 1 kHz sine)
+//!    via [`crate::net::http::REMOTE_COMMAND_SIGNAL`] if we landed
+//!    inside the per-hour acceptance window.
+//!
+//! ## Why poll instead of an absolute timer
+//!
+//! `embassy_time::Timer::at` can't reach across an SNTP-driven wall
+//! clock — its instants are monotonic (boot-relative). The task
+//! recomputes the next-fire delay from the live RTC each loop so a
+//! mid-day clock correction (DST shift, late SNTP sync, manual nudge)
+//! corrects on the very next iteration.
+
+use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
+use embassy_time::{Duration, Timer};
+use stackchan_core::RemoteCommand;
+use stackchan_core::voice::{Locale, PhraseId, Priority};
+
+use crate::board::SharedI2cBus;
+use crate::net::http::REMOTE_COMMAND_SIGNAL;
+
+/// Acceptance window around the top-of-hour. Sleep math + RTC read
+/// jitter can drift the wakeup by a few hundred milliseconds; if the
+/// landed minute is `00` we accept regardless, otherwise the window
+/// guards against double-firing if the loop wakes a hair before
+/// rollover.
+const TOP_OF_HOUR_WINDOW_SECS: u8 = 5;
+
+/// Polling delay used while the wall clock is unreliable (RTC failure
+/// or unset year — the BM8563 boots reading year=2000 / 1970-ish).
+const WAIT_FOR_CLOCK_SECS: u64 = 30;
+
+/// Lower bound on a parsed RTC year before the chime task trusts it.
+/// The BM8563 reports `year = 2000` on power-up before SNTP runs;
+/// gating the schedule on a year we know is post-firmware-release
+/// avoids firing 23 chimes on the way to actual wall time.
+const MIN_TRUSTED_YEAR: u16 = 2025;
+
+/// Embassy task that emits the hourly chirp. `i2c_bus` is the shared
+/// I²C handle the SNTP / wallclock task uses too — the chime task
+/// only reads, never writes the RTC.
+#[embassy_executor::task]
+pub async fn chime_task(i2c_bus: &'static SharedI2cBus, enabled: bool) {
+    if !enabled {
+        defmt::info!("chime: disabled in config — task exiting");
+        return;
+    }
+    defmt::info!(
+        "chime: hourly chime enabled (window ±{=u8}s)",
+        TOP_OF_HOUR_WINDOW_SECS
+    );
+
+    let mut bus = I2cDevice::new(i2c_bus);
+    loop {
+        let dt = match crate::wallclock::read_datetime(&mut bus).await {
+            Some(dt) if dt.year >= MIN_TRUSTED_YEAR => dt,
+            _ => {
+                // Wall clock not yet trustworthy. Wait a bit and retry
+                // — SNTP usually nails the RTC within a minute of join.
+                Timer::after(Duration::from_secs(WAIT_FOR_CLOCK_SECS)).await;
+                continue;
+            }
+        };
+
+        let secs_until = secs_until_top_of_hour(dt.minutes, dt.seconds);
+        Timer::after(Duration::from_secs(u64::from(secs_until))).await;
+
+        // Re-read after the sleep — RTC drift, NTP corrections, or a
+        // tiny over-/undershoot from the embassy timer can land us
+        // a couple of seconds off.
+        let Some(post) = crate::wallclock::read_datetime(&mut bus).await else {
+            defmt::warn!("chime: post-sleep RTC read failed; will resync");
+            continue;
+        };
+        if !is_within_top_of_hour_window(post.minutes, post.seconds) {
+            defmt::warn!(
+                "chime: woke off-window at {=u8:02}:{=u8:02}:{=u8:02}; resyncing",
+                post.hours,
+                post.minutes,
+                post.seconds,
+            );
+            continue;
+        }
+
+        defmt::info!("chime: hour {=u8:02}:00 — emitting WakeChirp", post.hours);
+        REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::Speak {
+            phrase: PhraseId::WakeChirp,
+            locale: Locale::En,
+            priority: Priority::Normal,
+        });
+        // Avoid a double-fire if we land slightly before :00:00 and
+        // the next iteration's `secs_until_top_of_hour` returns 0.
+        Timer::after(Duration::from_secs(u64::from(TOP_OF_HOUR_WINDOW_SECS) + 1)).await;
+    }
+}
+
+/// Compute seconds remaining until the next `mm=00, ss=00`. If we're
+/// already at `00:00`, returns 3600 (skip to the next hour rather
+/// than firing twice in the same minute).
+#[must_use]
+pub const fn secs_until_top_of_hour(minutes: u8, seconds: u8) -> u32 {
+    let m = minutes as u32;
+    let s = seconds as u32;
+    if m == 0 && s == 0 {
+        return 3600;
+    }
+    // Seconds elapsed in the current hour, then the complement.
+    let elapsed = m * 60 + s;
+    3600 - elapsed
+}
+
+/// Check whether `(mm, ss)` is within `TOP_OF_HOUR_WINDOW_SECS` of
+/// the top of an hour (either side).
+///
+/// Used to suppress a fire when the wall clock has drifted away from
+/// `mm=00` between scheduling and waking.
+#[must_use]
+pub const fn is_within_top_of_hour_window(minutes: u8, seconds: u8) -> bool {
+    if minutes == 0 && seconds <= TOP_OF_HOUR_WINDOW_SECS {
+        return true;
+    }
+    if minutes == 59 && seconds >= 60_u8.saturating_sub(TOP_OF_HOUR_WINDOW_SECS) {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secs_until_zero_when_at_top_returns_full_hour() {
+        // Exactly `:00:00` should not fire immediately — return
+        // a full hour so the very next loop iteration sleeps until
+        // the next top-of-hour rather than re-firing in-place.
+        assert_eq!(secs_until_top_of_hour(0, 0), 3600);
+    }
+
+    #[test]
+    fn secs_until_handles_partial_minute() {
+        // `:30:15` → 29*60 + 45 = 1785s remaining.
+        assert_eq!(secs_until_top_of_hour(30, 15), 29 * 60 + 45);
+    }
+
+    #[test]
+    fn secs_until_handles_late_in_hour() {
+        // `:59:55` → 5s.
+        assert_eq!(secs_until_top_of_hour(59, 55), 5);
+    }
+
+    #[test]
+    fn within_window_accepts_just_before_and_after() {
+        assert!(is_within_top_of_hour_window(0, 0));
+        assert!(is_within_top_of_hour_window(0, TOP_OF_HOUR_WINDOW_SECS));
+        assert!(is_within_top_of_hour_window(
+            59,
+            60 - TOP_OF_HOUR_WINDOW_SECS
+        ));
+    }
+
+    #[test]
+    fn within_window_rejects_mid_hour() {
+        assert!(!is_within_top_of_hour_window(15, 0));
+        assert!(!is_within_top_of_hour_window(45, 30));
+        // Just outside the window on either side.
+        assert!(!is_within_top_of_hour_window(
+            0,
+            TOP_OF_HOUR_WINDOW_SECS + 1
+        ));
+    }
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -24,6 +24,7 @@ pub mod board;
 pub mod body_touch;
 pub mod button;
 pub mod camera;
+pub mod chime;
 pub mod clock;
 pub mod event_log;
 pub mod framebuffer;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1129,6 +1129,15 @@ async fn main(spawner: Spawner) -> ! {
         defmt::panic!("spawn(mdns_task) failed: {}", defmt::Debug2Format(&e));
     }
 
+    // Hourly chime — opt-in via `behavior.hourly_chime_enabled`. The
+    // task exits early when disabled, so the spawn is unconditional.
+    if let Err(e) = spawner.spawn(stackchan_firmware::chime::chime_task(
+        board_io.i2c_bus,
+        net_config.behavior.hourly_chime_enabled,
+    )) {
+        defmt::panic!("spawn(chime_task) failed: {}", defmt::Debug2Format(&e));
+    }
+
     // BLE peripheral. Shares the same `&'static esp_radio::Controller`
     // as Wi-Fi — coex (enabled via the `coex` feature on `esp-radio`)
     // schedules airtime between the two stacks. The BLE address +

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -119,6 +119,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        soliloquy_enabled: {},",
         config.behavior.soliloquy_enabled
     );
+    let _ = writeln!(
+        out,
+        "        hourly_chime_enabled: {},",
+        config.behavior.hourly_chime_enabled
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -471,10 +476,12 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse the `behavior: (soliloquy_enabled)` block.
+    /// Parse the `behavior: (soliloquy_enabled, hourly_chime_enabled)`
+    /// block. Both fields default to `false` if absent.
     fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
         self.expect_char('(')?;
         let mut soliloquy_enabled: Option<bool> = None;
+        let mut hourly_chime_enabled: Option<bool> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -486,6 +493,7 @@ impl<'a> Parser<'a> {
             self.skip_ws_and_comments();
             match key {
                 "soliloquy_enabled" => soliloquy_enabled = Some(self.parse_bool()?),
+                "hourly_chime_enabled" => hourly_chime_enabled = Some(self.parse_bool()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -495,6 +503,7 @@ impl<'a> Parser<'a> {
         }
         Ok(BehaviorConfig {
             soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
+            hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -238,8 +238,8 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     out.push_str("},\"behavior\":{");
     let _ = write!(
         out,
-        "\"soliloquy_enabled\":{}",
-        config.behavior.soliloquy_enabled
+        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{}",
+        config.behavior.soliloquy_enabled, config.behavior.hourly_chime_enabled
     );
     out.push_str("}}");
     Ok(out)
@@ -733,10 +733,13 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse the optional `"behavior": { "soliloquy_enabled": <bool> }` block.
+    /// Parse the optional `"behavior"` object. Both fields default
+    /// to `false` if absent so a JSON body that pre-dates a flag's
+    /// introduction round-trips cleanly.
     fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
         self.expect_char('{')?;
         let mut soliloquy_enabled: Option<bool> = None;
+        let mut hourly_chime_enabled: Option<bool> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -753,6 +756,12 @@ impl<'a> Parser<'a> {
                     }
                     soliloquy_enabled = Some(self.parse_bool()?);
                 }
+                "hourly_chime_enabled" => {
+                    if hourly_chime_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "hourly_chime_enabled"));
+                    }
+                    hourly_chime_enabled = Some(self.parse_bool()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -762,6 +771,7 @@ impl<'a> Parser<'a> {
         }
         Ok(BehaviorConfig {
             soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
+            hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
         })
     }
 
@@ -983,6 +993,7 @@ mod tests {
             },
             behavior: BehaviorConfig {
                 soliloquy_enabled: true,
+                hourly_chime_enabled: false,
             },
         }
     }
@@ -1299,6 +1310,7 @@ mod tests {
             },
             behavior: BehaviorConfig {
                 soliloquy_enabled: true,
+                hourly_chime_enabled: false,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -292,6 +292,14 @@ pub struct BehaviorConfig {
     /// follow-up that adds the corresponding phrase pool to the
     /// baked TTS catalog).
     pub soliloquy_enabled: bool,
+    /// When `true`, the firmware emits a chirp at the top of every
+    /// wall-clock hour (00, 01, ..., 23). Off by default so a
+    /// desk-toy in a quiet office stays quiet; operators opt in via
+    /// the boot config or `PUT /settings`. The task waits for an
+    /// SNTP-synced wall clock before scheduling, then resyncs after
+    /// each chime so a mid-day clock correction doesn't drift the
+    /// next-fire time.
+    pub hourly_chime_enabled: bool,
 }
 
 /// Time / SNTP configuration.


### PR DESCRIPTION
## Summary

Opt-in hourly chime: a short `WakeChirp` at every wall-clock top-of-hour. Off by default so a desk-toy in a quiet office stays quiet; operators flip `behavior.hourly_chime_enabled` in `STACKCHAN.RON` or via `PUT /settings`.

- New `BehaviorConfig::hourly_chime_enabled: bool` (default `false`). RON + JSON parsers/renderers updated to round-trip the new field; existing configs without it default to `false`, so the schema bump is back-compatible.
- New `stackchan_firmware::chime::chime_task` module. Loops on RTC read → sleep until `mm=00` → re-read after the sleep, fire if landed inside the ±5s window. Re-reading every iteration means a mid-day clock correction (DST shift, late SNTP sync, manual nudge) corrects on the very next loop.
- Gated on `year >= MIN_TRUSTED_YEAR` so we don't fire 23 chimes on the way from the BM8563's power-up year=2000 to actual SNTP-synced time.
- Host-testable `secs_until_top_of_hour` + `is_within_top_of_hour_window` helpers — 4 new unit tests cover boundary conditions (already at `:00:00`, mid-hour, late-in-hour, just-before-top window).

## Test plan

- [x] `just check` — host clippy + tests
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `just check-firmware` — firmware build
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc` — doc gate
- [ ] On-device: enable in config, observe chirp at the next top-of-hour wall-clock minute