### PR TITLE
feat(net): MCP take_photo — capture trigger + snapshot URL

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -1015,6 +1015,19 @@ async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
                 tool_parse_detail(&e),
             ),
         },
+        "take_photo" => {
+            // Trigger the camera-task capture path; the actual SD
+            // write happens out-of-band ~200–500 ms later. The MCP
+            // client polls `GET /camera/snapshot` to retrieve it.
+            crate::camera::CAMERA_CAPTURE_REQUEST.signal(());
+            defmt::info!("mcp: take_photo → camera capture queued");
+            render_success(
+                id,
+                &render_tool_text_result(
+                    r#"{"url":"/camera/snapshot","format":"rgb565be","width":320,"height":240,"note":"available within ~500ms"}"#,
+                ),
+            )
+        }
         "get_state" => {
             let snap = snapshot::read();
             render_success(id, &render_tool_text_result(&state_body(snap)))
@@ -1160,8 +1173,14 @@ async fn handle_get_camera_snapshot(socket: &mut TcpSocket<'_>) -> Result<(), Ht
                 return write_text(socket, 503, "storage unavailable\n").await;
             }
         };
+    // Frame layout headers let an MCP / curl client know exactly
+    // what the byte stream is without a separate descriptor. Format
+    // is fixed: 320 × 240 RGB565 big-endian, 153 600 bytes total —
+    // matches what the GC0308 capture path writes.
     let header = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\n\
+         X-Frame-Format: rgb565be\r\nX-Frame-Width: 320\r\nX-Frame-Height: 240\r\n\
+         Content-Length: {len}\r\nConnection: close\r\n\r\n",
         len = frame.len(),
     );
     socket

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -621,6 +621,7 @@ pub const INITIALIZE_RESULT_JSON: &str = concat!(
 /// - `create_reminder(fire_in_secs: integer, phrase: string) -> { id }`
 /// - `list_reminders() -> { reminders: [...] }`
 /// - `cancel_reminder(id: integer)`
+/// - `take_photo() -> { url, format, width, height }`
 /// - `get_state()`
 ///
 /// Schemas are minimal — no enum constraints on emotion / mood /
@@ -639,6 +640,7 @@ pub const TOOLS_LIST_RESULT_JSON: &str = concat!(
     r#"{"name":"create_reminder","description":"Schedule a baked phrase to play in N seconds. Returns the reminder id. Runtime-only — does not survive reboot.","inputSchema":{"type":"object","properties":{"fire_in_secs":{"type":"integer","minimum":1,"maximum":432000},"phrase":{"type":"string"}},"required":["fire_in_secs","phrase"]}},"#,
     r#"{"name":"list_reminders","description":"Return the currently-scheduled reminders.","inputSchema":{"type":"object","properties":{}}},"#,
     r#"{"name":"cancel_reminder","description":"Cancel a previously-scheduled reminder by id. Returns 404 / not-found if no matching reminder exists.","inputSchema":{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}},"#,
+    r#"{"name":"take_photo","description":"Trigger the camera to capture the next frame and write it to /sd/CAPTURE.565. The frame is then fetchable via GET /camera/snapshot as raw 320x240 RGB565 big-endian bytes (X-Frame-Format / X-Frame-Width / X-Frame-Height response headers describe the layout). Returns the snapshot URL and dimensions.","inputSchema":{"type":"object","properties":{}}},"#,
     r#"{"name":"get_state","description":"Return the current avatar snapshot (emotion, mood, head pose, decorator, battery, Wi-Fi, audio).","inputSchema":{"type":"object","properties":{}}}"#,
     "]}",
 );


### PR DESCRIPTION
## Summary

Add `take_photo` to the MCP tool list. The tool signals `CAMERA_CAPTURE_REQUEST`; the camera task writes the next frame to `/sd/CAPTURE.565` ~200-500 ms later; the tool's response points the client at `GET /camera/snapshot` for retrieval.

`/camera/snapshot` now sends `X-Frame-Format: rgb565be` / `X-Frame-Width: 320` / `X-Frame-Height: 240` headers so clients can decode the raw bytes without a separate descriptor.

## Why URL-based, not inline JPEG

Inline JPEG-encoded image content (base64 in the MCP response) is the natural follow-up — needs a no_std JPEG encoder dep + binary-size verification on-device, which is out of scope for an auto-merge cycle. The trigger-and-fetch shape lets MCP clients integrate the capture path today; swapping the binary payload from raw RGB565 to JPEG later is a server-side change with no MCP-tool API breakage.

## Test plan

- [x] `just check` — host clippy + tests
- [x] `just clippy-firmware`
- [x] `just check-firmware`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`
- [ ] On-device: invoke `take_photo` via MCP → fetch `/camera/snapshot` → render the RGB565 payload through any standard image viewer