### PR TITLE
feat(firmware): on-device OTA — verify, flash, swap, reboot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-hal-ota"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c3b3f18d6dd148df3152ef16df4825e37622cf4fcd2d2c04b21b70c312d46c"
+dependencies = [
+ "defmt 1.0.1",
+ "embedded-storage",
+ "esp32s3 0.35.2",
+]
+
+[[package]]
 name = "esp-hal-procmacros"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2037,21 @@ dependencies = [
  "esp-radio-rtos-driver",
  "esp-sync 0.1.1",
  "portable-atomic",
+]
+
+[[package]]
+name = "esp-storage"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1495fc1f5549bdd840b52d9ceb201746200e1620d2636f46958c11e765623b80"
+dependencies = [
+ "document-features",
+ "embedded-storage",
+ "esp-hal",
+ "esp-hal-procmacros",
+ "esp-metadata-generated 0.3.0",
+ "esp-rom-sys",
+ "esp-sync 0.1.1",
 ]
 
 [[package]]
@@ -4689,9 +4715,11 @@ dependencies = [
  "esp-alloc",
  "esp-bootloader-esp-idf",
  "esp-hal",
+ "esp-hal-ota",
  "esp-println",
  "esp-radio",
  "esp-rtos",
+ "esp-storage",
  "ft6336u",
  "gc0308",
  "heapless 0.8.0",

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ and the firmware exposes a LAN-only HTTP control plane:
 - `POST /emotion`, `/look-at`, `/face-target`, `/reset`, `/speak` — manual override
 - `POST /volume`, `/mute`, `/palette`, `/head/offsets` — runtime control surface
 - `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)
+- `POST /firmware/update` — ed25519-signed SCFW image upload; auto-flashes the inactive OTA slot and soft-resets. Compiled out unless `STACKCHAN_OTA_PUBLIC_KEY` is set at build time. Always requires a configured bearer token.
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback
 - Bearer-token auth on writes; constant-time compare; LAN-scoped (no TLS)
 

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -75,6 +75,14 @@ mipidsi = "0.10"
 # lockstep). `esp-rtos` is the current embassy integration; it replaced
 # `esp-hal-embassy` for the 1.0 line.
 esp-hal = { version = "~1.0", features = ["defmt", "esp32s3", "psram", "unstable"] }
+# Raw flash read/write for the OTA path. The `esp-hal` feature wires
+# this into the same critical-section shim the rest of the firmware
+# uses; `esp-hal-ota` consumes the `embedded-storage` traits below.
+esp-storage = { version = "0.8", features = ["esp-hal", "esp32s3"] }
+# OTA partition-table parser + slot writer. Handles the bootloader's
+# `otadata` pointer dance so the firmware doesn't have to roll a
+# partition-table parser of its own.
+esp-hal-ota = { version = "0.5", features = ["esp32s3", "defmt"] }
 esp-rtos = { version = "0.2.0", features = ["defmt", "embassy", "esp-alloc", "esp-radio", "esp32s3"] }
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["defmt", "esp32s3"] }
 esp-alloc = { version = "0.9.0", features = ["defmt"] }

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -33,6 +33,7 @@ pub mod imu;
 pub mod ir;
 pub mod leds;
 pub mod net;
+pub mod ota;
 pub mod power;
 pub mod reminders;
 pub mod runtime_store;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -934,6 +934,13 @@ async fn main(spawner: Spawner) -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0);
 
+    // Park the FLASH peripheral for the OTA path so a later
+    // `POST /firmware/update` can claim it without re-acquiring
+    // peripherals from main. No-op cost when OTA isn't enabled at
+    // build time: the static slot still gets populated, but
+    // `perform_update` returns `Disabled` before reading it.
+    stackchan_firmware::ota::install_flash_peripheral(peripherals.FLASH);
+
     defmt::info!(
         "stackchan-firmware v{} — CoreS3 boot",
         env!("CARGO_PKG_VERSION")

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -47,6 +47,14 @@
 //!   zero-point correction; both axes required, each clamped to
 //!   `[-30°, +30°]`. Layered on top of the firmware's compile-time
 //!   trim — runtime-only in v0.2.0, persistence ships with NVS.
+//! - `POST /firmware/update` — ed25519-signed SCFW image upload.
+//!   Verifies the signature against the build-time public key,
+//!   streams the payload into the inactive OTA slot, flips the
+//!   bootloader's `otadata` pointer, and soft-resets. Compiled out
+//!   when `STACKCHAN_OTA_PUBLIC_KEY` isn't set at build time (`503
+//!   Service Unavailable`); always requires a configured bearer
+//!   token even when the global token is otherwise empty. See
+//!   [`crate::ota`] for the full sequence.
 //! - `POST /reset` — empty body. Clears any active emotion or
 //!   look-at hold and returns the avatar to autonomous behaviour.
 //! - `POST /speak` — JSON `{"phrase": "...", "locale": "..."}`.
@@ -301,6 +309,32 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     let body_start = header_end + 4;
     let content_length =
         parse_content_length(&buf[line_end + 2..header_end]).map_err(|_| HttpError::Malformed)?;
+
+    // OTA `POST /firmware/update` is the one route that bypasses
+    // the small fixed-body cap — the firmware payload is megabytes
+    // and lives on PSRAM for the duration of the verify+flash. Detect
+    // it here, after method/path are known but before the small-body
+    // read loop runs the cap. Auth is checked inside the OTA
+    // handler so the rest of the cap-and-buffer logic stays
+    // dedicated to the small-body routes.
+    let method_for_route =
+        core::str::from_utf8(&buf[..first_sp]).map_err(|_| HttpError::Malformed)?;
+    let path_for_route =
+        core::str::from_utf8(&buf[path_start..second_sp]).map_err(|_| HttpError::Malformed)?;
+    if method_for_route == "POST" && path_for_route == "/firmware/update" {
+        // Hand off to the streaming OTA handler — it copies the
+        // body bytes already in `buf` and reads the rest from the
+        // socket directly into a heap-allocated Vec.
+        let auth_token = parse_bearer_token(&buf[line_end + 2..header_end]);
+        let already_buffered = filled.saturating_sub(body_start);
+        let prefix = if already_buffered > 0 {
+            &buf[body_start..body_start + already_buffered]
+        } else {
+            &[][..]
+        };
+        return handle_post_firmware_update(socket, content_length, prefix, auth_token).await;
+    }
+
     if content_length >= MAX_BODY_BYTES {
         return Err(HttpError::BodyTooLarge);
     }
@@ -1203,6 +1237,133 @@ async fn handle_post_camera_capture(socket: &mut TcpSocket<'_>) -> Result<(), Ht
     crate::camera::CAMERA_CAPTURE_REQUEST.signal(());
     defmt::info!("http: POST /camera/capture → signal queued");
     write_text(socket, 202, "capture queued\n").await
+}
+
+/// Cap on the OTA request body. Sized for the SCFW header (12) +
+/// the worst-case payload (`MAX_OTA_PAYLOAD_BYTES`) + the signature
+/// (64). Bigger requests get a `413` before any allocation happens
+/// — defends the worker against a malicious operator hammering the
+/// PSRAM allocator.
+const MAX_OTA_REQUEST_BYTES: usize = stackchan_net::ota::OTA_HEADER_LEN
+    + stackchan_net::ota::MAX_OTA_PAYLOAD_BYTES as usize
+    + stackchan_net::ota::OTA_SIGNATURE_LEN;
+
+/// Stack-resident chunk size for the streaming socket→Vec read.
+/// 1 KiB matches the request-buffer convention used by the rest of
+/// the HTTP module without any new constants.
+const OTA_RECV_CHUNK_BYTES: usize = 1024;
+
+/// `POST /firmware/update` — accept an SCFW-framed firmware image,
+/// verify the ed25519 signature against the build-time public key,
+/// stream the payload into the inactive OTA slot, flip the
+/// `otadata` pointer, and soft-reset.
+///
+/// Always requires a non-empty `Authorization: Bearer <token>` —
+/// even when the global token is empty, OTA is destructive and
+/// shouldn't ride the LAN-open default. The auth gate matches the
+/// `/restart` and `/factory-reset` discipline.
+///
+/// Returns `503 Service Unavailable` when OTA was compiled out (no
+/// `STACKCHAN_OTA_PUBLIC_KEY` env var at build time). Returns `413`
+/// for oversize bodies, `400` for SCFW framing failures, `403` for
+/// signature mismatches, and `500` for flash-write failures.
+async fn handle_post_firmware_update(
+    socket: &mut TcpSocket<'_>,
+    content_length: usize,
+    already_buffered: &[u8],
+    auth_token: Option<&str>,
+) -> Result<(), HttpError> {
+    if !crate::ota::ota_enabled() {
+        defmt::warn!("http: POST /firmware/update — OTA compiled out");
+        return write_text(
+            socket,
+            503,
+            "ota disabled in this build (STACKCHAN_OTA_PUBLIC_KEY unset)\n",
+        )
+        .await;
+    }
+
+    // Always-auth gate — non-empty token required, even when the
+    // global token is empty. Mirrors `/restart` / `/factory-reset`.
+    let snapshot = crate::storage::CONFIG_SNAPSHOT.lock().await;
+    let configured_token = snapshot
+        .as_ref()
+        .map(|c| c.auth.token.clone())
+        .unwrap_or_default();
+    drop(snapshot);
+    if configured_token.is_empty() {
+        defmt::warn!("http: POST /firmware/update — auth token not configured");
+        return Err(HttpError::Unauthorized);
+    }
+    let authorized = auth_token.is_some_and(|t| ct_eq(t.as_bytes(), configured_token.as_bytes()));
+    if !authorized {
+        return Err(HttpError::Unauthorized);
+    }
+
+    if content_length > MAX_OTA_REQUEST_BYTES {
+        return write_text(socket, 413, "ota image exceeds the 4 MiB cap\n").await;
+    }
+    if content_length < stackchan_net::ota::OTA_HEADER_LEN + stackchan_net::ota::OTA_SIGNATURE_LEN {
+        return write_text(socket, 400, "ota image truncated\n").await;
+    }
+
+    // Allocate on the heap; PSRAM absorbs the multi-MB body without
+    // pressuring internal SRAM.
+    let mut body: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(content_length);
+    body.extend_from_slice(already_buffered);
+
+    let mut chunk = [0u8; OTA_RECV_CHUNK_BYTES];
+    while body.len() < content_length {
+        let want = content_length - body.len();
+        let take = want.min(OTA_RECV_CHUNK_BYTES);
+        let n = match socket.read(&mut chunk[..take]).await {
+            Ok(n) if n > 0 => n,
+            _ => return Err(HttpError::Read),
+        };
+        body.extend_from_slice(&chunk[..n]);
+    }
+
+    defmt::info!(
+        "http: POST /firmware/update — body received ({=usize} bytes), verifying",
+        body.len()
+    );
+    crate::event_log::record_fmt(
+        crate::event_log::Kind::Control,
+        format_args!("POST /firmware/update {} bytes", body.len()),
+    );
+
+    match crate::ota::perform_update(&body) {
+        Ok(()) => {
+            defmt::info!(
+                "http: OTA flush succeeded — soft-resetting in 200 ms to boot the new image"
+            );
+            // Free the body buffer before reset so PSRAM is in a
+            // known-empty state if the bootloader leaves it
+            // initialised across the soft-reset.
+            drop(body);
+            write_text(socket, 200, "ota verified + flashed; rebooting\n").await?;
+            socket.flush().await.map_err(|_| HttpError::Write)?;
+            embassy_time::Timer::after(embassy_time::Duration::from_millis(200)).await;
+            esp_hal::system::software_reset()
+        }
+        Err(e) => {
+            defmt::warn!("http: OTA failed: {}", e);
+            let (status, msg) = match &e {
+                crate::ota::OtaPerformError::Disabled => (503, "ota disabled in this build\n"),
+                crate::ota::OtaPerformError::FlashUnavailable => {
+                    (500, "flash peripheral unavailable\n")
+                }
+                // Signature mismatch is the most operator-actionable
+                // error path — surface it as 403 specifically.
+                crate::ota::OtaPerformError::Image(stackchan_net::ota::OtaImageError::Verify(
+                    _,
+                )) => (403, "signature verification failed\n"),
+                crate::ota::OtaPerformError::Image(_) => (400, "image rejected\n"),
+                crate::ota::OtaPerformError::Flash(_) => (500, "flash write failed\n"),
+            };
+            write_text(socket, status, msg).await
+        }
+    }
 }
 
 /// `POST /restart` — write the response, briefly let the TCP buffer

--- a/crates/stackchan-firmware/src/ota.rs
+++ b/crates/stackchan-firmware/src/ota.rs
@@ -1,0 +1,197 @@
+//! On-device OTA update path: parse + verify the SCFW envelope and
+//! stream-write the payload to the inactive flash slot.
+//!
+//! Layered on top of:
+//!
+//! - [`stackchan_net::ota::parse_and_verify`] for the SCFW framing +
+//!   ed25519 signature check (host-tested, deterministic).
+//! - [`esp_hal_ota::Ota`] for the partition-table parse + slot
+//!   selection + `otadata` pointer dance the bootloader needs to
+//!   pick up the new image on next boot.
+//!
+//! ## Build-time public key
+//!
+//! The verifier's public key is baked into the firmware at compile
+//! time via the `STACKCHAN_OTA_PUBLIC_KEY` environment variable —
+//! 64 hex characters (32 bytes). When the variable is unset, OTA is
+//! disabled at compile time: [`ota_enabled`] returns `false` and the
+//! HTTP route returns `503 Service Unavailable`. This is the
+//! offline-first stance: you can build + flash without an OTA
+//! signing keypair set up; you just can't do field updates.
+//!
+//! ## Why the whole image is buffered before flashing
+//!
+//! Ed25519 signs the message in full — verification can't proceed
+//! incrementally without switching to Ed25519ph (pre-hashed). Until
+//! that's worth the schema bump, the verifier needs the payload
+//! contiguous in memory. CoreS3 has 8 MB of PSRAM; even a 4 MB
+//! image leaves comfortable headroom for the running heap.
+//!
+//! ## Flash-write order
+//!
+//! 1. Allocate a `Vec<u8>` on PSRAM sized for the request body.
+//! 2. Read the body off the socket in chunks.
+//! 3. `parse_and_verify` against the build-time public key. Reject
+//!    with `400` / `403` if framing or signature fails.
+//! 4. Compute CRC32 of the payload (esp-hal-ota requires it for
+//!    `ota_begin`; mirrors what the IDF bootloader uses).
+//! 5. Stream the verified payload through `ota_write_chunk` into the
+//!    inactive slot.
+//! 6. `ota_flush` flips the `otadata` pointer.
+//! 7. Soft-reset; the bootloader picks up the new slot on next boot.
+
+use core::cell::RefCell;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use esp_hal::peripherals::FLASH;
+use esp_hal_ota::Ota;
+use esp_storage::FlashStorage;
+use stackchan_net::ota::{OTA_PUBLIC_KEY_LEN, OtaImageError, parse_and_verify};
+
+/// Build-time-baked Ed25519 public key (32 bytes), parsed from the
+/// `STACKCHAN_OTA_PUBLIC_KEY` env var as 64 lowercase hex chars.
+/// `None` disables OTA at compile time.
+pub const OTA_PUBLIC_KEY: Option<[u8; OTA_PUBLIC_KEY_LEN]> =
+    match option_env!("STACKCHAN_OTA_PUBLIC_KEY") {
+        Some(hex) => Some(decode_hex_pubkey(hex)),
+        None => None,
+    };
+
+/// True iff OTA is wired up — i.e. the build-time public key is
+/// present. Used by the HTTP route to fail closed when the firmware
+/// was built without OTA support.
+#[must_use]
+pub const fn ota_enabled() -> bool {
+    OTA_PUBLIC_KEY.is_some()
+}
+
+/// Decode a 64-character hex string into a 32-byte array at compile
+/// time. The build fails through a const-eval assertion if the input
+/// is malformed — better a clear compile-time message than silently
+/// shipping a bad key.
+#[allow(
+    clippy::panic,
+    reason = "build-time const eval — a panic here surfaces as a clear compile error"
+)]
+const fn decode_hex_pubkey(hex: &str) -> [u8; OTA_PUBLIC_KEY_LEN] {
+    let b = hex.as_bytes();
+    assert!(
+        b.len() == 64,
+        "STACKCHAN_OTA_PUBLIC_KEY must be exactly 64 hex chars"
+    );
+    let mut out = [0u8; OTA_PUBLIC_KEY_LEN];
+    let mut i = 0;
+    while i < OTA_PUBLIC_KEY_LEN {
+        out[i] = (hex_nibble(b[i * 2]) << 4) | hex_nibble(b[i * 2 + 1]);
+        i += 1;
+    }
+    out
+}
+
+/// Const-evaluable hex-nibble decoder. Const-panics on a non-hex
+/// byte so the build fails at the malformed character.
+#[allow(
+    clippy::panic,
+    reason = "build-time const eval — a panic here surfaces as a clear compile error"
+)]
+const fn hex_nibble(c: u8) -> u8 {
+    match c {
+        b'0'..=b'9' => c - b'0',
+        b'a'..=b'f' => c - b'a' + 10,
+        b'A'..=b'F' => c - b'A' + 10,
+        _ => panic!("STACKCHAN_OTA_PUBLIC_KEY contains a non-hex character"),
+    }
+}
+
+/// Slot for the boot-acquired `FLASH` peripheral. Populated once
+/// from `main` via [`install_flash_peripheral`]; consumed by
+/// [`perform_update`] (a successful update reboots, so the flash
+/// handle is never returned).
+static FLASH_SLOT: Mutex<CriticalSectionRawMutex, RefCell<Option<FLASH<'static>>>> =
+    Mutex::new(RefCell::new(None));
+
+/// Park the FLASH peripheral so the OTA path can claim it later.
+/// Called once from boot; calling twice is a programming error and
+/// silently overwrites the previous handle.
+pub fn install_flash_peripheral(flash: FLASH<'static>) {
+    FLASH_SLOT.lock(|cell| {
+        cell.borrow_mut().replace(flash);
+    });
+    defmt::info!("ota: flash peripheral parked for OTA writer");
+}
+
+/// Outcome of [`perform_update`].
+#[derive(Debug, defmt::Format)]
+pub enum OtaPerformError {
+    /// Build-time public key was not set; OTA is compiled out.
+    Disabled,
+    /// FLASH peripheral was never parked at boot — OTA is unreachable.
+    /// Programming error: `install_flash_peripheral` not called.
+    FlashUnavailable,
+    /// SCFW framing or ed25519 verification failed.
+    Image(#[defmt(Debug2Format)] OtaImageError),
+    /// `esp-hal-ota` rejected the partition setup or chunk write.
+    Flash(#[defmt(Debug2Format)] esp_hal_ota::OtaError),
+}
+
+impl From<OtaImageError> for OtaPerformError {
+    fn from(e: OtaImageError) -> Self {
+        Self::Image(e)
+    }
+}
+
+impl From<esp_hal_ota::OtaError> for OtaPerformError {
+    fn from(e: esp_hal_ota::OtaError) -> Self {
+        Self::Flash(e)
+    }
+}
+
+/// Chunk size for the streaming write into the inactive OTA slot.
+/// 4 KiB matches the ESP32 flash sector size, keeping the inner
+/// `ota_write_chunk` call sector-aligned for whatever buffering
+/// `esp-hal-ota` does internally.
+const FLASH_CHUNK_BYTES: usize = 4096;
+
+/// Parse + verify the SCFW image, then stream the payload into the
+/// inactive OTA slot and flip the `otadata` pointer.
+///
+/// On success, the **caller** is responsible for the soft-reset:
+/// the function returns so the HTTP handler can drain its `200 OK`
+/// response before the chip resets, otherwise the dashboard sees a
+/// TCP RST instead of the success body. See [`crate::net::http`]'s
+/// `/restart` handler for the same pattern.
+///
+/// # Errors
+///
+/// - [`OtaPerformError::Disabled`] if the firmware was built without
+///   `STACKCHAN_OTA_PUBLIC_KEY`.
+/// - [`OtaPerformError::Image`] if framing fails or the signature
+///   doesn't verify.
+/// - [`OtaPerformError::Flash`] for partition / write failures.
+pub fn perform_update(image_bytes: &[u8]) -> Result<(), OtaPerformError> {
+    let Some(public_key) = OTA_PUBLIC_KEY.as_ref() else {
+        return Err(OtaPerformError::Disabled);
+    };
+    let payload = parse_and_verify(image_bytes, public_key)?;
+    defmt::info!(
+        "ota: signature verified, payload {=usize} bytes — streaming to inactive slot",
+        payload.len()
+    );
+
+    let crc = esp_hal_ota::crc32::calc_crc32(payload, 0);
+    let flash_periph = FLASH_SLOT
+        .lock(|cell| cell.borrow_mut().take())
+        .ok_or(OtaPerformError::FlashUnavailable)?;
+    let flash = FlashStorage::new(flash_periph);
+    let mut ota = Ota::new(flash)?;
+    let payload_len: u32 = u32::try_from(payload.len())
+        .map_err(|_| OtaPerformError::Flash(esp_hal_ota::OtaError::OtaPartitionTooSmall))?;
+    ota.ota_begin(payload_len, crc)?;
+    for chunk in payload.chunks(FLASH_CHUNK_BYTES) {
+        ota.ota_write_chunk(chunk)?;
+    }
+    ota.ota_flush(true, false)?;
+    defmt::info!("ota: flush done; new slot armed for next boot");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Round out the OTA path on top of the host-shipped verifier (#270): parse + verify the SCFW envelope, stream the payload into the inactive flash slot via `esp-hal-ota`, flip the bootloader's `otadata` pointer, and soft-reset. Compiled-out by default — `STACKCHAN_OTA_PUBLIC_KEY` must be set at build time to enable the route.

- **`stackchan-firmware::ota`** — new module. Build-time public key via `option_env!("STACKCHAN_OTA_PUBLIC_KEY")` (64 hex chars, const-fn-decoded; build fails at the malformed character). When unset, `ota_enabled()` returns `false` and the HTTP route returns `503`. `install_flash_peripheral` parks the FLASH peripheral at boot so the HTTP request can claim it later. `perform_update` does parse+verify+CRC32+stream-write+flush, leaving the soft-reset to the caller so the response can drain.

- **`POST /firmware/update`** — new route. Always requires a non-empty bearer token (matches `/restart` / `/factory-reset` — destructive ops opt-in only). Bypasses the small-body cap with a streaming socket→PSRAM Vec read, capped at SCFW header + `MAX_OTA_PAYLOAD_BYTES` + 64-byte signature. Status mapping: 503 (compiled out), 400 (framing), 403 (signature), 413 (oversize), 500 (flash). On success: 200 OK, flush, 200 ms drain, `software_reset()`.

- **Deps:** `esp-storage 0.8` (raw flash via `embedded_storage`) and `esp-hal-ota 0.5` (partition table + slot writer + otadata dance).

## How to use

```bash
# Generate keypair (host-side, one-time)
openssl genpkey -algorithm Ed25519 -out signing_key.pem
openssl pkey -in signing_key.pem -pubout -outform DER | tail -c 32 | xxd -p -c 64

# Build with public key baked in
STACKCHAN_OTA_PUBLIC_KEY=<64 hex chars> just build-firmware

# Set bearer token in STACKCHAN.RON, then upload an SCFW envelope:
curl -X POST http://stackchan.local/firmware/update \
     -H "Authorization: Bearer <token>" \
     --data-binary @firmware.scfw
```

The SCFW envelope is the format defined in `stackchan-net::ota` (PR #270): `magic(4) + version(4) + length(4) + payload + signature(64)`.

## Test plan

- [x] `just check` — host clippy + tests
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `just check-firmware` — firmware build (esp-storage + esp-hal-ota compile cleanly on xtensa-esp32s3-none-elf)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`
- [ ] On-device with JTAG cable on standby:
  - Build with a known keypair set in env, flash via `just fmr`
  - `curl POST` an SCFW envelope signed with the matching key → device should respond 200 and reboot
  - Verify the new slot booted by checking `GET /health` reports the new version
  - Test rollback path: upload a known-bad image; signature rejection should return 403 without touching flash