### PR TITLE
feat(core): HeadFromBodyGesture — randomized head nudge on swipe / press

### DIFF
--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -200,6 +200,8 @@ pub enum Field {
     Dormancy,
     /// `entity.mind.mood`
     Mood,
+    /// `entity.mind.last_gesture`
+    Gesture,
 
     // ---- Voice ----
     /// `entity.voice.chirp_request`
@@ -307,7 +309,8 @@ impl Field {
             | Self::Attention
             | Self::Engagement
             | Self::Dormancy
-            | Self::Mood => FieldGroup::Mind,
+            | Self::Mood
+            | Self::Gesture => FieldGroup::Mind,
             Self::ChirpRequest | Self::UtteranceRequest | Self::IsSpeaking => FieldGroup::Voice,
             Self::TapPending | Self::RemotePending | Self::RemoteCommand => FieldGroup::Input,
         }
@@ -411,6 +414,7 @@ impl Field {
             Self::Engagement => before.mind.engagement != after.mind.engagement,
             Self::Dormancy => before.mind.dormancy != after.mind.dormancy,
             Self::Mood => before.mind.mood != after.mind.mood,
+            Self::Gesture => before.mind.last_gesture != after.mind.last_gesture,
             Self::ChirpRequest => before.voice.chirp_request != after.voice.chirp_request,
             Self::UtteranceRequest => {
                 before.voice.utterance_request != after.voice.utterance_request

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -67,7 +67,9 @@ pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};
 pub use lipsync::{
     LipSync, VISEME_HIGH_ZCR_HZ, VISEME_LOW_ZCR_HZ, VISEME_SILENCE_RMS, Viseme, classify_viseme,
 };
-pub use mind::{Affect, Attention, Autonomy, Dormancy, Engagement, Intent, Mind, OverrideSource};
+pub use mind::{
+    Affect, Attention, Autonomy, BodyGesture, Dormancy, Engagement, Intent, Mind, OverrideSource,
+};
 pub use modifier::Modifier;
 pub use mood::Mood;
 pub use motor::Motor;

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -290,6 +290,41 @@ impl Dormancy {
     }
 }
 
+/// Most recently fired back-of-head gesture.
+///
+/// Exposed so downstream modifiers can react with their own visual
+/// / motion overlay without duplicating the
+/// [`crate::modifiers::IntentFromBodyTouch`] state machine.
+///
+/// Variants mirror the upstream `m5stack/StackChan` gesture model
+/// (`hal_head_touch.cpp`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BodyGesture {
+    /// Initial press on any zone. The triggering zone is captured so
+    /// reactions that care about left/centre/right can specialise
+    /// (factory firmware varies the pose-nudge direction with the
+    /// zone). Uses the same `0..=3` intensity surface the perception
+    /// layer publishes; `0` everywhere is impossible here because
+    /// `Press` only fires on a transition from no-touch to touched.
+    Press {
+        /// Left-zone intensity (`0..=3`) at the moment of press.
+        left: u8,
+        /// Centre-zone intensity (`0..=3`) at the moment of press.
+        centre: u8,
+        /// Right-zone intensity (`0..=3`) at the moment of press.
+        right: u8,
+    },
+    /// Centroid shifted left → right past the swipe threshold during
+    /// a touch run.
+    SwipeForward,
+    /// Centroid shifted right → left past the swipe threshold during
+    /// a touch run.
+    SwipeBackward,
+    /// Touch run released — back to no-touch.
+    Release,
+}
+
 /// Persistent facts the entity remembers across boots. Placeholder
 /// marker type; not yet populated.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -326,6 +361,14 @@ pub struct Mind {
     /// [`crate::modifiers::StyleFromMood`] which scales blink rate,
     /// breath depth, and idle drift on top of the per-emotion targets.
     pub mood: Mood,
+    /// Most recent back-of-head gesture, with the wall-clock instant
+    /// it fired. Written by
+    /// [`crate::modifiers::IntentFromBodyTouch`] on each gesture
+    /// transition; read by reaction modifiers in later phases. The
+    /// timestamp lets readers debounce against stale gestures (e.g.
+    /// a head-pet motion modifier ignores anything older than its
+    /// own reaction window). `None` until the first gesture lands.
+    pub last_gesture: Option<(BodyGesture, Instant)>,
     /// Persistent facts.
     pub memory: Memory,
 }

--- a/crates/stackchan-core/src/modifiers/head_from_body_gesture.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_body_gesture.rs
@@ -221,9 +221,16 @@ fn envelope(elapsed: u64, attack_ms: u64, total_ms: u64) -> f32 {
 }
 
 /// Derive `(pan_sign, tilt_sign)` from a firing instant via a
