### PR TITLE
feat: face geometry presets — POST /face-geometry + selectable silhouettes

### DIFF
--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -156,6 +156,183 @@ impl Default for Style {
     }
 }
 
+/// Eye geometry baseline — the static layout for a preset.
+///
+/// Holds the values a [`FaceGeometry`] contributes when applied.
+/// Dynamic state ([`Eye::phase`], [`Eye::weight`], [`Eye::open_weight`])
+/// is preserved across preset swaps and lives only on [`Eye`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EyeBaseline {
+    /// Center of the eye in framebuffer space.
+    pub center: Point,
+    /// Horizontal half-axis in pixels.
+    pub radius_x: u16,
+    /// Vertical half-axis in pixels.
+    pub radius_y: u16,
+}
+
+/// Mouth geometry baseline. Dynamic state ([`Mouth::weight`],
+/// [`Mouth::mouth_open`]) is preserved across preset swaps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MouthBaseline {
+    /// Center of the mouth in framebuffer space.
+    pub center: Point,
+    /// Horizontal half-axis in pixels.
+    pub radius_x: u16,
+    /// Vertical half-axis in pixels.
+    pub radius_y: u16,
+}
+
+/// Named face-geometry preset.
+///
+/// Picks one of the curated baseline silhouettes bundled with the
+/// firmware. `Default` matches the neutral resting face from v0.1.0
+/// so a missing field on disk renders identically.
+///
+/// Geometry presets are orthogonal to [`crate::palette::Palette`]
+/// (skin colours) and [`Style`] (emotion-driven modulators). Picking
+/// `Chibi` swaps the eye / mouth *baseline*; emotion still scales
+/// eye size, blink cadence, and breath depth on top of that baseline
+/// via `Style`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FaceGeometry {
+    /// Original v0.1.0 baseline: round eyes at framebuffer-quarter
+    /// positions, small mouth.
+    #[default]
+    Default,
+    /// Kawaii silhouette: enlarged eyes, smaller mouth, lower-set.
+    Chibi,
+    /// Cartoon silhouette: far-set eyes, wider mouth.
+    Wide,
+    /// Droopy silhouette: lower-set eyes, narrower vertical axis.
+    /// Distinct from the `Sleepy` emotion (which modulates `Style`)
+    /// — this is a baseline-shape choice the operator pins.
+    Sleepy,
+}
+
+impl FaceGeometry {
+    /// Lowercase wire name for the HTTP `POST /face-geometry` body
+    /// and the persisted `RUNTIME.RON` field. Mirrors the convention
+    /// from [`crate::palette::Palette::wire_str`].
+    #[must_use]
+    pub const fn wire_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Chibi => "chibi",
+            Self::Wide => "wide",
+            Self::Sleepy => "sleepy",
+        }
+    }
+
+    /// Single-byte wire encoding for any future BLE GATT exposure.
+    /// Append-only; new variants get the next free integer.
+    #[must_use]
+    pub const fn wire_byte(self) -> u8 {
+        match self {
+            Self::Default => 0,
+            Self::Chibi => 1,
+            Self::Wide => 2,
+            Self::Sleepy => 3,
+        }
+    }
+
+    /// Parse a lowercase wire string back into a [`FaceGeometry`].
+    #[must_use]
+    pub fn from_wire_str(s: &str) -> Option<Self> {
+        match s {
+            "default" => Some(Self::Default),
+            "chibi" => Some(Self::Chibi),
+            "wide" => Some(Self::Wide),
+            "sleepy" => Some(Self::Sleepy),
+            _ => None,
+        }
+    }
+
+    /// Every variant in declaration order. Manually maintained — the
+    /// exhaustive matches in [`Self::wire_str`] / [`Self::wire_byte`]
+    /// guard the encoding side; the
+    /// `all_length_matches_variant_count` test trips on variant
+    /// addition.
+    pub const ALL: &'static [Self] = &[Self::Default, Self::Chibi, Self::Wide, Self::Sleepy];
+
+    /// Resolve to the (left eye, right eye, mouth) baseline geometry
+    /// for the renderer.
+    #[must_use]
+    pub const fn baseline(self) -> (EyeBaseline, EyeBaseline, MouthBaseline) {
+        match self {
+            Self::Default => (
+                EyeBaseline {
+                    center: Point::new(100, 110),
+                    radius_x: 25,
+                    radius_y: 25,
+                },
+                EyeBaseline {
+                    center: Point::new(220, 110),
+                    radius_x: 25,
+                    radius_y: 25,
+                },
+                MouthBaseline {
+                    center: Point::new(160, 180),
+                    radius_x: 32,
+                    radius_y: 10,
+                },
+            ),
+            Self::Chibi => (
+                EyeBaseline {
+                    center: Point::new(105, 115),
+                    radius_x: 32,
+                    radius_y: 32,
+                },
+                EyeBaseline {
+                    center: Point::new(215, 115),
+                    radius_x: 32,
+                    radius_y: 32,
+                },
+                MouthBaseline {
+                    center: Point::new(160, 195),
+                    radius_x: 18,
+                    radius_y: 6,
+                },
+            ),
+            Self::Wide => (
+                EyeBaseline {
+                    center: Point::new(85, 105),
+                    radius_x: 22,
+                    radius_y: 22,
+                },
+                EyeBaseline {
+                    center: Point::new(235, 105),
+                    radius_x: 22,
+                    radius_y: 22,
+                },
+                MouthBaseline {
+                    center: Point::new(160, 180),
+                    radius_x: 44,
+                    radius_y: 12,
+                },
+            ),
+            Self::Sleepy => (
+                EyeBaseline {
+                    center: Point::new(100, 125),
+                    radius_x: 22,
+                    radius_y: 14,
+                },
+                EyeBaseline {
+                    center: Point::new(220, 125),
+                    radius_x: 22,
+                    radius_y: 14,
+                },
+                MouthBaseline {
+                    center: Point::new(160, 188),
+                    radius_x: 24,
+                    radius_y: 6,
+                },
+            ),
+        }
+    }
+}
+
 /// The visual surface of the entity. Owns everything the renderer reads
 /// to produce a frame — both the geometric primitives ([`Eye`], [`Mouth`])
 /// and the emotion-driven modulators ([`Style`]).
