### PR TITLE
docs: v0.2.0 milestone — README parity refresh + changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes are documented here. Format follows
 [SemVer](https://semver.org/) with the v0.x caveats in
 [STABILITY.md](STABILITY.md).
 
+## [Unreleased] — v0.2.0 parity push
+
+The desk-toy surface keeps growing while staying fully local — no LLM, no
+cloud. Per-crate version bumps land on each PR via release-please; this
+section summarises the milestone work in human terms.
+
+### Avatar surface
+
+- Speech-bubble text overlay drawn above the face, with a TTL the
+  `BubbleExpiry` modifier sweeps each frame.
+- Decorator badges (heart, sweat, sleep, anger, shy) sit on top of
+  the base face. Emotion edges trigger `Angry` / `Shy` automatically;
+  the existing reactive triggers still fire `Heart` / `Sweat` / `Sleep`.
+- Runtime color palette swap through named presets (`default` / `dark`
+  / `cute` / `dog`) — affects the four "skin" colours of the avatar
+  while symbolic overlays keep their dedicated colours.
+- Lifelike-gaze fallback: `LostTargetSearch` modifier emits a brief
+  directional saccade after a tracked target disappears, with sourced
+  200 ms saccade latency and 0.5–1.5 s microsaccade intervals.
+- Optional soliloquy mode (`behavior.soliloquy_enabled`) — random
+  idle bubbles at random intervals; yields gracefully to operator-set
+  bubbles. Off by default.
+- Optional hourly chime (`behavior.hourly_chime_enabled`) — a short
+  `WakeChirp` at every wall-clock top-of-hour. Off by default; gated
+  on an SNTP-synced RTC.
+
+### Networking + control plane
+
+- mDNS extends from hostname-only `A` records to full DNS-SD service
+  advertising for `_stackchan._tcp.local.` (PTR + SRV + TXT + A).
+  TXT carries `kai=1` as a variant marker so kai-aware clients gate
+  on extension endpoints; a generic Bonjour browser still lists the
+  device alongside upstream stackchan units.
+- ESP-NOW gains a TX path: pose-mirror frames when the head moves
+  plus a heartbeat liveness signal, broadcast on the configured
+  channel. RX continues to gate on the static-peer allowlist plus an
+  opt-in pairing window.
+- New HTTP routes: `POST /face-target` (normalised camera coordinates
+  for an external CV pipeline), `POST /palette`, `POST /head/offsets`
+  (runtime servo zero-point correction layered on top of the
+  compile-time trim).
+- MCP gains `set_volume` / `set_mute` / `create_reminder` /
+  `list_reminders` / `cancel_reminder`. Reminders are monotonic
+  (fire-in-N-seconds), in-RAM, capped with a five-day horizon.
+- Time configuration honours the `time.tz` field at boot — a small
+  catalog of named IANA zones plus `Etc/GMT±N` is enough for the
+  desk-toy use case without pulling in a real timezone library.
+
+### Stability + plumbing
+
+- Modifier registry capacity bumped to accommodate the new
+  symbolic-overlay and fallback-gaze modifiers.
+- Greptile-driven post-merge fix on the ESP-NOW TX path: the
+  dispatcher no longer starves under inbound traffic and no longer
+  latches a NaN pose into the delta-comparison cache.
+
 ## [0.1.0] — 2026-04-23
 
 First release. CoreS3 boots to a double-buffered 320×240 face that blinks,

--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ for the details.
 ## Features
 
 - **Animated face** — eased transitions across the m5stack-avatar emotion palette, blink / breath / idle-drift at double-buffered 30 FPS
-- **Head motion** — Feetech SCServo pan/tilt with a calibration bench (`just bench`)
+- **Symbolic overlays** — speech-bubble text and decorator badges (heart, sweat, sleep, anger, shy) layered on top of the base face
+- **Color palette swap** — runtime theme switch through a small set of named presets (default / dark / cute / dog) without disturbing the symbolic-overlay layer's distinctness
+- **Head motion** — Feetech SCServo pan/tilt with a calibration bench (`just bench`) and a runtime zero-point correction surface for day-of mounting drift
 - **9-axis sensing** — BMI270 accel + gyro, BMM150 magnetometer (compensated µT, live bench via `just mag-bench`)
 - **Local inputs** — FT6336U touch, Si12T body-touch strip, LTR-553 ambient + proximity, NEC IR decoder
 - **Timekeeping + peripherals** — BM8563 RTC, PY32 co-processor, WS2812 neck LED ring (`just leds-bench`)
 - **Camera tracking** — GC0308 capture into a block-grid motion tracker, engagement-driven gaze with microsaccades and lost-target search
+- **Optional autonomy** — opt-in soliloquy bubbles at random intervals; opt-in top-of-hour chime
 - **Host-side sim** — runs the full modifier stack on the host with pixel-golden tests + an `egui` visualiser (`cargo run -p stackchan-sim --bin viz --features viz`); cuts behaviour iteration from ~30 s build cycles to under a second
 - **Safe by default** — no `unwrap` in library code, typed errors throughout, `unsafe` denied workspace-wide
 
@@ -86,10 +89,23 @@ and the firmware exposes a LAN-only HTTP control plane:
 
 - `GET /` — operator dashboard, single-page HTML embedded in the binary
 - `GET /state/stream` — live state via Server-Sent Events
-- `POST /emotion`, `/look-at`, `/reset`, `/speak` — manual override
-- `POST /volume`, `/mute` — persistent audio control (atomic SD writeback)
+- `POST /emotion`, `/look-at`, `/face-target`, `/reset`, `/speak` — manual override
+- `POST /volume`, `/mute`, `/palette`, `/head/offsets` — runtime control surface
+- `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback
 - Bearer-token auth on writes; constant-time compare; LAN-scoped (no TLS)
+
+Discovery and inter-device:
+
+- **mDNS** — `<hostname>.local` plus DNS-SD service records (`_stackchan._tcp.local.`)
+  carrying a `kai=1` variant marker so kai-aware clients gate on extension endpoints
+  while a generic Bonjour browser still lists the device alongside upstream stackchan units
+- **ESP-NOW** — peer-allowlisted RX driving the same `RemoteCommand` plumbing as HTTP,
+  plus a TX path that broadcasts pose-mirror + heartbeat frames so multiple units can
+  choreograph against each other
+- **BLE peripheral** — Device Information / Battery / emotion / Wi-Fi provisioning /
+  audio / avatar control / camera-view services, advertised as `stackchan-XXXXXX`
+  (last three MAC bytes); shares the radio with Wi-Fi via `esp-radio` coex
 
 Without an SD card the firmware boots offline and the desk-toy surface works
 the same. See [HTTP control plane](https://andymai.github.io/stackchan-kai/http)


### PR DESCRIPTION
## Summary

Bring the top-level docs forward to reflect the v0.2.0 parity push.

- **README Features** — speech-bubble + decorator overlays, runtime palette swap, runtime servo offset surface, optional soliloquy + hourly chime added to the feature catalog.
- **README Networking** — full DNS-SD service advertising (PTR/SRV/TXT/A on `_stackchan._tcp.local.` with `kai=1` variant marker), ESP-NOW TX path alongside RX, BLE peripheral coverage, expanded HTTP route inventory including `POST /face-target` / `/palette` / `/head/offsets` and the `/mcp` endpoint with reminder/timer tools.
- **CHANGELOG** — new `[Unreleased]` v0.2.0 section grouping avatar-surface, networking + control plane, and stability fixes. Per-crate version bumps continue via release-please; this section is the human-facing milestone summary.

## Test plan

- [x] Renders correctly on github.com/andymai/stackchan-kai
- [x] No counts in human-facing prose (per `feedback_no_count_in_docs`)
- [x] No AI-tells / marketing fluff (per `feedback_no_claude_code_in_public_docs`)