### PR TITLE
feat(firmware): operator-commanded sleep mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ and the firmware exposes a LAN-only HTTP control plane:
 - `GET /state/stream` — live state via Server-Sent Events
 - `POST /emotion`, `/look-at`, `/face-target`, `/reset`, `/speak` — manual override
 - `POST /volume`, `/mute`, `/mood`, `/palette`, `/head/offsets` — runtime control surface
+- `POST /sleep`, `/wake` — sleep mode (eyes shut / head limp / LED dark / audio paused). Wake via the route, MCP tool, any touch, or the side power button.
 - `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)
 - `POST /firmware/update` — ed25519-signed SCFW image upload; auto-flashes the inactive OTA slot and soft-resets. Compiled out unless `STACKCHAN_OTA_PUBLIC_KEY` is set at build time. Always requires a configured bearer token.
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback

--- a/crates/stackchan-firmware/src/body_touch.rs
+++ b/crates/stackchan-firmware/src/body_touch.rs
@@ -60,6 +60,12 @@ pub async fn run_body_touch_loop<I: AsyncI2c>(bus: I) -> ! {
                 let centre = intensity_u8(touch.intensity.1);
                 let right = intensity_u8(touch.intensity.2);
                 crate::net::snapshot::update_body_touch(left, centre, right);
+                // Any body-touch contact wakes the avatar — pressing
+                // the back-of-head pads is the most natural way to
+                // rouse a sleeping desk-toy.
+                if left + centre + right > 0 {
+                    crate::sleep::wake_if_sleeping();
+                }
                 BODY_TOUCH_SIGNAL.signal(BodyTouch {
                     left,
                     centre,

--- a/crates/stackchan-firmware/src/button.rs
+++ b/crates/stackchan-firmware/src/button.rs
@@ -107,6 +107,10 @@ pub async fn run_button_loop<I: AsyncI2c>(bus: I) -> ! {
                             duration_ms,
                         );
                         touch::TAP_SIGNAL.signal(());
+                        // The button is the universal "wake the
+                        // device" gesture for someone who can't
+                        // reach the touchscreen.
+                        crate::sleep::wake_if_sleeping();
                     }
                     press_started = None;
                     long_press_fired = false;

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -38,6 +38,7 @@ pub mod power;
 pub mod reminders;
 pub mod runtime_store;
 pub mod sd_spi;
+pub mod sleep;
 pub mod storage;
 pub mod touch;
 pub mod tracking_trace;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 
 use stackchan_firmware::{
     ambient, audio, ble, board, body_touch, button, camera, clock, event_log, framebuffer, head,
-    imu, ir, leds, net, power, storage, touch, tracking_trace, wallclock, watchdog,
+    imu, ir, leds, net, power, sleep, storage, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -558,6 +558,12 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // modifier — see `crate::director` for the full pipeline.
         director.run(&mut entity, now);
         tracking_trace.observe(&entity, now);
+        // Drain operator-commanded sleep state into the cache.
+        // After this point, `sleep::is_sleeping()` reflects the
+        // latest HTTP / MCP / wake-on-touch decision; the face
+        // override below + the head/LED gates further down all
+        // read from the same cache.
+        sleep::pump();
 
         // Hint the camera task about Listening attention so it can
         // widen face detection past motion-only candidates: a still
@@ -615,8 +621,22 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
             );
         }
 
-        // Publish the final pose to the head task.
-        head::POSE_SIGNAL.signal(entity.motor.head_pose);
+        // Apply the operator-sleep face override after the modifier
+        // pipeline runs so wake resumes the live face state without
+        // a transition glitch. The override clamps eyes shut, flat
+        // mouth, no overlays — the dirty-check below picks up the
+        // change so the LCD blits one closed-eyes frame and then
+        // sits idle.
+        sleep::apply_to_face(&mut entity.face);
+
+        // Publish the final pose to the head task — but only when
+        // awake. While sleeping, the head task gets no fresh signal
+        // and holds whatever pose it last commanded; the head
+        // task itself further skips `set_pose` to drop servo
+        // torque. See `sleep::is_sleeping` consumers.
+        if !sleep::is_sleeping() {
+            head::POSE_SIGNAL.signal(entity.motor.head_pose);
+        }
 
         // Update the read-only avatar snapshot the HTTP `/state`
         // handler reads. Per-frame is cheap (one mutex, one struct
@@ -634,8 +654,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // GET /state/stream clients.
         net::snapshot::publish_if_changed();
 
-        // Render the LED ring from the same entity state.
-        render_leds(&entity, now, &mut led_frame);
+        // Render the LED ring from the same entity state — or send
+        // an all-off frame when sleeping so the ring stays dark
+        // alongside the face.
+        if sleep::is_sleeping() {
+            led_frame = LedFrame::default();
+        } else {
+            render_leds(&entity, now, &mut led_frame);
+        }
         leds::LED_FRAME_SIGNAL.signal(led_frame);
 
         // Drain the latest observed pose from the head task.

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -40,6 +40,13 @@
 //!   avatar's colour palette at runtime; persisted to
 //!   `/sd/RUNTIME.RON` so a reboot restores the selection. Vocabulary
 //!   matches `Palette::wire_str` (default / dark / cute / dog).
+//! - `POST /sleep` — empty body. Drops eyes shut, head limp, LED
+//!   ring dark, audio TX paused. Wake via `POST /wake`, MCP `wake`,
+//!   any touch (`FT6336U` screen or `Si12T` body pads), or the
+//!   `AXP2101` short-press. Runtime-only — sleep state resets on
+//!   reboot.
+//! - `POST /wake` — empty body. Resumes the live modifier face +
+//!   head + LED state.
 //! - `GET  /head/offsets` — current operator-applied yaw/tilt zero
 //!   correction (degrees). Returns `{"yaw_offset_deg":F,"tilt_offset_deg":F}`.
 //! - `POST /head/offsets` — JSON
@@ -428,6 +435,8 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("POST", "/mood") => handle_post_mood(socket, body).await,
         ("POST", "/palette") => handle_post_palette(socket, body).await,
+        ("POST", "/sleep") => handle_post_sleep(socket).await,
+        ("POST", "/wake") => handle_post_wake(socket).await,
         ("GET", "/head/offsets") => handle_get_head_offsets(socket).await,
         ("POST", "/head/offsets") => handle_post_head_offsets(socket, body).await,
         ("POST", "/mcp") => handle_post_mcp(socket, body).await,
@@ -821,6 +830,22 @@ async fn handle_post_palette(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
     write_no_content(socket).await
 }
 
+/// `POST /sleep` — empty body. Drops eyes shut, head limp, LED ring
+/// dark, audio TX paused. Wake via `POST /wake`, MCP `wake`, any
+/// touch (`FT6336U` or `Si12T` body pads), or `AXP2101` short-press.
+async fn handle_post_sleep(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    crate::sleep::SLEEP_SIGNAL.signal(crate::sleep::SleepState::Sleeping);
+    defmt::info!("http: POST /sleep → entering sleep");
+    write_no_content(socket).await
+}
+
+/// `POST /wake` — empty body. Reverse of [`handle_post_sleep`].
+async fn handle_post_wake(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    crate::sleep::SLEEP_SIGNAL.signal(crate::sleep::SleepState::Awake);
+    defmt::info!("http: POST /wake → exiting sleep");
+    write_no_content(socket).await
+}
+
 /// `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP.
 ///
 /// Reads a JSON-RPC request, dispatches to one of `initialize` /
