### PR TITLE
feat(firmware): MCP reminder/timer tools — runtime scheduler

### DIFF
--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ir;
 pub mod leds;
 pub mod net;
 pub mod power;
+pub mod reminders;
 pub mod sd_spi;
 pub mod storage;
 pub mod touch;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1138,6 +1138,14 @@ async fn main(spawner: Spawner) -> ! {
         defmt::panic!("spawn(chime_task) failed: {}", defmt::Debug2Format(&e));
     }
 
+    // Reminder dispatcher — drains due reminders at 1 Hz and routes
+    // them through `REMOTE_COMMAND_SIGNAL` for the speak path. The
+    // queue is empty at boot so the task is a low-cost noop until an
+    // operator schedules one via MCP `create_reminder`.
+    if let Err(e) = spawner.spawn(stackchan_firmware::reminders::reminders_task()) {
+        defmt::panic!("spawn(reminders_task) failed: {}", defmt::Debug2Format(&e));
+    }
+
     // BLE peripheral. Shares the same `&'static esp_radio::Controller`
     // as Wi-Fi — coex (enabled via the `coex` feature on `esp-radio`)
     // schedules airtime between the two stacks. The BLE address +

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -967,12 +967,100 @@ async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
                 tool_parse_detail(&e),
             ),
         },
+        "create_reminder" => match json::parse_create_reminder(arguments) {
+            Ok(req) => {
+                let create_req = crate::reminders::CreateRequest {
+                    fire_in_secs: u64::from(req.fire_in_secs),
+                    phrase: req.phrase,
+                };
+                match crate::reminders::add_reminder(embassy_time::Instant::now(), create_req) {
+                    Ok(reminder_id) => {
+                        let body = format!(r#"{{"id":{reminder_id}}}"#);
+                        render_success(id, &render_tool_text_result(&body))
+                    }
+                    Err(e) => render_error(
+                        Some(id),
+                        JsonRpcErrorCode::InvalidParams,
+                        reminder_error_detail(e),
+                    ),
+                }
+            }
+            Err(e) => render_error(
+                Some(id),
+                JsonRpcErrorCode::InvalidParams,
+                tool_parse_detail(&e),
+            ),
+        },
+        "list_reminders" => {
+            let body = render_reminders_json(&crate::reminders::list_reminders());
+            render_success(id, &render_tool_text_result(&body))
+        }
+        "cancel_reminder" => match json::parse_cancel_reminder(arguments) {
+            Ok(reminder_id) => {
+                if crate::reminders::cancel_reminder(reminder_id) {
+                    render_success(id, &render_tool_text_result("reminder cancelled"))
+                } else {
+                    render_error(
+                        Some(id),
+                        JsonRpcErrorCode::InvalidParams,
+                        "no reminder with that id",
+                    )
+                }
+            }
+            Err(e) => render_error(
+                Some(id),
+                JsonRpcErrorCode::InvalidParams,
+                tool_parse_detail(&e),
+            ),
+        },
         "get_state" => {
             let snap = snapshot::read();
             render_success(id, &render_tool_text_result(&state_body(snap)))
         }
         _ => render_error(Some(id), JsonRpcErrorCode::MethodNotFound, "unknown tool"),
     }
