### PR TITLE
feat(core): 3D IK lookAtPoint — Attention::Point + /look-at-point HTTP route

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ and the firmware exposes a LAN-only HTTP control plane:
 
 - `GET /` — operator dashboard, single-page HTML embedded in the binary
 - `GET /state/stream` — live state via Server-Sent Events
-- `POST /emotion`, `/look-at`, `/face-target`, `/reset`, `/speak` — manual override
+- `POST /emotion`, `/look-at`, `/look-at-point`, `/face-target`, `/reset`, `/speak` — manual override
 - `POST /volume`, `/mute`, `/mood`, `/palette`, `/head/offsets` — runtime control surface
 - `POST /sleep`, `/wake` — sleep mode (eyes shut / head limp / LED dark / audio paused). Wake via the route, MCP tool, any touch, or the side power button.
 - `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)

--- a/crates/stackchan-core/src/head.rs
+++ b/crates/stackchan-core/src/head.rs
@@ -21,6 +21,13 @@
 //!   travel from horizontal. Firmware const-table trim is applied
 //!   *after* Pose is produced, so the core-visible range is uniform.
 
+// `F32Ext` provides `atan2`/`sqrt`/`to_degrees` on the `no_std`
+// firmware target. On host (`cfg(test)`) these methods come from
+// `std`, so the import looks unused — silence the lint rather than
+// branch the import on `cfg`.
+#[allow(unused_imports)]
+use micromath::F32Ext as _;
+
 use crate::clock::Instant;
 
 /// Conservative upper bound on pan travel in degrees (±).
@@ -93,6 +100,60 @@ impl Pose {
             tilt_deg: clamp_range_or_zero(self.tilt_deg, MIN_TILT_DEG, MAX_TILT_DEG),
         }
     }
+
+    /// 3D inverse kinematics: convert a Cartesian world point into the
+    /// pose that aims the head at it. Right-handed coordinates with
+    /// `+Z` forward (head's natural gaze axis), `+X` right, `+Y` up.
+    ///
+    /// - Pan (yaw) = `atan2(x, z)` — rotation around the vertical axis.
+    /// - Tilt (pitch) = `atan2(y, sqrt(x² + z²))` — elevation above
+    ///   the horizontal plane.
+    ///
+    /// Returns `None` when the target lies at the origin (or so close
+    /// that the math is undefined): there's no direction to aim at.
+    /// The factory firmware's `motion.h::lookAtPoint` documents this
+    /// same singularity.
+    ///
+    /// Inputs must be finite — NaN or Inf in any axis returns `None`.
+    /// The returned pose is *unclamped*; callers that need the
+    /// mechanical-safe range should pipe the result through
+    /// [`Self::clamped`].
+    #[must_use]
+    pub fn from_xyz_lookat(x: f32, y: f32, z: f32) -> Option<Self> {
+        // Tolerance keeps us from amplifying float noise into wild
+        // angles when the point is "essentially the origin." 1 mm-ish
+        // in any sensible application unit.
+        const ORIGIN_EPSILON_SQ: f32 = 1e-6;
+
+        if !x.is_finite() || !y.is_finite() || !z.is_finite() {
+            return None;
+        }
+        // Squared planar distance avoids a sqrt for the singularity
+        // check. `mul_add` would need libm on no_std for f32; the
+        // straightforward form keeps the math platform-uniform.
+        #[allow(
+            clippy::suboptimal_flops,
+            reason = "f32::mul_add needs libm on no_std; straight multiply-add is platform-uniform here"
+        )]
+        let planar_sq = x * x + z * z;
+        #[allow(clippy::suboptimal_flops, reason = "see above")]
+        let radial_sq = planar_sq + y * y;
+        if radial_sq < ORIGIN_EPSILON_SQ {
+            return None;
+        }
+        // `atan2` + `sqrt` come from `micromath`'s `F32Ext` polyfill;
+        // matches the rest of the workspace's no_std math stance.
+        let pan_rad = x.atan2(z);
+        // sqrt(planar_sq) is fine even at x=z=0 because radial_sq >=
+        // ORIGIN_EPSILON_SQ guarantees y is large enough that the
+        // tilt branch dominates.
+        let planar = planar_sq.sqrt();
+        let tilt_rad = y.atan2(planar);
+        Some(Self {
+            pan_deg: pan_rad.to_degrees(),
+            tilt_deg: tilt_rad.to_degrees(),
+        })
+    }
 }
 
 /// Clamp `value` into `[-max, +max]`, collapsing NaN to `0.0`.
@@ -140,8 +201,10 @@ pub trait HeadDriver {
 #[cfg(test)]
 #[allow(
     clippy::float_cmp,
+    clippy::expect_used,
+    clippy::unwrap_used,
     reason = "tests compare bit-exact outputs of our own clamp/const code, \
-              not results of floating-point arithmetic where epsilon matters"
+              and unwrap on values our own helper just produced"
 )]
 mod tests {
     use super::*;
@@ -183,5 +246,88 @@ mod tests {
         let p = Pose::new(f32::NAN, f32::NAN).clamped();
         assert_eq!(p.pan_deg, 0.0);
         assert_eq!(p.tilt_deg, 0.0);
+    }
+
+    #[test]
+    fn lookat_forward_is_neutral() {
+        // Straight ahead on +Z, level → pan = 0, tilt = 0.
+        let p = Pose::from_xyz_lookat(0.0, 0.0, 1.0).expect("forward target is well-defined");
+        assert!(p.pan_deg.abs() < 0.5);
+        assert!(p.tilt_deg.abs() < 0.5);
+    }
+
+    #[test]
+    fn lookat_right_yields_positive_pan() {
+        // Pure +X (one unit to the right, no Y, no Z) → pan = +90°.
+        let p = Pose::from_xyz_lookat(1.0, 0.0, 0.0).expect("right target is well-defined");
+        assert!(
+            (p.pan_deg - 90.0).abs() < 0.5,
+            "expected pan ≈ +90, got {}",
+            p.pan_deg
+        );
+        assert!(p.tilt_deg.abs() < 0.5);
+    }
+
+    #[test]
+    fn lookat_left_yields_negative_pan() {
+        let p = Pose::from_xyz_lookat(-1.0, 0.0, 0.0).expect("left target is well-defined");
+        assert!(
+            (p.pan_deg - (-90.0)).abs() < 0.5,
+            "expected pan ≈ -90, got {}",
+            p.pan_deg
+        );
+    }
+
+    #[test]
+    fn lookat_above_yields_positive_tilt() {
+        // Up (+Y), forward (+Z) → tilt ≈ +45°.
+        let p = Pose::from_xyz_lookat(0.0, 1.0, 1.0).expect("up-forward target is well-defined");
+        assert!(p.pan_deg.abs() < 0.5);
+        assert!(
+            (p.tilt_deg - 45.0).abs() < 1.0,
+            "expected tilt ≈ +45, got {}",
+            p.tilt_deg
+        );
+    }
+
+    #[test]
+    fn lookat_below_yields_negative_tilt() {
+        let p = Pose::from_xyz_lookat(0.0, -1.0, 1.0).expect("down-forward target is well-defined");
+        assert!(
+            (p.tilt_deg - (-45.0)).abs() < 1.0,
+            "expected tilt ≈ -45, got {}",
+            p.tilt_deg
+        );
+    }
+
+    #[test]
+    fn lookat_origin_is_singularity() {
+        assert!(Pose::from_xyz_lookat(0.0, 0.0, 0.0).is_none());
+    }
+
+    #[test]
+    fn lookat_rejects_nan_and_infinity() {
+        assert!(Pose::from_xyz_lookat(f32::NAN, 0.0, 1.0).is_none());
+        assert!(Pose::from_xyz_lookat(0.0, f32::INFINITY, 1.0).is_none());
+        assert!(Pose::from_xyz_lookat(0.0, 0.0, f32::NEG_INFINITY).is_none());
+    }
+
+    #[test]
+    fn lookat_independent_of_target_distance() {
+        // Doubling all coordinates keeps the same direction → same pose.
+        let near = Pose::from_xyz_lookat(0.5, 0.3, 1.0).expect("near target well-defined");
+        let far = Pose::from_xyz_lookat(50.0, 30.0, 100.0).expect("far target well-defined");
+        assert!(
+            (near.pan_deg - far.pan_deg).abs() < 0.5,
+            "pan should be distance-invariant: {} vs {}",
+            near.pan_deg,
+            far.pan_deg
+        );
+        assert!(
+            (near.tilt_deg - far.tilt_deg).abs() < 0.5,
+            "tilt should be distance-invariant: {} vs {}",
+            near.tilt_deg,
+            far.tilt_deg
+        );
     }
 }

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -49,6 +49,19 @@ pub enum RemoteCommand {
         /// Hold duration in milliseconds.
         hold_ms: u32,
     },
+    /// Set [`crate::Attention::Point`] toward an explicit 3D world
+    /// point and hold for `hold_ms`. Right-handed coordinates with
+    /// `+Z` forward, `+X` right, `+Y` up; only the direction matters
+    /// (target distance is irrelevant). The modifier graph converts
+    /// the point to a head pose via [`crate::Pose::from_xyz_lookat`];
+    /// targets at the origin (singularity) are rejected by the
+    /// firmware-side parser before this variant ever lands.
+    LookAtPoint {
+        /// Cartesian world point `(x, y, z)`.
+        target: (f32, f32, f32),
+        /// Hold duration in milliseconds.
+        hold_ms: u32,
+    },
     /// Clear any active emotion or look-at hold and return to
     /// autonomous behavior.
     Reset,

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -161,6 +161,27 @@ pub enum Attention {
         /// When the tracking attention began.
         since: Instant,
     },
+    /// Aiming at an explicit 3D world point. Right-handed coordinates
+    /// with `+Z` forward (head's natural gaze axis), `+X` right, `+Y`
+    /// up; units are arbitrary (only direction matters).
+    ///
+    /// Set by the operator surface — HTTP `POST /look-at-point`, MCP
+    /// tool `robot.look_at_point`, ESP-NOW remote command — when a
+    /// caller wants 3D control rather than the existing pan/tilt 2D
+    /// shape. Read by
+    /// [`crate::modifiers::HeadFromAttention`] and
+    /// [`crate::modifiers::GazeFromAttention`], which convert the
+    /// point into a head pose via [`Pose::from_xyz_lookat`].
+    ///
+    /// The singularity at the origin is honoured: when `(x, y, z) ==
+    /// (0, 0, 0)` the conversion returns `None` and consumers fall
+    /// back to neutral pose.
+    Point {
+        /// Cartesian world point `(x, y, z)`.
+        target: (f32, f32, f32),
+        /// When this attention began.
+        since: Instant,
+    },
 }
 
 /// Face-lock engagement state.