@@ -189,6 +366,41 @@ pub struct Face {
     /// overlays keep their own dedicated colours so a palette swap
     /// doesn't desaturate the symbolic-overlay layer's distinctness.
     pub palette: crate::palette::Palette,
+    /// Active geometry preset. Picks the baseline eye / mouth layout
+    /// from [`FaceGeometry`]. Mutated through [`Face::set_geometry`]
+    /// so dynamic state on [`Eye`] / [`Mouth`] (blink phase, mouth
+    /// open amount) survives the swap.
+    pub geometry: FaceGeometry,
+}
+
+impl Face {
+    /// Construct a fresh `Face` initialised to the given geometry preset.
+    /// Style / decorator / bubble / palette take their default values.
+    #[must_use]
+    pub fn with_geometry(geometry: FaceGeometry) -> Self {
+        let mut face = Self::default();
+        face.set_geometry(geometry);
+        face
+    }
+
+    /// Swap the geometry preset, replacing baseline eye / mouth
+    /// dimensions while preserving dynamic state ([`Eye::phase`],
+    /// [`Eye::weight`], [`Eye::open_weight`], [`Mouth::weight`],
+    /// [`Mouth::mouth_open`]). A mid-blink swap therefore continues
+    /// the blink at the new geometry instead of forcing eyes open.
+    pub const fn set_geometry(&mut self, geometry: FaceGeometry) {
+        let (left, right, mouth) = geometry.baseline();
+        self.geometry = geometry;
+        self.left_eye.center = left.center;
+        self.left_eye.radius_x = left.radius_x;
+        self.left_eye.radius_y = left.radius_y;
+        self.right_eye.center = right.center;
+        self.right_eye.radius_x = right.radius_x;
+        self.right_eye.radius_y = right.radius_y;
+        self.mouth.center = mouth.center;
+        self.mouth.radius_x = mouth.radius_x;
+        self.mouth.radius_y = mouth.radius_y;
+    }
 }
 
 impl Default for Face {
@@ -224,6 +436,7 @@ impl Default for Face {
             decorator: None,
             bubble: None,
             palette: crate::palette::Palette::Default,
+            geometry: FaceGeometry::Default,
         }
     }
 }
