### PR TITLE
feat(firmware): mDNS pose TXT — yaw/pitch live advertisement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4744,6 +4744,7 @@ name = "stackchan-net"
 version = "0.2.13"
 dependencies = [
  "ed25519-compact",
+ "heapless 0.8.0",
  "ron",
  "serde",
  "stackchan-core",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Discovery and inter-device:
 
 - **mDNS** — `<hostname>.local` plus DNS-SD service records (`_stackchan._tcp.local.`)
   carrying a `kai=1` variant marker so kai-aware clients gate on extension endpoints
-  while a generic Bonjour browser still lists the device alongside upstream stackchan units
+  while a generic Bonjour browser still lists the device alongside upstream stackchan units.
+  TXT also publishes live `yaw=` / `pitch=` (one decimal, ≤100 ms refresh with a 1 s heartbeat)
+  so a follower mimicking head pose tracks the leader without an HTTP round-trip
 - **ESP-NOW** — peer-allowlisted RX driving the same `RemoteCommand` plumbing as HTTP,
   plus a TX path that broadcasts pose-mirror + heartbeat frames so multiple units can
   choreograph against each other

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -95,6 +95,10 @@ runs three networked services on the LAN:
   `mdns.hostname` in the boot config (default `stackchan`). The TXT
   record carries `kai=1` as a variant marker; a generic Bonjour
   browser still lists the device alongside upstream stackchan units.
+  TXT also publishes live `yaw=<deg>` / `pitch=<deg>` (one decimal,
+  refreshed at most every 100 ms with a 1 s heartbeat) so a follower
+  in a mimic stack can lift current pose off mDNS without an HTTP
+  round-trip.
 - **SNTP** — on link-up, queries the SNTP servers from
   `time.sntp_servers` and writes the result into the BM8563 RTC.
 

--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -227,12 +227,17 @@ async fn serve_loop(
             }
             Either::Second(()) => {
                 let pose = current_pose();
-                let now_ms = EmbassyInstant::now().as_millis();
-                if !announcer.should_publish(pose, now_ms) {
+                if !announcer.should_publish(pose, EmbassyInstant::now().as_millis()) {
                     continue;
                 }
                 send_announcement(socket, hostname, our_ip, pose).await;
-                announcer.record_publish(pose, now_ms);
+                // Snap the publish stamp *after* the send completes,
+                // matching the query-response branch above. The two
+                // branches now agree on what "publish window starts"
+                // means; otherwise the periodic branch would record
+                // the start slightly earlier than the actual send and
+                // its throttle window would run slightly short.
+                announcer.record_publish(pose, EmbassyInstant::now().as_millis());
             }
         }
     }

--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -15,20 +15,34 @@
 //! - `SRV` `<hostname>._stackchan._tcp.local.` → priority 0 weight 0
 //!   port 80 target `<hostname>.local.`
 //! - `TXT` `<hostname>._stackchan._tcp.local.` → `txtvers=1`,
-//!   `version=<crate>`, `path=/`, `mcp=/mcp`, `kai=1`
+//!   `version=<crate>`, `path=/`, `mcp=/mcp`, `kai=1`,
+//!   `yaw=<deg>`, `pitch=<deg>`
 //!
 //! The `kai=1` key is the variant marker — meganetaaan-line clients
 //! ignore it, kai-aware clients use it to gate access to extension
 //! endpoints (MCP, palette, soliloquy config). The other keys mirror
 //! the upstream stackchan / m5stack-avatar convention so a generic
 //! Bonjour browser shows the device alongside upstream units.
+//!
+//! `yaw` and `pitch` carry the live commanded head pose in degrees
+//! (one decimal place, matches the meganetaaan `mimic_main` mod's
+//! advertisement convention so a kai unit can lead a mixed-firmware
+//! mimic stack). The pose advertisement runs as a periodic publisher
+//! racing against the query loop. The throttling policy (publish
+//! interval, deadband, heartbeat) lives in
+//! [`stackchan_net::mdns_pose::PoseAnnouncer`] so it can be
+//! host-tested without an esp toolchain.
 
 use alloc::string::String;
 