--- a/crates/stackchan-core/src/modifiers/gaze_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/gaze_from_attention.rs
@@ -119,6 +119,18 @@ impl Modifier for GazeFromAttention {
             (None, Attention::Tracking { target, .. }) => {
                 target_to_offset(target.pan_deg, target.tilt_deg)
             }
+            (
+                None,
+                Attention::Point {
+                    target: (x, y, z), ..
+                },
+            ) => {
+                // Convert the 3D point into a head-pose direction; if
+                // the target sits at the singularity, drop the
+                // contribution.
+                crate::Pose::from_xyz_lookat(x, y, z)
+                    .map_or((0, 0), |p| target_to_offset(p.pan_deg, p.tilt_deg))
+            }
             (None, Attention::None | Attention::Listening { .. }) => (0, 0),
         };
 

--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -90,10 +90,26 @@ pub struct HeadFromAttention {
     /// unless currently easing out.
     release_since: Option<Instant>,
     /// Smoothed tracking target (single-pole low-pass over the live
-    /// `Attention::Tracking{target}`). `None` between Tracking runs;
-    /// the next entry to Tracking re-anchors at the live target so
-    /// there's no overshoot from a stale value.
+    /// `Attention::Tracking{target}` or the IK-converted
+    /// `Attention::Point{target}`). `None` between active runs; the
+    /// next entry re-anchors at the live target so there's no overshoot
+    /// from a stale value.
     smoothed_target: Option<Pose>,
+    /// Which attention variant produced the active `smoothed_target`.
+    /// Tracked so an atomic `Tracking` ↔ `Point` swap (skipping
+    /// `Attention::None`) resets the smoother — otherwise the new arm
+    /// would chase from the prior arm's pose.
+    smoothed_source: Option<SmoothedSource>,
+}
+
+/// Discriminant for which attention variant currently owns
+/// [`HeadFromAttention::smoothed_target`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SmoothedSource {
+    /// `Attention::Tracking` produced the smoothed target.
+    Tracking,
+    /// `Attention::Point` produced the smoothed target (after IK).
+    Point,
 }
 
 impl HeadFromAttention {
@@ -106,6 +122,7 @@ impl HeadFromAttention {
             listen_since: None,
             release_since: None,
             smoothed_target: None,
+            smoothed_source: None,
         }
     }
 }