@@ -250,5 +463,115 @@ mod tests {
         assert_eq!(s.eye_scale, SCALE_DEFAULT);
         assert_eq!(s.blink_rate_scale, SCALE_DEFAULT);
         assert_eq!(s.breath_depth_scale, SCALE_DEFAULT);
+    }
+
+    #[test]
+    fn face_geometry_all_length_matches_variant_count() {
+        assert_eq!(
+            FaceGeometry::ALL.len(),
+            4,
+            "update FaceGeometry::ALL when adding a variant",
+        );
+    }
+
+    #[test]
+    fn face_geometry_wire_byte_mapping_is_stable() {
+        assert_eq!(FaceGeometry::Default.wire_byte(), 0);
+        assert_eq!(FaceGeometry::Chibi.wire_byte(), 1);
+        assert_eq!(FaceGeometry::Wide.wire_byte(), 2);
+        assert_eq!(FaceGeometry::Sleepy.wire_byte(), 3);
+    }
+
+    #[test]
+    fn face_geometry_wire_str_round_trip() {
+        for &g in FaceGeometry::ALL {
+            assert_eq!(FaceGeometry::from_wire_str(g.wire_str()), Some(g));
+        }
+    }
+
+    #[test]
+    fn face_geometry_from_wire_str_rejects_unknown() {
+        assert_eq!(FaceGeometry::from_wire_str(""), None);
+        assert_eq!(FaceGeometry::from_wire_str("DEFAULT"), None);
+        assert_eq!(FaceGeometry::from_wire_str("compact"), None);
+    }
+
+    #[test]
+    fn face_geometry_default_baseline_matches_legacy_face_default() {
+        let baseline = FaceGeometry::Default.baseline();
+        let legacy = Face::default();
+        assert_eq!(baseline.0.center, legacy.left_eye.center);
+        assert_eq!(baseline.0.radius_x, legacy.left_eye.radius_x);
+        assert_eq!(baseline.0.radius_y, legacy.left_eye.radius_y);
+        assert_eq!(baseline.1.center, legacy.right_eye.center);
+        assert_eq!(baseline.2.center, legacy.mouth.center);
+        assert_eq!(baseline.2.radius_x, legacy.mouth.radius_x);
+        assert_eq!(baseline.2.radius_y, legacy.mouth.radius_y);
+    }
+
+    #[test]
+    fn face_geometry_baselines_are_pairwise_distinct() {
+        for (i, &a) in FaceGeometry::ALL.iter().enumerate() {
+            for &b in &FaceGeometry::ALL[i + 1..] {
+                assert_ne!(
+                    a.baseline(),
+                    b.baseline(),
+                    "{a:?} and {b:?} share an identical baseline",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn set_geometry_preserves_dynamic_state() {
+        let mut face = Face::default();
+        face.left_eye.phase = EyePhase::Closed;
+        face.left_eye.weight = 30;
+        face.left_eye.open_weight = 80;
+        face.right_eye.weight = 25;
+        face.mouth.weight = 50;
+        face.mouth.mouth_open = 0.6;
+
+        face.set_geometry(FaceGeometry::Chibi);
+
+        assert_eq!(face.geometry, FaceGeometry::Chibi);
+        // Geometry replaced.
+        assert_eq!(face.left_eye.center, Point::new(105, 115));
+        assert_eq!(face.left_eye.radius_x, 32);
+        // Dynamic state untouched.
+        assert_eq!(face.left_eye.phase, EyePhase::Closed);
+        assert_eq!(face.left_eye.weight, 30);
+        assert_eq!(face.left_eye.open_weight, 80);
+        assert_eq!(face.right_eye.weight, 25);
+        assert_eq!(face.mouth.weight, 50);
+        assert!((face.mouth.mouth_open - 0.6).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn with_geometry_starts_from_default_dynamic_state() {
+        let face = Face::with_geometry(FaceGeometry::Wide);
+        assert_eq!(face.geometry, FaceGeometry::Wide);
+        assert_eq!(face.left_eye.center, Point::new(85, 105));
+        assert_eq!(face.left_eye.phase, EyePhase::Open);
+        assert_eq!(face.left_eye.weight, 100);
+        assert_eq!(face.mouth.weight, 0);
+        assert!(face.mouth.mouth_open.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn baseline_eye_centers_are_horizontally_symmetric() {
+        // Every preset places the eyes mirrored about the
+        // 320 px-wide framebuffer's vertical centre line. A typo
+        // in any preset's coordinates trips here.
+        for &g in FaceGeometry::ALL {
+            let (left, right, _) = g.baseline();
+            let left_offset = 160 - left.center.x;
+            let right_offset = right.center.x - 160;
+            assert_eq!(
+                left_offset, right_offset,
+                "{g:?} eyes are not symmetric about x=160",
+            );
+            assert_eq!(left.center.y, right.center.y, "{g:?} eyes differ in y");
+        }
     }
 }

--- a/crates/stackchan-core/src/lib.rs
+++ b/crates/stackchan-core/src/lib.rs
@@ -63,7 +63,10 @@ pub use director::{
 pub use emotion::Emotion;
 pub use entity::{Entity, Tick};
 pub use events::Events;
-pub use face::{Eye, EyePhase, Face, Mouth, Point, SCALE_DEFAULT, Style};
+pub use face::{
+    Eye, EyeBaseline, EyePhase, Face, FaceGeometry, Mouth, MouthBaseline, Point, SCALE_DEFAULT,
+    Style,
+};
 pub use head::{HeadDriver, MAX_PAN_DEG, MAX_TILT_DEG, MIN_TILT_DEG, Pose};
 pub use input::{Input, RemoteCommand};
 pub use leds::{BRIGHTNESS_PEAK, LED_COUNT, LedFrame, render_leds};

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -497,6 +497,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         if let Some(palette) = net::http::PALETTE_SIGNAL.try_take() {
             entity.face.palette = palette;
         }
+        // Drain the latest face-geometry preset. Routed through
+        // `Face::set_geometry` so blink phase / mouth open amount
+        // survive the swap — a geometry change mid-blink continues
+        // the blink at the new baseline radii rather than snapping
+        // eyes open.
+        if let Some(geometry) = net::http::FACE_GEOMETRY_SIGNAL.try_take() {
+            entity.face.set_geometry(geometry);
+        }
         // Drain a freshly-uploaded dance script from `POST /dance`
         // into `entity.input.dance_script`; the `DancePlayer`
         // modifier consumes it inside `Director::run`. Latest-wins.
@@ -662,6 +670,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
             Some(entity.motor.head_pose_actual),
             entity.face.decorator.map(|d| d.kind),
             entity.mind.mood,
+            entity.face.geometry,
         );
         // Push the latest snapshot to any connected SSE subscribers.
         // Throttled internally so a 30 Hz render doesn't firehose
@@ -1092,10 +1101,12 @@ async fn main(spawner: Spawner) -> ! {
             let runtime = stackchan_firmware::runtime_store::load_into_cache().await;
             net::http::PALETTE_SIGNAL.signal(runtime.palette);
             net::http::MOOD_SIGNAL.signal(runtime.mood);
+            net::http::FACE_GEOMETRY_SIGNAL.signal(runtime.face_geometry);
             defmt::info!(
-                "runtime store: restored palette={=str} mood={=str}",
+                "runtime store: restored palette={=str} mood={=str} face_geometry={=str}",
                 runtime.palette.wire_str(),
                 runtime.mood.wire_str(),
+                runtime.face_geometry.wire_str(),
             );
             cfg
         }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -191,6 +191,16 @@ pub static MOOD_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Mood> = 
 /// follow-up alongside the NVS `RuntimeStore`.
 pub static PALETTE_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::Palette> = Signal::new();
 
+/// Latest face-geometry preset the operator has selected via
+/// `POST /face-geometry` or MCP `set_face_geometry`.
+///
+/// Drained by the render task, which calls `Face::set_geometry` so
+/// dynamic state (blink phase, mouth open amount) survives the swap.
+/// Latest-wins; persisted to `/sd/RUNTIME.RON` via
+/// `runtime_store::update_face_geometry`.
+pub static FACE_GEOMETRY_SIGNAL: Signal<CriticalSectionRawMutex, stackchan_core::FaceGeometry> =
+    Signal::new();
+
 /// Latest dance script uploaded via `POST /dance`.
 ///
 /// Drained by the render task into `DancePlayer` via
@@ -449,6 +459,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/mute") => handle_post_mute(socket, body).await,
         ("POST", "/mood") => handle_post_mood(socket, body).await,
         ("POST", "/palette") => handle_post_palette(socket, body).await,
+        ("POST", "/face-geometry") => handle_post_face_geometry(socket, body).await,
         ("POST", "/sleep") => handle_post_sleep(socket).await,
         ("POST", "/wake") => handle_post_wake(socket).await,
         ("GET", "/head/offsets") => handle_get_head_offsets(socket).await,
@@ -872,6 +883,30 @@ async fn handle_post_palette(socket: &mut TcpSocket<'_>, body: &str) -> Result<(
     write_no_content(socket).await
 }
 
+/// `POST /face-geometry` — parse `{"geometry": "<string>"}`, push the
+/// selected preset at the render task via [`FACE_GEOMETRY_SIGNAL`],
+/// and persist the choice to `/sd/RUNTIME.RON` so a reboot restores it.
+async fn handle_post_face_geometry(
+    socket: &mut TcpSocket<'_>,
+    body: &str,
+) -> Result<(), HttpError> {
+    let geometry = match json::parse_face_geometry(body) {
+        Ok(g) => g,
+        Err(e) => {
+            defmt::warn!(
+                "http: POST /face-geometry parse failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            let body = format!("invalid request body: {e:?}\n");
+            return write_text(socket, 400, &body).await;
+        }
+    };
+    FACE_GEOMETRY_SIGNAL.signal(geometry);
+    let _ = crate::runtime_store::update_face_geometry(geometry).await;
+    defmt::info!("http: POST /face-geometry → {}", geometry.wire_str());
+    write_no_content(socket).await
+}
+
 /// `POST /sleep` — empty body. Drops eyes shut, head limp, LED ring
 /// dark, audio TX paused. Wake via `POST /wake`, MCP `wake`, any
 /// touch (`FT6336U` or `Si12T` body pads), or `AXP2101` short-press.
@@ -991,6 +1026,18 @@ async fn mcp_dispatch_tool(id: i64, tool: &str, arguments: &str) -> String {
                 crate::net::http::MOOD_SIGNAL.signal(mood);
                 let _ = crate::runtime_store::update_mood(mood).await;
                 render_success(id, &render_tool_text_result("mood enqueued"))
+            }
+            Err(e) => render_error(
+                Some(id),
+                JsonRpcErrorCode::InvalidParams,
+                tool_parse_detail(&e),
+            ),
+        },
+        "set_face_geometry" => match json::parse_face_geometry(arguments) {
+            Ok(geometry) => {
+                FACE_GEOMETRY_SIGNAL.signal(geometry);
+                let _ = crate::runtime_store::update_face_geometry(geometry).await;
+                render_success(id, &render_tool_text_result("face geometry enqueued"))
             }
             Err(e) => render_error(
                 Some(id),
@@ -1233,6 +1280,7 @@ const fn tool_parse_detail(e: &JsonError) -> &'static str {
         E::UnknownLocale => "unknown locale",
         E::UnknownMood => "unknown mood",
         E::UnknownPalette => "unknown palette",
+        E::UnknownFaceGeometry => "unknown face geometry",
         E::VolumeOutOfRange(_) => "volume out of range",
     }
 }
@@ -1678,6 +1726,7 @@ fn state_body(s: AvatarSnapshot) -> String {
         "{{\
 \"emotion\":\"{emotion}\",\
 \"mood\":\"{mood}\",\
+\"face_geometry\":\"{face_geometry}\",\
 \"decorator\":{decorator},\
 \"head_pose\":{{\"pan_deg\":{pan:.2},\"tilt_deg\":{tilt:.2}}},\
 \"head_actual\":{actual},\
@@ -1688,6 +1737,7 @@ fn state_body(s: AvatarSnapshot) -> String {
 }}\n",
         emotion = s.emotion.wire_str(),
         mood = s.mood.wire_str(),
+        face_geometry = s.face_geometry.wire_str(),
         pan = s.head_pose.pan_deg,
         tilt = s.head_pose.tilt_deg,
         connected = s.wifi.connected,

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -14,7 +14,7 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pubsub::PubSubChannel;
 use embassy_time::Instant as EmbassyInstant;
 use stackchan_core::head::Pose;
-use stackchan_core::{Decorator, Emotion, Mood};
+use stackchan_core::{Decorator, Emotion, FaceGeometry, Mood};
 use stackchan_net::config::AudioConfig;
 
 /// Battery snapshot — published by the power task.
@@ -72,6 +72,10 @@ pub struct AvatarSnapshot {
     /// Operator-selected energy baseline. Mirrors `entity.mind.mood`;
     /// HTTP `POST /mood` updates this through `MOOD_SIGNAL`.
     pub mood: Mood,
+    /// Operator-selected face geometry preset. Mirrors
+    /// `entity.face.geometry`; HTTP `POST /face-geometry` and MCP
+    /// `set_face_geometry` update this through `FACE_GEOMETRY_SIGNAL`.
+    pub face_geometry: FaceGeometry,
 }
 
 impl AvatarSnapshot {
@@ -101,6 +105,7 @@ impl AvatarSnapshot {
             && self.camera_mode == other.camera_mode
             && self.decorator == other.decorator
             && self.mood == other.mood
+            && self.face_geometry == other.face_geometry
     }
 }
 
@@ -116,6 +121,7 @@ impl Default for AvatarSnapshot {
             camera_mode: false,
             decorator: None,
             mood: Mood::Neutral,
+            face_geometry: FaceGeometry::Default,
         }
     }
 }
@@ -142,6 +148,7 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
         camera_mode: false,
         decorator: None,
         mood: Mood::Neutral,
+        face_geometry: FaceGeometry::Default,
     }));
 
 /// Replace the avatar/head fields. Called per render tick.
@@ -151,6 +158,7 @@ pub fn update_avatar(
     head_actual: Option<Pose>,
     decorator: Option<Decorator>,
     mood: Mood,
+    face_geometry: FaceGeometry,
 ) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
@@ -159,6 +167,7 @@ pub fn update_avatar(
         s.head_actual = head_actual;
         s.decorator = decorator;
         s.mood = mood;
+        s.face_geometry = face_geometry;
         cell.set(s);
     });
 }

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -24,6 +24,7 @@
 //! ```text
 //! palette=cute
 //! mood=playful