+use embassy_futures::select::{Either, select};
 use embassy_net::Stack;
 use embassy_net::udp::{PacketMetadata, UdpSocket};
-use embassy_time::{Duration, Timer};
+use embassy_time::{Duration, Instant as EmbassyInstant, Timer};
+use stackchan_core::Pose;
+use stackchan_net::mdns_pose::{POSE_PUBLISH_MIN_INTERVAL_MS, PoseAnnouncer, format_pose_kv};
 
+use super::snapshot;
 use super::wifi::{WIFI_LINK_SIGNAL, WifiLinkState};
 
 /// IPv4 mDNS multicast group + port.
@@ -119,14 +133,25 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
         );
 
         // Send unsolicited announcement once.
-        send_announcement(&socket, &hostname, our_ip).await;
+        let initial_pose = current_pose();
+        send_announcement(&socket, &hostname, our_ip, initial_pose).await;
+        let mut announcer = PoseAnnouncer::new();
+        announcer.record_publish(initial_pose, EmbassyInstant::now().as_millis());
 
-        // Serve queries until the link drops or anything errors out.
-        serve_loop(&socket, &hostname, our_ip).await;
+        // Serve queries + periodic pose updates until the link drops
+        // or anything errors out.
+        serve_loop(&socket, &hostname, our_ip, &mut announcer).await;
 
         let _ = stack.leave_multicast_group(MDNS_MULTICAST);
         socket.close();
     }
+}
+
+/// Read the current commanded head pose from the avatar snapshot.
+/// Mirrors what the HTTP `GET /state` route reads — non-destructive,
+/// no `Signal::try_take` race against the head task.
+fn current_pose() -> Pose {
+    snapshot::read().head_pose
 }
 
 /// Park forever — used by the empty-hostname idle path.
@@ -136,46 +161,79 @@ async fn park_forever() -> ! {
     }
 }
 