-/// splitmix-style hash on the millisecond count. Output values are
-/// `±1.0`; same `at` always produces the same pair so the sim's
-/// golden assertions stay stable.
+/// splitmix-style hash on the millisecond count.
+///
+/// Pan returns `±1.0` randomly. **Tilt is always `+1.0`** — a head-pet
+/// is physically a head-lift response (chin rises), and the asymmetric
+/// pose clamp ([`crate::head::MIN_TILT_DEG`] is `0.0`) silently
+/// swallows negative tilt at the resting position. Without this bias,
+/// roughly half of pet reactions would produce no visible tilt.
+///
+/// Same `at` always produces the same pan sign so the sim's golden
+/// assertions stay stable.
 const fn random_signs(at: Instant) -> (f32, f32) {
     let ms = at.as_millis();
     // SplitMix64 finalizer — cheap, well-distributed bit mixer.
@@ -232,8 +239,7 @@ const fn random_signs(at: Instant) -> (f32, f32) {
     z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
     z ^= z >> 31;
     let pan_sign = if z & 1 == 0 { 1.0 } else { -1.0 };
-    let tilt_sign = if (z >> 1) & 1 == 0 { 1.0 } else { -1.0 };
-    (pan_sign, tilt_sign)
+    (pan_sign, 1.0)
 }
 
 #[cfg(test)]
@@ -362,12 +368,65 @@ mod tests {
     }
 
     #[test]
-    fn random_signs_are_pm_one() {
-        // Sweep a few timestamps; outputs are always ±1.
+    fn random_signs_pan_is_pm_one() {
+        // Sweep a few timestamps; pan magnitude is always 1.
         for ms in [0u64, 1, 2, 3, 100, 12_345, 999_999] {
-            let (pan, tilt) = random_signs(Instant::from_millis(ms));
+            let (pan, _) = random_signs(Instant::from_millis(ms));
             assert!(pan.abs() == 1.0);
-            assert!(tilt.abs() == 1.0);
+        }
+    }
+
+    #[test]
+    fn random_signs_tilt_always_positive() {
+        // Regression guard: tilt MUST always be +1.0 across the
+        // timestamp distribution. Negative tilt clamps to 0 at the
+        // resting pose (`MIN_TILT_DEG = 0`), making half of all
+        // pet reactions invisible. A future tweak that re-randomises
+        // tilt will fail here before it ships.
+        for ms in [
+            0u64,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            100,
+            12_345,
+            999_999,
+            u64::MAX / 2,
+        ] {
+            let (_, tilt) = random_signs(Instant::from_millis(ms));
+            assert_eq!(tilt, 1.0, "tilt must be +1.0 at ms={ms}, got {tilt}");
+        }
+    }
+
+    #[test]
+    fn pet_reaction_visible_from_resting_pose() {
+        // Regression guard for the negative-tilt-clamp bug. With the
+        // upstream pose at the resting position (tilt = 0 = MIN_TILT_DEG),
+        // a swipe must still produce a visible head nudge. Sweep
+        // several gesture timestamps to exercise the random pan signs.
+        for at_ms in [0u64, 1, 17, 100, 12_345, 999_999] {
+            let mut m = HeadFromBodyGesture::new();
+            let mut entity = Entity::default();
+            // Resting pose — both axes at the lower clamp.
+            entity.motor.head_pose = Pose::new(0.0, 0.0);
+            entity.mind.last_gesture =
+                Some((BodyGesture::SwipeForward, Instant::from_millis(at_ms)));
+            entity.tick.now = Instant::from_millis(at_ms);
+            m.update(&mut entity);
+            // Re-apply the upstream pose like the firmware render
+            // loop does, then advance to the envelope peak.
+            entity.motor.head_pose = Pose::new(0.0, 0.0);
+            entity.tick.now = Instant::from_millis(at_ms + HEADPET_REACTION_ATTACK_MS);
+            m.update(&mut entity);
+            assert!(
+                entity.motor.head_pose.tilt_deg > 0.5,
+                "swipe at ms={at_ms} produced no visible tilt from resting pose: {:?}",
+                entity.motor.head_pose,
+            );
         }
     }
 

--- a/crates/stackchan-core/src/modifiers/head_from_body_gesture.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_body_gesture.rs
@@ -1,0 +1,414 @@
+//! [`HeadFromBodyGesture`] — applies a randomized head-pose nudge
+//! when the back-of-head touch strip fires a reaction-eligible
+//! gesture (`Press` / `SwipeForward` / `SwipeBackward`).
+//!
+//! Mirrors the upstream `m5stack/StackChan/firmware/main/stackchan/modifiers/head_pet.h`
+//! reaction shape: a brief randomized head lift / tilt, then a slower
+//! decay back to whatever the upstream modifier stack wanted. Reads
+//! `mind.last_gesture` (set by [`super::IntentFromBodyTouch`] on every
+//! gesture transition) and runs an attack/decay envelope over a
+//! reaction window; subsequent gestures inside the window restart
+//! the envelope from the new firing instant.
+//!
+//! ## Composition
+//!
+//! Phase `Motion`, priority `35` — runs *after* the rest of the head
+//! stack (`HeadFromEmotion` 10, `HeadFromAttention` 20, `HeadFromIntent`
+//! 30) so the pet reaction lands on top of any concurrent attention
+//! follow / emotion bias / startle recoil. Composes additively via
+//! diff-and-undo: the modifier subtracts its previous contribution
+//! to recover the upstream pose, adds its new contribution, clamps
+//! to mechanical range, then stores the post-clamp effective delta
+//! for the next tick.
+//!
+//! ## Randomisation
+//!
+//! No RNG dependency — the randomized pan/tilt direction is derived
+//! deterministically from the firing instant's millisecond bits via a
+//! splitmix-style hash. Same instant produces the same nudge so the
+//! sim's golden assertions stay stable.
+//!
+//! ## Why not in `HeadFromIntent`
+//!
+//! `HeadFromIntent` reacts to `Intent::Startled` (single edge) with a
+//! fixed asymmetric recoil. The pet reaction has different timing
+//! (longer hold, slower decay), different triggering events
+//! (gesture transitions, not intent change), and a randomized nudge
+//! direction — different envelope, different write trigger. Sharing
+//! a modifier would force one kind of reaction to fight the other's
+//! state machine.
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::head::Pose;
+use crate::mind::BodyGesture;
+use crate::modifier::Modifier;
+
+/// Total reaction window, in milliseconds.
+///
+/// 1500 ms covers the upstream factory firmware's "head lift / tilt
+/// for ~1.5–2.5 s" beat at the lower end. Long enough to read as a
+/// reaction without dragging the head off whatever it was tracking.
+pub const HEADPET_REACTION_TOTAL_MS: u64 = 1_500;
+
+/// Attack duration, in milliseconds — how fast the envelope ramps in.
+///
+/// 80 ms is roughly two render frames, fast enough that the reaction
+/// reads as instantaneous to the audience.
+pub const HEADPET_REACTION_ATTACK_MS: u64 = 80;
+
+/// Maximum pan offset, in degrees. Applied with random sign.
+pub const HEADPET_PAN_DEG: f32 = 6.0;
+
+/// Maximum tilt offset, in degrees. Applied with random sign.
+pub const HEADPET_TILT_DEG: f32 = 5.0;
+
+/// Modifier that applies a randomized head-pose nudge on body-touch
+/// gesture transitions. See module docs.
+#[derive(Debug, Clone, Copy)]
+pub struct HeadFromBodyGesture {
+    /// Total reaction window, in milliseconds.
+    pub total_ms: u64,
+    /// Attack duration, in milliseconds.
+    pub attack_ms: u64,
+    /// Maximum pan magnitude, in degrees.
+    pub pan_deg: f32,
+    /// Maximum tilt magnitude, in degrees.
+    pub tilt_deg: f32,
+    /// Wall-clock instant the active reaction was anchored. `None`
+    /// once the envelope has fully decayed.
+    started_at: Option<Instant>,
+    /// Pan offset of the active reaction, sign-randomized. Cached
+    /// because re-deriving it every tick from the anchor would couple
+    /// the random output to per-tick interpolation.
+    target_pan_deg: f32,
+    /// Tilt offset of the active reaction, sign-randomized.
+    target_tilt_deg: f32,
+    /// Last gesture timestamp consumed; used as the rising-edge gate
+    /// against [`crate::mind::Mind::last_gesture`].
+    last_consumed_at: Option<Instant>,
+    /// Pan delta this modifier applied on the previous tick — needed
+    /// for the diff-and-undo composition.
+    last_applied_pan_deg: f32,
+    /// Tilt delta this modifier applied on the previous tick.
+    last_applied_tilt_deg: f32,
+}
+
+impl HeadFromBodyGesture {
+    /// Construct with the documented default constants.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            total_ms: HEADPET_REACTION_TOTAL_MS,
+            attack_ms: HEADPET_REACTION_ATTACK_MS,
+            pan_deg: HEADPET_PAN_DEG,
+            tilt_deg: HEADPET_TILT_DEG,
+            started_at: None,
+            target_pan_deg: 0.0,
+            target_tilt_deg: 0.0,
+            last_consumed_at: None,
+            last_applied_pan_deg: 0.0,
+            last_applied_tilt_deg: 0.0,
+        }
+    }
+}
+
+impl Default for HeadFromBodyGesture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for HeadFromBodyGesture {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "HeadFromBodyGesture",
+            description: "On Press / SwipeForward / SwipeBackward edges (mind.last_gesture), \
+                          applies a randomized head-pose nudge with attack/decay envelope. \
+                          Composes additively after the rest of the head stack via diff-and-undo. \
+                          Mirrors m5stack/StackChan head_pet.h's reaction shape.",
+            phase: Phase::Motion,
+            priority: 35,
+            reads: &[Field::Gesture, Field::HeadPose],
+            writes: &[Field::HeadPose],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+
+        // Check for a fresh, reaction-eligible gesture and re-anchor.
+        if let Some((gesture, at)) = entity.mind.last_gesture
+            && self.last_consumed_at != Some(at)
+            && reaction_eligible(gesture)
+        {
+            self.last_consumed_at = Some(at);
+            self.started_at = Some(at);
+            let (pan_sign, tilt_sign) = random_signs(at);
+            self.target_pan_deg = pan_sign * self.pan_deg;
+            self.target_tilt_deg = tilt_sign * self.tilt_deg;
+        }
+
+        // Compute the current envelope amplitude (0..=1) for the
+        // active reaction, if any. Clear the anchor once the envelope
+        // has fully decayed.
+        let amplitude = match self.started_at {
+            Some(start) => {
+                let elapsed = now.saturating_duration_since(start);
+                if elapsed >= self.total_ms {
+                    self.started_at = None;
+                    0.0
+                } else {
+                    envelope(elapsed, self.attack_ms, self.total_ms)
+                }
+            }
+            None => 0.0,
+        };
+
+        let target_pan = self.target_pan_deg * amplitude;
+        let target_tilt = self.target_tilt_deg * amplitude;
+
+        // Diff-and-undo: subtract our previous applied contribution
+        // to recover the upstream pose, add the new contribution,
+        // clamp, then store the post-clamp effective delta so next
+        // tick's diff-and-undo lands on the right reference point.
+        let upstream_pan = entity.motor.head_pose.pan_deg - self.last_applied_pan_deg;
+        let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_applied_tilt_deg;
+        let combined = Pose::new(upstream_pan + target_pan, upstream_tilt + target_tilt).clamped();
+        self.last_applied_pan_deg = combined.pan_deg - upstream_pan;
+        self.last_applied_tilt_deg = combined.tilt_deg - upstream_tilt;
+        entity.motor.head_pose = combined;
+    }
+}
+
+/// Which gestures earn a head-pose reaction. Release is excluded
+/// because the pose is already on its way back to the post-touch
+/// resting state via the rest of the modifier stack — adding a nudge
+/// at release just chatters the servo.
+const fn reaction_eligible(gesture: BodyGesture) -> bool {
+    matches!(
+        gesture,
+        BodyGesture::Press { .. } | BodyGesture::SwipeForward | BodyGesture::SwipeBackward
+    )
+}
+
+/// Compute the envelope amplitude `[0, 1]` for `elapsed` into a
+/// reaction of length `total_ms` with attack `attack_ms`.
+///
+/// Linear ramp up over the attack, then linear decay back to zero
+/// over the remainder. Deliberately simple — the audience reads the
+/// silhouette of the motion, not the easing curve, and a non-linear
+/// curve would buy nothing visible at this duration.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "u64→f32 over time-window magnitudes well under 2^24"
+)]
+fn envelope(elapsed: u64, attack_ms: u64, total_ms: u64) -> f32 {
+    if elapsed >= total_ms {
+        return 0.0;
+    }
+    if elapsed < attack_ms {
+        return (elapsed as f32) / (attack_ms.max(1) as f32);
+    }
+    let decay_ms = total_ms - attack_ms;
+    let decay_elapsed = elapsed - attack_ms;
+    if decay_ms == 0 {
+        return 0.0;
+    }
+    1.0 - (decay_elapsed as f32 / decay_ms as f32)
+}
+
+/// Derive `(pan_sign, tilt_sign)` from a firing instant via a
+/// splitmix-style hash on the millisecond count. Output values are
+/// `±1.0`; same `at` always produces the same pair so the sim's
+/// golden assertions stay stable.
+const fn random_signs(at: Instant) -> (f32, f32) {
+    let ms = at.as_millis();
+    // SplitMix64 finalizer — cheap, well-distributed bit mixer.
+    let mut z = ms.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    let pan_sign = if z & 1 == 0 { 1.0 } else { -1.0 };
+    let tilt_sign = if (z >> 1) & 1 == 0 { 1.0 } else { -1.0 };
+    (pan_sign, tilt_sign)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: bit-exact assertions on our own envelope math"
+)]
+mod tests {
+    use super::*;
+
+    fn entity_with_gesture(gesture: BodyGesture, at_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.mind.last_gesture = Some((gesture, Instant::from_millis(at_ms)));
+        e.tick.now = Instant::from_millis(at_ms);
+        e
+    }
+
+    #[test]
+    fn idle_with_no_gesture_writes_no_pose() {
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = Entity::default();
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose, Pose::default());
+    }
+
+    #[test]
+    fn release_does_not_anchor_reaction() {
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = entity_with_gesture(BodyGesture::Release, 100);
+        m.update(&mut entity);
+        // No envelope was started, so nothing should be applied.
+        assert_eq!(entity.motor.head_pose, Pose::default());
+        assert!(m.started_at.is_none());
+    }
+
+    #[test]
+    fn press_anchors_envelope() {
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = entity_with_gesture(
+            BodyGesture::Press {
+                left: 0,
+                centre: 3,
+                right: 0,
+            },
+            100,
+        );
+        m.update(&mut entity);
+        assert_eq!(m.started_at, Some(Instant::from_millis(100)));
+        // Envelope at elapsed=0 is exactly 0 → no head displacement
+        // on the entry tick. Displacement appears next tick.
+        assert_eq!(entity.motor.head_pose.pan_deg, 0.0);
+    }
+
+    #[test]
+    fn envelope_peaks_at_attack_then_decays() {
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = entity_with_gesture(BodyGesture::SwipeForward, 0);
+        m.update(&mut entity);
+
+        // At elapsed = attack_ms, amplitude should be ≈ 1.0 →
+        // |head_pose| ≈ pan_deg / tilt_deg.
+        entity.tick.now = Instant::from_millis(HEADPET_REACTION_ATTACK_MS);
+        // Same gesture timestamp; the modifier shouldn't re-anchor.
+        m.update(&mut entity);
+        let pan_at_peak = entity.motor.head_pose.pan_deg.abs();
+        assert!(
+            (pan_at_peak - HEADPET_PAN_DEG).abs() < 0.01,
+            "expected peak pan ≈ {HEADPET_PAN_DEG}, got {pan_at_peak}"
+        );
+
+        // Halfway through decay → roughly half amplitude.
+        let half_decay_ms = HEADPET_REACTION_ATTACK_MS
+            + (HEADPET_REACTION_TOTAL_MS - HEADPET_REACTION_ATTACK_MS) / 2;
+        entity.tick.now = Instant::from_millis(half_decay_ms);
+        m.update(&mut entity);
+        let pan_at_half = entity.motor.head_pose.pan_deg.abs();
+        assert!(
+            pan_at_half < pan_at_peak,
+            "expected pan to decay below peak ({pan_at_half} vs {pan_at_peak})"
+        );
+        assert!(
+            pan_at_half > 0.5 * pan_at_peak * 0.5,
+            "expected pan still meaningful at half-decay ({pan_at_half})"
+        );
+    }
+
+    #[test]
+    fn envelope_returns_to_zero_after_total() {
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = entity_with_gesture(BodyGesture::SwipeForward, 0);
+        m.update(&mut entity);
+
+        // Past total_ms, amplitude is 0 and the anchor has cleared.
+        entity.tick.now = Instant::from_millis(HEADPET_REACTION_TOTAL_MS + 100);
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.pan_deg, 0.0);
+        assert_eq!(entity.motor.head_pose.tilt_deg, 0.0);
+        assert!(m.started_at.is_none());
+    }
+
+    #[test]
+    fn second_gesture_within_window_restarts_envelope() {
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = entity_with_gesture(BodyGesture::SwipeForward, 0);
+        m.update(&mut entity);
+        let first_anchor = m.started_at;
+
+        // A second gesture at t=400, well inside the 1500 ms window —
+        // the modifier should re-anchor to the new instant.
+        entity.mind.last_gesture = Some((BodyGesture::SwipeBackward, Instant::from_millis(400)));
+        entity.tick.now = Instant::from_millis(400);
+        m.update(&mut entity);
+        assert_eq!(m.started_at, Some(Instant::from_millis(400)));
+        assert_ne!(m.started_at, first_anchor);
+    }
+
+    #[test]
+    fn random_signs_are_deterministic() {
+        // Same instant → same signs. Locks the determinism contract
+        // the sim's golden assertions rely on.
+        let a = random_signs(Instant::from_millis(100));
+        let b = random_signs(Instant::from_millis(100));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn random_signs_are_pm_one() {
+        // Sweep a few timestamps; outputs are always ±1.
+        for ms in [0u64, 1, 2, 3, 100, 12_345, 999_999] {
+            let (pan, tilt) = random_signs(Instant::from_millis(ms));
+            assert!(pan.abs() == 1.0);
+            assert!(tilt.abs() == 1.0);
+        }
+    }
+
+    #[test]
+    fn diff_and_undo_composes_with_upstream() {
+        // Pick an upstream pose that lives well inside the
+        // mechanical range so the diff-and-undo math doesn't have
+        // its delta absorbed by `Pose::clamped`. Tilt is asymmetric
+        // (`MIN_TILT_DEG = 0.0`, `MAX_TILT_DEG = 30.0`) so a
+        // negative tilt would be clamped to 0 and the test would
+        // fail spuriously.
+        let upstream = Pose::new(3.0, 10.0);
+
+        let mut m = HeadFromBodyGesture::new();
+        let mut entity = Entity::default();
+        // Upstream wrote a pose first. With no gesture, our delta is
+        // zero and the upstream pose passes through unchanged.
+        entity.motor.head_pose = upstream;
+        m.update(&mut entity);
+        assert_eq!(entity.motor.head_pose, upstream);
+
+        // Anchor a gesture, advance to peak; the modifier should add
+        // its randomized offset on top of the upstream pose.
+        entity.mind.last_gesture = Some((BodyGesture::SwipeForward, Instant::from_millis(0)));
+        entity.tick.now = Instant::from_millis(0);
+        m.update(&mut entity);
+        // At elapsed=0 amplitude is 0; pose still equals upstream.
+        assert_eq!(entity.motor.head_pose.pan_deg, upstream.pan_deg);
+
+        // Tick to peak — re-apply the upstream pose first (this
+        // models the firmware's render loop where upstream modifiers
+        // run before this one each frame), then expect our nudge on
+        // top.
+        entity.motor.head_pose = upstream;
+        entity.tick.now = Instant::from_millis(HEADPET_REACTION_ATTACK_MS);
+        m.update(&mut entity);
+        let dx = entity.motor.head_pose.pan_deg - upstream.pan_deg;
+        let dy = entity.motor.head_pose.tilt_deg - upstream.tilt_deg;
+        assert!(
+            dx.abs() > 0.5 && dy.abs() > 0.5,
+            "expected non-zero nudge layered on upstream pose, got dx={dx} dy={dy}"
+        );
+    }
+}