@@ -229,10 +246,16 @@ impl Modifier for HeadFromAttention {
                     // filter smooths jittery per-frame centroids.
                     //
                     // On entry to Tracking the smoother anchors at the
-                    // live target (no chase from a stale value).
-                    let prev = self.smoothed_target.unwrap_or(target);
+                    // live target (no chase from a stale value). Re-anchor
+                    // also when switching from the Point source so the
+                    // 3D pose isn't carried into 2D tracking.
+                    let prev = match self.smoothed_source {
+                        Some(SmoothedSource::Tracking) => self.smoothed_target.unwrap_or(target),
+                        _ => target,
+                    };
                     let smoothed = lerp_pose(prev, target);
                     self.smoothed_target = Some(smoothed);
+                    self.smoothed_source = Some(SmoothedSource::Tracking);
                     (
                         smoothed.pan_deg - upstream_pan,
                         smoothed.tilt_deg - upstream_tilt,
@@ -249,9 +272,18 @@ impl Modifier for HeadFromAttention {
                     // fall through to no contribution), then run the
                     // same low-pass smoother as the Tracking branch.
                     if let Some(point_target) = Pose::from_xyz_lookat(x, y, z).map(Pose::clamped) {
-                        let prev = self.smoothed_target.unwrap_or(point_target);
+                        // Re-anchor on entry or on a Tracking → Point
+                        // swap so the 2D pose isn't carried into the
+                        // 3D IK target.
+                        let prev = match self.smoothed_source {
+                            Some(SmoothedSource::Point) => {
+                                self.smoothed_target.unwrap_or(point_target)
+                            }
+                            _ => point_target,
+                        };
                         let smoothed = lerp_pose(prev, point_target);
                         self.smoothed_target = Some(smoothed);
+                        self.smoothed_source = Some(SmoothedSource::Point);
                         (
                             smoothed.pan_deg - upstream_pan,
                             smoothed.tilt_deg - upstream_tilt,
@@ -260,13 +292,16 @@ impl Modifier for HeadFromAttention {
                         // Origin / NaN / Inf — drop the smoother and
                         // contribute nothing this tick.
                         self.smoothed_target = None;
+                        self.smoothed_source = None;
                         (0.0, 0.0)
                     }
                 }
                 (None, Attention::Listening { .. } | Attention::None) => {
-                    // Drop the smoother anchor so a future Tracking run
-                    // re-anchors at the live target (no stale chase).
+                    // Drop the smoother anchor so a future Tracking /
+                    // Point run re-anchors at the live target (no
+                    // stale chase).
                     self.smoothed_target = None;
+                    self.smoothed_source = None;
                     // Tilt-only contribution, eased by the listen / release
                     // anchors. Pan stays at zero (no contribution).
                     let target_tilt = match (self.listen_since, self.release_since) {
@@ -655,5 +690,87 @@ mod tests {
         // Pan contribution should be zero (no attention, no
         // listening ease for pan).
         assert_eq!(m.last_pan_deg, 0.0);
+    }
+
+    #[test]
+    fn tracking_to_point_swap_re_anchors_smoother() {
+        // Atomic Tracking → Point swap (skipping Attention::None):
+        // the smoother MUST re-anchor at the IK target rather than
+        // chase from the prior tracking pose. Without the
+        // smoothed_source discriminant, the Point arm's
+        // `unwrap_or(point_target)` would carry the 2D tracking pose
+        // forward and produce a brief smooth chase from the 2D pose
+        // to the 3D point.
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+
+        // Settle into a tracking pose far from where the point will land.
+        entity.mind.attention = tracking(Pose::new(20.0, 5.0));
+        for t in 0..40 {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        let after_tracking = entity.motor.head_pose;
+        assert!(
+            (after_tracking.pan_deg - 20.0).abs() < 0.5,
+            "tracking should have settled at +20°, got {after_tracking:?}",
+        );
+
+        // Atomic swap to a 3D point straight ahead (yaw = 0). Re-apply
+        // the upstream pose first so the diff-and-undo comparison is
+        // honest (mimics what the firmware render task does each
+        // frame).
+        entity.motor.head_pose = after_tracking;
+        entity.mind.attention = Attention::Point {
+            target: (0.0, 0.0, 1.0),
+            since: Instant::from_millis(40 * 33),
+        };
+        entity.tick.now = Instant::from_millis(40 * 33);
+        m.update(&mut entity);
+
+        // First tick after the swap: head should snap toward the IK
+        // target (yaw ≈ 0), not blend from the +20° tracking pose. If
+        // the smoother had inherited the tracking state, we'd expect
+        // a value close to +20° (one frame's lerp toward 0 is
+        // ~20 × (1 - 0.22) ≈ 15.6°).
+        assert!(
+            entity.motor.head_pose.pan_deg.abs() < 1.0,
+            "Tracking → Point swap should snap to IK target ≈ 0°, got {:?}",
+            entity.motor.head_pose,
+        );
+    }
+
+    #[test]
+    fn point_to_tracking_swap_re_anchors_smoother() {
+        // Symmetric guard for the reverse swap.
+        let mut m = HeadFromAttention::new();
+        let mut entity = Entity::default();
+
+        // Settle into a Point hold pointing hard right (+X, +Z).
+        entity.mind.attention = Attention::Point {
+            target: (1.0, 0.0, 0.0),
+            since: Instant::from_millis(0),
+        };
+        for t in 0..40 {
+            entity.tick.now = Instant::from_millis(t * 33);
+            m.update(&mut entity);
+        }
+        let after_point = entity.motor.head_pose;
+        // Point at +X,+Z=0 → atan2(1,0) = 90°, clamped to MAX_PAN_DEG.
+        assert!(after_point.pan_deg > 30.0);
+
+        // Swap to a centre-pointing tracking target.
+        entity.motor.head_pose = after_point;
+        entity.mind.attention = tracking(Pose::new(0.0, 0.0));
+        entity.tick.now = Instant::from_millis(40 * 33);
+        m.update(&mut entity);
+
+        // Should snap toward the new tracking target on entry rather
+        // than chase from the prior point pose.
+        assert!(
+            entity.motor.head_pose.pan_deg.abs() < 1.0,
+            "Point → Tracking swap should snap to 0°, got {:?}",
+            entity.motor.head_pose,
+        );
     }
 }

--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -238,6 +238,31 @@ impl Modifier for HeadFromAttention {
                         smoothed.tilt_deg - upstream_tilt,
                     )
                 }
+                (
+                    None,
+                    Attention::Point {
+                        target: (x, y, z), ..
+                    },
+                ) => {
+                    // 3D look-at: compute the pose direction once (the
+                    // singularity at the origin returns `None` and we
+                    // fall through to no contribution), then run the
+                    // same low-pass smoother as the Tracking branch.
+                    if let Some(point_target) = Pose::from_xyz_lookat(x, y, z).map(Pose::clamped) {
+                        let prev = self.smoothed_target.unwrap_or(point_target);
+                        let smoothed = lerp_pose(prev, point_target);
+                        self.smoothed_target = Some(smoothed);
+                        (
+                            smoothed.pan_deg - upstream_pan,
+                            smoothed.tilt_deg - upstream_tilt,
+                        )
+                    } else {
+                        // Origin / NaN / Inf — drop the smoother and
+                        // contribute nothing this tick.
+                        self.smoothed_target = None;
+                        (0.0, 0.0)
+                    }
+                }
                 (None, Attention::Listening { .. } | Attention::None) => {
                     // Drop the smoother anchor so a future Tracking run
                     // re-anchors at the live target (no stale chase).

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -63,6 +63,11 @@ pub struct RemoteCommandModifier {
     /// `since` is captured at the first frame of the hold so the
     /// rendered ease-in does not restart every tick.
     lookat_hold: Option<(Pose, Instant, Instant)>,
+    /// Active 3D look-at-point hold, if any. `(target, since, hold_until)`.
+    /// `target` is the raw `(x, y, z)` world point — the modifier graph
+    /// does the IK conversion each tick rather than caching the pose,
+    /// so a future re-clamp or convention change picks up automatically.
+    lookat_point_hold: Option<((f32, f32, f32), Instant, Instant)>,
     /// Active listen hold, if any. `(since, hold_until)`. `since`
     /// pins to the entry frame so listening-pose ease-in animations
     /// don't restart per tick (same idiom as [`Self::lookat_hold`]).
@@ -80,6 +85,7 @@ impl RemoteCommandModifier {
         Self {
             emotion_hold: None,
             lookat_hold: None,
+            lookat_point_hold: None,
             listen_hold: None,
             pairing_hold: None,
         }
@@ -101,6 +107,15 @@ impl RemoteCommandModifier {
                 let until = now + u64::from(hold_ms);
                 entity.mind.attention = Attention::Tracking { target, since: now };
                 self.lookat_hold = Some((target, now, until));
+                // A new 2D look-at supersedes any active 3D point hold.
+                self.lookat_point_hold = None;
+            }
+            RemoteCommand::LookAtPoint { target, hold_ms } => {
+                let until = now + u64::from(hold_ms);
+                entity.mind.attention = Attention::Point { target, since: now };
+                self.lookat_point_hold = Some((target, now, until));
+                // A new 3D point supersedes any active 2D look-at hold.
+                self.lookat_hold = None;
             }
             RemoteCommand::Reset => {
                 entity.mind.autonomy.manual_until = None;
@@ -108,6 +123,7 @@ impl RemoteCommandModifier {
                 entity.mind.attention = Attention::None;
                 self.emotion_hold = None;
                 self.lookat_hold = None;
+                self.lookat_point_hold = None;
                 self.listen_hold = None;
                 self.pairing_hold = None;
             }
@@ -193,6 +209,20 @@ impl Modifier for RemoteCommandModifier {
             } else {
                 self.lookat_hold = None;
                 if matches!(entity.mind.attention, Attention::Tracking { target: t, .. } if t == target)
+                {
+                    entity.mind.attention = Attention::None;
+                }
+            }
+        }
+
+        if let Some((target, since, until)) = self.lookat_point_hold {
+            if now < until {
+                entity.mind.attention = Attention::Point { target, since };
+            } else {
+                self.lookat_point_hold = None;
+                // Only release attention if it's still our point —
+                // another modifier may have already taken over.
+                if matches!(entity.mind.attention, Attention::Point { target: t, .. } if t == target)
                 {
                     entity.mind.attention = Attention::None;
                 }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -426,6 +426,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("PUT", "/settings") => handle_put_settings(socket, body).await,
         ("POST", "/emotion") => handle_remote(socket, json::parse_set_emotion(body)).await,
         ("POST", "/look-at") => handle_remote(socket, json::parse_look_at(body)).await,
+        ("POST", "/look-at-point") => handle_remote(socket, json::parse_look_at_point(body)).await,
         ("POST", "/face-target") => handle_remote(socket, json::parse_face_target(body)).await,
         ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
         ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -143,6 +143,67 @@ pub fn parse_look_at(body: &str) -> Result<RemoteCommand, JsonError> {
     })
 }
 
+/// Parse a `POST /look-at-point` body into a
+/// [`RemoteCommand::LookAtPoint`].
+///
+/// Required: `x`, `y`, `z` (all numbers in arbitrary world units —
+/// only direction matters; right-handed coordinates with `+Z`
+/// forward). Optional: `hold_ms` (integer, defaults to
+/// [`DEFAULT_HOLD_MS`]).
+///
+/// # Errors
+///
+/// Returns a [`JsonError`] variant for missing required keys, unknown
+/// keys, malformed JSON shape, or a target at the singularity (origin).
+pub fn parse_look_at_point(body: &str) -> Result<RemoteCommand, JsonError> {
+    let mut x: Option<f32> = None;
+    let mut y: Option<f32> = None;
+    let mut z: Option<f32> = None;
+    let mut hold_ms: Option<u32> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "x" => {
+                if x.is_some() {
+                    return Err(JsonError::DuplicateKey("x"));
+                }
+                x = Some(parse_f32(scanner)?);
+            }
+            "y" => {
+                if y.is_some() {
+                    return Err(JsonError::DuplicateKey("y"));
+                }
+                y = Some(parse_f32(scanner)?);
+            }
+            "z" => {
+                if z.is_some() {
+                    return Err(JsonError::DuplicateKey("z"));
+                }
+                z = Some(parse_f32(scanner)?);
+            }
+            "hold_ms" => {
+                if hold_ms.is_some() {
+                    return Err(JsonError::DuplicateKey("hold_ms"));
+                }
+                hold_ms = Some(parse_u32(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    let x = x.ok_or(JsonError::MissingKey("x"))?;
+    let y = y.ok_or(JsonError::MissingKey("y"))?;
+    let z = z.ok_or(JsonError::MissingKey("z"))?;
+    // Reject the singularity at the source; the modifier graph would
+    // otherwise have to handle a None pose every tick of the hold.
+    if stackchan_core::Pose::from_xyz_lookat(x, y, z).is_none() {
+        return Err(JsonError::BadValue);
+    }
+    Ok(RemoteCommand::LookAtPoint {
+        target: (x, y, z),
+        hold_ms: hold_ms.unwrap_or(DEFAULT_HOLD_MS),
+    })
+}
+
 /// Parse a `POST /face-target` body into a [`RemoteCommand::LookAt`].
 ///
 /// Required: `x`, `y` (both numbers in normalised frame coordinates

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -1144,6 +1144,92 @@ mod tests {
     }
 
     #[test]
+    fn look_at_point_with_explicit_hold() {
+        let body = r#"{"x":1.0,"y":0.5,"z":2.0,"hold_ms":15000}"#;
+        match parse_look_at_point(body).unwrap() {
+            RemoteCommand::LookAtPoint { target, hold_ms } => {
+                assert_eq!(target, (1.0, 0.5, 2.0));
+                assert_eq!(hold_ms, 15_000);
+            }
+            other => panic!("expected LookAtPoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_point_defaults_hold_when_omitted() {
+        let body = r#"{"x":0.0,"y":0.0,"z":1.0}"#;
+        match parse_look_at_point(body).unwrap() {
+            RemoteCommand::LookAtPoint { hold_ms, .. } => assert_eq!(hold_ms, DEFAULT_HOLD_MS),
+            other => panic!("expected LookAtPoint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn look_at_point_rejects_missing_axis() {
+        for body in [
+            r#"{"y":0.0,"z":1.0}"#,
+            r#"{"x":0.0,"z":1.0}"#,
+            r#"{"x":0.0,"y":0.0}"#,
+        ] {
+            assert!(
+                matches!(parse_look_at_point(body), Err(JsonError::MissingKey(_))),
+                "expected MissingKey for body {body}",
+            );
+        }
+    }
+
+    #[test]
+    fn look_at_point_rejects_duplicate_key() {
+        let body = r#"{"x":0.0,"x":1.0,"y":0.0,"z":1.0}"#;
+        assert!(matches!(
+            parse_look_at_point(body),
+            Err(JsonError::DuplicateKey("x"))
+        ));
+    }
+
+    #[test]
+    fn look_at_point_rejects_unknown_key() {
+        let body = r#"{"x":0.0,"y":0.0,"z":1.0,"speed":1.0}"#;
+        assert!(matches!(
+            parse_look_at_point(body),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn look_at_point_rejects_origin_singularity() {
+        // The IK helper returns None at the origin; the parser must
+        // surface this as BadValue so the modifier graph never sees a
+        // None pose. This is the main domain-logic gate at the edge
+        // — guarding it explicitly catches a future epsilon tweak that
+        // would silently let near-origin targets through.
+        let body = r#"{"x":0.0,"y":0.0,"z":0.0}"#;
+        assert!(matches!(
+            parse_look_at_point(body),
+            Err(JsonError::BadValue)
+        ));
+    }
+
+    #[test]
+    fn look_at_point_rejects_nan_and_infinity() {
+        // Same singularity gate; from_xyz_lookat returns None on
+        // non-finite inputs, parser turns that into BadValue.
+        for body in [
+            r#"{"x":0.0,"y":0.0,"z":1e400}"#, // Inf
+            // The hand-rolled parser feeds the value to f32::from_str,
+            // which doesn't parse "NaN"/"Infinity" tokens, so those
+            // would already be BadValue at the number-parse stage.
+            // Test the singularity path with a near-origin instead:
+            r#"{"x":0.0000001,"y":0.0,"z":0.0}"#,
+        ] {
+            assert!(
+                matches!(parse_look_at_point(body), Err(JsonError::BadValue)),
+                "expected BadValue for body {body}",
+            );
+        }
+    }
+
+    #[test]
     fn empty_object_is_missing_required() {
         // No keys → required-key error surfaces, not a parser error.
         assert!(matches!(


### PR DESCRIPTION
## Summary

- New `Pose::from_xyz_lookat(x, y, z) -> Option<Pose>` performs 3D yaw/pitch IK with the right-handed `+Z` forward / `+X` right / `+Y` up convention; origin returns `None` (singularity); rejects NaN/Inf.
- New `Attention::Point` variant feeds the existing `gaze_from_attention` + `head_from_attention` modifiers via the same low-pass smoother as `Attention::Tracking`.
- New `RemoteCommand::LookAtPoint { target, hold_ms }` plumbed through `RemoteCommandModifier`. Mutually exclusive with `LookAt`: a new 3D hold supersedes any active 2D hold and vice versa.
- New HTTP route `POST /look-at-point` with body `{x, y, z, hold_ms?}`. The parser rejects origin / NaN / Inf at the edge so the modifier graph never sees a `None` pose.

Closes the third of four factory-firmware-parity gaps. Mirrors `m5stack/StackChan/firmware/main/stackchan/motion/motion.h::lookAtPoint` semantics.

## Test plan

- [x] `cargo +stable test -p stackchan-core` — 409 + 8 new IK tests passing
- [x] `cargo +stable test -p stackchan-net` — 239 tests passing
- [x] `cargo +stable clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS=-D warnings cargo +stable doc --no-deps --workspace --exclude stackchan-firmware --all-features` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp build --release` — clean
- [ ] Hardware boot smoke (`just fmr`) + `curl -X POST http://stackchan.local/look-at-point -d '{"x":1,"y":0.5,"z":1}'` — **blocked**: CoreS3 not enumerated. Will re-verify before merge.

Stacks alongside #284 (mDNS pose) and #285 (HeadPet reaction) — branched off main, no inter-PR dependencies.