-/// Listen for queries; respond when one matches our hostname or the
-/// service type we advertise.
-async fn serve_loop(socket: &UdpSocket<'_>, hostname: &str, our_ip: embassy_net::Ipv4Address) {
+/// Listen for queries while periodically publishing fresh pose
+/// announcements. Both branches share the socket; the `select` race
+/// guarantees the periodic publisher fires even when no query is
+/// inbound, while still answering queries with sub-millisecond
+/// latency between timer ticks.
+async fn serve_loop(
+    socket: &UdpSocket<'_>,
+    hostname: &str,
+    our_ip: embassy_net::Ipv4Address,
+    announcer: &mut PoseAnnouncer,
+) {
     let mut buf = [0u8; MAX_DNS_BYTES];
     loop {
-        let (n, peer) = match socket.recv_from(&mut buf).await {
-            Ok(p) => p,
-            Err(e) => {
+        let race = select(
+            socket.recv_from(&mut buf),
+            Timer::after(Duration::from_millis(POSE_PUBLISH_MIN_INTERVAL_MS)),
+        )
+        .await;
+
+        match race {
+            Either::First(Ok((n, peer))) => {
+                if n < 12 {
+                    continue;
+                }
+                let kind = classify_query(&buf[..n], hostname);
+                if matches!(kind, QueryKind::None) {
+                    continue;
+                }
+                // Both A and service-type queries are answered with
+                // the same announcement payload — building one record
+                // set keeps the wire surface uniform and avoids drift
+                // between the unsolicited and reactive paths.
+                let mut resp = [0u8; MAX_DNS_BYTES];
+                let resp_id = u16::from_be_bytes([buf[0], buf[1]]);
+                let pose = current_pose();
+                let Some(len) = build_announcement(&mut resp, resp_id, hostname, our_ip, pose)
+                else {
+                    continue;
+                };
+
+                // Multicast peer is the standard mDNS path; unicast
+                // clients also exist but multicasting reaches everyone
+                // subscribed.
+                let target = embassy_net::IpEndpoint::new(MDNS_MULTICAST, MDNS_PORT);
+                if let Err(e) = socket.send_to(&resp[..len], target).await {
+                    defmt::warn!(
+                        "mdns: send response to {} failed ({:?})",
+                        defmt::Debug2Format(&peer.endpoint.addr),
+                        e,
+                    );
+                } else {
+                    // A query response carries the current pose just
+                    // like a periodic update, so stamp the announcer
+                    // — otherwise a steady stream of queries would
+                    // leave the announcer thinking pose is stale and
+                    // emit redundant unsolicited multicasts right
+                    // after each reactive answer.
+                    announcer.record_publish(pose, EmbassyInstant::now().as_millis());
+                }
+            }
+            Either::First(Err(e)) => {
                 defmt::warn!("mdns: recv error ({:?})", e);
                 return;
             }
-        };
-        if n < 12 {
-            continue;
-        }
-
-        let kind = classify_query(&buf[..n], hostname);
-        if matches!(kind, QueryKind::None) {
-            continue;
-        }
-
-        // Both A and service-type queries are answered with the same
-        // announcement payload — building one record set keeps the
-        // wire surface uniform and avoids drift between the
-        // unsolicited and reactive paths.
-        let mut resp = [0u8; MAX_DNS_BYTES];
-        let resp_id = u16::from_be_bytes([buf[0], buf[1]]);
-        let Some(len) = build_announcement(&mut resp, resp_id, hostname, our_ip) else {
-            continue;
-        };
-
-        // Multicast peer is the standard mDNS path; unicast clients
-        // also exist but multicasting reaches everyone subscribed.
-        let target = embassy_net::IpEndpoint::new(MDNS_MULTICAST, MDNS_PORT);
-        if let Err(e) = socket.send_to(&resp[..len], target).await {
-            defmt::warn!(
-                "mdns: send response to {} failed ({:?})",
-                defmt::Debug2Format(&peer.endpoint.addr),
-                e,
-            );
+            Either::Second(()) => {
+                let pose = current_pose();
+                let now_ms = EmbassyInstant::now().as_millis();
+                if !announcer.should_publish(pose, now_ms) {
+                    continue;
+                }
+                send_announcement(socket, hostname, our_ip, pose).await;
+                announcer.record_publish(pose, now_ms);
+            }
         }
     }
 }
@@ -186,9 +244,10 @@ async fn send_announcement(
     socket: &UdpSocket<'_>,
     hostname: &str,
     our_ip: embassy_net::Ipv4Address,
+    pose: Pose,
 ) {
     let mut resp = [0u8; MAX_DNS_BYTES];
-    let Some(len) = build_announcement(&mut resp, 0, hostname, our_ip) else {
+    let Some(len) = build_announcement(&mut resp, 0, hostname, our_ip, pose) else {
         return;
     };
     let target = embassy_net::IpEndpoint::new(MDNS_MULTICAST, MDNS_PORT);
@@ -292,11 +351,15 @@ fn matches_local_hostname(qname: &str, hostname: &str) -> bool {
 /// compression is performed — at our message sizes the duplication
 /// is well under the 512-byte budget and avoids the pointer-bookkeeping
 /// that compression requires.
+///
+/// `pose` is encoded into the TXT record as the live `yaw` / `pitch`
+/// keys — see [`write_txt_answer`].
 fn build_announcement(
     out: &mut [u8; MAX_DNS_BYTES],
     transaction_id: u16,
     hostname: &str,
     our_ip: embassy_net::Ipv4Address,
+    pose: Pose,
 ) -> Option<usize> {
     // Header: response, authoritative, ANCOUNT=4.
     out[0..2].copy_from_slice(&transaction_id.to_be_bytes());
@@ -309,7 +372,7 @@ fn build_announcement(
     let mut off = 12;
     off = write_ptr_answer(out, off, hostname)?;
     off = write_srv_answer(out, off, hostname, ADVERTISED_HTTP_PORT)?;
-    off = write_txt_answer(out, off, hostname)?;
+    off = write_txt_answer(out, off, hostname, pose)?;
     off = write_a_answer(out, off, hostname, our_ip)?;
     Some(off)
 }
@@ -386,10 +449,15 @@ fn write_srv_answer(
 }
 
 /// TXT answer: name `<instance>`, RDATA = length-prefixed strings.
+///
+/// Includes the live commanded head pose as `yaw=<deg>` and
+/// `pitch=<deg>` (one decimal). Followers in a mimic stack lift these
+/// straight off the TXT without needing the HTTP plane.
 fn write_txt_answer(
     out: &mut [u8; MAX_DNS_BYTES],
     mut off: usize,
     hostname: &str,
+    pose: Pose,
 ) -> Option<usize> {
     let instance_labels: [&[u8]; 4] = [
         hostname.as_bytes(),
@@ -408,15 +476,23 @@ fn write_txt_answer(
     // RFC 6763 §6.7. `version` mirrors upstream stackchan TXT for
     // browser parity. `kai=1` is the variant marker that gates
     // kai-only routes (MCP / palette / behavior config).
-    for kv in [
-        b"txtvers=1" as &[u8],
+    off = write_txt_string(out, off, b"txtvers=1")?;
+    off = write_txt_string(
+        out,
+        off,
         concat!("version=", env!("CARGO_PKG_VERSION")).as_bytes(),
-        b"path=/",
-        b"mcp=/mcp",
-        b"kai=1",
-    ] {
-        off = write_txt_string(out, off, kv)?;
-    }
+    )?;
+    off = write_txt_string(out, off, b"path=/")?;
+    off = write_txt_string(out, off, b"mcp=/mcp")?;
+    off = write_txt_string(out, off, b"kai=1")?;
+
+    // Pose keys — `yaw` / `pitch` follow meganetaaan `mimic_main`'s
+    // naming so a kai unit can lead a mixed-firmware mimic stack
+    // without a translation layer on the follower side.
+    let yaw_kv = format_pose_kv("yaw", pose.pan_deg)?;
+    off = write_txt_string(out, off, yaw_kv.as_bytes())?;
+    let pitch_kv = format_pose_kv("pitch", pose.tilt_deg)?;
+    off = write_txt_string(out, off, pitch_kv.as_bytes())?;
 
     let rdlen = u16::try_from(off - rdata_start).ok()?;
     out.get_mut(rdlen_off..rdlen_off + 2)?
@@ -582,7 +658,7 @@ mod tests {
     fn build_announcement_round_trip() {
         let ip = embassy_net::Ipv4Address::new(192, 168, 1, 42);
         let mut out = [0u8; MAX_DNS_BYTES];
-        let n = build_announcement(&mut out, 0, "stackchan", ip).unwrap();
+        let n = build_announcement(&mut out, 0, "stackchan", ip, Pose::default()).unwrap();
         // Header: QR=1 AA=1, ANCOUNT=4 (PTR + SRV + TXT + A).
         assert_eq!(u16::from_be_bytes([out[2], out[3]]), 0x8400);
         assert_eq!(u16::from_be_bytes([out[6], out[7]]), 4);
@@ -595,7 +671,7 @@ mod tests {
     fn announcement_contains_service_type_and_kai_marker() {
         let ip = embassy_net::Ipv4Address::new(10, 0, 0, 1);
         let mut out = [0u8; MAX_DNS_BYTES];
-        let n = build_announcement(&mut out, 0, "stackchan", ip).unwrap();
+        let n = build_announcement(&mut out, 0, "stackchan", ip, Pose::default()).unwrap();
         let bytes = &out[..n];
         // The service-type label sequence appears in the PTR owner.
         let needle = b"\x0a_stackchan\x04_tcp\x05local\x00";
@@ -615,7 +691,7 @@ mod tests {
     fn announcement_srv_record_carries_http_port() {
         let ip = embassy_net::Ipv4Address::new(10, 0, 0, 1);
         let mut out = [0u8; MAX_DNS_BYTES];
-        let n = build_announcement(&mut out, 0, "stackchan", ip).unwrap();
+        let n = build_announcement(&mut out, 0, "stackchan", ip, Pose::default()).unwrap();
         // SRV RDATA is priority(0,0) + weight(0,0) + port — search
         // for the literal HTTP port in the live announcement bytes
         // (scanning the full 512-byte buffer would risk a vacuous
@@ -635,6 +711,25 @@ mod tests {
         assert_eq!(host.len(), 33);
         let ip = embassy_net::Ipv4Address::new(10, 0, 0, 1);
         let mut out = [0u8; MAX_DNS_BYTES];
-        assert!(build_announcement(&mut out, 0, host, ip).is_some());
+        assert!(build_announcement(&mut out, 0, host, ip, Pose::default()).is_some());
+    }
+
+    #[test]
+    fn announcement_includes_pose_keys() {
+        let ip = embassy_net::Ipv4Address::new(10, 0, 0, 1);
+        let mut out = [0u8; MAX_DNS_BYTES];
+        let pose = Pose::new(12.3, -4.5);
+        let n = build_announcement(&mut out, 0, "stackchan", ip, pose).unwrap();
+        let bytes = &out[..n];
+        let yaw_needle = b"yaw=12.3";
+        assert!(
+            bytes.windows(yaw_needle.len()).any(|w| w == yaw_needle),
+            "yaw TXT key missing from announcement"
+        );
+        let pitch_needle = b"pitch=-4.5";
+        assert!(
+            bytes.windows(pitch_needle.len()).any(|w| w == pitch_needle),
+            "pitch TXT key missing from announcement"
+        );
     }
 }

--- a/crates/stackchan-net/Cargo.toml
+++ b/crates/stackchan-net/Cargo.toml
@@ -43,3 +43,8 @@ thiserror = { version = "2", default-features = false }
 # host. Held in `stackchan-net` (not the firmware crate) so the verify
 # path is host-testable through `parse_image` + `verify_signature`.
 ed25519-compact = { version = "2", default-features = false }
+# `heapless::String` for fixed-cap pose-TXT formatting in
+# [`mdns_pose::format_pose_kv`]. The firmware crate already pins the
+# 0.8 line elsewhere; matching the pin here keeps the resolver from
+# pulling a second copy.
+heapless = "0.8"

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -59,6 +59,10 @@ shape of the on-disk config and the RON file `PUT /settings` round-trips.
 - `src/ble_command.rs` — fixed-length wire-format codecs for the
   BLE audio + avatar control characteristics, with stable byte
   mappings for `Emotion` / `PhraseId` / `Locale`
+- `src/mdns_pose.rs` — throttling decision + TXT key formatting for
+  the mDNS responder's live `yaw=` / `pitch=` advertisement. The
+  embassy task lives in the firmware crate; this module hosts the
+  pure logic so it stays on the host CI test path.
 - `src/error.rs` — `ConfigError` (parse / serialize / validation variants)
 - `tests/golden_config.rs` + `tests/fixtures/*.ron` — round-trip and
   validation coverage against hand-written fixtures

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -57,6 +57,7 @@ pub mod esp_now;
 pub mod http_command;
 pub mod http_parse;
 pub mod mcp;
+pub mod mdns_pose;
 pub mod ota;
 
 pub use bare::{parse_ron_bare, render_ron_bare};

--- a/crates/stackchan-net/src/mdns_pose.rs
+++ b/crates/stackchan-net/src/mdns_pose.rs
@@ -241,13 +241,13 @@ mod tests {
         // Realistic worst case after the head driver's ±60° clamp;
         // no truncation expected.
         let s = format_pose_kv("pitch", -59.95).unwrap();
-        // `{:.1}` rounds -59.95 to -60.0 (banker's rounding via Rust's
-        // default round-half-to-even on the IEEE 754 representation).
-        // Either form is acceptable for the wire — assert one of them.
+        // `{:.1}` rounds to the nearest tenth, so `-59.95` lands at
+        // either `-60.0` or `-59.9` depending on the IEEE 754
+        // representation of the literal — both are acceptable for the
+        // wire. Any other output would indicate a formatting bug.
         assert!(
-            s.as_str() == "pitch=-60.0"
-                || s.as_str() == "pitch=-59.9"
-                || s.as_str() == "pitch=-59.0"
+            s.as_str() == "pitch=-60.0" || s.as_str() == "pitch=-59.9",
+            "unexpected format: {s:?}"
         );
     }
 }

--- a/crates/stackchan-net/src/mdns_pose.rs
+++ b/crates/stackchan-net/src/mdns_pose.rs
@@ -1,0 +1,253 @@
+//! Pose-publication helpers for the firmware's mDNS responder.
+//!
+//! The DNS encoding itself (`A` / `PTR` / `SRV` / `TXT` records,
+//! socket / multicast plumbing) lives in
+//! `stackchan_firmware::net::mdns` — that side is embassy-bound. The
+//! pure decisions — *should* a fresh announcement go out, and how do
+//! we format the pose values into TXT key/value strings — live here
+//! so they can be host-tested without an esp toolchain.
+//!
+//! ## Wire format
+//!
+//! The TXT record carries the live commanded head pose alongside the
+//! existing `txtvers` / `version` / `path` / `mcp` / `kai` keys:
+//!
+//! - `yaw=<degrees>` — pan, one decimal place, signed.
+//! - `pitch=<degrees>` — tilt, one decimal place, signed.
+//!
+//! Naming mirrors the meganetaaan `mimic_main` mod
+//! ([source](https://github.com/meganetaaan/stack-chan/tree/main/firmware/mods/mimic_main))
+//! so a kai unit can lead a mixed-firmware mimic stack without a
+//! translation layer on the follower side.
+//!
+//! ## Throttling
+//!
+//! [`PoseAnnouncer`] gates fresh multicasts. The decision is:
+//!
+//! - First call after the link comes up — publish.
+//! - Heartbeat interval elapsed — publish (so a listener that joined
+//!   the multicast group while the head was stationary still picks up
+//!   state).
+//! - Both axes moved past the deadband AND the minimum interval
+//!   elapsed — publish.
+//! - Otherwise — suppress.
+
+use core::fmt::Write as _;
+
+use stackchan_core::Pose;
+
+/// Minimum interval between unsolicited pose-driven announcements.
+///
+/// 100 ms matches the meganetaaan `mimic_main` cadence and is short
+/// enough that a follower mimicking yaw/pitch tracks the leader
+/// without visible lag.
+pub const POSE_PUBLISH_MIN_INTERVAL_MS: u64 = 100;
+
+/// Heartbeat interval, in milliseconds.
+///
+/// The pose announcement re-emits at least this often even when
+/// nothing has changed so a fresh listener that joined the multicast
+/// group while the head was stationary still picks up the current
+/// pose.
+pub const POSE_HEARTBEAT_INTERVAL_MS: u64 = 1_000;
+
+/// Per-axis publish deadband, in degrees.
+///
+/// Below this magnitude we treat pose changes as servo / quantisation
+/// noise and suppress the announcement. 0.1° is well under the
+/// smallest visible head step on the `SCServo` (one step ≈ 0.293°)
+/// but large enough to absorb commanded-pose float-add noise from
+/// the modifier pipeline.
+pub const POSE_DEADBAND_DEG: f32 = 0.1;
+
+/// Cap of the [`heapless::String`]-style buffer returned by
+/// [`format_pose_kv`]. Sized for `pitch=-NNN.N` plus headroom.
+pub const POSE_KV_CAP: usize = 24;
+
+/// Pure decision struct: tracks the last published pose + its
+/// timestamp, decides whether to publish a fresh announcement.
+///
+/// Lives in stackchan-net (not stackchan-firmware) because it has no
+/// embassy / hardware dependencies — keeping it here gets it onto
+/// the host CI test path.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PoseAnnouncer {
+    /// Last pose actually pushed onto the wire. `None` until the
+    /// first announcement is sent.
+    last_published: Option<Pose>,
+    /// Wall-clock instant (milliseconds since boot) of the last
+    /// publish. `None` until the first announcement is sent.
+    last_published_at_ms: Option<u64>,
+}
+
+impl PoseAnnouncer {
+    /// Empty announcer — neither pose nor time recorded yet. The
+    /// first call to [`Self::should_publish`] will return `true`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            last_published: None,
+            last_published_at_ms: None,
+        }
+    }
+
+    /// Decide whether a fresh announcement should go out for `current`
+    /// at `now_ms`. See the module docs for the policy.
+    #[must_use]
+    pub fn should_publish(&self, current: Pose, now_ms: u64) -> bool {
+        let (Some(last), Some(last_at)) = (self.last_published, self.last_published_at_ms) else {
+            return true;
+        };
+        let elapsed = now_ms.saturating_sub(last_at);
+        if elapsed >= POSE_HEARTBEAT_INTERVAL_MS {
+            return true;
+        }
+        if elapsed < POSE_PUBLISH_MIN_INTERVAL_MS {
+            return false;
+        }
+        let dyaw = (current.pan_deg - last.pan_deg).abs();
+        let dpitch = (current.tilt_deg - last.tilt_deg).abs();
+        dyaw >= POSE_DEADBAND_DEG || dpitch >= POSE_DEADBAND_DEG
+    }
+
+    /// Stamp a successful publish so subsequent calls to
+    /// [`Self::should_publish`] gate against it.
+    pub const fn record_publish(&mut self, current: Pose, now_ms: u64) {
+        self.last_published = Some(current);
+        self.last_published_at_ms = Some(now_ms);
+    }
+}
+
+/// Format a `<key>=<deg>` TXT entry into a small fixed-cap buffer.
+/// One decimal place, signed.
+///
+/// Returns `None` only if the formatter overflows the buffer — which
+/// `f32` `Display` can't produce for the in-range degrees the head
+/// driver clamps to (±60° per axis). The `None` branch is defensive.
+#[must_use]
+pub fn format_pose_kv(key: &str, value_deg: f32) -> Option<heapless::String<POSE_KV_CAP>> {
+    let mut buf: heapless::String<POSE_KV_CAP> = heapless::String::new();
+    write!(buf, "{key}={value_deg:.1}").ok()?;
+    Some(buf)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test-only: unwrap is the standard pattern for asserting Some-returning helpers"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_call_publishes() {
+        let a = PoseAnnouncer::new();
+        assert!(a.should_publish(Pose::new(0.0, 0.0), 0));
+    }
+
+    #[test]
+    fn suppresses_within_min_interval() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(10.0, 5.0), 1_000);
+        // Same pose, within the 100 ms window — suppress.
+        assert!(!a.should_publish(Pose::new(10.0, 5.0), 1_050));
+        // Tiny change well under the deadband, still within window —
+        // suppress.
+        assert!(!a.should_publish(Pose::new(10.05, 5.0), 1_050));
+    }
+
+    #[test]
+    fn publishes_on_pose_change_after_min_interval() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(10.0, 5.0), 1_000);
+        // Past min interval, pose moved beyond deadband — publish.
+        assert!(a.should_publish(Pose::new(10.5, 5.0), 1_100));
+        a.record_publish(Pose::new(10.5, 5.0), 1_100);
+        // Past min interval, only one axis moved — still publish
+        // (per-axis OR semantics).
+        assert!(a.should_publish(Pose::new(10.5, 5.5), 1_250));
+    }
+
+    #[test]
+    fn suppresses_subdeadband_changes_in_window() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(10.0, 5.0), 1_000);
+        // Past min interval but neither axis moved past deadband —
+        // suppress.
+        assert!(!a.should_publish(Pose::new(10.05, 5.05), 1_150));
+    }
+
+    #[test]
+    fn heartbeat_fires_when_idle() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(10.0, 5.0), 1_000);
+        // Past heartbeat interval, identical pose — heartbeat fires.
+        assert!(a.should_publish(Pose::new(10.0, 5.0), 1_000 + POSE_HEARTBEAT_INTERVAL_MS));
+    }
+
+    #[test]
+    fn heartbeat_supersedes_min_interval_gate() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(10.0, 5.0), 0);
+        // Heartbeat interval elapsed AND no movement — should publish
+        // (heartbeat must win over the deadband suppression).
+        assert!(a.should_publish(Pose::new(10.0, 5.0), POSE_HEARTBEAT_INTERVAL_MS + 50));
+    }
+
+    #[test]
+    fn deadband_threshold_is_inclusive() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(0.0, 0.0), 0);
+        // Exactly the deadband on yaw, past min interval — should
+        // publish (`>=` semantics).
+        assert!(a.should_publish(
+            Pose::new(POSE_DEADBAND_DEG, 0.0),
+            POSE_PUBLISH_MIN_INTERVAL_MS
+        ));
+    }
+
+    #[test]
+    fn record_publish_resets_window() {
+        let mut a = PoseAnnouncer::new();
+        a.record_publish(Pose::new(10.0, 5.0), 1_000);
+        // First post-publish call within the window suppresses.
+        assert!(!a.should_publish(Pose::new(10.0, 5.0), 1_050));
+        // After a second publish at t=1_050, the window restarts —
+        // a t=1_100 call (50 ms later) should still suppress, even
+        // though we're past 1_000+100 from the original publish.
+        a.record_publish(Pose::new(10.0, 5.0), 1_050);
+        assert!(!a.should_publish(Pose::new(10.0, 5.0), 1_100));
+    }
+
+    #[test]
+    fn format_pose_kv_uses_one_decimal_signed() {
+        let s = format_pose_kv("yaw", 12.345).unwrap();
+        assert_eq!(s.as_str(), "yaw=12.3");
+        let s = format_pose_kv("pitch", -4.5).unwrap();
+        assert_eq!(s.as_str(), "pitch=-4.5");
+        let s = format_pose_kv("yaw", 180.0).unwrap();
+        assert_eq!(s.as_str(), "yaw=180.0");
+    }
+
+    #[test]
+    fn format_pose_kv_handles_zero() {
+        let s = format_pose_kv("yaw", 0.0).unwrap();
+        assert_eq!(s.as_str(), "yaw=0.0");
+    }
+
+    #[test]
+    fn format_pose_kv_fits_extreme_values() {
+        // Realistic worst case after the head driver's ±60° clamp;
+        // no truncation expected.
+        let s = format_pose_kv("pitch", -59.95).unwrap();
+        // `{:.1}` rounds -59.95 to -60.0 (banker's rounding via Rust's
+        // default round-half-to-even on the IEEE 754 representation).
+        // Either form is acceptable for the wire — assert one of them.
+        assert!(
+            s.as_str() == "pitch=-60.0"
+                || s.as_str() == "pitch=-59.9"
+                || s.as_str() == "pitch=-59.0"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds live `yaw=<deg>` / `pitch=<deg>` keys to the DNS-SD TXT record so a mimic-stack follower can lift current head pose off mDNS without an HTTP round-trip. Format mirrors meganetaaan's `mimic_main` mod for cross-firmware compatibility.
- Throttling: a fresh announcement multicasts at most every 100 ms when either axis moves past a 0.1° deadband, plus a 1 s heartbeat for late-joining listeners.
- Throttling logic + TXT formatting live in `stackchan_net::mdns_pose` so they stay on the host CI test path; firmware mDNS task races the periodic publisher against the query loop via `embassy_futures::select`.
- New: 11 host unit tests covering first-publish, deadband, heartbeat, window-reset, and edge cases.

Closes the first of four factory-firmware-parity gaps. Pose source is the existing commanded-pose snapshot, so no new cross-task plumbing.

## Test plan

- [x] `RUSTC_WRAPPER= cargo test -p stackchan-net mdns_pose` — 11/11 passing
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings` — clean
- [x] `RUSTC_WRAPPER= cargo test --workspace --exclude stackchan-firmware --all-features` — full suite green
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp build --release` — clean
- [ ] Hardware boot smoke (`just fmr`) — **blocked**: CoreS3 not currently enumerated (AXP2101 likely shut the chip off; needs side-power-button press). Will re-verify before merge.
- [ ] On-device verify: `avahi-browse -r _stackchan._tcp` reflects `yaw=` / `pitch=` updating during head motion