+}
+
+/// Map a [`crate::reminders::ReminderError`] to a `&'static str`
+/// MCP error detail. Mirrors [`audio_persist_detail`] in shape.
+const fn reminder_error_detail(e: crate::reminders::ReminderError) -> &'static str {
+    use crate::reminders::ReminderError;
+    match e {
+        ReminderError::NotInTheFuture => "fire_in_secs must be > 0",
+        ReminderError::HorizonExceeded => "fire_in_secs exceeds the 5-day horizon",
+        ReminderError::QueueFull => "reminder list is full",
+    }
+}
+
+/// Render the reminder list as a compact JSON object — no allocation
+/// beyond the `String` — for the MCP `list_reminders` text payload.
+fn render_reminders_json(
+    list: &heapless::Vec<crate::reminders::Reminder, { crate::reminders::MAX_REMINDERS }>,
+) -> String {
+    use core::fmt::Write as _;
+    let mut out = String::new();
+    out.push_str(r#"{"reminders":["#);
+    let now = embassy_time::Instant::now();
+    for (idx, r) in list.iter().enumerate() {
+        if idx > 0 {
+            out.push(',');
+        }
+        // Convert the monotonic deadline back into a relative
+        // "fires in N seconds" so the operator-facing surface stays
+        // shielded from boot-relative ticks. Saturating subtraction
+        // keeps already-due reminders at 0 instead of underflowing.
+        let remaining_secs = r.deadline.saturating_duration_since(now).as_secs();
+        let phrase = r.phrase;
+        let _ = write!(
+            out,
+            r#"{{"id":{},"fire_in_secs":{},"phrase":"{}"}}"#,
+            r.id,
+            remaining_secs,
+            json::phrase_wire_str(phrase),
+        );
+    }
+    out.push_str("]}");
+    out
 }
 
 /// Map a non-`Persisted` [`crate::audio::AudioPersistOutcome`] to a

--- a/crates/stackchan-firmware/src/reminders.rs
+++ b/crates/stackchan-firmware/src/reminders.rs
@@ -1,0 +1,306 @@
+//! In-memory reminder/timer scheduler.
+//!
+//! Holds a small fixed-capacity list of pending reminders. Each entry
+//! pairs a fire deadline (monotonic [`Instant`]) with a phrase to play
+//! when the deadline arrives. A 1 Hz embassy task drains due entries
+//! and dispatches them through the same
+//! [`REMOTE_COMMAND_SIGNAL`](crate::net::http::REMOTE_COMMAND_SIGNAL)
+//! that HTTP / MCP / ESP-NOW use, so the audio path stays uniform.
+//!
+//! ## Why monotonic, not wall-clock
+//!
+//! Wall-clock-based reminders need an SNTP-synced RTC, calendar
+//! arithmetic, and a story for what happens when the clock is
+//! corrected mid-flight. Monotonic deadlines (boot-relative) sidestep
+//! all of that for the v0.2.0 MVP — operators schedule "in N seconds"
+//! reminders, not absolute calendar times. A wall-clock variant can
+//! ship as a follow-up that reuses this scheduler with a converter on
+//! the input side.
+//!
+//! ## Persistence
+//!
+//! None — the list lives in RAM and resets on reboot. Persistence
+//! across reboots ships alongside the NVS `RuntimeStore` follow-up.
+
+use core::cell::RefCell;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_time::{Duration, Instant, Ticker};
+use heapless::Vec;
+use stackchan_core::RemoteCommand;
+use stackchan_core::voice::{Locale, PhraseId, Priority};
+
+use crate::net::http::REMOTE_COMMAND_SIGNAL;
+
+/// Maximum simultaneous reminders. 16 is well beyond plausible
+/// operator use (a desk-toy isn't a calendar) and bounded enough to
+/// keep the static buffer small.
+pub const MAX_REMINDERS: usize = 16;
+
+/// Cap on the seconds-from-now operators can schedule.
+///
+/// Five days is generous for any legitimate desk-toy reminder; the
+/// cap exists to surface accidental "fire in 31536000 seconds"
+/// inputs as a validation error rather than a silent five-year-
+/// from-now sleep.
+pub const MAX_REMINDER_HORIZON_SECS: u64 = 5 * 24 * 60 * 60;
+
+/// Tick cadence for the dispatcher task. 1 Hz — operator-facing
+/// reminders don't need sub-second precision and a slower poll keeps
+/// the firmware's idle power floor low.
+const REMINDER_TICK: Duration = Duration::from_secs(1);
+
+/// Monotonic id counter for `create_reminder` returns. Wraps at
+/// `u32::MAX` (a single device would have to schedule 4 billion
+/// reminders to wrap), but the wrap is OK — no caller relies on
+/// `id` ordering.
+static NEXT_ID: AtomicU32 = AtomicU32::new(1);
+
+/// Shared reminder list. The dispatcher task and the HTTP/MCP create
+/// paths both touch this static; the critical-section mutex covers
+/// the brief in/out moments without any await.
+static REMINDERS: Mutex<CriticalSectionRawMutex, RefCell<Vec<Reminder, MAX_REMINDERS>>> =
+    Mutex::new(RefCell::new(Vec::new()));
+
+/// One scheduled reminder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Reminder {
+    /// Stable identifier returned by `create_reminder` and consumed
+    /// by `cancel_reminder`.
+    pub id: u32,
+    /// Monotonic deadline at which the reminder fires.
+    pub deadline: Instant,
+    /// Baked phrase to play when the deadline passes.
+    pub phrase: PhraseId,
+}
+
+/// Operator-supplied creation request. Validated into a [`Reminder`]
+/// by [`add_reminder`] before insertion.
+#[derive(Debug, Clone, Copy)]
+pub struct CreateRequest {
+    /// Seconds from `now` until the reminder should fire. Must be
+    /// `> 0` and `<= MAX_REMINDER_HORIZON_SECS`.
+    pub fire_in_secs: u64,
+    /// Phrase the speak path will play on fire.
+    pub phrase: PhraseId,
+}
+
+/// Validation errors surfaced to the HTTP / MCP edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReminderError {
+    /// `fire_in_secs == 0`. Use `speak` for fire-now playback.
+    NotInTheFuture,
+    /// `fire_in_secs` exceeded [`MAX_REMINDER_HORIZON_SECS`].
+    HorizonExceeded,
+    /// The reminder list is full.
+    QueueFull,
+}
+
+/// Insert a reminder. Returns the assigned id, or a typed error.
+///
+/// # Errors
+///
+/// - [`ReminderError::NotInTheFuture`] if `fire_in_secs == 0`.
+/// - [`ReminderError::HorizonExceeded`] if `fire_in_secs` is past the
+///   advertised cap.
+/// - [`ReminderError::QueueFull`] if the static buffer is full.
+pub fn add_reminder(now: Instant, req: CreateRequest) -> Result<u32, ReminderError> {
+    if req.fire_in_secs == 0 {
+        return Err(ReminderError::NotInTheFuture);
+    }
+    if req.fire_in_secs > MAX_REMINDER_HORIZON_SECS {
+        return Err(ReminderError::HorizonExceeded);
+    }
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let reminder = Reminder {
+        id,
+        deadline: now + Duration::from_secs(req.fire_in_secs),
+        phrase: req.phrase,
+    };
+    REMINDERS.lock(|cell| {
+        let mut list = cell.borrow_mut();
+        list.push(reminder).map_err(|_| ReminderError::QueueFull)
+    })?;
+    Ok(id)
+}
+
+/// Remove the reminder with `id`. Returns `true` if a matching entry
+/// was found and dropped, `false` otherwise (caller surfaces a 404).
+pub fn cancel_reminder(id: u32) -> bool {
+    REMINDERS.lock(|cell| {
+        let mut list = cell.borrow_mut();
+        list.iter().position(|r| r.id == id).is_some_and(|idx| {
+            list.swap_remove(idx);
+            true
+        })
+    })
+}
+
+/// Snapshot the current reminder list. Allocates a fresh `Vec` so
+/// the caller can hold it across awaits without keeping the mutex.
+#[must_use]
+pub fn list_reminders() -> Vec<Reminder, MAX_REMINDERS> {
+    REMINDERS.lock(|cell| cell.borrow().clone())
+}
+
+/// Drain every reminder whose deadline is `<= now`, returning them
+/// in firing order. Used by both the dispatcher task and tests.
+fn drain_due(now: Instant) -> Vec<Reminder, MAX_REMINDERS> {
+    REMINDERS.lock(|cell| {
+        let mut list = cell.borrow_mut();
+        let mut due: Vec<Reminder, MAX_REMINDERS> = Vec::new();
+        let mut i = 0;
+        while i < list.len() {
+            if list[i].deadline <= now {
+                let r = list.swap_remove(i);
+                let _ = due.push(r);
+            } else {
+                i += 1;
+            }
+        }
+        due
+    })
+}
+
+/// Embassy task — drains due reminders at [`REMINDER_TICK`] cadence
+/// and dispatches each through `REMOTE_COMMAND_SIGNAL` as a
+/// [`RemoteCommand::Speak`]. The signal is single-waker, so a burst
+/// of simultaneously-due reminders fires sequentially with one tick
+/// of spacing — fine for a desk-toy that has at most a few in flight.
+#[embassy_executor::task]
+pub async fn reminders_task() {
+    defmt::info!(
+        "reminders: dispatcher up (cap={=usize}, horizon={=u64}s)",
+        MAX_REMINDERS,
+        MAX_REMINDER_HORIZON_SECS,
+    );
+    let mut ticker = Ticker::every(REMINDER_TICK);
+    loop {
+        ticker.next().await;
+        let due = drain_due(Instant::now());
+        for r in due {
+            defmt::info!(
+                "reminders: firing id={=u32} phrase={:?}",
+                r.id,
+                defmt::Debug2Format(&r.phrase),
+            );
+            REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::Speak {
+                phrase: r.phrase,
+                locale: Locale::En,
+                priority: Priority::Normal,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset_state() {
+        REMINDERS.lock(|cell| cell.borrow_mut().clear());
+        NEXT_ID.store(1, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn add_then_drain_returns_due_only() {
+        reset_state();
+        let t0 = Instant::from_ticks(0);
+        let id1 = add_reminder(
+            t0,
+            CreateRequest {
+                fire_in_secs: 1,
+                phrase: PhraseId::WakeChirp,
+            },
+        )
+        .unwrap();
+        let _id2 = add_reminder(
+            t0,
+            CreateRequest {
+                fire_in_secs: 60,
+                phrase: PhraseId::WakeChirp,
+            },
+        )
+        .unwrap();
+
+        let due = drain_due(t0 + Duration::from_secs(2));
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].id, id1);
+        // The far-future reminder remains.
+        assert_eq!(list_reminders().len(), 1);
+    }
+
+    #[test]
+    fn add_rejects_zero_horizon() {
+        reset_state();
+        let err = add_reminder(
+            Instant::from_ticks(0),
+            CreateRequest {
+                fire_in_secs: 0,
+                phrase: PhraseId::WakeChirp,
+            },
+        );
+        assert_eq!(err, Err(ReminderError::NotInTheFuture));
+    }
+
+    #[test]
+    fn add_rejects_horizon_above_cap() {
+        reset_state();
+        let err = add_reminder(
+            Instant::from_ticks(0),
+            CreateRequest {
+                fire_in_secs: MAX_REMINDER_HORIZON_SECS + 1,
+                phrase: PhraseId::WakeChirp,
+            },
+        );
+        assert_eq!(err, Err(ReminderError::HorizonExceeded));
+    }
+
+    #[test]
+    fn cancel_returns_false_for_unknown_id() {
+        reset_state();
+        assert!(!cancel_reminder(9999));
+    }
+
+    #[test]
+    fn cancel_removes_matching_id() {
+        reset_state();
+        let id = add_reminder(
+            Instant::from_ticks(0),
+            CreateRequest {
+                fire_in_secs: 30,
+                phrase: PhraseId::WakeChirp,
+            },
+        )
+        .unwrap();
+        assert!(cancel_reminder(id));
+        assert!(list_reminders().is_empty());
+        // Second cancel of the same id is a no-op.
+        assert!(!cancel_reminder(id));
+    }
+
+    #[test]
+    fn add_rejects_when_full() {
+        reset_state();
+        for _ in 0..MAX_REMINDERS {
+            add_reminder(
+                Instant::from_ticks(0),
+                CreateRequest {
+                    fire_in_secs: 30,
+                    phrase: PhraseId::WakeChirp,
+                },
+            )
+            .unwrap();
+        }
+        let err = add_reminder(
+            Instant::from_ticks(0),
+            CreateRequest {
+                fire_in_secs: 30,
+                phrase: PhraseId::WakeChirp,
+            },
+        );
+        assert_eq!(err, Err(ReminderError::QueueFull));
+    }
+}

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -437,6 +437,73 @@ pub fn parse_head_offsets(body: &str) -> Result<HeadOffsets, JsonError> {
     })
 }
 
+/// Operator-supplied reminder creation body, parsed by
+/// [`parse_create_reminder`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CreateReminderRequest {
+    /// Seconds from request reception until the reminder fires.
+    /// Range-checked at the firmware-side dispatcher.
+    pub fire_in_secs: u32,
+    /// Baked phrase to play on fire. Vocabulary mirrors `parse_speak`.
+    pub phrase: PhraseId,
+}
+
+/// Parse a `POST /reminders` (or MCP `create_reminder`) body. Both
+/// fields required.
+///
+/// # Errors
+///
+/// [`JsonError`] for missing/duplicate/unknown keys, malformed JSON
+/// shape, or unrecognised phrase strings.
+pub fn parse_create_reminder(body: &str) -> Result<CreateReminderRequest, JsonError> {
+    let mut fire_in_secs: Option<u32> = None;
+    let mut phrase: Option<PhraseId> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "fire_in_secs" => {
+                if fire_in_secs.is_some() {
+                    return Err(JsonError::DuplicateKey("fire_in_secs"));
+                }
+                fire_in_secs = Some(parse_u32(scanner)?);
+            }
+            "phrase" => {
+                if phrase.is_some() {
+                    return Err(JsonError::DuplicateKey("phrase"));
+                }
+                phrase = Some(parse_phrase(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    Ok(CreateReminderRequest {
+        fire_in_secs: fire_in_secs.ok_or(JsonError::MissingKey("fire_in_secs"))?,
+        phrase: phrase.ok_or(JsonError::MissingKey("phrase"))?,
+    })
+}
+
+/// Parse a `cancel_reminder` body — `{"id": <integer>}`.
+///
+/// # Errors
+///
+/// [`JsonError`] for missing/duplicate/unknown keys, malformed JSON.
+pub fn parse_cancel_reminder(body: &str) -> Result<u32, JsonError> {
+    let mut id: Option<u32> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "id" => {
+                if id.is_some() {
+                    return Err(JsonError::DuplicateKey("id"));
+                }
+                id = Some(parse_u32(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    id.ok_or(JsonError::MissingKey("id"))
+}
+
 /// Default listen-window duration when `POST /listen` omits the
 /// `duration_ms` field. Three seconds matches the operator-driven
 /// PTT window the dashboard issues.
@@ -735,6 +802,29 @@ fn parse_phrase(scanner: &mut Scanner<'_>) -> Result<PhraseId, JsonError> {
         "acknowledge_name" => Ok(PhraseId::AcknowledgeName),
         "battery_low" => Ok(PhraseId::BatteryLow),
         _ => Err(JsonError::UnknownPhrase),
+    }
+}
+
+/// Inverse of `parse_phrase` — render a [`PhraseId`] back to its
+/// wire string.
+///
+/// Variants outside the public phrase vocabulary fall back to
+/// `"unknown"`, which round-trips back to a
+/// [`JsonError::UnknownPhrase`] on parse — visible breakage rather
+/// than a silent misrender.
+#[must_use]
+pub const fn phrase_wire_str(p: PhraseId) -> &'static str {
+    match p {
+        PhraseId::WakeChirp => "wake_chirp",
+        PhraseId::PickupChirp => "pickup_chirp",
+        PhraseId::StartleChirp => "startle_chirp",
+        PhraseId::LowBatteryChirp => "low_battery_chirp",
+        PhraseId::CameraModeEnteredChirp => "camera_mode_entered_chirp",
+        PhraseId::CameraModeExitedChirp => "camera_mode_exited_chirp",
+        PhraseId::Greeting => "greeting",
+        PhraseId::AcknowledgeName => "acknowledge_name",
+        PhraseId::BatteryLow => "battery_low",
+        _ => "unknown",
     }
 }
 

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -618,6 +618,9 @@ pub const INITIALIZE_RESULT_JSON: &str = concat!(
 /// - `enter_pairing(duration_ms?: integer)`
 /// - `set_volume(level: integer)`
 /// - `set_mute(muted: bool)`
+/// - `create_reminder(fire_in_secs: integer, phrase: string) -> { id }`
+/// - `list_reminders() -> { reminders: [...] }`
+/// - `cancel_reminder(id: integer)`
 /// - `get_state()`
 ///
 /// Schemas are minimal — no enum constraints on emotion / mood /
@@ -633,6 +636,9 @@ pub const TOOLS_LIST_RESULT_JSON: &str = concat!(
     r#"{"name":"enter_pairing","description":"Open an ESP-NOW pairing window for the configured duration so an external remote can register.","inputSchema":{"type":"object","properties":{"duration_ms":{"type":"integer"}}}},"#,
     r#"{"name":"set_volume","description":"Set the speaker volume in percent (0..=100). Persists to STACKCHAN.RON; survives reboot.","inputSchema":{"type":"object","properties":{"level":{"type":"integer","minimum":0,"maximum":100}},"required":["level"]}},"#,
     r#"{"name":"set_mute","description":"Mute or unmute the speaker without losing the persisted volume level. Persists to STACKCHAN.RON.","inputSchema":{"type":"object","properties":{"muted":{"type":"boolean"}},"required":["muted"]}},"#,
+    r#"{"name":"create_reminder","description":"Schedule a baked phrase to play in N seconds. Returns the reminder id. Runtime-only — does not survive reboot.","inputSchema":{"type":"object","properties":{"fire_in_secs":{"type":"integer","minimum":1,"maximum":432000},"phrase":{"type":"string"}},"required":["fire_in_secs","phrase"]}},"#,
+    r#"{"name":"list_reminders","description":"Return the currently-scheduled reminders.","inputSchema":{"type":"object","properties":{}}},"#,
+    r#"{"name":"cancel_reminder","description":"Cancel a previously-scheduled reminder by id. Returns 404 / not-found if no matching reminder exists.","inputSchema":{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}},"#,
     r#"{"name":"get_state","description":"Return the current avatar snapshot (emotion, mood, head pose, decorator, battery, Wi-Fi, audio).","inputSchema":{"type":"object","properties":{}}}"#,
     "]}",
 );


### PR DESCRIPTION
## Summary

Three new MCP tools backed by an in-memory scheduler:

- `create_reminder { fire_in_secs, phrase }` → `{ id }`
- `list_reminders()` → `{ reminders: [{ id, fire_in_secs, phrase }] }`
- `cancel_reminder { id }` → success or 404

A 1 Hz dispatcher task drains due entries and routes them through `REMOTE_COMMAND_SIGNAL`, the same speak path HTTP / MCP / ESP-NOW / hourly chime use.

**Monotonic, not wall-clock**, for v0.2.0. Operators schedule "fire in N seconds"; this sidesteps SNTP gating, DST, RTC drift. A wall-clock variant can ship as a follow-up that converts on the input side.

## Bounds

- `MAX_REMINDERS = 16` (stack-buffer cap, surfaces as `QueueFull`)
- `MAX_REMINDER_HORIZON_SECS = 5 × 24 × 60 × 60` (surfaces as `HorizonExceeded`; guards against accidental "fire in 31536000s" inputs)
- `fire_in_secs == 0` rejected (`NotInTheFuture` — use `speak` for fire-now)

## Persistence

None — reset on reboot. NVS persistence ships alongside the `RuntimeStore` follow-up.

## Test plan

- [x] `just check` — host clippy + tests, including 6 new scheduler invariants
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `just check-firmware` — firmware build
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc` — doc gate
- [ ] On-device: `mcp/create_reminder { fire_in_secs: 10, phrase: "wake_chirp" }` should chirp 10 seconds later; cancelling beforehand should suppress