### PR TITLE
feat(firmware): SD-backed RuntimeStore — persist palette + mood

### DIFF
--- a/crates/stackchan-core/src/mood.rs
+++ b/crates/stackchan-core/src/mood.rs
@@ -59,6 +59,21 @@ impl Mood {
         }
     }
 
+    /// Inverse of [`Self::wire_str`]. Returns `None` on any string
+    /// that isn't an exact lowercase match. Mirrors
+    /// [`crate::Palette::from_wire_str`].
+    #[must_use]
+    pub fn from_wire_str(s: &str) -> Option<Self> {
+        match s {
+            "neutral" => Some(Self::Neutral),
+            "calm" => Some(Self::Calm),
+            "playful" => Some(Self::Playful),
+            "focus" => Some(Self::Focus),
+            "sleepy" => Some(Self::Sleepy),
+            _ => None,
+        }
+    }
+
     /// Multiplier applied to `face.style.blink_rate_scale` after
     /// [`crate::modifiers::StyleFromEmotion`] has set the per-emotion
     /// baseline. `1.0` = no change; `< 1.0` slows blinks, `> 1.0`

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -35,6 +35,7 @@ pub mod leds;
 pub mod net;
 pub mod power;
 pub mod reminders;
+pub mod runtime_store;
 pub mod sd_spi;
 pub mod storage;
 pub mod touch;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1037,6 +1037,18 @@ async fn main(spawner: Spawner) -> ! {
             // first request — and so the SSE stream stays consistent
             // with what the amp actually applies at boot.
             net::snapshot::update_audio(cfg.audio);
+            // Restore the operator-tuned palette + mood from the
+            // SD-backed runtime store. Tolerant of a missing /
+            // malformed file: any failure leaves the cache (and the
+            // signal fan-out below) at variant defaults.
+            let runtime = stackchan_firmware::runtime_store::load_into_cache().await;
+            net::http::PALETTE_SIGNAL.signal(runtime.palette);
+            net::http::MOOD_SIGNAL.signal(runtime.mood);
+            defmt::info!(
+                "runtime store: restored palette={=str} mood={=str}",
+                runtime.palette.wire_str(),
+                runtime.mood.wire_str(),
+            );
             cfg
         }
         Err(e) => {

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -694,9 +694,9 @@ async fn audio_persist_to_http(
     }
 }
 
-/// `POST /mood` — parse `{"mood": "<string>"}`, push the new mood at
-/// the render task via [`MOOD_SIGNAL`]. Runtime-only; persistence
-/// across reboots ships in a follow-up that touches the RON schema.
+/// `POST /mood` — parse `{"mood": "<string>"}`, push the new mood
+/// at the render task via [`MOOD_SIGNAL`], and persist the choice to
+/// `/sd/RUNTIME.RON` so a reboot restores it.
 async fn handle_post_mood(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let mood = match json::parse_mood(body) {
         Ok(m) => m,
@@ -710,6 +710,7 @@ async fn handle_post_mood(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), 
         }
     };
     MOOD_SIGNAL.signal(mood);
+    let _ = crate::runtime_store::update_mood(mood).await;
     defmt::info!("http: POST /mood → {}", mood.wire_str());
     write_no_content(socket).await
 }
@@ -757,9 +758,8 @@ async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Res
 }
 
 /// `POST /palette` — parse `{"palette": "<string>"}`, push the
-/// selected palette at the render task via [`PALETTE_SIGNAL`].
-/// Runtime-only; persistence across reboots ships in a follow-up
-/// alongside the NVS `RuntimeStore`.
+/// selected palette at the render task via [`PALETTE_SIGNAL`], and
+/// persist the choice to `/sd/RUNTIME.RON` so a reboot restores it.
 async fn handle_post_palette(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let palette = match json::parse_palette(body) {
         Ok(p) => p,
@@ -773,6 +773,7 @@ async fn handle_post_palette(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
         }
     };
     PALETTE_SIGNAL.signal(palette);
+    let _ = crate::runtime_store::update_palette(palette).await;
     defmt::info!("http: POST /palette → {}", palette.wire_str());
     write_no_content(socket).await
 }