--- a/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
@@ -19,8 +19,9 @@ use crate::clock::Instant;
 use crate::director::{Field, ModifierMeta, Phase};
 use crate::emotion::Emotion;
 use crate::entity::Entity;
-use crate::mind::OverrideSource;
+use crate::mind::{BodyGesture, OverrideSource};
 use crate::modifier::Modifier;
+use crate::perception::BodyTouch;
 
 /// Default emotion set on `Press` of the left zone (no centre touch).
 pub const DEFAULT_LEFT_PRESS: Emotion = Emotion::Sleepy;
@@ -130,12 +131,13 @@ impl Modifier for IntentFromBodyTouch {
             name: "IntentFromBodyTouch",
             description: "State-machine gesture recognition on perception.body_touch \
                           (Si12T petting strip): Press emits per-zone emotion, \
-                          SwipeForward/Backward emit Happy/Surprised. Mirrors M5Stack's \
-                          reference hal_head_touch.cpp gesture model.",
+                          SwipeForward/Backward emit Happy/Surprised, every transition \
+                          stamps mind.last_gesture for downstream reaction modifiers. \
+                          Mirrors M5Stack's reference hal_head_touch.cpp gesture model.",
             phase: Phase::Affect,
             priority: 0,
             reads: &[Field::BodyTouch],
-            writes: &[Field::Emotion, Field::Autonomy],
+            writes: &[Field::Emotion, Field::Autonomy, Field::Gesture],
         };
         &META
     }
