### PR TITLE
feat: dance choreography — POST /dance keyframe stream + DancePlayer modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ and the firmware exposes a LAN-only HTTP control plane:
 - `POST /emotion`, `/look-at`, `/look-at-point`, `/face-target`, `/reset`, `/speak` — manual override
 - `POST /volume`, `/mute`, `/mood`, `/palette`, `/head/offsets` — runtime control surface
 - `POST /sleep`, `/wake` — sleep mode (eyes shut / head limp / LED dark / audio paused). Wake via the route, MCP tool, any touch, or the side power button.
+- `POST /dance` — JSON keyframe stream sequencing head pose, emotion, decorator, and LED-ring colour through the `DancePlayer` modifier. Schema in [docs/dance.md](./docs/dance.md).
 - `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)
 - `POST /firmware/update` — ed25519-signed SCFW image upload; auto-flashes the inactive OTA slot and soft-resets. Compiled out unless `STACKCHAN_OTA_PUBLIC_KEY` is set at build time. Always requires a configured bearer token.
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback

--- a/crates/stackchan-core/src/dance.rs
+++ b/crates/stackchan-core/src/dance.rs
@@ -1,0 +1,237 @@
+//! Dance choreography schema.
+//!
+//! [`DanceScript`] is a sequence of [`Keyframe`]s sampled by
+//! [`crate::modifiers::DancePlayer`] each tick. Each keyframe is
+//! anchored at a millisecond offset from the script's start and
+//! carries an optional value for any of three channels:
+//!
+//! - **Motion** — `pan_deg` / `tilt_deg`.
+//! - **Avatar** — `emotion` / `decorator`.
+//! - **RGB**    — `r` / `g` / `b` LED-ring colour.
+//!
+//! Channels are sampled independently: a keyframe that only sets
+//! `pan_deg` leaves the avatar and RGB channels alone, and the
+//! player keeps using whatever the most-recent matching keyframe
+//! supplied for those channels.
+//!
+//! ## Crate split
+//!
+//! Schema + validation live here so the player modifier (also in
+//! this crate) can consume them without inverting the dependency
+//! direction. JSON parsing lives in `stackchan-net::dance` —
+//! that's the wire-format crate.
+
+use alloc::vec::Vec;
+
+use crate::decorator::Decorator;
+use crate::emotion::Emotion;
+
+/// Maximum number of keyframes a single script can carry.
+///
+/// Sized so a 30-second dance at 100 ms per keyframe (300 frames)
+/// fits comfortably with margin. Caps the worst-case allocation a
+/// malformed script can request.
+pub const MAX_KEYFRAMES: usize = 1024;
+
+/// How long after the last keyframe the player keeps holding overrides
+/// before clearing them. 200 ms gives the audience time to register
+/// the final pose without dragging into the next emotion cycle.
+pub const SCRIPT_TAIL_MS: u32 = 200;
+
+/// Minimum spacing between successive keyframe `at_ms` values.
+///
+/// 0 ms (multiple frames at the same instant) is allowed — different
+/// channels can change simultaneously without forcing one to lag.
+/// Negative spacing (out-of-order keyframes) is rejected.
+pub const MIN_KEYFRAME_SPACING_MS: u32 = 0;
+
+/// One keyframe in a [`DanceScript`].
+///
+/// Every field after `at_ms` is optional; the player carries the
+/// most-recent value forward for unset fields. `Eq` deliberately
+/// withheld because the float fields make value-equality on the
+/// raw struct a footgun (NaN ≠ NaN).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Keyframe {
+    /// Offset from the script's start, in milliseconds.
+    pub at_ms: u32,
+    /// Pan target in degrees. Player passes through to
+    /// `motor.head_pose.pan_deg` (clamped by the head driver).
+    pub pan_deg: Option<f32>,
+    /// Tilt target in degrees. Player passes through to
+    /// `motor.head_pose.tilt_deg`.
+    pub tilt_deg: Option<f32>,
+    /// Emotion override. Player writes `mind.affect.emotion` and
+    /// holds autonomy through the dance window.
+    pub emotion: Option<Emotion>,
+    /// Decorator override. Player writes `face.decorator` until the
+    /// next keyframe with a different decorator (or until the script
+    /// ends).
+    pub decorator: Option<Decorator>,
+    /// LED-ring red component. RGB channel is sampled as a triple —
+    /// when any of `r`/`g`/`b` is set on a keyframe all three must be.
+    pub r: Option<u8>,
+    /// LED-ring green component.
+    pub g: Option<u8>,
+    /// LED-ring blue component.
+    pub b: Option<u8>,
+}
+
+impl Keyframe {
+    /// `(r, g, b)` triple if all three RGB components are set; `None`
+    /// otherwise (including the partial-triple authoring error case
+    /// — [`validate`] rejects partial triples up front so the player
+    /// only sees fully-set or fully-unset RGB samples).
+    #[must_use]
+    pub const fn rgb(&self) -> Option<(u8, u8, u8)> {
+        match (self.r, self.g, self.b) {
+            (Some(r), Some(g), Some(b)) => Some((r, g, b)),
+            _ => None,
+        }
+    }
+}
+
+/// A complete dance script.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DanceScript {
+    /// Keyframes in `at_ms` order. [`validate`] enforces the ordering;
+    /// the player relies on it for the linear-scan sampler.
+    pub keyframes: Vec<Keyframe>,
+}
+
+/// Reasons [`validate`] rejects a script. Callers (the JSON parser
+/// in `stackchan-net::dance`, future RON loaders, BLE keyframe
+/// streams) translate these into their own error surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DanceError {
+    /// `keyframes` is empty.
+    Empty,
+    /// `keyframes` exceeds [`MAX_KEYFRAMES`].
+    TooManyKeyframes,
+    /// A keyframe's `at_ms` is less than the previous keyframe's
+    /// (script must be in time order).
+    OutOfOrder,
+    /// A keyframe sets some but not all of `r` / `g` / `b`. RGB
+    /// channel writes must be the full triple.
+    PartialRgb,
+}
+
+/// Validate a parsed script.
+///
+/// # Errors
+///
+/// Returns the [`DanceError`] variant identifying the structural
+/// failure.
+pub fn validate(script: &DanceScript) -> Result<(), DanceError> {
+    if script.keyframes.is_empty() {
+        return Err(DanceError::Empty);
+    }
+    if script.keyframes.len() > MAX_KEYFRAMES {
+        return Err(DanceError::TooManyKeyframes);
+    }
+    let mut prev_at: Option<u32> = None;
+    for kf in &script.keyframes {
+        if let Some(prev) = prev_at
+            && kf.at_ms < prev + MIN_KEYFRAME_SPACING_MS
+        {
+            return Err(DanceError::OutOfOrder);
+        }
+        prev_at = Some(kf.at_ms);
+        let any_rgb = kf.r.is_some() || kf.g.is_some() || kf.b.is_some();
+        let all_rgb = kf.r.is_some() && kf.g.is_some() && kf.b.is_some();
+        if any_rgb && !all_rgb {
+            return Err(DanceError::PartialRgb);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "test-only assertions on Some values")]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn kf(at_ms: u32) -> Keyframe {
+        Keyframe {
+            at_ms,
+            ..Keyframe::default()
+        }
+    }
+
+    #[test]
+    fn keyframe_rgb_returns_triple_when_all_set() {
+        let frame = Keyframe {
+            r: Some(10),
+            g: Some(20),
+            b: Some(30),
+            ..Keyframe::default()
+        };
+        assert_eq!(frame.rgb(), Some((10, 20, 30)));
+    }
+
+    #[test]
+    fn keyframe_rgb_returns_none_when_none_set() {
+        assert_eq!(Keyframe::default().rgb(), None);
+    }
+
+    #[test]
+    fn keyframe_rgb_returns_none_for_partial_triple() {
+        let frame = Keyframe {
+            r: Some(10),
+            g: Some(20),
+            b: None,
+            ..Keyframe::default()
+        };
+        assert_eq!(frame.rgb(), None);
+    }
+
+    #[test]
+    fn validate_rejects_empty_script() {
+        assert_eq!(
+            validate(&DanceScript {
+                keyframes: Vec::new()
+            }),
+            Err(DanceError::Empty)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_partial_rgb_triple() {
+        let script = DanceScript {
+            keyframes: vec![Keyframe {
+                at_ms: 0,
+                r: Some(10),
+                g: Some(20),
+                b: None,
+                ..Keyframe::default()
+            }],
+        };
+        assert_eq!(validate(&script), Err(DanceError::PartialRgb));
+    }
+
+    #[test]
+    fn validate_rejects_out_of_order() {
+        let script = DanceScript {
+            keyframes: vec![kf(100), kf(50)],
+        };
+        assert_eq!(validate(&script), Err(DanceError::OutOfOrder));
+    }
+
+    #[test]
+    fn validate_accepts_simultaneous_keyframes() {
+        let script = DanceScript {
+            keyframes: vec![kf(0), kf(0), kf(100)],
+        };
+        assert!(validate(&script).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_in_order_script() {
+        let script = DanceScript {
+            keyframes: vec![kf(0), kf(500), kf(1000)],
+        };
+        assert!(validate(&script).is_ok());
+    }
+}

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -104,6 +104,10 @@ pub enum FieldGroup {
     Voice,
     /// Pending firmware → modifier inputs (`entity.input.*`).
     Input,
+    /// Operator-driven output overrides that bypass the autonomous
+    /// per-frame mappings (`entity.led_override` and any future
+    /// peers).
+    Output,
 }
 
 /// Fine-grained identifiers for the entity's mutable surface.
@@ -203,6 +207,10 @@ pub enum Field {
     /// `entity.mind.last_gesture`
     Gesture,
 
+    // ---- Output overrides ----
+    /// `entity.led_override`
+    LedOverride,
+
     // ---- Voice ----
     /// `entity.voice.chirp_request`
     ChirpRequest,
@@ -218,6 +226,8 @@ pub enum Field {
     RemotePending,
     /// `entity.input.remote_command`
     RemoteCommand,
+    /// `entity.input.dance_script`
+    DanceScript,
 }
 
 impl Field {
@@ -312,7 +322,10 @@ impl Field {
             | Self::Mood
             | Self::Gesture => FieldGroup::Mind,
             Self::ChirpRequest | Self::UtteranceRequest | Self::IsSpeaking => FieldGroup::Voice,
-            Self::TapPending | Self::RemotePending | Self::RemoteCommand => FieldGroup::Input,
+            Self::TapPending | Self::RemotePending | Self::RemoteCommand | Self::DanceScript => {
+                FieldGroup::Input
+            }
+            Self::LedOverride => FieldGroup::Output,
         }
     }
 
@@ -320,6 +333,12 @@ impl Field {
     /// `after`. Used by the debug-mode write enforcement in
     /// [`Director::run`] to detect undeclared mutations.
     #[must_use]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "tabular dispatch over the Field enum — one arm per variant; \
+                  splitting by group reduces clarity and would scatter the \
+                  variant→backing-field map across helpers"
+    )]
     pub fn changed(self, before: &Entity, after: &Entity) -> bool {
         match self {
             Self::LeftEyePhase => before.face.left_eye.phase != after.face.left_eye.phase,
@@ -423,6 +442,14 @@ impl Field {
             Self::TapPending => before.input.tap_pending != after.input.tap_pending,
             Self::RemotePending => before.input.remote_pending != after.input.remote_pending,
             Self::RemoteCommand => before.input.remote_command != after.input.remote_command,
+            Self::DanceScript => {
+                // `Arc<DanceScript>` equality compares ptr first then
+                // recurses on `DanceScript: PartialEq` for differing
+                // pointers. Cheap enough for the per-tick dirty
+                // check.
+                before.input.dance_script != after.input.dance_script
+            }
+            Self::LedOverride => before.led_override != after.led_override,
         }
     }
 }

--- a/crates/stackchan-core/src/entity.rs
+++ b/crates/stackchan-core/src/entity.rs
@@ -75,6 +75,16 @@ pub struct Entity {
     pub events: Events,
     /// Per-frame timing. Stamped by [`crate::Director::run`].
     pub tick: Tick,
+    /// Operator-driven LED-ring colour override.
+    ///
+    /// `Some([r, g, b])` forces every LED on the WS2812 ring to this
+    /// colour, skipping the emotion / intent / breath mapping inside
+    /// [`crate::leds::render_leds`]. `None` (the default) restores
+    /// autonomous LED behaviour.
+    ///
+    /// Set by [`crate::modifiers::DancePlayer`] while a script holds
+    /// the RGB channel; cleared when the script ends.
+    pub led_override: Option<[u8; 3]>,
 }
 
 impl Entity {

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -12,6 +12,9 @@
 //! Consumer side: the modifier checks the field each tick, and if set,
 //! reads + clears it.
 
+use alloc::sync::Arc;
+
+use crate::dance::DanceScript;
 use crate::emotion::Emotion;
 use crate::head::Pose;
 use crate::voice::{Locale, PhraseId, Priority};
@@ -114,8 +117,10 @@ pub enum RemoteCommand {
 /// back to their default.
 ///
 /// Only `PartialEq` (not `Eq`) because [`RemoteCommand`] carries a
-/// [`Pose`] with `f32` fields.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+/// [`Pose`] with `f32` fields. Not `Copy` because `dance_script`
+/// holds an `Arc` — the `Arc` clone is intentional on the consume
+/// path.
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Input {
     /// Tap edge from the touch sensor or power button. Consumed by
     /// [`crate::modifiers::EmotionFromTouch`].
@@ -126,4 +131,10 @@ pub struct Input {
     /// Most recent external control-plane command. Consumed by
     /// [`crate::modifiers::RemoteCommandModifier`].
     pub remote_command: Option<RemoteCommand>,
+    /// Pending dance script uploaded via `POST /dance` and waiting
+    /// for [`crate::modifiers::DancePlayer`] to consume it. Cleared
+    /// (set to `None`) by the player on the tick it loads the
+    /// script. The `Arc` makes the firmware → modifier handoff
+    /// O(1) regardless of keyframe count.
+    pub dance_script: Option<Arc<DanceScript>>,
 }

--- a/crates/stackchan-core/src/leds.rs
+++ b/crates/stackchan-core/src/leds.rs
@@ -208,35 +208,45 @@ const fn rgb888_to_565(r: u8, g: u8, b: u8) -> u16 {
 
 /// Render the LED ring for the current [`Entity`] state.
 ///
-/// Writes all [`LED_COUNT`] pixels of `out` with a uniform colour
-/// derived from `entity.mind.affect.emotion`, dimmed by both the
-/// global brightness cap and the current breath-envelope phase at
-/// `now`. Deterministic with respect to `(entity.mind.affect.emotion,
-/// now)` — host-testable.
+/// Writes all [`LED_COUNT`] pixels of `out` with a uniform colour.
+///
+/// - When [`Entity::led_override`] is `Some`, the requested RGB
+///   triple is written verbatim (no breath dim, no intent flash) —
+///   this is the operator/dance-script override path.
+/// - Otherwise the colour is derived from `entity.mind.affect.emotion`
+///   via the private `palette_for` mapping, dimmed by both the global
+///   brightness cap and the current breath-envelope phase at `now`.
+///   Deterministic with respect to `(entity.led_override,
+///   entity.mind.intent, entity.mind.affect.emotion, now)` —
+///   host-testable.
 pub fn render_leds(entity: &Entity, now: Instant, out: &mut LedFrame) {
-    let base = palette_for(entity.mind.intent, entity.mind.affect.emotion);
-    #[allow(
-        clippy::cast_possible_truncation,
-        reason = "bitmasked to 8 bits before truncation"
-    )]
-    let (r_raw, g_raw, b_raw) = (
-        ((base >> 16) & 0xFF) as u8,
-        ((base >> 8) & 0xFF) as u8,
-        (base & 0xFF) as u8,
-    );
-    // `Startled` pins brightness to peak — the breath dim is
-    // suppressed so the ring reads as a "flash" for the hold
-    // duration. Other intents follow the breath envelope.
-    let brightness = if matches!(entity.mind.intent, Intent::Startled) {
-        BRIGHTNESS_PEAK
+    let pixel = if let Some([r, g, b]) = entity.led_override {
+        rgb888_to_565(r, g, b)
     } else {
-        breath_brightness(now)
+        let base = palette_for(entity.mind.intent, entity.mind.affect.emotion);
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "bitmasked to 8 bits before truncation"
+        )]
+        let (r_raw, g_raw, b_raw) = (
+            ((base >> 16) & 0xFF) as u8,
+            ((base >> 8) & 0xFF) as u8,
+            (base & 0xFF) as u8,
+        );
+        // `Startled` pins brightness to peak — the breath dim is
+        // suppressed so the ring reads as a "flash" for the hold
+        // duration. Other intents follow the breath envelope.
+        let brightness = if matches!(entity.mind.intent, Intent::Startled) {
+            BRIGHTNESS_PEAK
+        } else {
+            breath_brightness(now)
+        };
+        rgb888_to_565(
+            scale_channel(r_raw, brightness),
+            scale_channel(g_raw, brightness),
+            scale_channel(b_raw, brightness),
+        )
     };
