### PR TITLE
fix: v0.2.0 quality pass — bug fixes + tests + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ and the firmware exposes a LAN-only HTTP control plane:
 - `GET /` — operator dashboard, single-page HTML embedded in the binary
 - `GET /state/stream` — live state via Server-Sent Events
 - `POST /emotion`, `/look-at`, `/face-target`, `/reset`, `/speak` — manual override
-- `POST /volume`, `/mute`, `/palette`, `/head/offsets` — runtime control surface
+- `POST /volume`, `/mute`, `/mood`, `/palette`, `/head/offsets` — runtime control surface
 - `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)
 - `POST /firmware/update` — ed25519-signed SCFW image upload; auto-flashes the inactive OTA slot and soft-resets. Compiled out unless `STACKCHAN_OTA_PUBLIC_KEY` is set at build time. Always requires a configured bearer token.
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback

--- a/crates/stackchan-core/src/mood.rs
+++ b/crates/stackchan-core/src/mood.rs
@@ -183,4 +183,23 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn wire_str_round_trip_for_all_variants() {
+        // Pins the exact string each variant maps to. A future
+        // rename in `wire_str` without an update here will trip
+        // this rather than silently breaking persisted runtime
+        // state and HTTP body parsers downstream.
+        for &m in Mood::ALL {
+            let s = m.wire_str();
+            assert_eq!(Mood::from_wire_str(s), Some(m));
+        }
+    }
+
+    #[test]
+    fn from_wire_str_rejects_unknown() {
+        assert_eq!(Mood::from_wire_str(""), None);
+        assert_eq!(Mood::from_wire_str("NEUTRAL"), None); // case sensitive
+        assert_eq!(Mood::from_wire_str("ecstatic"), None);
+    }
 }

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -108,9 +108,8 @@ pub static HEAD_POSE_ACTUAL_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Sign
 /// [`TILT_TRIM_DEG`]: the const trims absorb the per-unit servo
 /// encoder offset (a hardware property of the assembled module);
 /// `OFFSETS` absorbs day-of mounting / cabling differences that an
-/// operator wants to dial in without reflashing. Stored runtime-only
-/// in v0.2.0 — persistence across reboots ships alongside the NVS
-/// `RuntimeStore` follow-up.
+/// operator wants to dial in without reflashing. Not yet enrolled in
+/// the SD-backed `RuntimeStore` — head offsets reset on reboot.
 pub static OFFSETS_SIGNAL: Signal<CriticalSectionRawMutex, HeadOffsets> = Signal::new();
 
 /// Operator-supplied head zero-point correction; latched in the head

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -483,8 +483,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // Drain the latest palette selection from `POST /palette`.
         // Same latest-wins semantics as MOOD_SIGNAL — the palette
         // persists across operator-driven changes and emotion swings,
-        // and only flips on explicit re-selection (or reboot, since
-        // palette persistence is a follow-up).
+        // and only flips on explicit re-selection. The selection
+        // itself survives reboots via /sd/RUNTIME.RON (see
+        // `runtime_store::update_palette`).
         if let Some(palette) = net::http::PALETTE_SIGNAL.try_take() {
             entity.face.palette = palette;
         }

--- a/crates/stackchan-firmware/src/net/esp_now.rs
+++ b/crates/stackchan-firmware/src/net/esp_now.rs
@@ -386,8 +386,11 @@ async fn send_heartbeat(sender: &mut esp_radio::esp_now::EspNowSender<'_>) -> bo
 
 /// Allowlist check: accept frames from the configured static peer
 /// always; accept anything during a pairing window; drop the rest.
-/// Broadcast-destination frames pass — the firmware is the intended
-/// audience for the broadcast pattern that bulk operator tooling uses.
+///
+/// Broadcasts from random senders fall through to the pairing-window
+/// gate intentionally — accepting unicast operator commands from the
+/// LAN at large would be an open RX port, so the broadcast pattern
+/// only helps once an operator has explicitly opened pairing.
 fn is_allowlisted(
     frame: &ReceivedData,
     static_peer: Option<[u8; 6]>,
@@ -395,12 +398,7 @@ fn is_allowlisted(
     now: Instant,
 ) -> bool {
     let src = frame.info.src_address;
-    if let Some(allowed) = static_peer
-        && src == allowed
-    {
-        return true;
-    }
-    if frame.info.dst_address == BROADCAST_ADDRESS && static_peer == Some(src) {
+    if static_peer == Some(src) {
         return true;
     }
     window.refresh_and_check(now)
@@ -434,10 +432,6 @@ const fn hex_nibble(b: u8) -> Option<u8> {
         _ => None,
     }
 }
-
-/// Default pairing window when the HTTP route is hit without explicit
-/// duration. Mirrors `stackchan_net::http_command::DEFAULT_PAIRING_DURATION_MS`.
-pub const PAIR_WINDOW_DEFAULT_MS: u64 = 30_000;
 
 /// Open the pairing window for `duration_ms`. Producer-side helper
 /// for the HTTP route + MCP tool: signals [`PAIR_WINDOW`] with the

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -37,8 +37,8 @@
 //!   `/look-at` so cognition modifiers don't have to distinguish the
 //!   command source.
 //! - `POST /palette` — JSON `{"palette": "<name>"}`. Switches the
-//!   avatar's colour palette at runtime. Runtime-only;
-//!   persistence ships alongside the NVS `RuntimeStore`. Vocabulary
+//!   avatar's colour palette at runtime; persisted to
+//!   `/sd/RUNTIME.RON` so a reboot restores the selection. Vocabulary
 //!   matches `Palette::wire_str` (default / dark / cute / dog).
 //! - `GET  /head/offsets` — current operator-applied yaw/tilt zero
 //!   correction (degrees). Returns `{"yaw_offset_deg":F,"tilt_offset_deg":F}`.
@@ -170,9 +170,11 @@ const DASHBOARD_GZ: &[u8] = include_bytes!("../../../../web/dist/index.html.gz")
 /// render task drains will overwrite the first.
 pub static REMOTE_COMMAND_SIGNAL: Signal<CriticalSectionRawMutex, RemoteCommand> = Signal::new();
 
-/// Latest mood the operator has selected via `POST /mood`. Drained by
-/// the render task into `entity.mind.mood` ahead of `Director::run`.
-/// Latest-wins semantics; persistence ships in a follow-up.
+/// Latest mood the operator has selected via `POST /mood`.
+///
+/// Drained by the render task into `entity.mind.mood` ahead of
+/// `Director::run`. Latest-wins semantics; the selection survives
+/// reboots via `/sd/RUNTIME.RON` (see `runtime_store::update_mood`).
 pub static MOOD_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Mood> = Signal::new();
 
 /// Latest palette the operator has selected via `POST /palette`.
@@ -764,8 +766,9 @@ async fn handle_get_head_offsets(socket: &mut TcpSocket<'_>) -> Result<(), HttpE
 
 /// `POST /head/offsets` — parse the JSON body and push the new
 /// offsets at the head task via
-/// [`crate::head::OFFSETS_SIGNAL`]. Runtime-only — persistence
-/// across reboots ships alongside the NVS `RuntimeStore` follow-up.
+/// [`crate::head::OFFSETS_SIGNAL`]. Runtime-only; head offsets are
+/// not yet enrolled in the SD-backed `RuntimeStore` and reset on
+/// reboot.
 async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let offsets = match json::parse_head_offsets(body) {
         Ok(o) => o,
@@ -783,6 +786,12 @@ async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Res
         tilt_offset_deg: offsets.tilt_offset_deg,
     };
     crate::head::OFFSETS_SIGNAL.signal(firmware_offsets);
+    // Also publish to the read-back cache directly so an immediate
+    // `GET /head/offsets` from the same client doesn't lag behind
+    // the head task's signal-drain (which only runs at the 50 Hz
+    // tick, leaving a small POST-then-GET window where the read
+    // returns the prior value).
+    crate::head::OFFSETS_CACHE.lock(|cell| cell.set(firmware_offsets));
     defmt::info!(
         "http: POST /head/offsets → yaw={=f32} tilt={=f32}",
         firmware_offsets.yaw_offset_deg,
@@ -1253,6 +1262,29 @@ const MAX_OTA_REQUEST_BYTES: usize = stackchan_net::ota::OTA_HEADER_LEN
 /// the HTTP module without any new constants.
 const OTA_RECV_CHUNK_BYTES: usize = 1024;
 
+/// Single-flight latch on `POST /firmware/update`.
+///
+/// `HTTP_WORKER_COUNT` workers can otherwise each spin up their own
+/// PSRAM-backed body buffer in parallel, OOM-ing the heap on a
+/// flood of concurrent OTA requests (4 × ~4 MiB > available
+/// PSRAM after the framebuffer + heap overhead). One in-flight
+/// upload at a time is the right concurrency for an irreversible
+/// reboot anyway.
+static OTA_IN_FLIGHT: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
+/// RAII helper that releases the `OTA_IN_FLIGHT` latch on every
+/// non-reboot exit path of [`handle_post_firmware_update`]. A
+/// successful flash soft-resets before drop runs, which is fine —
+/// the latch's only job is to gate concurrent attempts in the
+/// pre-reboot window.
+struct OtaInFlightGuard;
+
+impl Drop for OtaInFlightGuard {
+    fn drop(&mut self) {
+        OTA_IN_FLIGHT.store(false, core::sync::atomic::Ordering::Release);
+    }
+}
+
 /// `POST /firmware/update` — accept an SCFW-framed firmware image,
 /// verify the ed25519 signature against the build-time public key,
 /// stream the payload into the inactive OTA slot, flip the
@@ -1273,6 +1305,19 @@ async fn handle_post_firmware_update(
     already_buffered: &[u8],
     auth_token: Option<&str>,
 ) -> Result<(), HttpError> {
+    use core::sync::atomic::Ordering;
+    if OTA_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        defmt::warn!("http: POST /firmware/update — refused, another OTA in flight");
+        return write_text(socket, 409, "ota already in flight; retry after reboot\n").await;
+    }
+    // Defer-style guard: clear the latch on every exit. Successful
+    // updates soft-reset before this runs (so the latch never
+    // releases — which is correct: the reboot is the only outcome
+    // we want after a verified flash).
+    let _release = OtaInFlightGuard;
     if !crate::ota::ota_enabled() {
         defmt::warn!("http: POST /firmware/update — OTA compiled out");
         return write_text(

--- a/crates/stackchan-firmware/src/ota.rs
+++ b/crates/stackchan-firmware/src/ota.rs
@@ -51,8 +51,9 @@ use stackchan_net::ota::{OTA_PUBLIC_KEY_LEN, OtaImageError, parse_and_verify};
 
 /// Build-time-baked Ed25519 public key (32 bytes), parsed from the
 /// `STACKCHAN_OTA_PUBLIC_KEY` env var as 64 lowercase hex chars.
-/// `None` disables OTA at compile time.
-pub const OTA_PUBLIC_KEY: Option<[u8; OTA_PUBLIC_KEY_LEN]> =
+/// `None` disables OTA at compile time. Module-private — callers
+/// use [`ota_enabled`] for the feature-flag check.
+const OTA_PUBLIC_KEY: Option<[u8; OTA_PUBLIC_KEY_LEN]> =
     match option_env!("STACKCHAN_OTA_PUBLIC_KEY") {
         Some(hex) => Some(decode_hex_pubkey(hex)),
         None => None,

--- a/crates/stackchan-firmware/src/reminders.rs
+++ b/crates/stackchan-firmware/src/reminders.rs
@@ -19,8 +19,9 @@
 //!
 //! ## Persistence
 //!
-//! None — the list lives in RAM and resets on reboot. Persistence
-//! across reboots ships alongside the NVS `RuntimeStore` follow-up.
+//! None — the list lives in RAM and resets on reboot. Reminders are
+//! short-horizon by definition (5-day cap); the operator-tooling
+//! cost of re-arming after a reboot is acceptable.
 
 use core::cell::RefCell;
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -191,9 +192,25 @@ pub async fn reminders_task() {
                 locale: Locale::En,
                 priority: Priority::Normal,
             });
+            // The render task drains REMOTE_COMMAND_SIGNAL once per
+            // ~33 ms render frame; signalling a second reminder
+            // before that drain runs would silently overwrite the
+            // first (Signal is single-waker, latest-wins). Pace
+            // bursts so each signalled command is consumed before
+            // the next replaces it.
+            embassy_time::Timer::after(embassy_time::Duration::from_millis(
+                REMINDER_BURST_SPACING_MS,
+            ))
+            .await;
         }
     }
 }
+
+/// Spacing between back-to-back reminder fires when several land
+/// due in the same tick. Sized comfortably above the 33 ms render
+/// cadence so the consumer drains `REMOTE_COMMAND_SIGNAL` between
+/// each push.
+const REMINDER_BURST_SPACING_MS: u64 = 100;
 
 #[cfg(test)]
 mod tests {

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -164,19 +164,29 @@ pub async fn load_into_cache() -> RuntimeState {
 /// already updated, so the runtime change still takes effect; only
 /// the across-reboot persistence is lost).
 pub async fn update_palette(palette: Palette) -> bool {
-    let mut state = current();
-    state.palette = palette;
-    set_cache(state);
-    persist(state).await
+    let snapshot = mutate(|s| s.palette = palette);
+    persist(snapshot).await
 }
 
 /// Update the mood field and persist the cache. Same semantics as
 /// [`update_palette`].
 pub async fn update_mood(mood: Mood) -> bool {
-    let mut state = current();
-    state.mood = mood;
-    set_cache(state);
-    persist(state).await
+    let snapshot = mutate(|s| s.mood = mood);
+    persist(snapshot).await
+}
+
+/// Apply `f` to the cache atomically (read + modify + write happen
+/// inside one critical section) and return the post-mutation
+/// snapshot. The previous shape — `current()` then `set_cache(...)`
+/// — left a window where a second `update_*` could clobber the
+/// first axis between the read and the set.
+fn mutate(f: impl FnOnce(&mut RuntimeState)) -> RuntimeState {
+    CACHE.lock(|cell| {
+        let mut s = cell.get();
+        f(&mut s);
+        cell.set(s);
+        s
+    })
 }
 
 /// Render `state` and atomically replace `/sd/RUNTIME.RON`.

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -1526,6 +1526,83 @@ mod tests {
     }
 
     #[test]
+    fn create_reminder_parses_required_fields() {
+        let body = r#"{"fire_in_secs":60,"phrase":"wake_chirp"}"#;
+        let req = parse_create_reminder(body).unwrap();
+        assert_eq!(req.fire_in_secs, 60);
+        assert_eq!(req.phrase, PhraseId::WakeChirp);
+    }
+
+    #[test]
+    fn create_reminder_rejects_missing_fire_in_secs() {
+        let body = r#"{"phrase":"wake_chirp"}"#;
+        assert!(matches!(
+            parse_create_reminder(body),
+            Err(JsonError::MissingKey("fire_in_secs"))
+        ));
+    }
+
+    #[test]
+    fn create_reminder_rejects_missing_phrase() {
+        let body = r#"{"fire_in_secs":60}"#;
+        assert!(matches!(
+            parse_create_reminder(body),
+            Err(JsonError::MissingKey("phrase"))
+        ));
+    }
+
+    #[test]
+    fn create_reminder_rejects_unknown_phrase() {
+        let body = r#"{"fire_in_secs":60,"phrase":"nope"}"#;
+        assert!(matches!(
+            parse_create_reminder(body),
+            Err(JsonError::UnknownPhrase)
+        ));
+    }
+
+    #[test]
+    fn create_reminder_rejects_unknown_key() {
+        let body = r#"{"fire_in_secs":60,"phrase":"wake_chirp","extra":1}"#;
+        assert!(matches!(
+            parse_create_reminder(body),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn create_reminder_rejects_duplicate_key() {
+        let body = r#"{"fire_in_secs":60,"fire_in_secs":120,"phrase":"wake_chirp"}"#;
+        assert!(matches!(
+            parse_create_reminder(body),
+            Err(JsonError::DuplicateKey("fire_in_secs"))
+        ));
+    }
+
+    #[test]
+    fn cancel_reminder_parses_id() {
+        let body = r#"{"id":42}"#;
+        assert_eq!(parse_cancel_reminder(body).unwrap(), 42);
+    }
+
+    #[test]
+    fn cancel_reminder_rejects_missing_id() {
+        let body = "{}";
+        assert!(matches!(
+            parse_cancel_reminder(body),
+            Err(JsonError::MissingKey("id"))
+        ));
+    }
+
+    #[test]
+    fn cancel_reminder_rejects_unknown_key() {
+        let body = r#"{"id":1,"extra":2}"#;
+        assert!(matches!(
+            parse_cancel_reminder(body),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
     fn face_target_lower_edges_pan_left_and_tilt_up() {
         // Mirror of the right-edge / down test — covers the negative
         // half of the FOV mapping.

--- a/crates/stackchan-net/src/ota.rs
+++ b/crates/stackchan-net/src/ota.rs
@@ -206,7 +206,7 @@ pub fn build_header(payload_len: u32) -> [u8; OTA_HEADER_LEN] {
 /// Length of an Ed25519 public key in bytes.
 pub const OTA_PUBLIC_KEY_LEN: usize = 32;
 
-/// Failure modes for [`verify_signature`].
+/// Failure modes for `verify_signature`.
 ///
 /// `MalformedKey` is the only structurally-impossible variant in
 /// production (the firmware's build-time public key is checked
@@ -233,10 +233,14 @@ pub enum VerifyError {
 /// embeds in the firmware at build time. The matching signing key
 /// stays on the operator's host and never enters the firmware.
 ///
+/// `pub(crate)` — production callers use [`parse_and_verify`]
+/// instead; the crate-internal split keeps the test surface
+/// granular without leaking a parse-then-verify-yourself shape.
+///
 /// # Errors
 ///
 /// See [`VerifyError`].
-pub fn verify_signature(
+pub(crate) fn verify_signature(
     image: &ParsedImage<'_>,
     public_key: &[u8; OTA_PUBLIC_KEY_LEN],
 ) -> Result<(), VerifyError> {
@@ -255,7 +259,8 @@ pub fn verify_signature(
 /// # Errors
 ///
 /// [`OtaImageError`] — either a framing problem from
-/// [`parse_image`] or a signature problem from [`verify_signature`].
+/// [`parse_image`] or a signature problem from the crate-internal
+/// `verify_signature`.
 pub fn parse_and_verify<'a>(
     bytes: &'a [u8],
     public_key: &[u8; OTA_PUBLIC_KEY_LEN],
@@ -268,7 +273,7 @@ pub fn parse_and_verify<'a>(
 /// Top-level OTA failure surface.
 ///
 /// Either a framing error from [`parse_image`] or a verification
-/// error from [`verify_signature`]. Used by [`parse_and_verify`] so
+/// error from `verify_signature`. Used by [`parse_and_verify`] so
 /// handlers have a single error type to map onto HTTP status codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OtaImageError {


### PR DESCRIPTION
## Summary

Quality pass over the v0.2.0 work, driven by a parallel run of gap-finder, code-reviewer, and code-simplifier agents. Findings consolidated into one PR since they're all small fixes around the same surface.

### P1 bugs

- **Reminders burst dispatch loses entries.** `REMOTE_COMMAND_SIGNAL` is single-waker / latest-wins; firing N due reminders in a tight loop meant only the last one was consumed by the render task. Pace bursts at 100 ms so each signalled command drains between pushes.
- **`GET /head/offsets` returned a stale cache after a `POST`.** POST handler signalled `OFFSETS_SIGNAL` but only the head task updated `OFFSETS_CACHE`, lagging up to 20 ms. POST handler now also writes the cache directly.

### P2 fixes

- **`update_palette` / `update_mood` race.** Concurrent dashboard requests could read+modify+set in two interleaved sequences and lose one field's update. Replaced with a `mutate` closure that holds the critical-section across read+modify+set.
- **`POST /firmware/update` had no single-flight gate.** 4 HTTP workers × 4 MiB PSRAM buffers in parallel = OOM. Added `OTA_IN_FLIGHT` AtomicBool with an RAII guard that releases on every non-reboot exit (successful flashes reboot before drop).
- **`is_allowlisted` had a dead branch.** Broadcast-from-static-peer was already covered by the first check. Removed and tightened the doc to match what actually ships (broadcasts from random senders fall through to the pairing window — intentional, accepting unicast operator commands LAN-wide would be an open RX port).

### Test coverage

- `parse_create_reminder` / `parse_cancel_reminder` had zero rejection tests — added the standard battery (missing / duplicate / unknown keys + happy paths) matching peer parsers.
- `Mood::from_wire_str` had no round-trip vocabulary pin — a future rename in `wire_str` could silently break persisted runtime state + HTTP body parsers without tripping any test. Added the exhaustive round-trip pattern `Palette` uses.

### Stale-comment + doc sweep

Removed five "ships alongside the NVS RuntimeStore follow-up" references that pre-date #266 (RuntimeStore shipped, SD-backed). README updated to list `POST /mood` alongside its peers in the runtime control surface.

### Trivial cleanup (simplifier wins)

- Dropped unused `pub const PAIR_WINDOW_DEFAULT_MS` (the HTTP route uses `stackchan-net`'s constant).
- Demoted `OTA_PUBLIC_KEY` and `verify_signature` to module-private since no external callers exist (host tests use `parse_and_verify`; firmware uses the same).

## Test plan

- [x] `just check` — host clippy + tests, including 9 new parser tests + 2 new mood vocabulary tests
- [x] `just clippy-firmware`
- [x] `just check-firmware`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`

## What I deliberately didn't change

The simplifier flagged a few moderate-risk cleanups I'm leaving for a follow-up:

- Atomic-staging-write helper (3 callers in `storage.rs`) — DRY win but touches the boot path.
- `Latch<T>` wrapper for `Mutex<CSRawMutex, Cell<T>>` — would unify palette/mood/head-offset cache shapes but the divergence is partly justified.
- `build_header` gating behind `cfg(feature = "ota-tooling")` — public API surface change.

Worth their own PRs after this lands.