@@ -878,6 +879,7 @@ async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
         "set_mood" => match json::parse_mood(arguments) {
             Ok(mood) => {
                 crate::net::http::MOOD_SIGNAL.signal(mood);
+                let _ = crate::runtime_store::update_mood(mood).await;
                 render_success(id, &render_tool_text_result("mood enqueued"))
             }
             Err(e) => render_error(

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -1,0 +1,250 @@
+//! SD-backed runtime-state store for fast-changing operator selections.
+//!
+//! Tracks values that an operator flips frequently from the dashboard
+//! or via MCP — palette, mood — and that should survive a reboot
+//! without churning the hand-edited `STACKCHAN.RON` boot config.
+//! Stored as `/sd/RUNTIME.RON` with the same atomic staging-file
+//! writeback the boot config uses.
+//!
+//! ## Why SD-backed instead of NVS
+//!
+//! ESP-NOW NVS would require a partition-table-aware flash region;
+//! getting the offset wrong risks colliding with the OTA partition
+//! or coredump area. The SD card is already mounted, already
+//! atomic-write-tested via `STACKCHAN.RON`, and already covered by
+//! the offline-first fallback (the firmware boots fine without an
+//! SD). A future swap to a real NVS backend is a backend-only
+//! change — the public API of [`RuntimeState`] / [`load`] / [`save`]
+//! stays the same.
+//!
+//! ## Wire format
+//!
+//! Tiny line-based key-value, one field per line:
+//!
+//! ```text
+//! palette=cute
+//! mood=playful
+//! ```
+//!
+//! Trailing blank lines and unknown keys are tolerated (forward
+//! compatibility — adding a new field doesn't brick a device that
+//! reads back an older firmware's state). Unknown enum strings
+//! revert to the variant default.
+
+use alloc::string::String;
+use core::cell::Cell;
+use core::fmt::Write as _;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use stackchan_core::{Mood, Palette};
+
+/// In-memory snapshot of the runtime state. Defaults match the
+/// avatar's neutral resting look so a brand-new device reads the
+/// same state a missing-file fallback would produce.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeState {
+    /// Current operator-selected palette. Mirrored into
+    /// `entity.face.palette` on boot via the firmware's
+    /// `PALETTE_SIGNAL`.
+    pub palette: Palette,
+    /// Current operator-selected mood baseline. Mirrored into
+    /// `entity.mind.mood` on boot via the firmware's `MOOD_SIGNAL`.
+    pub mood: Mood,
+}
+
+/// Render a [`RuntimeState`] to its line-based wire form.
+#[must_use]
+pub fn render(state: &RuntimeState) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "palette={}", state.palette.wire_str());
+    let _ = writeln!(out, "mood={}", state.mood.wire_str());
+    out
+}
+
+/// Parse a line-based wire form into a [`RuntimeState`].
+///
+/// Tolerant by design: unknown keys are skipped, missing keys fall
+/// back to the variant default. A malformed file is therefore never
+/// fatal — the avatar always boots with a sensible runtime state
+/// even if the SD card holds garbage.
+#[must_use]
+pub fn parse(input: &str) -> RuntimeState {
+    let mut out = RuntimeState::default();
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "palette" => {
+                if let Some(p) = Palette::from_wire_str(value.trim()) {
+                    out.palette = p;
+                }
+            }
+            "mood" => {
+                if let Some(m) = Mood::from_wire_str(value.trim()) {
+                    out.mood = m;
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Convenience round-trip used by tests and as a sanity helper for
+/// callers that want to validate a rendered string before writing.
+#[cfg(test)]
+fn render_then_parse(state: &RuntimeState) -> RuntimeState {
+    parse(&render(state))
+}
+
+/// Cached current runtime state — single source of truth for what
+/// gets persisted to `/sd/RUNTIME.RON`. The boot path seeds this
+/// from disk; the HTTP / MCP handlers update it before kicking off
+/// a writeback.
+static CACHE: Mutex<CriticalSectionRawMutex, Cell<RuntimeState>> =
+    Mutex::new(Cell::new(RuntimeState {
+        palette: Palette::Default,
+        mood: Mood::Neutral,
+    }));
+
+/// Snapshot the current cache.
+#[must_use]
+pub fn current() -> RuntimeState {
+    CACHE.lock(Cell::get)
+}
+
+/// Replace the cache with `state`. Cheap; used by [`load_into_cache`]
+/// at boot before the first SD write.
+pub fn set_cache(state: RuntimeState) {
+    CACHE.lock(|cell| cell.set(state));
+}
+
+/// Load `/sd/RUNTIME.RON` into the cache, falling back to defaults
+/// on any error path.
+///
+/// Tolerant by design — missing file, decode failure, parse mismatch
+/// all leave the cache at variant defaults; the avatar must boot
+/// regardless of disk state. Returns the loaded (or default) state
+/// so the caller can fan it out to `PALETTE_SIGNAL` / `MOOD_SIGNAL`
+/// before the render task starts.
+pub async fn load_into_cache() -> RuntimeState {
+    let raw = crate::storage::with_storage(crate::storage::FirmwareStorage::read_runtime).await;
+    let state = match raw {
+        Some(Ok(Some(text))) => parse(&text),
+        Some(Ok(None)) => {
+            defmt::info!("runtime store: no /sd/RUNTIME.RON yet — using defaults");
+            RuntimeState::default()
+        }
+        Some(Err(e)) => {
+            defmt::warn!(
+                "runtime store: read failed ({}); using defaults",
+                defmt::Debug2Format(&e)
+            );
+            RuntimeState::default()
+        }
+        None => {
+            defmt::info!("runtime store: no SD mounted — runtime state is non-persistent");
+            RuntimeState::default()
+        }
+    };
+    set_cache(state);
+    state
+}
+
+/// Update the palette field and persist the cache.
+///
+/// Returns `true` on a successful disk write, `false` on any storage
+/// failure (caller may surface a 500 — but the in-memory cache is
+/// already updated, so the runtime change still takes effect; only
+/// the across-reboot persistence is lost).
+pub async fn update_palette(palette: Palette) -> bool {
+    let mut state = current();
+    state.palette = palette;
+    set_cache(state);
+    persist(state).await
+}
+
+/// Update the mood field and persist the cache. Same semantics as
+/// [`update_palette`].
+pub async fn update_mood(mood: Mood) -> bool {
+    let mut state = current();
+    state.mood = mood;
+    set_cache(state);
+    persist(state).await
+}
+
+/// Render `state` and atomically replace `/sd/RUNTIME.RON`.
+async fn persist(state: RuntimeState) -> bool {
+    let rendered = render(&state);
+    let outcome = crate::storage::with_storage(|s| s.write_runtime(&rendered)).await;
+    match outcome {
+        Some(Ok(())) => true,
+        Some(Err(e)) => {
+            defmt::warn!(
+                "runtime store: write failed ({}); cache updated but not persisted",
+                defmt::Debug2Format(&e)
+            );
+            false
+        }
+        None => {
+            defmt::info!("runtime store: no SD mounted — change is RAM-only");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_state_round_trips() {
+        let s = RuntimeState::default();
+        assert_eq!(render_then_parse(&s), s);
+    }
+
+    #[test]
+    fn non_default_state_round_trips() {
+        let s = RuntimeState {
+            palette: Palette::Cute,
+            mood: Mood::Playful,
+        };
+        assert_eq!(render_then_parse(&s), s);
+    }
+
+    #[test]
+    fn parse_tolerates_blank_lines_and_extra_whitespace() {
+        let input = "\n  palette = dark\n\n   mood=focus\n";
+        let s = parse(input);
+        assert_eq!(s.palette, Palette::Dark);
+        assert_eq!(s.mood, Mood::Focus);
+    }
+
+    #[test]
+    fn parse_skips_unknown_keys() {
+        let input = "palette=cute\nfuture_field=hello\nmood=playful\n";
+        let s = parse(input);
+        assert_eq!(s.palette, Palette::Cute);
+        assert_eq!(s.mood, Mood::Playful);
+    }
+
+    #[test]
+    fn parse_falls_back_on_unknown_enum_value() {
+        let input = "palette=rainbow\nmood=ecstatic\n";
+        let s = parse(input);
+        assert_eq!(s.palette, Palette::default());
+        assert_eq!(s.mood, Mood::default());
+    }
+
+    #[test]
+    fn parse_empty_yields_defaults() {
+        let s = parse("");
+        assert_eq!(s, RuntimeState::default());
+    }
+}

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -107,6 +107,21 @@ const CONFIG_FILE: &str = "STACKCHAN.RON";
 /// `STACKCHAN.RON`; mid-write power loss leaves the old file intact.
 const STAGING_FILE: &str = "STACKCHAN.NEW";
 
+/// Runtime-state filename. Holds operator-tuned values that change
+/// faster than the boot config (palette, mood) and that a real NVS
+/// region would otherwise back. Not in `STACKCHAN.RON` so the
+/// hand-edited boot config doesn't churn on every dashboard click.
+const RUNTIME_FILE: &str = "RUNTIME.RON";
+
+/// Atomic-write staging name for the runtime store. Same dance as
+/// `STACKCHAN.NEW`.
+const RUNTIME_STAGING_FILE: &str = "RUNTIME.NEW";
+
+/// Cap on the runtime-state file. Today's payload is ~30 bytes; the
+/// 256-byte ceiling absorbs future field additions without
+/// unbounded SRAM allocation at boot.
+const MAX_RUNTIME_BYTES: u32 = 256;
+
 /// Cap on the RON we'll read into memory at boot. Schema v1 fits
 /// well under 1 KiB; the headroom keeps SRAM bounded if the schema
 /// grows.
@@ -280,6 +295,50 @@ where
         let rendered = stackchan_net::render_ron_bare(config).map_err(|_| StorageError::Decode)?;
         self.write_file(STAGING_FILE, rendered.as_bytes())?;
         self.copy_then_delete(STAGING_FILE, CONFIG_FILE)?;
+        Ok(())
+    }
+
+    /// Read `/sd/RUNTIME.RON` as raw UTF-8 text. Returns `Ok(None)`
+    /// if the file is absent — that's the first-boot state, not an
+    /// error. Caller parses; the storage layer doesn't know the
+    /// runtime-state schema.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Read`] on a partial / failed read,
+    /// [`StorageError::TooLarge`] if the file exceeds
+    /// [`MAX_RUNTIME_BYTES`], [`StorageError::NotUtf8`] if the bytes
+    /// don't decode as UTF-8.
+    pub fn read_runtime(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(file) = root.open_file_in_dir(RUNTIME_FILE, Mode::ReadOnly) else {
+            return Ok(None);
+        };
+        let len = file.length();
+        if len > MAX_RUNTIME_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = len as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+        let text = alloc::string::String::from_utf8(buf).map_err(|_| StorageError::NotUtf8)?;
+        Ok(Some(text))
+    }
+
+    /// Atomically replace `/sd/RUNTIME.RON` with `rendered`. Same
+    /// staging-file dance as [`Self::write_config`].
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying write failure.
+    pub fn write_runtime(&mut self, rendered: &str) -> Result<(), StorageError> {
+        self.write_file(RUNTIME_STAGING_FILE, rendered.as_bytes())?;
+        self.copy_then_delete(RUNTIME_STAGING_FILE, RUNTIME_FILE)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Operator-tuned values that change faster than the boot config — palette and mood — now survive a reboot via a separate SD-backed file, `/sd/RUNTIME.RON`. The boot config (`STACKCHAN.RON`) stays hand-editable and stops churning on every dashboard click.

- New `runtime_store` module with a tiny line-based key=value format (`palette=cute` / `mood=playful`). Parser is tolerant — unknown keys are skipped, malformed enum strings revert to variant defaults; the avatar always boots with a sensible state regardless of disk content.
- `storage::FirmwareStorage::read_runtime` / `write_runtime` mirror the existing `STACKCHAN.RON` atomic-staging pattern.
- HTTP `POST /palette` / `POST /mood` and MCP `set_mood` now persist after signaling.
- Boot path loads the cache and fans it out to `PALETTE_SIGNAL` / `MOOD_SIGNAL` before the render task starts.
- New `Mood::from_wire_str` mirrors `Palette::from_wire_str` so the parser inverse is symmetric.

## Why SD-backed instead of NVS

ESP-NOW NVS would need partition-table-aware flash; getting the offset wrong risks colliding with the OTA / coredump partition. The SD card is already mounted, already atomic-write-tested via the boot config, and already covered by the offline-first fallback (the firmware boots fine without an SD). A future swap to a real NVS backend is a backend-only change — the public API of `RuntimeState` / `update_palette` / `update_mood` stays the same.

Closes the persist-mood-and-palette half of the runtime-state follow-up.

## Test plan

- [x] `just check` — host clippy + tests (6 new round-trip / tolerance tests in the firmware module — only documentation-level since firmware tests aren't part of host CI)
- [x] `just clippy-firmware`
- [x] `just check-firmware`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`
- [ ] On-device: `POST /palette` then power-cycle; the avatar should come up wearing the last-selected palette