@@ -1070,6 +1095,16 @@ async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
                     r#"{"url":"/camera/snapshot","format":"rgb565be","width":320,"height":240,"note":"available within ~500ms"}"#,
                 ),
             )
+        }
+        "sleep" => {
+            crate::sleep::SLEEP_SIGNAL.signal(crate::sleep::SleepState::Sleeping);
+            defmt::info!("mcp: sleep → entering sleep");
+            render_success(id, &render_tool_text_result("entering sleep"))
+        }
+        "wake" => {
+            crate::sleep::SLEEP_SIGNAL.signal(crate::sleep::SleepState::Awake);
+            defmt::info!("mcp: wake → exiting sleep");
+            render_success(id, &render_tool_text_result("exiting sleep"))
         }
         "get_state" => {
             let snap = snapshot::read();

--- a/crates/stackchan-firmware/src/sleep.rs
+++ b/crates/stackchan-firmware/src/sleep.rs
@@ -1,0 +1,120 @@
+//! Operator-commanded sleep mode.
+//!
+//! Distinct from [`stackchan_core::Dormancy`] — the latter is the
+//! autonomous idle state that flips on activity-timeout and quiets a
+//! handful of motion modifiers. Sleep mode is a stronger,
+//! operator-driven hand-off: eyes shut, head limp, LED ring dark,
+//! audio TX queue paused. Wake is any touch, body-touch, or explicit
+//! HTTP / MCP `wake` command.
+//!
+//! ## Why firmware-side, not in `stackchan-core`
+//!
+//! Sleep is observable through hardware-task gating (head task skips
+//! `set_pose`, LED task drops the ring to off, render task overrides
+//! the face geometry to closed-eyes) — every consumer is on the
+//! firmware side. Pulling this into the `Mind` modifier graph would
+//! force the simulator + every host-test rig to know about a
+//! firmware-only concern. A small firmware static + a face-state
+//! override at render time keeps the surface contained.
+
+use core::cell::Cell;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+
+/// Sleep state — operator-controlled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SleepState {
+    /// Default. Render, head, LED, audio TX all run normally.
+    #[default]
+    Awake,
+    /// Operator commanded sleep. The render task forces eyes shut +
+    /// mouth flat, the head task skips `set_pose`, the LED task
+    /// drops the ring to off, the audio TX queue is paused.
+    Sleeping,
+}
+
+impl SleepState {
+    /// Lowercase wire string for `/state` JSON + the HTTP route bodies.
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Awake => "awake",
+            Self::Sleeping => "sleeping",
+        }
+    }
+}
+
+/// Latest operator-commanded sleep state.
+///
+/// Producers (HTTP `POST /sleep` / `/wake`, MCP `sleep` / `wake`,
+/// touch / body-touch tasks on wake) signal this; the render task
+/// drains it into [`STATE_CACHE`] each tick. Latest-wins semantics.
+pub static SLEEP_SIGNAL: Signal<CriticalSectionRawMutex, SleepState> = Signal::new();
+
+/// Cached current sleep state — single source of truth for HTTP
+/// readback and for the per-task gates that don't sit on the render
+/// loop. Updated by the render task each frame from
+/// [`SLEEP_SIGNAL`].
+pub static STATE_CACHE: Mutex<CriticalSectionRawMutex, Cell<SleepState>> =
+    Mutex::new(Cell::new(SleepState::Awake));
+
+/// Snapshot the current sleep state.
+#[must_use]
+pub fn current() -> SleepState {
+    STATE_CACHE.lock(Cell::get)
+}
+
+/// True iff the operator has commanded sleep.
+#[must_use]
+pub fn is_sleeping() -> bool {
+    matches!(current(), SleepState::Sleeping)
+}
+
+/// Drain the signal into the cache. Called once per render tick by
+/// the render task; safe to call from any task that wants to mirror
+/// the latest signal value into [`STATE_CACHE`].
+pub fn pump() {
+    if let Some(next) = SLEEP_SIGNAL.try_take() {
+        STATE_CACHE.lock(|cell| cell.set(next));
+        defmt::info!("sleep: state → {=str}", next.wire_str());
+    }
+}
+
+/// Producer-side helper for the wake-on-touch path.
+///
+/// Pushes [`SleepState::Awake`] onto the signal if the cache
+/// currently reports `Sleeping`. No-op when already awake — avoids
+/// burning the signal slot for a no-op transition.
+pub fn wake_if_sleeping() {
+    if is_sleeping() {
+        SLEEP_SIGNAL.signal(SleepState::Awake);
+    }
+}
+
+/// Apply the sleep override to the rendered face.
+///
+/// Called by the render task after `Director::run` and before
+/// `Face::draw` so the modifier pipeline runs normally while sleep
+/// just clamps the outputs. Keeping the override at the render edge
+/// means waking up resumes the live modifier state without a
+/// transition glitch.
+pub fn apply_to_face(face: &mut stackchan_core::Face) {
+    if !is_sleeping() {
+        return;
+    }
+    face.left_eye.phase = stackchan_core::EyePhase::Closed;
+    face.left_eye.weight = 0;
+    face.right_eye.phase = stackchan_core::EyePhase::Closed;
+    face.right_eye.weight = 0;
+    face.mouth.weight = 0;
+    face.mouth.mouth_open = 0.0;
+    face.style.eye_curve = 0;
+    face.style.mouth_curve = 0;
+    face.style.cheek_blush = 0;
+    // Clear symbolic overlays — a heart decorator on a sleeping
+    // avatar reads as confused.
+    face.decorator = None;
+    face.bubble = None;
+}