@@ -162,6 +164,7 @@ impl Modifier for IntentFromBodyTouch {
                     return;
                 };
                 pin_emotion(entity, emotion, self.hold_ms);
+                stamp_gesture(entity, press_gesture(touch));
                 self.state = State::Touched {
                     initial_position: touch.position(),
                 };
@@ -171,18 +174,37 @@ impl Modifier for IntentFromBodyTouch {
                 let delta = touch.position() - initial_position;
                 if delta >= self.swipe_delta {
                     pin_emotion(entity, self.mapping.swipe_forward, self.hold_ms);
+                    stamp_gesture(entity, BodyGesture::SwipeForward);
                     self.state = State::Swiping;
                 } else if delta <= -self.swipe_delta {
                     pin_emotion(entity, self.mapping.swipe_backward, self.hold_ms);
+                    stamp_gesture(entity, BodyGesture::SwipeBackward);
                     self.state = State::Swiping;
                 }
             }
             (State::Touched { .. } | State::Swiping, false) => {
                 // Release: return to Idle, no emotion change.
+                stamp_gesture(entity, BodyGesture::Release);
                 self.state = State::Idle;
             }
         }
     }
+}
+
+/// Capture the current touch zones into a [`BodyGesture::Press`].
+const fn press_gesture(touch: BodyTouch) -> BodyGesture {
+    BodyGesture::Press {
+        left: touch.left,
+        centre: touch.centre,
+        right: touch.right,
+    }
+}
+
+/// Stamp a fresh gesture on `mind.last_gesture` with the current
+/// tick. Reaction modifiers in later phases gate on this.
+const fn stamp_gesture(entity: &mut Entity, gesture: BodyGesture) {
+    let now = entity.tick.now;
+    entity.mind.last_gesture = Some((gesture, now));
 }
 
 /// Write emotion + autonomy hold for any body-touch gesture.

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -101,6 +101,7 @@ mod emotion_from_touch;
 mod emotion_from_voice;
 mod gaze_from_attention;
 mod head_from_attention;