+//! face_geometry=chibi
 //! ```
 //!
 //! Trailing blank lines and unknown keys are tolerated (forward
@@ -37,7 +38,7 @@ use core::fmt::Write as _;
 
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-use stackchan_core::{Mood, Palette};
+use stackchan_core::{FaceGeometry, Mood, Palette};
 
 /// In-memory snapshot of the runtime state. Defaults match the
 /// avatar's neutral resting look so a brand-new device reads the
@@ -51,6 +52,10 @@ pub struct RuntimeState {
     /// Current operator-selected mood baseline. Mirrored into
     /// `entity.mind.mood` on boot via the firmware's `MOOD_SIGNAL`.
     pub mood: Mood,
+    /// Current operator-selected face geometry preset. Applied to
+    /// `entity.face` on boot via the firmware's
+    /// `FACE_GEOMETRY_SIGNAL`.
+    pub face_geometry: FaceGeometry,
 }
 
 /// Render a [`RuntimeState`] to its line-based wire form.
@@ -59,6 +64,7 @@ pub fn render(state: &RuntimeState) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "palette={}", state.palette.wire_str());
     let _ = writeln!(out, "mood={}", state.mood.wire_str());
+    let _ = writeln!(out, "face_geometry={}", state.face_geometry.wire_str());
     out
 }
 
