### PR TITLE
fix(firmware): greptile post-merge findings on #273 + #275

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -1311,7 +1311,17 @@ async fn handle_post_firmware_update(
         .is_err()
     {
         defmt::warn!("http: POST /firmware/update — refused, another OTA in flight");
-        return write_text(socket, 409, "ota already in flight; retry after reboot\n").await;
+        // The in-flight latch releases on every non-reboot exit
+        // (auth fail, signature mismatch, flash error). Operators
+        // who hit this message can retry as soon as the prior
+        // request finishes — only a successful flash blocks them
+        // until the soft-reset cycles the device.
+        return write_text(
+            socket,
+            409,
+            "ota already in flight; retry shortly or after reboot\n",
+        )
+        .await;
     }
     // Defer-style guard: clear the latch on every exit. Successful
     // updates soft-reset before this runs (so the latch never
@@ -1395,12 +1405,14 @@ async fn handle_post_firmware_update(
             defmt::warn!("http: OTA failed: {}", e);
             let (status, msg) = match &e {
                 crate::ota::OtaPerformError::Disabled => (503, "ota disabled in this build\n"),
+                // Both flash-state errors are 503 (service
+                // unavailable) — `FlashUnavailable` is a build-time
+                // miswiring, `FlashConsumedThisBoot` is a runtime
+                // exhaustion; both are operationally "OTA can't
+                // serve this request" rather than "server bug".
                 crate::ota::OtaPerformError::FlashUnavailable => {
-                    (500, "flash peripheral unavailable\n")
+                    (503, "flash peripheral unavailable\n")
                 }
-                // Distinct from FlashUnavailable so the operator
-                // sees a clear "reboot to retry" path rather than
-                // assuming the build doesn't support OTA.
                 crate::ota::OtaPerformError::FlashConsumedThisBoot => (
                     503,
                     "flash consumed by a prior failed ota; reboot to retry\n",

--- a/crates/stackchan-firmware/src/ota.rs
+++ b/crates/stackchan-firmware/src/ota.rs
@@ -198,20 +198,22 @@ pub fn perform_update(image_bytes: &[u8]) -> Result<(), OtaPerformError> {
     );
 
     let crc = esp_hal_ota::crc32::calc_crc32(payload, 0);
-    let flash_periph = FLASH_SLOT
-        .lock(|cell| cell.borrow_mut().take())
-        .ok_or_else(|| {
-            if FLASH_CONSUMED.load(core::sync::atomic::Ordering::Acquire) {
-                OtaPerformError::FlashConsumedThisBoot
-            } else {
-                OtaPerformError::FlashUnavailable
-            }
-        })?;
-    // Mark consumed before we hand the peripheral to FlashStorage —
-    // anything that fails after this point leaves the slot empty
-    // for the rest of this boot, and the next call needs to know
-    // why.
-    FLASH_CONSUMED.store(true, core::sync::atomic::Ordering::Release);
+    // Take + consumed-flag check + consumed-flag set all happen in
+    // one critical section. Folding them avoids a TOCTOU window
+    // between the take and a subsequent read of `FLASH_CONSUMED`
+    // that's harmless on a single-core cooperative scheduler today
+    // but easy to break later (a second core, an interrupt that
+    // calls into OTA, etc.).
+    let flash_periph = FLASH_SLOT.lock(|cell| match cell.borrow_mut().take() {
+        Some(periph) => {
+            FLASH_CONSUMED.store(true, core::sync::atomic::Ordering::Release);
+            Ok(periph)
+        }
+        None if FLASH_CONSUMED.load(core::sync::atomic::Ordering::Acquire) => {
+            Err(OtaPerformError::FlashConsumedThisBoot)
+        }
+        None => Err(OtaPerformError::FlashUnavailable),
+    })?;
     let flash = FlashStorage::new(flash_periph);
     let mut ota = Ota::new(flash)?;
     let payload_len: u32 = u32::try_from(payload.len())


### PR DESCRIPTION
## Summary

Three P2 cleanups from greptile's post-merge review of #273 and #275.

- **(#273) 409 retry hint was misleading.** "Retry after reboot" but the in-flight latch releases on every non-reboot exit (auth fail, signature mismatch, flash error). Operators who hit the 409 during a failed prior request can retry as soon as it finishes; only a successful flash blocks until the soft-reset. Reworded to "retry shortly or after reboot".

- **(#275) `FLASH_CONSUMED` load was outside the `FLASH_SLOT` lock.** Benign on a single-core cooperative scheduler — no await point between the take and the consumed-flag check — but trivially broken if a second core or interrupt ever calls `perform_update`. Folded the take, consumed-flag check, and consumed-flag set into one critical section.

- **(#275) `FlashUnavailable` was 500, `FlashConsumedThisBoot` was 503.** Two structurally similar "OTA can't serve this request" errors with different status codes for no operator-visible reason. Both are now 503; message text still distinguishes the two cases.

## Test plan

- [x] `just check`
- [x] `just clippy-firmware`
- [x] `just check-firmware`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`