+mod head_from_body_gesture;
 mod head_from_emotion;
 mod head_from_intent;
 mod idle_drift;
@@ -145,6 +146,10 @@ pub use emotion_from_voice::{
 };
 pub use gaze_from_attention::{GAZE_MAX_OFFSET_PX, GAZE_PIXELS_PER_DEG, GazeFromAttention};
 pub use head_from_attention::{HeadFromAttention, LISTEN_HEAD_EASE_MS, LISTEN_HEAD_TILT_DEG};
+pub use head_from_body_gesture::{
+    HEADPET_PAN_DEG, HEADPET_REACTION_ATTACK_MS, HEADPET_REACTION_TOTAL_MS, HEADPET_TILT_DEG,
+    HeadFromBodyGesture,
+};
 pub use head_from_emotion::HeadFromEmotion;
 pub use head_from_intent::{
     HeadFromIntent, STARTLE_HEAD_ATTACK_MS, STARTLE_HEAD_DECAY_MS, STARTLE_HEAD_PAN_DEG,

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -78,10 +78,10 @@ use stackchan_core::{
         DecoratorFromBodyTouch, DecoratorFromEmotion, DecoratorFromListening, DecoratorFromLoud,
         DecoratorFromShake, DormancyFromActivity, EmotionCycle, EmotionFromAmbient,
         EmotionFromBattery, EmotionFromIntent, EmotionFromRemote, EmotionFromTouch,
-        EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromEmotion, HeadFromIntent,
-        IdleDrift, IdleHeadDrift, IntentFromBodyTouch, IntentFromLoud, LostTargetSearch,
-        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, Soliloquy,
-        StyleFromEmotion, StyleFromIntent, StyleFromMood,
+        EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromBodyGesture,
+        HeadFromEmotion, HeadFromIntent, IdleDrift, IdleHeadDrift, IntentFromBodyTouch,
+        IntentFromLoud, LostTargetSearch, MicrosaccadeFromAttention, MouthFromAudio,
+        RemoteCommandModifier, Soliloquy, StyleFromEmotion, StyleFromIntent, StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -226,6 +226,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut head_from_attention = HeadFromAttention::new();
     let mut lost_target_search = LostTargetSearch::new();
     let mut head_from_intent = HeadFromIntent::new();
+    let mut head_from_body_gesture = HeadFromBodyGesture::new();
     let mut mouth_from_audio = MouthFromAudio::new();
     let mut listening = Listening::new();
     let mut petting = Petting::new();
@@ -365,6 +366,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         .add_modifier(&mut head_from_intent)
         .expect("registry full");
     director
+        .add_modifier(&mut head_from_body_gesture)
+        .expect("registry full");
+    director
         .add_modifier(&mut mouth_from_audio)
         .expect("registry full");
     director
@@ -394,7 +398,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-sim/tests/body_gesture.rs
+++ b/crates/stackchan-sim/tests/body_gesture.rs
@@ -18,9 +18,10 @@
 
 use stackchan_core::modifiers::{
     DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS, DEFAULT_RIGHT_PRESS, DEFAULT_SWIPE_BACKWARD,
-    DEFAULT_SWIPE_FORWARD, IntentFromBodyTouch,
+    DEFAULT_SWIPE_FORWARD, HEADPET_REACTION_ATTACK_MS, HEADPET_REACTION_TOTAL_MS,
+    HeadFromBodyGesture, IntentFromBodyTouch,
 };
-use stackchan_core::{BodyTouch, Director, Emotion, Entity, Instant, OverrideSource};
+use stackchan_core::{BodyGesture, BodyTouch, Director, Emotion, Entity, Instant, OverrideSource};
 
 const TICK_MS: u64 = 33;
 
@@ -134,4 +135,91 @@ fn no_perception_keeps_neutral() {
     run_for(&mut director, &mut entity, 0, 30);
     assert_eq!(entity.mind.affect.emotion, Emotion::Neutral);
     assert!(entity.mind.autonomy.manual_until.is_none());
+}
+
+#[test]
+fn intent_from_body_touch_stamps_last_gesture_on_press_swipe_release() {
+    let mut entity = Entity::default();
+    let mut gesture = IntentFromBodyTouch::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+
+    // Press fires Press(zones).
+    entity.perception.body_touch = Some(BodyTouch {
+        centre: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+    assert!(matches!(
+        entity.mind.last_gesture,
+        Some((BodyGesture::Press { centre: 3, .. }, _))
+    ));
+
+    // Slide right → SwipeForward.
+    entity.perception.body_touch = Some(BodyTouch {
+        right: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(100));
+    assert!(matches!(
+        entity.mind.last_gesture,
+        Some((BodyGesture::SwipeForward, _))
+    ));
+
+    // Release → Release.
+    entity.perception.body_touch = Some(BodyTouch::default());
+    director.run(&mut entity, Instant::from_millis(200));
+    assert!(matches!(
+        entity.mind.last_gesture,
+        Some((BodyGesture::Release, _))
+    ));
+}
+
+#[test]
+fn swipe_drives_head_pet_reaction_through_director() {
+    // Drive the full Affect→Motion chain: IntentFromBodyTouch sets
+    // emotion + stamps last_gesture; HeadFromBodyGesture reads
+    // last_gesture and applies a randomized head-pose nudge.
+    let mut entity = Entity::default();
+    let mut gesture = IntentFromBodyTouch::new();
+    let mut head_pet = HeadFromBodyGesture::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut gesture).unwrap();
+    director.add_modifier(&mut head_pet).unwrap();
+
+    // Press → Swipe.
+    entity.perception.body_touch = Some(BodyTouch {
+        left: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(0));
+    entity.perception.body_touch = Some(BodyTouch {
+        right: 3,
+        ..BodyTouch::default()
+    });
+    director.run(&mut entity, Instant::from_millis(50));
+
+    // Advance to the envelope peak. The pose should now reflect the
+    // head-pet nudge.
+    director.run(
+        &mut entity,
+        Instant::from_millis(50 + HEADPET_REACTION_ATTACK_MS),
+    );
+    assert!(
+        entity.motor.head_pose.pan_deg.abs() > 0.5 || entity.motor.head_pose.tilt_deg.abs() > 0.5,
+        "expected head pose to reflect the swipe-driven pet reaction at peak, got {:?}",
+        entity.motor.head_pose,
+    );
+
+    // After total reaction window, the pose should return to the
+    // upstream baseline (zero, since no other Motion modifier wrote).
+    director.run(
+        &mut entity,
+        Instant::from_millis(50 + HEADPET_REACTION_TOTAL_MS + 200),
+    );
+    assert!(
+        entity.motor.head_pose.pan_deg.abs() < 0.01 && entity.motor.head_pose.tilt_deg.abs() < 0.01,
+        "expected head pose to settle back to zero after reaction window, got {:?}",
+        entity.motor.head_pose,
+    );
 }


### PR DESCRIPTION
## Summary

- Adds the `HeadFromBodyGesture` modifier in `Phase::Motion` that mirrors `m5stack/StackChan`'s `head_pet.h` reaction shape: a randomized head lift / tilt with an attack-decay envelope, fired on Press / SwipeForward / SwipeBackward edges.
- Plumbs a new `mind.last_gesture: Option<(BodyGesture, Instant)>` field as the carrier between the existing `IntentFromBodyTouch` state machine and the new reaction modifier — no swipe-detection duplication.
- Composes additively after the rest of the head stack via diff-and-undo (same idiom as `HeadFromIntent`'s startle recoil).
- Determinism: random sign comes from a SplitMix64-style hash on the firing instant, so sim golden assertions stay stable.

Closes the second of four factory-firmware-parity gaps. Swipe **detection** was already implemented; this adds the **reaction**.

## Test plan

- [x] `cargo test -p stackchan-core` — 410+ tests passing, includes 8 new unit tests for `HeadFromBodyGesture`
- [x] `cargo test -p stackchan-sim --test body_gesture` — 7/7 passing, includes new end-to-end Director-driven test for the swipe → head reaction flow
- [x] `cargo clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp build --release` — clean
- [ ] Hardware boot smoke (`just fmr`) — **blocked**: CoreS3 not enumerated. Will re-verify before merge.
- [ ] On-device verify: pet the back-of-head strip, confirm the head reacts with a brief randomized nudge

Stacks on top of #284 in spirit (independent of mDNS pose), but branched off main so it can land in either order.