### PR TITLE
chore(face-geometry): address greptile findings on #290

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,4 +120,4 @@ Conventional-commit check at `.githooks/commit-msg`.
 
 Boot-time network + auth config lives at `/sd/STACKCHAN.RON` — schema in [`stackchan-net::config`](crates/stackchan-net/src/config.rs), atomic writeback via `PUT /settings`. The firmware boots offline if the SD card is absent.
 
-Face geometry is hardcoded in `stackchan-core::face`. Later releases may add RON-configurable appearance.
+Face geometry is operator-selectable via `POST /face-geometry` and MCP `set_face_geometry`. Presets are defined as the [`FaceGeometry`](crates/stackchan-core/src/face.rs) enum in `stackchan-core`; the active selection is persisted to `/sd/RUNTIME.RON` alongside palette + mood and restored on boot.

--- a/web/src/components/FaceGeometry.tsx
+++ b/web/src/components/FaceGeometry.tsx
@@ -12,7 +12,7 @@ export function FaceGeometry() {
       await postJson("/face-geometry", { geometry });
       showToast(`face → ${geometry}`);
     } catch (e) {
-      showToast((e as Error).message, true);
+      showToast(e instanceof Error ? e.message : String(e), true);
     }
   };
 


### PR DESCRIPTION
## Summary

Two P2 Greptile findings on #290 (already merged); both were legitimate.

- `CLAUDE.md:123` — line still claimed face geometry was hardcoded; refreshed to point at `POST /face-geometry` + the `FaceGeometry` enum + runtime-store persistence.
- `web/src/components/FaceGeometry.tsx:15` — `(e as Error).message` produces `undefined` for non-`Error` rejections; replaced with `instanceof Error ? e.message : String(e)`.

The same cast pattern exists in 19 other dashboard components — left for a focused audit PR (probably worth turning on `useUnknownInCatchVariables` in `tsconfig.json` and fixing the resulting type errors in one pass).

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `npm run build` — TypeScript typecheck + Vite build clean