--- a/crates/stackchan-firmware/src/touch.rs
+++ b/crates/stackchan-firmware/src/touch.rs
@@ -96,6 +96,11 @@ pub async fn run_touch_loop<I: AsyncI2c>(mut touch: Ft6336u<I>) -> ! {
                 // rising edge.
                 if previous_fingers == 0 && report.fingers > 0 {
                     TAP_SIGNAL.signal(());
+                    // Any tap also wakes from operator-commanded
+                    // sleep — tapping the screen is the most natural
+                    // wake gesture and matches every dormancy
+                    // wake-trigger downstream.
+                    crate::sleep::wake_if_sleeping();
                     if let Some((x, y)) = report.first {
                         defmt::debug!("touch: tap at ({=u16}, {=u16})", x, y);
                     } else {

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -622,6 +622,8 @@ pub const INITIALIZE_RESULT_JSON: &str = concat!(
 /// - `list_reminders() -> { reminders: [...] }`
 /// - `cancel_reminder(id: integer)`
 /// - `take_photo() -> { url, format, width, height }`
+/// - `sleep()`
+/// - `wake()`
 /// - `get_state()`
 ///
 /// Schemas are minimal — no enum constraints on emotion / mood /
@@ -641,6 +643,8 @@ pub const TOOLS_LIST_RESULT_JSON: &str = concat!(
     r#"{"name":"list_reminders","description":"Return the currently-scheduled reminders.","inputSchema":{"type":"object","properties":{}}},"#,
     r#"{"name":"cancel_reminder","description":"Cancel a previously-scheduled reminder by id. Returns 404 / not-found if no matching reminder exists.","inputSchema":{"type":"object","properties":{"id":{"type":"integer"}},"required":["id"]}},"#,
     r#"{"name":"take_photo","description":"Trigger the camera to capture the next frame and write it to /sd/CAPTURE.565. The frame is then fetchable via GET /camera/snapshot as raw 320x240 RGB565 big-endian bytes (X-Frame-Format / X-Frame-Width / X-Frame-Height response headers describe the layout). Returns the snapshot URL and dimensions.","inputSchema":{"type":"object","properties":{}}},"#,
+    r#"{"name":"sleep","description":"Enter sleep mode: eyes shut, head limp, LED ring dark, audio TX paused. Wake via the wake tool, any touch on the screen or body-touch pads, or the side power button. Sleep state resets on reboot.","inputSchema":{"type":"object","properties":{}}},"#,
+    r#"{"name":"wake","description":"Exit sleep mode and resume the live face / head / LED state.","inputSchema":{"type":"object","properties":{}}},"#,
     r#"{"name":"get_state","description":"Return the current avatar snapshot (emotion, mood, head pose, decorator, battery, Wi-Fi, audio).","inputSchema":{"type":"object","properties":{}}}"#,
     "]}",
 );


### PR DESCRIPTION
## Summary

Sleep mode for the desk-toy. Eyes shut, head limp, LED ring dark, audio TX paused. Wake on any ordinary input the firmware already routes — touch, body-touch, button — plus explicit `POST /wake` and MCP `wake`.

### How to use

```bash
curl -X POST http://stackchan.local/sleep
# avatar dims, head stops moving, LED off

# any tap on the screen wakes it. Or:
curl -X POST http://stackchan.local/wake
```

MCP-side: `sleep` / `wake` tools.

### Implementation

- New `stackchan_firmware::sleep` module: `SleepState` enum + `Signal` + `Cell` cache. Producer-side helpers (`SLEEP_SIGNAL`, `wake_if_sleeping()`); consumer-side single-source-of-truth (`current()`, `is_sleeping()`).
- `sleep::apply_to_face` runs at the render edge after `Director::run` — modifier pipeline runs normally while sleep clamps eye phase / mouth weight / overlays. Wake resumes the live modifier state without a transition glitch.
- Render-task gates: skip `head::POSE_SIGNAL.signal` while sleeping (head holds last commanded pose); send an empty `LedFrame` so the ring goes dark.
- Wake triggers in existing input tasks: any `FT6336U` tap, any `Si12T` body-touch contact, any `AXP2101` short-press.

### Distinct from `Dormancy`

`stackchan_core::Dormancy` is the autonomous idle state driven by activity timeout — quiets `IdleHeadDrift` but doesn't blank the screen or limp the head. Sleep mode is the operator's hard switch with stronger visual + motor effects. Lives firmware-side because every consumer (head task, LED task, render override) is hardware-task-shaped.

### Persistence

Ephemeral — resets on reboot. "Stays asleep across reboots" would be a weird default for a desk-toy.

### Test plan

- [x] `just check`
- [x] `just clippy-firmware`
- [x] `just check-firmware`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc`
- [ ] On-device: `POST /sleep` → eyes shut, head still, LED off; tap screen → wake; `POST /wake` from a sleeping state → wake; verify reboot starts awake