### PR TITLE
fix: round-2 review — disk race in runtime_store + stuck FLASH on OTA fail

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -1398,6 +1398,13 @@ async fn handle_post_firmware_update(
                 crate::ota::OtaPerformError::FlashUnavailable => {
                     (500, "flash peripheral unavailable\n")
                 }
+                // Distinct from FlashUnavailable so the operator
+                // sees a clear "reboot to retry" path rather than
+                // assuming the build doesn't support OTA.
+                crate::ota::OtaPerformError::FlashConsumedThisBoot => (
+                    503,
+                    "flash consumed by a prior failed ota; reboot to retry\n",
+                ),
                 // Signature mismatch is the most operator-actionable
                 // error path — surface it as 403 specifically.
                 crate::ota::OtaPerformError::Image(stackchan_net::ota::OtaImageError::Verify(

--- a/crates/stackchan-firmware/src/ota.rs
+++ b/crates/stackchan-firmware/src/ota.rs
@@ -107,10 +107,20 @@ const fn hex_nibble(c: u8) -> u8 {
 
 /// Slot for the boot-acquired `FLASH` peripheral. Populated once
 /// from `main` via [`install_flash_peripheral`]; consumed by
-/// [`perform_update`] (a successful update reboots, so the flash
-/// handle is never returned).
+/// [`perform_update`] on the first attempt. Once moved into a
+/// `FlashStorage`, the underlying `Flash<'_>` can't be recovered
+/// (esp-storage owns it), so a failed flash leaves the slot empty
+/// for the rest of this boot — see [`FLASH_CONSUMED`].
 static FLASH_SLOT: Mutex<CriticalSectionRawMutex, RefCell<Option<FLASH<'static>>>> =
     Mutex::new(RefCell::new(None));
+
+/// Sticky flag — set on the first `perform_update` that takes the
+/// FLASH peripheral. Distinguishes "OTA never installed" (programming
+/// error) from "FLASH was claimed by a prior attempt and is now
+/// inside a `FlashStorage` we can't extract from" (operator needs
+/// to power-cycle to retry). The HTTP route maps each case to a
+/// different status code so the operator gets an actionable error.
+static FLASH_CONSUMED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
 /// Park the FLASH peripheral so the OTA path can claim it later.
 /// Called once from boot; calling twice is a programming error and
@@ -130,6 +140,13 @@ pub enum OtaPerformError {
     /// FLASH peripheral was never parked at boot — OTA is unreachable.
     /// Programming error: `install_flash_peripheral` not called.
     FlashUnavailable,
+    /// FLASH was consumed by a prior `perform_update` call this boot
+    /// (the prior call entered the flash-write path and `esp-storage`
+    /// took ownership of the peripheral). A reboot is required to
+    /// retry. Operationally distinct from `FlashUnavailable` so the
+    /// HTTP layer can surface a "reboot to retry" hint instead of
+    /// "OTA disabled".
+    FlashConsumedThisBoot,
     /// SCFW framing or ed25519 verification failed.
     Image(#[defmt(Debug2Format)] OtaImageError),
     /// `esp-hal-ota` rejected the partition setup or chunk write.
@@ -183,7 +200,18 @@ pub fn perform_update(image_bytes: &[u8]) -> Result<(), OtaPerformError> {
     let crc = esp_hal_ota::crc32::calc_crc32(payload, 0);
     let flash_periph = FLASH_SLOT
         .lock(|cell| cell.borrow_mut().take())
-        .ok_or(OtaPerformError::FlashUnavailable)?;
+        .ok_or_else(|| {
+            if FLASH_CONSUMED.load(core::sync::atomic::Ordering::Acquire) {
+                OtaPerformError::FlashConsumedThisBoot
+            } else {
+                OtaPerformError::FlashUnavailable
+            }
+        })?;
+    // Mark consumed before we hand the peripheral to FlashStorage —
+    // anything that fails after this point leaves the slot empty
+    // for the rest of this boot, and the next call needs to know
+    // why.
+    FLASH_CONSUMED.store(true, core::sync::atomic::Ordering::Release);
     let flash = FlashStorage::new(flash_periph);
     let mut ota = Ota::new(flash)?;
     let payload_len: u32 = u32::try_from(payload.len())

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -164,35 +164,46 @@ pub async fn load_into_cache() -> RuntimeState {
 /// already updated, so the runtime change still takes effect; only
 /// the across-reboot persistence is lost).
 pub async fn update_palette(palette: Palette) -> bool {
-    let snapshot = mutate(|s| s.palette = palette);
-    persist(snapshot).await
+    mutate(|s| s.palette = palette);
+    persist().await
 }
 
 /// Update the mood field and persist the cache. Same semantics as
 /// [`update_palette`].
 pub async fn update_mood(mood: Mood) -> bool {
-    let snapshot = mutate(|s| s.mood = mood);
-    persist(snapshot).await
+    mutate(|s| s.mood = mood);
+    persist().await
 }
 
-/// Apply `f` to the cache atomically (read + modify + write happen
-/// inside one critical section) and return the post-mutation
-/// snapshot. The previous shape — `current()` then `set_cache(...)`
-/// — left a window where a second `update_*` could clobber the
-/// first axis between the read and the set.
-fn mutate(f: impl FnOnce(&mut RuntimeState)) -> RuntimeState {
+/// Apply `f` to the cache atomically — read + modify + write happen
+/// inside one critical section.
+///
+/// The previous shape — `current()` then `set_cache(...)` — left a
+/// window where a second `update_*` could clobber the first axis
+/// between the read and the set.
+fn mutate(f: impl FnOnce(&mut RuntimeState)) {
     CACHE.lock(|cell| {
         let mut s = cell.get();
         f(&mut s);
         cell.set(s);
-        s
-    })
+    });
 }
 
-/// Render `state` and atomically replace `/sd/RUNTIME.RON`.
-async fn persist(state: RuntimeState) -> bool {
-    let rendered = render(&state);
-    let outcome = crate::storage::with_storage(|s| s.write_runtime(&rendered)).await;
+/// Render the **current** cache and atomically replace
+/// `/sd/RUNTIME.RON`.
+///
+/// Reading the cache inside the storage closure (rather than from a
+/// caller-captured snapshot) means a second `update_*` that lands
+/// between two persists doesn't get clobbered on disk: the second
+/// SD write reads the merged state. Without this, an A-then-B
+/// mutate sequence whose persists complete in B-then-A order would
+/// drop B's field on disk.
+async fn persist() -> bool {
+    let outcome = crate::storage::with_storage(|s| {
+        let rendered = render(&current());
+        s.write_runtime(&rendered)
+    })
+    .await;
     match outcome {
         Some(Ok(())) => true,
         Some(Err(e)) => {


### PR DESCRIPTION
## Summary

Round 2 of the quality pass — two P1 bugs caught by a fresh reviewer agent looking at #273's diff.

### 1. RuntimeStore disk race re-emerged after round-1 fix

Round 1 made the in-memory cache update atomic via `mutate`, but `persist(snapshot)` wrote a **captured** snapshot to disk. Two interleaved `update_*` calls A and B could each capture full snapshots before persisting. If A's SD write completed after B's, A's stale "B-old" field clobbered B's actual update on disk. Cache stayed correct; disk diverged.

**Fix:** `persist()` reads the live cache *inside* the storage closure (which runs inside the storage mutex's critical section). Each persist now writes the merged latest state. Two persists racing redundantly write the same content rather than diverging — wasteful but correct.

### 2. `FLASH_SLOT` permanently consumed on a failed OTA

`take()` removes the FLASH peripheral; once `FlashStorage` owns it, `esp-storage` doesn't expose a recovery path. Any `?` after the take left subsequent OTA attempts returning `OtaPerformError::FlashUnavailable` with a generic 500 — operators saw "flash peripheral unavailable" with no hint that a reboot would clear it.

**Fix:** track the take with a sticky `FLASH_CONSUMED: AtomicBool` and surface a new `OtaPerformError::FlashConsumedThisBoot` variant. HTTP route maps it to `503 flash consumed by a prior failed ota; reboot to retry`.

The deeper "let an in-boot retry succeed" fix would require holding `Ota<FlashStorage>` across calls or `esp-storage` exposing `into_inner()`. Out of scope here; for operationally important scenarios (CRC mismatch on retry of the same image), `reboot to retry` is no harder than `retry`.

## Test plan

- [x] `just check`
- [x] `just clippy-firmware`
- [x] `just check-firmware`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`

## Diminishing-returns notes

Round 2 cleared 8 other potential issues as not-bugs (reminders pacing budget, `mutate` re-entrancy, OTA atomic ordering, dual-writer mutex protection, `is_allowlisted` simplification, `verify_signature` visibility, signal-before-spawn boot ordering, `MIN_TRUSTED_YEAR`). Two real findings out of 10 inspected sites is the inflection point — running a round 3 won't be productive. Stopping after this lands.