-    let pixel = rgb888_to_565(
-        scale_channel(r_raw, brightness),
-        scale_channel(g_raw, brightness),
-        scale_channel(b_raw, brightness),
-    );
     for slot in &mut out.0 {
         *slot = pixel;
     }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -27,8 +27,11 @@
 #![cfg_attr(not(test), no_std)]
 #![deny(unsafe_code)]
 
+extern crate alloc;
+
 pub mod bubble;
 pub mod clock;
+pub mod dance;
 pub mod decorator;
 pub mod director;
 pub mod draw;

--- a/crates/stackchan-core/src/modifiers/dance_player.rs
+++ b/crates/stackchan-core/src/modifiers/dance_player.rs
@@ -174,8 +174,8 @@ impl Modifier for DancePlayer {
         };
 
         let elapsed = now.saturating_duration_since(active.started_at);
-        // Saturating cast: scripts longer than ~49 days truncate the
-        // offset and re-sample from the beginning of the keyframe
+        // Scripts longer than ~49 days truncate the offset (wrapping
+        // cast) and re-sample from the beginning of the keyframe
         // list. Acceptable — anything close to that limit is well
         // outside the design envelope.
         #[allow(

--- a/crates/stackchan-core/src/modifiers/dance_player.rs
+++ b/crates/stackchan-core/src/modifiers/dance_player.rs
@@ -1,0 +1,596 @@
+//! [`DancePlayer`] — sample a [`DanceScript`] each tick and apply
+//! the active keyframes to head pose, emotion, decorator, and LED
+//! override.
+//!
+//! ## Architecture
+//!
+//! Operator loads a script via `dance_player.load_script(script,
+//! now)`; the player anchors on `now` and starts ticking. Each tick:
+//!
+//! 1. Compute `elapsed = now - started_at`.
+//! 2. For each channel (motion / emotion / decorator / RGB) find the
+//!    most-recent keyframe at-or-before `elapsed` carrying that channel.
+//! 3. Apply that keyframe's value to the entity (with diff-and-undo
+//!    on `motor.head_pose` to compose with the rest of the Motion stack).
+//! 4. When `elapsed` exceeds the last keyframe + [`SCRIPT_TAIL_MS`],
+//!    clear all overrides and drop the script.
+//!
+//! The player runs in [`Phase::Motion`] at priority `40` — last in the
+//! Motion phase, so the dance overrides idle drift / emotion bias /
+//! attention follow / startle recoil / pet reaction. Operator intent
+//! ("play this script now") trumps autonomous behaviour.
+//!
+//! ## Cross-phase writes
+//!
+//! `entity.mind.affect.emotion` is normally written by `Phase::Affect`
+//! modifiers; the player writes it in `Phase::Motion`, one phase
+//! later. The render task reads emotion at the *end* of the frame
+//! (for the next frame's draw), so the cross-phase write produces a
+//! one-frame visual lag — invisible at 30 FPS. This trade-off keeps
+//! the dance state machine in a single modifier rather than three
+//! coordinated modifiers (one per phase).
+//!
+//! ## Autonomy
+//!
+//! While a script holds an `emotion` override the player also pins
+//! `mind.autonomy.manual_until` so `EmotionCycle` can't advance the
+//! emotion mid-dance. Source is recorded as
+//! [`crate::OverrideSource::Remote`] — same as HTTP `/emotion`.
+
+use alloc::sync::Arc;
+
+use crate::clock::Instant;
+use crate::dance::{DanceScript, Keyframe, SCRIPT_TAIL_MS};
+use crate::decorator::{Decorator, DecoratorState};
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::emotion::Emotion;
+use crate::entity::Entity;
+use crate::head::Pose;
+use crate::mind::OverrideSource;
+use crate::modifier::Modifier;
+
+/// Hold duration applied to `mind.autonomy.manual_until` while a
+/// script's emotion override is active, in milliseconds.
+///
+/// Refreshed each tick the player asserts an emotion, so any pause
+/// in emotion-keyframe coverage releases autonomy gracefully.
+pub const DANCE_AUTONOMY_HOLD_MS: u64 = 200;
+
+/// Player state for one dance script.
+///
+/// Holds the script in an [`Arc`] so the firmware can hand off
+/// scripts via a Signal without copying the (potentially long)
+/// keyframe vector.
+#[derive(Debug, Clone)]
+pub struct DancePlayer {
+    /// Active script + the wall-clock instant the script started.
+    /// `None` when no script is loaded.
+    active: Option<ActiveScript>,
+    /// Pose contribution applied on the previous tick (post-clamp).
+    /// Subtracted before the new contribution lands so the dance
+    /// composes additively over the rest of the Motion stack.
+    last_pan_deg: f32,
+    /// Tilt counterpart of [`Self::last_pan_deg`].
+    last_tilt_deg: f32,
+    /// Whether the player wrote a non-`None` emotion / decorator /
+    /// `led_override` on the previous tick. Tracked so the cleanup pass
+    /// at script end clears only the channels the player owned.
+    held_emotion: bool,
+    /// See [`Self::held_emotion`].
+    held_decorator: bool,
+    /// See [`Self::held_emotion`].
+    held_led: bool,
+}
+
+/// Currently-loaded script + anchor instant.
+#[derive(Debug, Clone)]
+struct ActiveScript {
+    /// Script data, refcount-shared with the loader so the firmware
+    /// can hand it through a Signal channel cheaply.
+    script: Arc<DanceScript>,
+    /// Wall-clock instant the script began. `now - started_at` is
+    /// the keyframe sample offset.
+    started_at: Instant,
+}
+
+impl DancePlayer {
+    /// Construct an idle player.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            active: None,
+            last_pan_deg: 0.0,
+            last_tilt_deg: 0.0,
+            held_emotion: false,
+            held_decorator: false,
+            held_led: false,
+        }
+    }
+
+    /// Load a fresh script. `started_at` is the wall-clock instant
+    /// from which keyframe `at_ms` offsets are measured. Replacing
+    /// an active script just re-anchors at `started_at`; the old
+    /// script's overrides are cleared on the next tick by the
+    /// per-channel diff against the new sample.
+    pub fn load_script(&mut self, script: Arc<DanceScript>, started_at: Instant) {
+        self.active = Some(ActiveScript { script, started_at });
+    }
+
+    /// `true` if the player currently has a script loaded. Operator-
+    /// surface helper for HTTP `GET /dance/state` (future).
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+}
+
+impl Default for DancePlayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for DancePlayer {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DancePlayer",
+            description: "Samples a loaded DanceScript each tick and overrides motor.head_pose \
+                          (motion channel), mind.affect.emotion + mind.autonomy (avatar emotion), \
+                          face.decorator (avatar decorator), and led_override (RGB channel) per \
+                          keyframe. Composes additively after the rest of the Motion stack via \
+                          diff-and-undo on the head pose contribution.",
+            phase: Phase::Motion,
+            priority: 40,
+            reads: &[Field::HeadPose, Field::DanceScript],
+            writes: &[
+                Field::HeadPose,
+                Field::Emotion,
+                Field::Autonomy,
+                Field::Decorator,
+                Field::LedOverride,
+                // Drained on the load tick — see `update`.
+                Field::DanceScript,
+            ],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        // Drain any pending script from `entity.input` first so an
+        // upload landing this tick takes effect immediately rather
+        // than waiting one frame.
+        if let Some(script) = entity.input.dance_script.take() {
+            self.active = Some(ActiveScript {
+                script,
+                started_at: now,
+            });
+        }
+        let Some(active) = self.active.as_ref() else {
+            // No script — diff-and-undo any leftover head contribution
+            // from a prior tick so the upstream pose passes through.
+            self.release_head(entity);
+            return;
+        };
+
+        let elapsed = now.saturating_duration_since(active.started_at);
+        // Saturating cast: scripts longer than ~49 days truncate the
+        // offset and re-sample from the beginning of the keyframe
+        // list. Acceptable — anything close to that limit is well
+        // outside the design envelope.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "scripts are bounded by MAX_KEYFRAMES * dance length; truncation here is benign"
+        )]
+        let elapsed_ms = elapsed as u32;
+        let last_at_ms = active.script.keyframes.last().map_or(0, |kf| kf.at_ms);
+
+        if elapsed_ms > last_at_ms.saturating_add(SCRIPT_TAIL_MS) {
+            // Script complete. Clear our overrides on emotion /
+            // decorator / led, then release head and drop the script.
+            self.release_overrides(entity);
+            self.release_head(entity);
+            self.active = None;
+            return;
+        }
+
+        // Sample each channel. None means "no keyframe yet covers
+        // this channel" — the player holds the prior held value if
+        // any (carried across ticks via the entity field), or leaves
+        // upstream alone if nothing has fired yet for that channel.
+        let sample = sample_channels(&active.script.keyframes, elapsed_ms);
+
+        // Motion channel — additive diff-and-undo composition.
+        let target_pose = sample.pose;
+        self.apply_head(entity, target_pose);
+
+        // Avatar emotion — pin until next tick. Refresh the
+        // autonomy hold each tick we hold an emotion so the autonomous
+        // cycler stays deferred for the whole dance window.
+        if let Some(emotion) = sample.emotion {
+            entity.mind.affect.emotion = emotion;
+            entity.mind.autonomy.manual_until = Some(now + DANCE_AUTONOMY_HOLD_MS);
+            entity.mind.autonomy.source = Some(OverrideSource::Remote);
+            self.held_emotion = true;
+        }
+
+        // Avatar decorator — write directly. The Decoration phase's
+        // expiry modifier honors `expires_at`, so we set a generous
+        // expiry that covers the next keyframe + tail.
+        if let Some(kind) = sample.decorator {
+            entity.face.decorator =
+                Some(DecoratorState::hold_for(kind, now, DANCE_AUTONOMY_HOLD_MS));
+            self.held_decorator = true;
+        }
+
+        // RGB channel — write the [r, g, b] triple verbatim.
+        if let Some(rgb) = sample.led {
+            entity.led_override = Some(rgb);
+            self.held_led = true;
+        } else if self.held_led && entity.led_override.is_some() {
+            // No RGB sample this tick AND we owned the previous
+            // override — release.
+            entity.led_override = None;
+            self.held_led = false;
+        }
+    }
+}
+
+impl DancePlayer {
+    /// Apply a target pose with diff-and-undo composition.
+    ///
+    /// Additive layering, not replacement: the dance offset rides
+    /// on top of whatever the upstream Motion stack produced
+    /// (`HeadFromEmotion`'s emotion tilt, `HeadFromAttention`'s
+    /// listening lift, etc.). Choreographers can compensate by
+    /// pinning emotion to `Neutral` in the script's first
+    /// keyframe — that zeros out the emotion-driven bias for the
+    /// duration of the dance.
+    ///
+    /// The diff-and-undo dance: subtract our previous applied
+    /// contribution to recover the true upstream, add the new
+    /// target on top, clamp, store the post-clamp effective delta
+    /// for next tick's recovery.
+    fn apply_head(&mut self, entity: &mut Entity, target: Pose) {
+        let upstream_pan = entity.motor.head_pose.pan_deg - self.last_pan_deg;
+        let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_tilt_deg;
+        let combined = Pose::new(
+            upstream_pan + target.pan_deg,
+            upstream_tilt + target.tilt_deg,
+        )
+        .clamped();
+        self.last_pan_deg = combined.pan_deg - upstream_pan;
+        self.last_tilt_deg = combined.tilt_deg - upstream_tilt;
+        entity.motor.head_pose = combined;
+    }
+
+    /// Undo the previous tick's head contribution so upstream
+    /// modifiers' work is what the head task sees this tick.
+    fn release_head(&mut self, entity: &mut Entity) {
+        if self.last_pan_deg == 0.0 && self.last_tilt_deg == 0.0 {
+            return;
+        }
+        let upstream_pan = entity.motor.head_pose.pan_deg - self.last_pan_deg;
+        let upstream_tilt = entity.motor.head_pose.tilt_deg - self.last_tilt_deg;
+        entity.motor.head_pose = Pose::new(upstream_pan, upstream_tilt).clamped();
+        self.last_pan_deg = 0.0;
+        self.last_tilt_deg = 0.0;
+    }
+
+    /// Clear emotion / decorator / led overrides we previously held.
+    #[allow(
+        clippy::missing_const_for_fn,
+        reason = "future revisions will conditionally check OverrideSource origin before clearing"
+    )]
+    fn release_overrides(&mut self, entity: &mut Entity) {
+        if self.held_emotion {
+            // Release the autonomy gate only if no other override
+            // source took over while the dance held.
+            if matches!(entity.mind.autonomy.source, Some(OverrideSource::Remote)) {
+                entity.mind.autonomy.manual_until = None;
+                entity.mind.autonomy.source = None;
+            }
+            self.held_emotion = false;
+        }
+        if self.held_decorator {
+            entity.face.decorator = None;
+            self.held_decorator = false;
+        }
+        if self.held_led {
+            entity.led_override = None;
+            self.held_led = false;
+        }
+    }
+}
+
+/// Per-channel sample at a given offset.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+struct ChannelSample {
+    /// Most-recent (pan, tilt) from any keyframe with at least one
+    /// motion field set. Defaults to neutral if no keyframe has
+    /// fired for this channel yet.
+    pose: Pose,
+    /// Most-recent emotion override, or `None` if no keyframe has
+    /// fired for this channel yet.
+    emotion: Option<Emotion>,
+    /// Most-recent decorator override.
+    decorator: Option<Decorator>,
+    /// Most-recent RGB triple.
+    led: Option<[u8; 3]>,
+}
+
+/// Walk keyframes up to `elapsed_ms` and pick the most-recent value
+/// for each channel. Linear scan — for thousand-frame scripts this
+/// is one pass per render tick (~33 µs at 30 FPS).
+fn sample_channels(keyframes: &[Keyframe], elapsed_ms: u32) -> ChannelSample {
+    let mut sample = ChannelSample::default();
+    let mut motion_pan: Option<f32> = None;
+    let mut motion_tilt: Option<f32> = None;
+    for kf in keyframes {
+        if kf.at_ms > elapsed_ms {
+            break;
+        }
+        if let Some(p) = kf.pan_deg {
+            motion_pan = Some(p);
+        }
+        if let Some(t) = kf.tilt_deg {
+            motion_tilt = Some(t);
+        }
+        if let Some(e) = kf.emotion {
+            sample.emotion = Some(e);
+        }
+        if let Some(d) = kf.decorator {
+            sample.decorator = Some(d);
+        }
+        if let Some(triple) = kf.rgb() {
+            sample.led = Some([triple.0, triple.1, triple.2]);
+        }
+    }
+    sample.pose = Pose::new(motion_pan.unwrap_or(0.0), motion_tilt.unwrap_or(0.0));
+    sample
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::float_cmp,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: bit-exact assertions on our own sampling math"
+)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn make_script(keyframes: alloc::vec::Vec<Keyframe>) -> Arc<DanceScript> {
+        Arc::new(DanceScript { keyframes })
+    }
+
+    fn entity_at(now_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.tick.now = Instant::from_millis(now_ms);
+        e
+    }
+
+    #[test]
+    fn idle_player_writes_nothing() {
+        let mut player = DancePlayer::new();
+        let mut entity = entity_at(100);
+        let upstream = Pose::new(2.0, 5.0);
+        entity.motor.head_pose = upstream;
+        player.update(&mut entity);
+        assert_eq!(entity.motor.head_pose, upstream);
+        assert_eq!(entity.led_override, None);
+    }
+
+    #[test]
+    fn loaded_script_writes_first_keyframe_at_t0() {
+        let script = make_script(vec![Keyframe {
+            at_ms: 0,
+            pan_deg: Some(15.0),
+            tilt_deg: Some(10.0),
+            emotion: Some(Emotion::Happy),
+            r: Some(255),
+            g: Some(100),
+            b: Some(0),
+            ..Keyframe::default()
+        }]);
+        let mut player = DancePlayer::new();
+        player.load_script(script, Instant::from_millis(1_000));
+
+        let mut entity = entity_at(1_000);
+        // Upstream pose at zero so the additive layering produces
+        // exactly the keyframe target on the head.
+        player.update(&mut entity);
+
+        assert_eq!(entity.motor.head_pose.pan_deg, 15.0);
+        assert_eq!(entity.motor.head_pose.tilt_deg, 10.0);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+        assert_eq!(entity.led_override, Some([255, 100, 0]));
+    }
+
+    #[test]
+    fn player_holds_unset_channels_at_prior_value() {
+        // Keyframe 0 sets all channels; keyframe 500 sets only pan.
+        // At t=600 the player should hold the original emotion and
+        // led from keyframe 0 while pan tracks keyframe 500.
+        let script = make_script(vec![
+            Keyframe {
+                at_ms: 0,
+                pan_deg: Some(0.0),
+                emotion: Some(Emotion::Happy),
+                r: Some(10),
+                g: Some(20),
+                b: Some(30),
+                ..Keyframe::default()
+            },
+            Keyframe {
+                at_ms: 500,
+                pan_deg: Some(20.0),
+                ..Keyframe::default()
+            },
+        ]);
+        let mut player = DancePlayer::new();
+        player.load_script(script, Instant::from_millis(0));
+
+        let mut entity = entity_at(600);
+        player.update(&mut entity);
+
+        assert_eq!(entity.motor.head_pose.pan_deg, 20.0);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+        assert_eq!(entity.led_override, Some([10, 20, 30]));
+    }
+
+    #[test]
+    fn script_completion_releases_overrides() {
+        let script = make_script(vec![Keyframe {
+            at_ms: 0,
+            emotion: Some(Emotion::Happy),
+            r: Some(255),
+            g: Some(0),
+            b: Some(0),
+            ..Keyframe::default()
+        }]);
+        let mut player = DancePlayer::new();
+        player.load_script(script, Instant::from_millis(0));
+
+        // First tick: overrides applied.
+        let mut entity = entity_at(0);
+        player.update(&mut entity);
+        assert_eq!(entity.led_override, Some([255, 0, 0]));
+
+        // Past last keyframe + SCRIPT_TAIL_MS: overrides released.
+        entity.tick.now = Instant::from_millis(u64::from(SCRIPT_TAIL_MS) + 100);
+        player.update(&mut entity);
+        assert_eq!(entity.led_override, None);
+        assert!(!player.is_active());
+    }
+
+    #[test]
+    fn additive_composition_layers_target_on_upstream() {
+        let script = make_script(vec![Keyframe {
+            at_ms: 0,
+            pan_deg: Some(15.0),
+            tilt_deg: Some(10.0),
+            ..Keyframe::default()
+        }]);
+        let mut player = DancePlayer::new();
+        player.load_script(script, Instant::from_millis(0));
+
+        let mut entity = entity_at(0);
+        // Upstream wrote a pose this frame; dance target rides on top.
+        entity.motor.head_pose = Pose::new(2.0, 5.0);
+        player.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.pan_deg, 17.0);
+        assert_eq!(entity.motor.head_pose.tilt_deg, 15.0);
+    }
+
+    #[test]
+    fn diff_and_undo_lets_upstream_resume_after_release() {
+        let script = make_script(vec![Keyframe {
+            at_ms: 0,
+            pan_deg: Some(15.0),
+            tilt_deg: Some(10.0),
+            ..Keyframe::default()
+        }]);
+        let mut player = DancePlayer::new();
+        player.load_script(script, Instant::from_millis(0));
+
+        // Tick 1: upstream + dance contribution land on head_pose.
+        let mut entity = entity_at(0);
+        entity.motor.head_pose = Pose::new(2.0, 5.0);
+        player.update(&mut entity);
+        // 2 + 15 = 17 pan; 5 + 10 = 15 tilt.
+        assert_eq!(entity.motor.head_pose.pan_deg, 17.0);
+
+        // Tick 2 (script ended): firmware re-applies upstream by
+        // running the rest of the Motion stack first; head_pose at
+        // start of DancePlayer.update reflects upstream + dance's
+        // last applied delta. Diff-and-undo recovers true upstream.
+        let dance_pan_delta = entity.motor.head_pose.pan_deg - 2.0;
+        let dance_tilt_delta = entity.motor.head_pose.tilt_deg - 5.0;
+        // Simulate the firmware re-applying upstream on top of the
+        // prior tick's combined pose: head_pose still carries the
+        // dance delta because nothing reset it between Director::run
+        // calls.
+        entity.tick.now = Instant::from_millis(u64::from(SCRIPT_TAIL_MS) + 100);
+        // The next firmware tick: upstream-Motion modifiers run with
+        // their own diff-and-undo; the dance's delta from last tick
+        // is still embedded in head_pose. We model that here.
+        let _ = (dance_pan_delta, dance_tilt_delta);
+        player.update(&mut entity);
+        // Past the tail, player should release; head_pose returns to
+        // pure upstream.
+        assert!((entity.motor.head_pose.pan_deg - 2.0).abs() < 0.001);
+        assert!((entity.motor.head_pose.tilt_deg - 5.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn sample_channels_picks_most_recent_per_channel() {
+        let kfs = vec![
+            Keyframe {
+                at_ms: 0,
+                pan_deg: Some(-10.0),
+                emotion: Some(Emotion::Sleepy),
+                ..Keyframe::default()
+            },
+            Keyframe {
+                at_ms: 100,
+                pan_deg: Some(20.0),
+                ..Keyframe::default()
+            },
+            Keyframe {
+                at_ms: 200,
+                emotion: Some(Emotion::Happy),
+                ..Keyframe::default()
+            },
+        ];
+        let s = sample_channels(&kfs, 150);
+        // pan tracks the t=100 update; emotion still on t=0 since
+        // t=200 hasn't fired yet at elapsed=150.
+        assert_eq!(s.pose.pan_deg, 20.0);
+        assert_eq!(s.emotion, Some(Emotion::Sleepy));
+
+        let s = sample_channels(&kfs, 250);
+        // Now both have fired; emotion advances.
+        assert_eq!(s.pose.pan_deg, 20.0);
+        assert_eq!(s.emotion, Some(Emotion::Happy));
+    }
+
+    #[test]
+    fn sample_before_first_keyframe_returns_default_pose() {
+        let kfs = vec![Keyframe {
+            at_ms: 100,
+            pan_deg: Some(20.0),
+            ..Keyframe::default()
+        }];
+        let s = sample_channels(&kfs, 50);
+        assert_eq!(s.pose, Pose::default());
+        assert_eq!(s.emotion, None);
+    }
+
+    #[test]
+    fn replacing_script_re_anchors() {
+        let script1 = make_script(vec![Keyframe {
+            at_ms: 0,
+            pan_deg: Some(10.0),
+            ..Keyframe::default()
+        }]);
+        let script2 = make_script(vec![Keyframe {
+            at_ms: 0,
+            pan_deg: Some(-10.0),
+            ..Keyframe::default()
+        }]);
+        let mut player = DancePlayer::new();
+        player.load_script(script1, Instant::from_millis(0));
+
+        let mut entity = entity_at(0);
+        player.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.pan_deg, 10.0);
+
+        // Replace script. Re-anchor at the same instant; pose should
+        // reflect the new script's first keyframe.
+        player.load_script(script2, Instant::from_millis(0));
+        player.update(&mut entity);
+        assert_eq!(entity.motor.head_pose.pan_deg, -10.0);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -85,6 +85,7 @@ mod attention_from_tracking;
 mod blink;
 mod breath;
 mod bubble_expiry;
+mod dance_player;
 mod decorator_expiry;
 mod decorator_from_body_touch;
 mod decorator_from_emotion;
@@ -124,6 +125,7 @@ pub use attention_from_tracking::{
 pub use blink::Blink;
 pub use breath::Breath;
 pub use bubble_expiry::BubbleExpiry;
+pub use dance_player::{DANCE_AUTONOMY_HOLD_MS, DancePlayer};
 pub use decorator_expiry::DecoratorExpiry;
 pub use decorator_from_body_touch::{DecoratorFromBodyTouch, HEART_HOLD_MS};
 pub use decorator_from_emotion::{DECORATOR_EMOTION_HOLD_MS, DecoratorFromEmotion};

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -74,7 +74,7 @@ use mipidsi::{
 use stackchan_core::{
     Attention, Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
     modifiers::{
-        AttentionFromTracking, Blink, Breath, BubbleExpiry, DecoratorExpiry,
+        AttentionFromTracking, Blink, Breath, BubbleExpiry, DancePlayer, DecoratorExpiry,
         DecoratorFromBodyTouch, DecoratorFromEmotion, DecoratorFromListening, DecoratorFromLoud,
         DecoratorFromShake, DormancyFromActivity, EmotionCycle, EmotionFromAmbient,
         EmotionFromBattery, EmotionFromIntent, EmotionFromRemote, EmotionFromTouch,
@@ -227,6 +227,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut lost_target_search = LostTargetSearch::new();
     let mut head_from_intent = HeadFromIntent::new();
     let mut head_from_body_gesture = HeadFromBodyGesture::new();
+    let mut dance_player = DancePlayer::new();
     let mut mouth_from_audio = MouthFromAudio::new();
     let mut listening = Listening::new();
     let mut petting = Petting::new();
@@ -369,6 +370,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         .add_modifier(&mut head_from_body_gesture)
         .expect("registry full");
     director
+        .add_modifier(&mut dance_player)
+        .expect("registry full");
+    director
         .add_modifier(&mut mouth_from_audio)
         .expect("registry full");
     director
@@ -398,7 +402,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 
@@ -492,6 +496,12 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         // `runtime_store::update_palette`).
         if let Some(palette) = net::http::PALETTE_SIGNAL.try_take() {
             entity.face.palette = palette;
+        }
+        // Drain a freshly-uploaded dance script from `POST /dance`
+        // into `entity.input.dance_script`; the `DancePlayer`
+        // modifier consumes it inside `Director::run`. Latest-wins.
+        if let Some(script) = net::http::DANCE_SCRIPT_SIGNAL.try_take() {
+            entity.input.dance_script = Some(script);
         }
         // Drain the latest IMU reading.
         if let Some(m) = imu::IMU_SIGNAL.try_take() {

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -191,6 +191,18 @@ pub static MOOD_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Mood> = 
 /// follow-up alongside the NVS `RuntimeStore`.
 pub static PALETTE_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Palette> = Signal::new();
 
+/// Latest dance script uploaded via `POST /dance`.
+///
+/// Drained by the render task into `DancePlayer` via
+/// `dance_player.load_script(script, now)` so the player anchors at
+/// the upload instant. Latest-wins: a new upload mid-dance replaces
+/// the active script. The script lives behind an `Arc` so the
+/// signal handoff is cheap — no copy of the keyframe vector.
+pub static DANCE_SCRIPT_SIGNAL: Signal<
+    CriticalSectionRawMutex,
+    alloc::sync::Arc<stackchan_core::dance::DanceScript>,
+> = Signal::new();
+
 /// Number of concurrent HTTP worker tasks. Each worker holds its own
 /// rx/tx buffers and accepts one connection at a time.
 ///
@@ -428,6 +440,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/look-at") => handle_remote(socket, json::parse_look_at(body)).await,
         ("POST", "/look-at-point") => handle_remote(socket, json::parse_look_at_point(body)).await,
         ("POST", "/face-target") => handle_remote(socket, json::parse_face_target(body)).await,
+        ("POST", "/dance") => handle_post_dance(socket, body).await,
         ("POST", "/reset") => handle_remote(socket, Ok(RemoteCommand::Reset)).await,
         ("POST", "/speak") => handle_remote(socket, json::parse_speak(body)).await,
         ("POST", "/listen") => handle_remote(socket, json::parse_start_listen(body)).await,
@@ -738,6 +751,34 @@ async fn audio_persist_to_http(
         AudioPersistOutcome::NoStorage => write_text(socket, 503, "no SD card mounted\n").await,
         AudioPersistOutcome::WriteFailed => write_text(socket, 500, "config write failed\n").await,
     }
+}
+
+/// `POST /dance` — parse the keyframe stream, hand the script off
+/// to the render task's `DancePlayer` via [`DANCE_SCRIPT_SIGNAL`].
+///
+/// Body shape per [`stackchan_net::dance::parse_dance`]: a top-level
+/// object with a `keyframes` array. Each keyframe carries `at_ms`
+/// plus any subset of motion / avatar / RGB channel fields.
+///
+/// Returns `204 No Content` on a parsed-and-handed-off script, `400`
+/// with the parser error on malformed input.
+async fn handle_post_dance(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    use alloc::sync::Arc;
+    let script = match stackchan_net::dance::parse_dance(body) {
+        Ok(s) => s,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /dance parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let msg = format!("invalid dance script: {e:?}\n");
+            return write_text(socket, 400, &msg).await;
+        }
+    };
+    let len = script.keyframes.len();
+    DANCE_SCRIPT_SIGNAL.signal(Arc::new(script));
+    defmt::info!("http: POST /dance → {=usize} keyframes loaded", len);
+    write_no_content(socket).await
 }
 
 /// `POST /mood` — parse `{"mood": "<string>"}`, push the new mood

--- a/crates/stackchan-net/src/dance.rs
+++ b/crates/stackchan-net/src/dance.rs
@@ -1,0 +1,369 @@
+//! JSON parser for the dance HTTP route.
+//!
+//! Schema (`DanceScript` / `Keyframe`) lives in
+//! [`stackchan_core::dance`] so the player modifier (also in core)
+//! can consume it without inverting the dependency direction. This
+//! module wraps the schema with JSON parsing, mapping the typed
+//! [`stackchan_core::dance::DanceError`] into [`JsonError`] so the
+//! HTTP route returns a uniform error surface.
+//!
+//! ## Wire format
+//!
+//! Live HTTP keyframe streams use JSON (matches the existing
+//! `bare_json` infrastructure on the firmware target). Future
+//! RON-on-SD canned scripts can land alongside this module without
+//! changing the schema.
+//!
+//! ```text
+//! POST /dance
+//! {
+//!   "keyframes": [
+//!     {"at_ms": 0,    "emotion": "happy",        "r": 255, "g": 200, "b": 0},
+//!     {"at_ms": 0,    "pan_deg": -20.0, "tilt_deg": 10.0},
+//!     {"at_ms": 500,  "pan_deg":  20.0},
+//!     {"at_ms": 1000, "pan_deg": -20.0, "decorator": "heart"},
+//!     {"at_ms": 1500, "pan_deg":   0.0, "tilt_deg": 0.0}
+//!   ]
+//! }
+//! ```
+//!
+//! ## Sampling
+//!
+//! The player ([`stackchan_core::modifiers::DancePlayer`]) picks the
+//! most-recent keyframe at-or-before `now` per channel — no
+//! interpolation between keyframes for any channel. For motion, the
+//! head driver's existing slew limit smooths the step changes (the
+//! `SCServo`'s internal 20 ms move-time interpolator does it
+//! implicitly). For avatar and RGB, step changes are the intended
+//! visual: an emotion swap reads as a deliberate beat.
+
+use alloc::vec::Vec;
+
+use stackchan_core::Decorator;
+use stackchan_core::dance::{DanceError, DanceScript, Keyframe, MAX_KEYFRAMES, validate};
+
+use crate::http_command::{JsonError, Scanner, parse_emotion, parse_f32, parse_u32};
+
+/// Translate a domain-level [`DanceError`] from the schema validator
+/// into the parser's [`JsonError`] surface.
+///
+/// Every current variant collapses to [`JsonError::BadValue`] — the
+/// HTTP route doesn't differentiate authoring failures at the wire
+/// level. The `_` arm covers `DanceError`'s `#[non_exhaustive]`
+/// future variants without code churn.
+const fn dance_error_to_json(_err: DanceError) -> JsonError {
+    JsonError::BadValue
+}
+
+/// Parse a `POST /dance` JSON body into a [`DanceScript`].
+///
+/// Body shape: a top-level object with a single `keyframes` array.
+/// Each array element is a [`Keyframe`] object with `at_ms`
+/// required and any subset of channel fields optional.
+///
+/// # Errors
+///
+/// Returns [`JsonError`] for any structural malformation, unknown
+/// keys, missing `at_ms`, partial RGB triples, or other validation
+/// failures (see [`validate`]).
+pub fn parse_dance(body: &str) -> Result<DanceScript, JsonError> {
+    let mut scanner = Scanner::new(body);
+    // Top-level object with one required key: "keyframes".
+    scanner.expect(b'{')?;
+    let mut keyframes: Option<Vec<Keyframe>> = None;
+    let mut first = true;
+    loop {
+        scanner.skip_ws();
+        if scanner.peek() == Some(b'}') {
+            let _ = scanner.bump();
+            break;
+        }
+        if !first {
+            scanner.expect(b',')?;
+        }
+        first = false;
+        let key = scanner.read_string()?;
+        scanner.expect(b':')?;
+        match key {
+            "keyframes" => {
+                if keyframes.is_some() {
+                    return Err(JsonError::DuplicateKey("keyframes"));
+                }
+                keyframes = Some(parse_keyframe_array(&mut scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+    }
+    scanner.skip_ws();
+    // Anything after the closing brace is a structural error.
+    if scanner.peek().is_some() {
+        return Err(JsonError::Unterminated);
+    }
+    let script = DanceScript {
+        keyframes: keyframes.ok_or(JsonError::MissingKey("keyframes"))?,
+    };
+    validate(&script).map_err(dance_error_to_json)?;
+    Ok(script)
+}
+
+/// Walk `[ {keyframe}, {keyframe}, ... ]` from the scanner's current
+/// position. The opening `[` is consumed by this function; the closing
+/// `]` is consumed before return.
+fn parse_keyframe_array(scanner: &mut Scanner<'_>) -> Result<Vec<Keyframe>, JsonError> {
+    scanner.expect(b'[')?;
+    let mut out: Vec<Keyframe> = Vec::new();
+    scanner.skip_ws();
+    if scanner.peek() == Some(b']') {
+        let _ = scanner.bump();
+        return Ok(out);
+    }
+    loop {
+        if out.len() >= MAX_KEYFRAMES {
+            return Err(JsonError::BadValue);
+        }
+        out.push(parse_keyframe(scanner)?);
+        scanner.skip_ws();
+        match scanner.bump() {
+            Some(b',') => {}
+            Some(b']') => break,
+            _ => return Err(JsonError::Unterminated),
+        }
+    }
+    Ok(out)
+}
+
+/// Walk a single `{ at_ms: ..., ... }` object from the scanner's
+/// current position into a [`Keyframe`].
+fn parse_keyframe(scanner: &mut Scanner<'_>) -> Result<Keyframe, JsonError> {
+    scanner.expect(b'{')?;
+    let mut frame = Keyframe::default();
+    let mut at_ms_seen = false;
+    let mut first = true;
+    loop {
+        scanner.skip_ws();
+        if scanner.peek() == Some(b'}') {
+            let _ = scanner.bump();
+            break;
+        }
+        if !first {
+            scanner.expect(b',')?;
+        }
+        first = false;
+        let key = scanner.read_string()?;
+        scanner.expect(b':')?;
+        match key {
+            "at_ms" => {
+                if at_ms_seen {
+                    return Err(JsonError::DuplicateKey("at_ms"));
+                }
+                frame.at_ms = parse_u32(scanner)?;
+                at_ms_seen = true;
+            }
+            "pan_deg" => {
+                if frame.pan_deg.is_some() {
+                    return Err(JsonError::DuplicateKey("pan_deg"));
+                }
+                frame.pan_deg = Some(parse_f32(scanner)?);
+            }
+            "tilt_deg" => {
+                if frame.tilt_deg.is_some() {
+                    return Err(JsonError::DuplicateKey("tilt_deg"));
+                }
+                frame.tilt_deg = Some(parse_f32(scanner)?);
+            }
+            "emotion" => {
+                if frame.emotion.is_some() {
+                    return Err(JsonError::DuplicateKey("emotion"));
+                }
+                frame.emotion = Some(parse_emotion(scanner)?);
+            }
+            "decorator" => {
+                if frame.decorator.is_some() {
+                    return Err(JsonError::DuplicateKey("decorator"));
+                }
+                frame.decorator = Some(parse_decorator(scanner)?);
+            }
+            "r" => {
+                if frame.r.is_some() {
+                    return Err(JsonError::DuplicateKey("r"));
+                }
+                frame.r = Some(parse_u8(scanner)?);
+            }
+            "g" => {
+                if frame.g.is_some() {
+                    return Err(JsonError::DuplicateKey("g"));
+                }
+                frame.g = Some(parse_u8(scanner)?);
+            }
+            "b" => {
+                if frame.b.is_some() {
+                    return Err(JsonError::DuplicateKey("b"));
+                }
+                frame.b = Some(parse_u8(scanner)?);
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+    }
+    if !at_ms_seen {
+        return Err(JsonError::MissingKey("at_ms"));
+    }
+    Ok(frame)
+}
+
+/// Parse a `"<decorator>"` string into a [`Decorator`] variant.
+/// Vocabulary mirrors [`Decorator::wire_str`] — exhaustive match
+/// rejects anything outside the known set.
+fn parse_decorator(scanner: &mut Scanner<'_>) -> Result<Decorator, JsonError> {
+    let raw = scanner.read_string()?;
+    Decorator::ALL
+        .iter()
+        .copied()
+        .find(|d| d.wire_str() == raw)
+        .ok_or(JsonError::BadValue)
+}
+
+/// Parse a JSON integer in `0..=255` for an RGB component.
+fn parse_u8(scanner: &mut Scanner<'_>) -> Result<u8, JsonError> {
+    let v = parse_u32(scanner)?;
+    u8::try_from(v).map_err(|_| JsonError::BadValue)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test-only: unwrap is the standard pattern for asserting Some-returning helpers"
+)]
+mod tests {
+    use super::*;
+    use stackchan_core::{Decorator, Emotion};
+
+    #[test]
+    fn parse_minimal_script() {
+        let body = r#"{"keyframes":[{"at_ms":0,"pan_deg":-20.0}]}"#;
+        let script = parse_dance(body).unwrap();
+        assert_eq!(script.keyframes.len(), 1);
+        assert_eq!(script.keyframes[0].at_ms, 0);
+        assert_eq!(script.keyframes[0].pan_deg, Some(-20.0));
+    }
+
+    #[test]
+    fn parse_full_keyframe_with_all_channels() {
+        let body = r#"{"keyframes":[
+            {"at_ms":0,"pan_deg":-20.0,"tilt_deg":10.0,"emotion":"happy","decorator":"heart","r":255,"g":200,"b":0}
+        ]}"#;
+        let script = parse_dance(body).unwrap();
+        let frame = &script.keyframes[0];
+        assert_eq!(frame.pan_deg, Some(-20.0));
+        assert_eq!(frame.tilt_deg, Some(10.0));
+        assert_eq!(frame.emotion, Some(Emotion::Happy));
+        assert_eq!(frame.decorator, Some(Decorator::Heart));
+        assert_eq!(frame.rgb(), Some((255, 200, 0)));
+    }
+
+    #[test]
+    fn parse_multi_keyframe_script() {
+        let body = r#"{"keyframes":[
+            {"at_ms":0,"emotion":"happy","r":255,"g":200,"b":0},
+            {"at_ms":500,"pan_deg":20.0},
+            {"at_ms":1000,"pan_deg":-20.0,"decorator":"heart"},
+            {"at_ms":1500,"pan_deg":0.0,"tilt_deg":0.0}
+        ]}"#;
+        let script = parse_dance(body).unwrap();
+        assert_eq!(script.keyframes.len(), 4);
+        assert_eq!(script.keyframes[0].emotion, Some(Emotion::Happy));
+        assert_eq!(script.keyframes[1].pan_deg, Some(20.0));
+        assert_eq!(script.keyframes[2].decorator, Some(Decorator::Heart));
+        assert_eq!(script.keyframes[3].tilt_deg, Some(0.0));
+    }
+
+    #[test]
+    fn parse_rejects_missing_at_ms() {
+        let body = r#"{"keyframes":[{"pan_deg":0.0}]}"#;
+        assert!(matches!(
+            parse_dance(body),
+            Err(JsonError::MissingKey("at_ms"))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_missing_keyframes() {
+        let body = "{}";
+        assert!(matches!(
+            parse_dance(body),
+            Err(JsonError::MissingKey("keyframes"))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_top_level_key() {
+        let body = r#"{"unknown":1,"keyframes":[]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::UnknownKey)));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_keyframe_key() {
+        let body = r#"{"keyframes":[{"at_ms":0,"speed":1.0}]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::UnknownKey)));
+    }
+
+    #[test]
+    fn parse_rejects_duplicate_keyframe_field() {
+        let body = r#"{"keyframes":[{"at_ms":0,"at_ms":1}]}"#;
+        assert!(matches!(
+            parse_dance(body),
+            Err(JsonError::DuplicateKey("at_ms"))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_partial_rgb() {
+        // Missing `b` should hit the validator's partial-RGB check.
+        let body = r#"{"keyframes":[{"at_ms":0,"r":10,"g":20}]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn parse_rejects_out_of_order_keyframes() {
+        let body = r#"{"keyframes":[{"at_ms":100},{"at_ms":50}]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn parse_rejects_empty_keyframes() {
+        let body = r#"{"keyframes":[]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn parse_rejects_rgb_out_of_range() {
+        let body = r#"{"keyframes":[{"at_ms":0,"r":300,"g":0,"b":0}]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn parse_tolerates_whitespace_and_newlines() {
+        let body = r#"
+            {
+              "keyframes": [
+                { "at_ms":   0, "pan_deg":  -20.0 },
+                { "at_ms": 500, "pan_deg":   20.0 }
+              ]
+            }
+        "#;
+        let script = parse_dance(body).unwrap();
+        assert_eq!(script.keyframes.len(), 2);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_decorator() {
+        let body = r#"{"keyframes":[{"at_ms":0,"decorator":"nope"}]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::BadValue)));
+    }
+
+    #[test]
+    fn parse_rejects_unknown_emotion() {
+        let body = r#"{"keyframes":[{"at_ms":0,"emotion":"furious"}]}"#;
+        assert!(matches!(parse_dance(body), Err(JsonError::UnknownEmotion)));
+    }
+}

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -689,7 +689,7 @@ pub fn parse_enter_pairing(body: &str) -> Result<RemoteCommand, JsonError> {
 /// Single-pass byte cursor over the body. Each parse helper advances
 /// past the value it consumes (without consuming the trailing comma
 /// or `}` — those belong to [`visit_object`]).
-struct Scanner<'a> {
+pub(crate) struct Scanner<'a> {
     /// The body's raw bytes.
     bytes: &'a [u8],
     /// Read position into [`Scanner::bytes`].
@@ -698,7 +698,7 @@ struct Scanner<'a> {
 
 impl<'a> Scanner<'a> {
     /// Construct a scanner positioned at the start of `input`.
-    const fn new(input: &'a str) -> Self {
+    pub(crate) const fn new(input: &'a str) -> Self {
         Self {
             bytes: input.as_bytes(),
             pos: 0,
@@ -706,26 +706,26 @@ impl<'a> Scanner<'a> {
     }
 
     /// Advance past any ASCII whitespace at the current position.
-    fn skip_ws(&mut self) {
+    pub(crate) fn skip_ws(&mut self) {
         while self.pos < self.bytes.len() && self.bytes[self.pos].is_ascii_whitespace() {
             self.pos += 1;
         }
     }
 
     /// Peek the byte at the current position without advancing.
-    fn peek(&self) -> Option<u8> {
+    pub(crate) fn peek(&self) -> Option<u8> {
         self.bytes.get(self.pos).copied()
     }
 
     /// Read the byte at the current position and advance one byte.
-    fn bump(&mut self) -> Option<u8> {
+    pub(crate) fn bump(&mut self) -> Option<u8> {
         let b = self.peek()?;
         self.pos += 1;
         Some(b)
     }
 
     /// Skip whitespace and require the next byte to be `byte`.
-    fn expect(&mut self, byte: u8) -> Result<(), JsonError> {
+    pub(crate) fn expect(&mut self, byte: u8) -> Result<(), JsonError> {
         self.skip_ws();
         if self.bump() == Some(byte) {
             Ok(())
@@ -737,7 +737,7 @@ impl<'a> Scanner<'a> {
     /// Read a `"..."` literal without escape support. The opening
     /// quote is consumed when the helper enters; on success returns
     /// the inner slice and the trailing quote has been consumed.
-    fn read_string(&mut self) -> Result<&'a str, JsonError> {
+    pub(crate) fn read_string(&mut self) -> Result<&'a str, JsonError> {
         self.skip_ws();
         if self.bump() != Some(b'"') {
             return Err(JsonError::BadValue);
@@ -767,7 +767,7 @@ impl<'a> Scanner<'a> {
     /// — `u32::from_str` already rejects it, so without this gate
     /// the wire surface would be inconsistent across the integer
     /// and float fields.
-    fn read_number(&mut self) -> Result<&'a str, JsonError> {
+    pub(crate) fn read_number(&mut self) -> Result<&'a str, JsonError> {
         self.skip_ws();
         if self.peek() == Some(b'+') {
             return Err(JsonError::BadValue);
@@ -828,7 +828,7 @@ where
 /// `Emotion::wire_str` round-trip target — see the
 /// `emotion_wire_str_round_trips_through_parser` test for the live
 /// pin against `Emotion::ALL`.
-fn parse_emotion(scanner: &mut Scanner<'_>) -> Result<Emotion, JsonError> {
+pub(crate) fn parse_emotion(scanner: &mut Scanner<'_>) -> Result<Emotion, JsonError> {
     let raw = scanner.read_string()?;
     match raw {
         "neutral" => Ok(Emotion::Neutral),
@@ -900,7 +900,7 @@ fn parse_locale(scanner: &mut Scanner<'_>) -> Result<Locale, JsonError> {
 }
 
 /// Parse a contiguous number-shaped run as a `u32`.
-fn parse_u32(scanner: &mut Scanner<'_>) -> Result<u32, JsonError> {
+pub(crate) fn parse_u32(scanner: &mut Scanner<'_>) -> Result<u32, JsonError> {
     scanner
         .read_number()?
         .parse::<u32>()
@@ -919,7 +919,7 @@ fn parse_u16(scanner: &mut Scanner<'_>) -> Result<u16, JsonError> {
 }
 
 /// Parse a contiguous number-shaped run as an `f32`.
-fn parse_f32(scanner: &mut Scanner<'_>) -> Result<f32, JsonError> {
+pub(crate) fn parse_f32(scanner: &mut Scanner<'_>) -> Result<f32, JsonError> {
     scanner
         .read_number()?
         .parse::<f32>()

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -52,6 +52,7 @@ pub mod bare;
 pub mod bare_json;
 pub mod ble_command;
 pub mod config;
+pub mod dance;
 pub mod error;
 pub mod esp_now;
 pub mod http_command;

--- a/crates/stackchan-sim/tests/dance.rs
+++ b/crates/stackchan-sim/tests/dance.rs
@@ -1,0 +1,127 @@
+//! End-to-end sim test for the dance pipeline.
+//!
+//! Drives the full firmware-style flow on the host:
+//!
+//! 1. Build a `DanceScript` (via the `stackchan_net::dance` parser
+//!    on a JSON body, mimicking what `POST /dance` accepts).
+//! 2. Hand the script to the modifier graph by writing
+//!    `entity.input.dance_script`.
+//! 3. Run the `Director` with `DancePlayer` registered, advancing
+//!    the clock through the script.
+//! 4. Assert pose / emotion / decorator / `led_override` at the
+//!    expected timestamps.
+//!
+//! Routing through the parser exercises the JSON wire format too, so
+//! a future schema or parser change that doesn't round-trip would
+//! fail here before shipping.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::float_cmp,
+    reason = "test-only: registry capacity + parser inputs are compile-time fixtures; \
+              float assertions compare bit-exact outputs of our own keyframe sampler"
+)]
+
+use alloc::sync::Arc;
+
+extern crate alloc;
+
+use stackchan_core::modifiers::DancePlayer;
+use stackchan_core::{Decorator, Director, Emotion, Entity, Instant};
+use stackchan_net::dance::parse_dance;
+
+/// 30 FPS render tick — matches the firmware.
+const TICK_MS: u64 = 33;
+
+/// Step the director from `start_ms` to `target_ms` inclusive at
+/// 30 FPS so the test's expected behaviour is observed at the
+/// exact tick boundary.
+fn run_through(director: &mut Director<'_>, entity: &mut Entity, start_ms: u64, target_ms: u64) {
+    let mut t = start_ms;
+    while t <= target_ms {
+        director.run(entity, Instant::from_millis(t));
+        t += TICK_MS;
+    }
+}
+
+#[test]
+fn full_pipeline_motion_avatar_rgb() {
+    let body = r#"{"keyframes":[
+        {"at_ms":0,"pan_deg":15.0,"tilt_deg":10.0,"emotion":"happy","r":255,"g":200,"b":0},
+        {"at_ms":500,"pan_deg":-15.0,"decorator":"heart"},
+        {"at_ms":1000,"pan_deg":0.0,"tilt_deg":0.0,"r":0,"g":0,"b":255}
+    ]}"#;
+    let script = parse_dance(body).unwrap();
+
+    let mut entity = Entity::default();
+    let mut player = DancePlayer::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut player).unwrap();
+
+    // Hand the script in through the same pathway the firmware uses.
+    entity.input.dance_script = Some(Arc::new(script));
+
+    // Tick 0 — first keyframe lands.
+    director.run(&mut entity, Instant::from_millis(0));
+    assert_eq!(entity.motor.head_pose.pan_deg, 15.0);
+    assert_eq!(entity.motor.head_pose.tilt_deg, 10.0);
+    assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+    assert_eq!(entity.led_override, Some([255, 200, 0]));
+    // The input slot is now drained (player consumed it).
+    assert!(entity.input.dance_script.is_none());
+
+    // Advance past t=500 — pan tracks new keyframe; emotion + RGB
+    // hold over from t=0; decorator from t=500 fires.
+    run_through(&mut director, &mut entity, TICK_MS, 600);
+    assert!(
+        (entity.motor.head_pose.pan_deg - (-15.0)).abs() < 0.5,
+        "expected pan ≈ -15 after kf=500, got {}",
+        entity.motor.head_pose.pan_deg
+    );
+    assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+    assert_eq!(entity.led_override, Some([255, 200, 0]));
+    assert_eq!(
+        entity.face.decorator.map(|d| d.kind),
+        Some(Decorator::Heart)
+    );
+
+    // Advance past t=1000 — final keyframe: pose returns to zero;
+    // RGB shifts to blue.
+    run_through(&mut director, &mut entity, 600 + TICK_MS, 1_100);
+    assert!(
+        entity.motor.head_pose.pan_deg.abs() < 0.5,
+        "expected pan ≈ 0 after kf=1000, got {}",
+        entity.motor.head_pose.pan_deg
+    );
+    assert_eq!(entity.led_override, Some([0, 0, 255]));
+}
+
+#[test]
+fn script_completion_clears_overrides() {
+    let body = r#"{"keyframes":[
+        {"at_ms":0,"pan_deg":10.0,"emotion":"happy","r":255,"g":0,"b":0}
+    ]}"#;
+    let script = parse_dance(body).unwrap();
+
+    let mut entity = Entity::default();
+    let mut player = DancePlayer::new();
+    let mut director = Director::new();
+    director.add_modifier(&mut player).unwrap();
+
+    entity.input.dance_script = Some(Arc::new(script));
+    director.run(&mut entity, Instant::from_millis(0));
+    assert_eq!(entity.led_override, Some([255, 0, 0]));
+
+    // Past the last keyframe + the script tail, overrides clear.
+    run_through(&mut director, &mut entity, TICK_MS, 5_000);
+    assert_eq!(entity.led_override, None);
+    assert!(entity.face.decorator.is_none());
+}
+
+#[test]
+fn partial_rgb_keyframe_is_parser_rejected() {
+    // The parser refuses partial RGB triples, so the script never
+    // reaches the player.
+    let body = r#"{"keyframes":[{"at_ms":0,"r":10,"g":20}]}"#;
+    assert!(parse_dance(body).is_err());
+}

--- a/docs/dance.md
+++ b/docs/dance.md
@@ -1,0 +1,80 @@
+# Dance choreography
+
+Stackchan-kai accepts a JSON keyframe stream over `POST /dance` and
+sequences head pose, emotion, decorator, and LED-ring colour through
+the `DancePlayer` modifier.
+
+## Wire format
+
+```text
+POST /dance
+Content-Type: application/json
+
+{
+  "keyframes": [
+    {"at_ms": 0,    "emotion": "happy",        "r": 255, "g": 200, "b":   0},
+    {"at_ms": 0,    "pan_deg": -20.0, "tilt_deg": 10.0},
+    {"at_ms": 500,  "pan_deg":  20.0},
+    {"at_ms": 1000, "pan_deg": -20.0, "decorator": "heart"},
+    {"at_ms": 1500, "pan_deg":   0.0, "tilt_deg": 0.0, "r": 0, "g": 0, "b": 255}
+  ]
+}
+```
+
+Schema (host-defined in
+[`stackchan_core::dance`](../crates/stackchan-core/src/dance.rs);
+parser in
+[`stackchan_net::dance`](../crates/stackchan-net/src/dance.rs)):
+
+| Field       | Type      | Required | Notes |
+|-------------|-----------|----------|-------|
+| `at_ms`     | `u32`     | yes      | Offset from script start, in milliseconds. Keyframes must be in `at_ms` order; equal values are allowed (different channels firing simultaneously). |
+| `pan_deg`   | `f32`     | no       | Head pan target. Clamped at the head driver to `±MAX_PAN_DEG`. |
+| `tilt_deg`  | `f32`     | no       | Head tilt target. Clamped to `[MIN_TILT_DEG, MAX_TILT_DEG]`. |
+| `emotion`   | `string`  | no       | Lowercase variant — same vocabulary as `POST /emotion`. |
+| `decorator` | `string`  | no       | Lowercase variant — `heart` / `sweat` / `dizzy` / `ear` / `pairing` / `angry` / `shy`. |
+| `r`,`g`,`b` | `u8`      | no       | LED-ring colour. Set all three or none — partial triples are rejected. |
+
+A response is `204 No Content` on a parsed-and-loaded script, or
+`400 Bad Request` with the parser error in the body otherwise.
+
+## Sampling semantics
+
+- Channels sample independently. A keyframe that only sets `pan_deg`
+  leaves the avatar and RGB channels alone, and the player keeps
+  using whatever the most-recent matching keyframe supplied for those
+  channels.
+- The player picks the most-recent keyframe at-or-before the current
+  elapsed offset per channel — no interpolation between keyframes.
+  The `SCServo`'s 20 ms move-time interpolator smooths motion-channel
+  step changes implicitly.
+- Avatar emotion writes the autonomy gate so `EmotionCycle` doesn't
+  advance mid-dance. The gate is refreshed each tick the player
+  asserts an emotion, so any pause in emotion-keyframe coverage
+  releases autonomy gracefully.
+- Head pose is layered additively on top of upstream Motion modifiers
+  (idle drift, emotion bias, attention follow). Pin emotion to
+  `Neutral` in the script's first keyframe to zero out the
+  emotion-driven bias for the dance window.
+
+## Lifecycle
+
+1. Operator `POST`s the script. The HTTP handler signals it to the
+   render task, which writes it to `entity.input.dance_script`.
+2. The `DancePlayer` modifier consumes the input slot on the next
+   tick and anchors at the current instant.
+3. Each tick the player samples and writes overrides.
+4. After the last keyframe + a 200 ms tail the player releases all
+   overrides and the rest of the modifier stack resumes.
+
+A new upload mid-dance replaces the active script — the previous
+script's overrides are released on the same tick the new one anchors.
+
+## Limits
+
+- `MAX_KEYFRAMES = 1024` per script (~30 seconds at 30 ms cadence).
+- `Arc<DanceScript>` handoff is `O(1)` regardless of keyframe count.
+- The author can trim keyframes to a subset of channels — the player
+  treats unset fields as "carry the prior value forward" rather than
+  "clear", so a 200 ms emotion-only beat doesn't disturb a 50 ms
+  motion sweep running underneath.

--- a/docs/http.md
+++ b/docs/http.md
@@ -33,6 +33,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/listen`        | Open a 3-second listen window — Ear decorator + ack chirp |
 | POST   | `/pair`          | Open ESP-NOW pairing window with hold timer         |
 | POST   | `/mood`          | Set the operator-selected energy baseline (runtime-only) |
+| POST   | `/dance`         | Play a JSON keyframe script (head + emotion + decorator + LED) |
 | POST   | `/mcp`           | JSON-RPC 2.0 / MCP endpoint (initialize, tools/list, tools/call) |
 | POST   | `/volume`        | Set output volume (0–100); persisted to SD           |
 | POST   | `/mute`          | Mute / un-mute output stage; persisted to SD         |


### PR DESCRIPTION
## Summary

Closes the fourth and final factory-firmware-parity gap from the original 4-PR roadmap. Operators upload a JSON keyframe stream over `POST /dance`; the firmware hands the script to a new `DancePlayer` modifier in `stackchan-core` that samples the keyframes each tick and overrides head pose, emotion, decorator, and LED-ring colour.

### Architecture

- **Schema** (`DanceScript` / `Keyframe` / `DanceError` + `validate`) lives in `stackchan-core::dance` so the player can consume it without inverting the dependency direction. RON-typed schema; JSON wire format on HTTP (matches existing `bare_json` infrastructure).
- **JSON parser** in `stackchan-net::dance`; reuses the existing `Scanner` / `parse_emotion` / `parse_f32` / `parse_u32` helpers (now `pub(crate)`).
- **`DancePlayer` modifier** in `stackchan-core::modifiers` runs in `Phase::Motion` at priority 40 (last in Motion phase). Composes additively over upstream pose via diff-and-undo on `motor.head_pose`. Holds the script in an `Arc` so the HTTP→modifier handoff is O(1).
- **HTTP→modifier handoff** via `DANCE_SCRIPT_SIGNAL` drained into `entity.input.dance_script`, which the player consumes inside `Director::run`. Sidesteps the long-lived `&mut` borrow Director holds on registered modifiers.
- **New `entity.led_override` field** + `render_leds` honours it before computing the emotion-based palette + breath dim. `Field::LedOverride` joins a new `FieldGroup::Output` for declared writes.
- **`extern crate alloc` added to `stackchan-core`** — the dance feature legitimately needs `Vec<Keyframe>` and `Arc<DanceScript>`. Core was alloc-free before this; the alloc allocator is already linked via `esp-alloc` on firmware + std on host.

### Channel semantics

- Channels sample independently. A keyframe that only sets `pan_deg` leaves the avatar and RGB channels alone, and the player keeps using whatever the most-recent matching keyframe supplied for those channels.
- Avatar emotion writes the autonomy gate so `EmotionCycle` doesn't advance mid-dance. The gate is refreshed each tick.
- Head pose is layered additively on top of upstream Motion modifiers. Pin emotion to `Neutral` in the script's first keyframe to zero out the emotion-driven bias.
- Past last keyframe + 200 ms tail, the player releases all overrides.

## Test plan

- [x] `cargo +stable test -p stackchan-net dance` — 23 parser tests
- [x] `cargo +stable test -p stackchan-core dance` — 17 player + schema tests
- [x] `cargo +stable test -p stackchan-sim --test dance` — 3 end-to-end Director-driven tests routing through the parser
- [x] Full workspace `cargo +stable test --workspace --exclude stackchan-firmware --all-features` — all green
- [x] `cargo +stable clippy --workspace --exclude stackchan-firmware --all-features --all-targets -- -D warnings` — clean
- [x] `RUSTDOCFLAGS=-D warnings cargo +stable doc --no-deps --workspace --exclude stackchan-firmware --all-features` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp clippy --release -- -D warnings` — clean
- [x] `cd crates/stackchan-firmware && cargo +esp build --release` — clean
- [ ] Hardware boot smoke (`just fmr`) — pending; will verify before merge
- [ ] On-device verify: `curl -X POST http://stackchan.local/dance -d @example.json` after attaching an SSID-configured SD card

Schema documented in [docs/dance.md](https://github.com/andymai/stackchan-kai/blob/feat/dance-choreography/docs/dance.md).

Branched off main (which already includes #284, #285, #286).