@@ -90,6 +96,11 @@ pub fn parse(input: &str) -> RuntimeState {
                     out.mood = m;
                 }
             }
+            "face_geometry" => {
+                if let Some(g) = FaceGeometry::from_wire_str(value.trim()) {
+                    out.face_geometry = g;
+                }
+            }
             _ => {}
         }
     }
@@ -111,6 +122,7 @@ static CACHE: Mutex<CriticalSectionRawMutex, Cell<RuntimeState>> =
     Mutex::new(Cell::new(RuntimeState {
         palette: Palette::Default,
         mood: Mood::Neutral,
+        face_geometry: FaceGeometry::Default,
     }));
 
 /// Snapshot the current cache.
@@ -175,6 +187,13 @@ pub async fn update_mood(mood: Mood) -> bool {
     persist().await
 }
 
+/// Update the face-geometry field and persist the cache. Same
+/// semantics as [`update_palette`].
+pub async fn update_face_geometry(geometry: FaceGeometry) -> bool {
+    mutate(|s| s.face_geometry = geometry);
+    persist().await
+}
+
 /// Apply `f` to the cache atomically — read + modify + write happen
 /// inside one critical section.
 ///
@@ -235,32 +254,48 @@ mod tests {
         let s = RuntimeState {
             palette: Palette::Cute,
             mood: Mood::Playful,
+            face_geometry: FaceGeometry::Chibi,
         };
         assert_eq!(render_then_parse(&s), s);
     }
 
     #[test]
     fn parse_tolerates_blank_lines_and_extra_whitespace() {
-        let input = "\n  palette = dark\n\n   mood=focus\n";
+        let input = "\n  palette = dark\n\n   mood=focus\n  face_geometry = wide \n";
         let s = parse(input);
         assert_eq!(s.palette, Palette::Dark);
         assert_eq!(s.mood, Mood::Focus);
+        assert_eq!(s.face_geometry, FaceGeometry::Wide);
     }
 
     #[test]
     fn parse_skips_unknown_keys() {
-        let input = "palette=cute\nfuture_field=hello\nmood=playful\n";
+        let input = "palette=cute\nfuture_field=hello\nmood=playful\nface_geometry=sleepy\n";
         let s = parse(input);
         assert_eq!(s.palette, Palette::Cute);
         assert_eq!(s.mood, Mood::Playful);
+        assert_eq!(s.face_geometry, FaceGeometry::Sleepy);
     }
 
     #[test]
     fn parse_falls_back_on_unknown_enum_value() {
-        let input = "palette=rainbow\nmood=ecstatic\n";
+        let input = "palette=rainbow\nmood=ecstatic\nface_geometry=compact\n";
         let s = parse(input);
         assert_eq!(s.palette, Palette::default());
         assert_eq!(s.mood, Mood::default());
+        assert_eq!(s.face_geometry, FaceGeometry::default());
+    }
+
+    #[test]
+    fn parse_omitted_face_geometry_yields_default() {
+        // Older firmware that wrote palette + mood only must still
+        // parse cleanly under a newer firmware that knows about
+        // face_geometry.
+        let input = "palette=cute\nmood=playful\n";
+        let s = parse(input);
+        assert_eq!(s.palette, Palette::Cute);
+        assert_eq!(s.mood, Mood::Playful);
+        assert_eq!(s.face_geometry, FaceGeometry::default());
     }
 
     #[test]

--- a/crates/stackchan-net/src/http_command.rs
+++ b/crates/stackchan-net/src/http_command.rs
@@ -20,7 +20,7 @@
 //! parsed in their entirety with [`core::str::FromStr`].
 
 use stackchan_core::voice::{Locale, PhraseId, Priority};
-use stackchan_core::{Emotion, Mood, Palette, Pose, RemoteCommand};
+use stackchan_core::{Emotion, FaceGeometry, Mood, Palette, Pose, RemoteCommand};
 
 /// Default hold window when the request body omits `hold_ms`.
 pub const DEFAULT_HOLD_MS: u32 = 30_000;
@@ -55,6 +55,8 @@ pub enum JsonError {
     UnknownMood,
     /// Palette string didn't match any [`Palette`] variant.
     UnknownPalette,
+    /// Geometry string didn't match any [`FaceGeometry`] variant.
+    UnknownFaceGeometry,
     /// `audio.volume_pct` value outside the documented `0..=100`
     /// range. Carries the offending value so the firmware's `400`
     /// response body is self-describing.
@@ -426,6 +428,38 @@ pub fn parse_palette(body: &str) -> Result<Palette, JsonError> {
         Ok(())
     })?;
     palette.ok_or(JsonError::MissingKey("palette"))
+}
+
+/// Parse a `POST /face-geometry` body into a [`FaceGeometry`].
+///
+/// Required: `geometry` (string, lowercase wire form). Vocabulary is
+/// whatever [`FaceGeometry::from_wire_str`] knows; anything else
+/// returns [`JsonError::UnknownFaceGeometry`]. No optional fields —
+/// the preset persists until the operator picks another (see
+/// `runtime_store::update_face_geometry`).
+///
+/// # Errors
+///
+/// [`JsonError`] for missing/unknown keys, malformed JSON, or
+/// unrecognised geometry strings.
+pub fn parse_face_geometry(body: &str) -> Result<FaceGeometry, JsonError> {
+    let mut geometry: Option<FaceGeometry> = None;
+    visit_object(body, |key, scanner| {
+        match key {
+            "geometry" => {
+                if geometry.is_some() {
+                    return Err(JsonError::DuplicateKey("geometry"));
+                }
+                let raw = scanner.read_string()?;
+                geometry = FaceGeometry::from_wire_str(raw)
+                    .ok_or(JsonError::UnknownFaceGeometry)
+                    .map(Some)?;
+            }
+            _ => return Err(JsonError::UnknownKey),
+        }
+        Ok(())
+    })?;
+    geometry.ok_or(JsonError::MissingKey("geometry"))
 }
 
 /// Maximum absolute value for either head-offset axis, in degrees.
@@ -1617,6 +1651,50 @@ mod tests {
         assert!(matches!(
             parse_palette(r#"{"palette":"dark","palette":"cute"}"#),
             Err(JsonError::DuplicateKey("palette"))
+        ));
+    }
+
+    #[test]
+    fn face_geometry_accepts_each_known_name() {
+        for &g in stackchan_core::FaceGeometry::ALL {
+            let body = format!("{{\"geometry\":\"{}\"}}", g.wire_str());
+            assert_eq!(
+                parse_face_geometry(&body).unwrap(),
+                g,
+                "round-trip failed for {g:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn face_geometry_rejects_missing_key() {
+        assert!(matches!(
+            parse_face_geometry("{}"),
+            Err(JsonError::MissingKey("geometry"))
+        ));
+    }
+
+    #[test]
+    fn face_geometry_rejects_unknown_name() {
+        assert!(matches!(
+            parse_face_geometry(r#"{"geometry":"compact"}"#),
+            Err(JsonError::UnknownFaceGeometry)
+        ));
+    }
+
+    #[test]
+    fn face_geometry_rejects_unknown_top_level_key() {
+        assert!(matches!(
+            parse_face_geometry(r#"{"preset":"chibi"}"#),
+            Err(JsonError::UnknownKey)
+        ));
+    }
+
+    #[test]
+    fn face_geometry_rejects_duplicate_key() {
+        assert!(matches!(
+            parse_face_geometry(r#"{"geometry":"chibi","geometry":"wide"}"#),
+            Err(JsonError::DuplicateKey("geometry"))
         ));
     }
 

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -612,6 +612,7 @@ pub const INITIALIZE_RESULT_JSON: &str = concat!(
 ///
 /// - `set_emotion(emotion: string, hold_ms?: integer)`
 /// - `set_mood(mood: string)`
+/// - `set_face_geometry(geometry: string)`
 /// - `look_at(pan_deg: number, tilt_deg: number, hold_ms?: integer)`
 /// - `speak(phrase: string, locale?: string)`
 /// - `start_listen(duration_ms?: integer)`
@@ -633,6 +634,7 @@ pub const TOOLS_LIST_RESULT_JSON: &str = concat!(
     r#"{"tools":["#,
     r#"{"name":"set_emotion","description":"Set the avatar's emotion with an optional hold timer (milliseconds). Vocabulary: neutral, happy, sad, sleepy, surprised, angry, doubt, boring, hi, loved, curious, confused, mad.","inputSchema":{"type":"object","properties":{"emotion":{"type":"string"},"hold_ms":{"type":"integer"}},"required":["emotion"]}},"#,
     r#"{"name":"set_mood","description":"Set the operator-selected mood baseline. Vocabulary: neutral, calm, playful, focus, sleepy.","inputSchema":{"type":"object","properties":{"mood":{"type":"string"}},"required":["mood"]}},"#,
+    r#"{"name":"set_face_geometry","description":"Set the avatar's face geometry preset — swaps the eye + mouth baseline silhouette while preserving emotion-driven modulators. Vocabulary: default, chibi, wide, sleepy. Persists across reboots via the runtime store.","inputSchema":{"type":"object","properties":{"geometry":{"type":"string"}},"required":["geometry"]}},"#,
     r#"{"name":"look_at","description":"Aim the avatar's head at a pan/tilt target in degrees, with an optional hold timer.","inputSchema":{"type":"object","properties":{"pan_deg":{"type":"number"},"tilt_deg":{"type":"number"},"hold_ms":{"type":"integer"}},"required":["pan_deg","tilt_deg"]}},"#,
     r#"{"name":"speak","description":"Play a baked phrase or chirp through the speaker.","inputSchema":{"type":"object","properties":{"phrase":{"type":"string"},"locale":{"type":"string"}},"required":["phrase"]}},"#,
     r#"{"name":"start_listen","description":"Open a listen window: queue an acknowledge chirp, set Attention::Listening, arm the Ear decorator. Default 3000 ms.","inputSchema":{"type":"object","properties":{"duration_ms":{"type":"integer"}}}},"#,

--- a/crates/stackchan-sim/tests/face_geometry.rs
+++ b/crates/stackchan-sim/tests/face_geometry.rs
@@ -1,0 +1,116 @@
+//! End-to-end test for the [`FaceGeometry`] preset surface.
+//!
+//! Exercises the same path the firmware takes when an operator
+//! calls `POST /face-geometry`:
+//!
+//! 1. Parse the JSON body via `stackchan_net::http_command`.
+//! 2. Apply the parsed preset to `entity.face` via
+//!    [`Face::set_geometry`] — the same call the render task makes
+//!    when draining `FACE_GEOMETRY_SIGNAL`.
+//! 3. Render the avatar and assert the geometry actually changed at
+//!    the pixel boundary, not just on the struct field.
+//!
+//! Together these guarantee the wire format, the in-memory swap, and
+//! the renderer all stay in sync — a parser typo or a missed
+//! geometry-channel field on `Face` would surface here before
+//! shipping.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: framebuffer DrawTarget is Infallible; parser inputs are compile-time fixtures"
+)]
+
+use embedded_graphics::pixelcolor::{Rgb565, RgbColor};
+use stackchan_core::{Entity, EyePhase, Face, FaceGeometry};
+use stackchan_net::http_command::parse_face_geometry;
+use stackchan_sim::Framebuffer;
+
+const WIDTH: u32 = 320;
+const HEIGHT: u32 = 240;
+
+#[test]
+fn parser_accepts_each_wire_string() {
+    for &g in FaceGeometry::ALL {
+        let body = format!(r#"{{"geometry":"{}"}}"#, g.wire_str());
+        let parsed = parse_face_geometry(&body).expect("known wire string parses");
+        assert_eq!(parsed, g, "round-trip failed for {g:?}");
+    }
+}
+
+#[test]
+fn baseline_swap_replaces_eye_and_mouth_geometry() {
+    let mut entity = Entity::default();
+    let default_left = entity.face.left_eye;
+    entity.face.set_geometry(FaceGeometry::Wide);
+
+    let (expected_left, expected_right, expected_mouth) = FaceGeometry::Wide.baseline();
+    assert_eq!(entity.face.left_eye.center, expected_left.center);
+    assert_eq!(entity.face.left_eye.radius_x, expected_left.radius_x);
+    assert_eq!(entity.face.right_eye.center, expected_right.center);
+    assert_eq!(entity.face.mouth.center, expected_mouth.center);
+    assert_eq!(entity.face.mouth.radius_x, expected_mouth.radius_x);
+
+    // Wide moves eyes outward — left eye should not be at the
+    // Default position any more.
+    assert_ne!(entity.face.left_eye.center, default_left.center);
+}
+
+#[test]
+fn mid_blink_swap_preserves_dynamic_state() {
+    let mut entity = Entity::default();
+    entity.face.left_eye.phase = EyePhase::Closed;
+    entity.face.left_eye.weight = 12;
+    entity.face.left_eye.open_weight = 80;
+    entity.face.right_eye.weight = 12;
+    entity.face.mouth.weight = 60;
+    entity.face.mouth.mouth_open = 0.4;
+
+    entity.face.set_geometry(FaceGeometry::Sleepy);
+
+    // Geometry replaced.
+    let (expected_left, _, _) = FaceGeometry::Sleepy.baseline();
+    assert_eq!(entity.face.left_eye.radius_y, expected_left.radius_y);
+    // Dynamic state untouched — a real blink in flight keeps closing.
+    assert_eq!(entity.face.left_eye.phase, EyePhase::Closed);
+    assert_eq!(entity.face.left_eye.weight, 12);
+    assert_eq!(entity.face.left_eye.open_weight, 80);
+    assert_eq!(entity.face.right_eye.weight, 12);
+    assert_eq!(entity.face.mouth.weight, 60);
+    assert!((entity.face.mouth.mouth_open - 0.4).abs() < f32::EPSILON);
+}
+
+#[test]
+fn chibi_renders_eye_at_chibi_baseline_not_default() {
+    let mut entity = Entity::default();
+    entity.face.set_geometry(FaceGeometry::Chibi);
+
+    let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+    entity
+        .face
+        .draw(&mut fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    // Default's left eye centre at (100, 110) is now background —
+    // Chibi's eye sits at (105, 115).
+    assert_eq!(
+        fb.pixel(105, 115),
+        Some(Rgb565::BLACK),
+        "Chibi left eye centre",
+    );
+    assert_eq!(
+        fb.pixel(215, 115),
+        Some(Rgb565::BLACK),
+        "Chibi right eye centre",
+    );
+}
+
+#[test]
+fn with_geometry_constructor_picks_up_the_baseline() {
+    let face = Face::with_geometry(FaceGeometry::Wide);
+    let (expected_left, expected_right, expected_mouth) = FaceGeometry::Wide.baseline();
+    assert_eq!(face.geometry, FaceGeometry::Wide);
+    assert_eq!(face.left_eye.center, expected_left.center);
+    assert_eq!(face.right_eye.center, expected_right.center);
+    assert_eq!(face.mouth.center, expected_mouth.center);
+}

--- a/docs/http.md
+++ b/docs/http.md
@@ -34,6 +34,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/pair`          | Open ESP-NOW pairing window with hold timer         |
 | POST   | `/mood`          | Set the operator-selected energy baseline (runtime-only) |
 | POST   | `/dance`         | Play a JSON keyframe script (head + emotion + decorator + LED) |
+| POST   | `/face-geometry` | Pick a face-geometry preset (eye + mouth baseline silhouette) |
 | POST   | `/mcp`           | JSON-RPC 2.0 / MCP endpoint (initialize, tools/list, tools/call) |
 | POST   | `/volume`        | Set output volume (0–100); persisted to SD           |
 | POST   | `/mute`          | Mute / un-mute output stage; persisted to SD         |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { State } from "./components/State";
 import { Emotion } from "./components/Emotion";
 import { Listen } from "./components/Listen";
 import { Mood } from "./components/Mood";
+import { FaceGeometry } from "./components/FaceGeometry";
 import { LookAt } from "./components/LookAt";
 import { Audio } from "./components/Audio";
 import { Camera } from "./components/Camera";
@@ -52,6 +53,7 @@ export function App() {
         <State />
         <Emotion />
         <Mood />
+        <FaceGeometry />
         <LookAt />
         <Audio />
         <Speak />

--- a/web/src/components/FaceGeometry.tsx
+++ b/web/src/components/FaceGeometry.tsx
@@ -1,0 +1,44 @@
+import { For } from "solid-js";
+import { postJson } from "../auth";
+import { showToast, snapshot } from "../store";
+
+// Wire-string vocabulary mirrors `FaceGeometry::wire_str` in
+// `crates/stackchan-core/src/face.rs`.
+const GEOMETRIES = ["default", "chibi", "wide", "sleepy"] as const;
+
+export function FaceGeometry() {
+  const send = async (geometry: string) => {
+    try {
+      await postJson("/face-geometry", { geometry });
+      showToast(`face → ${geometry}`);
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Face</h2>
+      <div class="btn-row">
+        <For each={GEOMETRIES}>
+          {(name) => {
+            const active = () => snapshot()?.face_geometry === name;
+            return (
+              <button
+                onClick={() => send(name)}
+                style={active() ? "border-color:var(--accent)" : ""}
+                data-face-geometry={name}
+              >
+                {name.charAt(0).toUpperCase() + name.slice(1)}
+              </button>
+            );
+          }}
+        </For>
+      </div>
+      <small>
+        Picks the eye + mouth baseline silhouette. Emotion still scales eye size, blink rate, and
+        breath depth on top of this. Persists across reboots via the runtime store.
+      </small>
+    </section>
+  );
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -21,6 +21,7 @@ export type AudioState = {
 export type AvatarSnapshot = {
   emotion: string;
   mood: string;
+  face_geometry: string;
   decorator: string | null;
   head_pose: Pose;
   head_actual: Pose | null;


### PR DESCRIPTION
## Summary

- Curated `FaceGeometry` enum (`Default` / `Chibi` / `Wide` / `Sleepy`) that swaps the eye + mouth baseline silhouette while preserving emotion-driven modulators on top.
- Operator-selectable surface mirrors the existing `Palette` / `Mood` pattern: HTTP route, MCP tool, dashboard chips, SD-persisted via the runtime store.
- Mid-blink swap preserves dynamic state (eye phase / weight / mouth open amount) so a preset change doesn't snap eyes open or mute talking.

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just ci` — adds cargo-deny + workspace doc-lint
- [x] `just clippy-firmware` — strict clippy on the `xtensa-esp32s3-none-elf` target
- [x] New sim integration test (`crates/stackchan-sim/tests/face_geometry.rs`) parses each wire string, applies preset, asserts geometry-replace + dynamic-state preservation, and renders Chibi to verify pixels land at the new baseline
- [x] New unit tests in `crates/stackchan-core/src/face.rs` cover `wire_str` round-trip, `wire_byte` stability, `ALL` length tripwire, baseline pairwise distinctness, horizontal symmetry across all variants
- [x] Runtime-store tests verify forward compatibility — older state files (without `face_geometry=…`) parse cleanly with the field at default
- [ ] On-device verification via `just fmr` (cycle through presets via dashboard chips and via MCP `set_face_geometry`)

## Notes

- `/palette` is still missing from `docs/http.md`'s routes table (same drift Greptile flagged for `/dance` last round). Worth closing in a tiny follow-up.