### PR TITLE
feat(web): tracker calibration UI + restore tracker round-trip on PUT /settings

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -24,8 +24,11 @@ beats pulling a full HTTP framework into the firmware target.
 | GET    | `/`              | Operator dashboard (HTML + JS, embedded in firmware) |
 | GET    | `/health`        | Uptime, firmware version, free heap                  |
 | GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi, audio |
+| GET    | `/sensors`       | Live IMU / ambient / audio-RMS / body-touch sample   |
 | GET    | `/camera/snapshot` | Most recent `/sd/CAPTURE.565` frame as raw QVGA RGB565 BE |
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
+| GET    | `/head/offsets`  | Current yaw + tilt zero-point offsets               |
+| POST   | `/head/offsets`  | Update yaw + tilt zero-point offsets (runtime-only) |
 | POST   | `/emotion`       | Set affect with hold timer                          |
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |
@@ -33,6 +36,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/listen`        | Open a 3-second listen window — Ear decorator + ack chirp |
 | POST   | `/pair`          | Open ESP-NOW pairing window with hold timer         |
 | POST   | `/mood`          | Set the operator-selected energy baseline (runtime-only) |
+| POST   | `/palette`       | Pick the avatar's colour palette (skin / eye / mouth) |
 | POST   | `/dance`         | Play a JSON keyframe script (head + emotion + decorator + LED) |
 | POST   | `/face-geometry` | Pick a face-geometry preset (eye + mouth baseline silhouette) |
 | POST   | `/mcp`           | JSON-RPC 2.0 / MCP endpoint (initialize, tools/list, tools/call) |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { FaceGeometry } from "./components/FaceGeometry";
 import { LookAt } from "./components/LookAt";
 import { Audio } from "./components/Audio";
 import { Camera } from "./components/Camera";
+import { Calibration } from "./components/Calibration";
 import { Events } from "./components/Events";
 import { Recovery } from "./components/Recovery";
 import { Sensors } from "./components/Sensors";
@@ -60,6 +61,7 @@ export function App() {
         <Listen />
         <Pair />
         <Camera />
+        <Calibration />
         <Sensors />
         <TaskHealth />
         <Events />

--- a/web/src/components/Calibration.tsx
+++ b/web/src/components/Calibration.tsx
@@ -1,0 +1,338 @@
+import { Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { authedFetch, postJson } from "../auth";
+import { showToast, snapshot } from "../store";
+import type { HeadOffsets, Settings as SettingsType, Tracker } from "../types";
+
+const FRAME_WIDTH = 320;
+const FRAME_HEIGHT = 240;
+
+const TRACKER_DEFAULT: Tracker = {
+  fov_h_deg: 62.0,
+  fov_v_deg: 49.0,
+  target_smoothing_alpha: 1.0,
+  flip_x: false,
+  flip_y: false,
+};
+
+const HEAD_OFFSETS_DEFAULT: HeadOffsets = {
+  yaw_offset_deg: 0,
+  tilt_offset_deg: 0,
+};
+
+// Mirrors the firmware's `Aw88298` 200-ms render-stall budget per
+// capture. 2 s gives the avatar comfortable breathing room while
+// still tracking the operator's reference target as they move it.
+const AUTO_CAPTURE_INTERVAL_MS = 2000;
+
+function rgb565beToImageData(buf: Uint8Array): ImageData {
+  const out = new ImageData(FRAME_WIDTH, FRAME_HEIGHT);
+  const dst = out.data;
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  for (let i = 0; i < FRAME_WIDTH * FRAME_HEIGHT; i++) {
+    const px = view.getUint16(i * 2, false);
+    const r5 = (px >> 11) & 0x1f;
+    const g6 = (px >> 5) & 0x3f;
+    const b5 = px & 0x1f;
+    dst[i * 4] = (r5 << 3) | (r5 >> 2);
+    dst[i * 4 + 1] = (g6 << 2) | (g6 >> 4);
+    dst[i * 4 + 2] = (b5 << 3) | (b5 >> 2);
+    dst[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+export function Calibration() {
+  const [tracker, setTracker] = createSignal<Tracker>(TRACKER_DEFAULT);
+  const [offsets, setOffsets] = createSignal<HeadOffsets>(HEAD_OFFSETS_DEFAULT);
+  const [autoCapture, setAutoCapture] = createSignal(false);
+  const [hasSnapshot, setHasSnapshot] = createSignal(false);
+  // Cached opaque copy of the rest of /settings so we can PUT just
+  // the tracker block without clobbering wifi / mdns / time / auth.
+  // The Settings component does the same thing in reverse.
+  const [settingsCache, setSettingsCache] = createSignal<SettingsType | null>(null);
+  let canvasRef: HTMLCanvasElement | undefined;
+  let captureTimer: ReturnType<typeof setInterval> | null = null;
+
+  const loadSettings = async () => {
+    try {
+      const res = await fetch("/settings");
+      if (!res.ok) {
+        if (res.status === 503) {
+          showToast("calibration unavailable (no SD card)", true);
+        } else {
+          showToast(`GET /settings: ${res.status}`, true);
+        }
+        return;
+      }
+      const c = (await res.json()) as SettingsType;
+      setSettingsCache(c);
+      setTracker(c.tracker);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  const loadOffsets = async () => {
+    try {
+      const res = await fetch("/head/offsets");
+      if (!res.ok) {
+        showToast(`GET /head/offsets: ${res.status}`, true);
+        return;
+      }
+      const o = (await res.json()) as HeadOffsets;
+      setOffsets(o);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  onMount(() => {
+    void loadSettings();
+    void loadOffsets();
+  });
+
+  const saveTracker = async () => {
+    const cache = settingsCache();
+    if (!cache) {
+      showToast("reload settings first", true);
+      return;
+    }
+    const body: SettingsType = { ...cache, tracker: tracker() };
+    try {
+      const res = await authedFetch("/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${text || res.statusText}`);
+      }
+      const reply = (await res.json().catch(() => ({}))) as { reboot_required?: boolean };
+      showToast(reply.reboot_required ? "tracker saved — reboot to apply" : "tracker saved");
+      // Refresh the cache so the next save sees the persisted state.
+      setSettingsCache(body);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  const saveOffsets = async () => {
+    try {
+      await postJson("/head/offsets", offsets());
+      showToast(`offsets saved — yaw ${offsets().yaw_offset_deg}°, tilt ${offsets().tilt_offset_deg}°`);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  const capture = async () => {
+    try {
+      const captureRes = await authedFetch("/camera/capture", { method: "POST" });
+      if (!captureRes.ok) {
+        const text = await captureRes.text().catch(() => "");
+        throw new Error(`${captureRes.status}: ${text || captureRes.statusText}`);
+      }
+      // The capture returns 202 immediately; the SD write completes
+      // asynchronously. Wait long enough for the SPI burst to
+      // finish before fetching, otherwise we re-render the prior
+      // frame — confusing during calibration where the operator
+      // expects each "Capture" click to reflect the current camera.
+      await new Promise((r) => setTimeout(r, 350));
+      const viewRes = await authedFetch("/camera/snapshot");
+      if (!viewRes.ok) {
+        const text = await viewRes.text().catch(() => "");
+        throw new Error(`${viewRes.status}: ${text || viewRes.statusText}`);
+      }
+      const buf = new Uint8Array(await viewRes.arrayBuffer());
+      const expected = FRAME_WIDTH * FRAME_HEIGHT * 2;
+      if (buf.length !== expected) {
+        throw new Error(`unexpected size ${buf.length}; want ${expected}`);
+      }
+      const ctx = canvasRef?.getContext("2d");
+      if (!ctx) throw new Error("canvas 2d context unavailable");
+      ctx.putImageData(rgb565beToImageData(buf), 0, 0);
+      setHasSnapshot(true);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  const toggleAutoCapture = () => {
+    const next = !autoCapture();
+    setAutoCapture(next);
+    if (next) {
+      captureTimer = setInterval(() => void capture(), AUTO_CAPTURE_INTERVAL_MS);
+      void capture(); // immediate first frame
+    } else if (captureTimer != null) {
+      clearInterval(captureTimer);
+      captureTimer = null;
+    }
+  };
+
+  onCleanup(() => {
+    if (captureTimer != null) clearInterval(captureTimer);
+  });
+
+  const cameraMode = createMemo(() => snapshot()?.camera_mode ?? false);
+  const toggleCameraMode = async () => {
+    try {
+      await postJson("/camera/mode", { enabled: !cameraMode() });
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Calibration</h2>
+
+      <h3>Camera</h3>
+      <div class="btn-row">
+        <button type="button" onClick={() => void capture()}>
+          Capture &amp; view
+        </button>
+        <button type="button" onClick={toggleAutoCapture}>
+          <Show when={autoCapture()} fallback="Auto-capture (every 2 s)">
+            Stop auto-capture
+          </Show>
+        </button>
+        <button type="button" onClick={() => void toggleCameraMode()}>
+          <Show when={cameraMode()} fallback="LCD: avatar → camera">
+            LCD: camera → avatar
+          </Show>
+        </button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={FRAME_WIDTH}
+        height={FRAME_HEIGHT}
+        style={{
+          display: hasSnapshot() ? "block" : "none",
+          "margin-top": "8px",
+          "max-width": "100%",
+          border: "1px solid var(--muted)",
+        }}
+      />
+
+      <h3>Tracker</h3>
+      <div class="grid grid-2">
+        <label>
+          Horizontal FOV: <span>{tracker().fov_h_deg.toFixed(1)}°</span>
+          <input
+            type="range"
+            min={20}
+            max={120}
+            step={0.5}
+            value={tracker().fov_h_deg}
+            onInput={(e) =>
+              setTracker({ ...tracker(), fov_h_deg: Number(e.currentTarget.value) })
+            }
+          />
+        </label>
+        <label>
+          Vertical FOV: <span>{tracker().fov_v_deg.toFixed(1)}°</span>
+          <input
+            type="range"
+            min={20}
+            max={120}
+            step={0.5}
+            value={tracker().fov_v_deg}
+            onInput={(e) =>
+              setTracker({ ...tracker(), fov_v_deg: Number(e.currentTarget.value) })
+            }
+          />
+        </label>
+        <label>
+          Smoothing α: <span>{tracker().target_smoothing_alpha.toFixed(2)}</span>
+          <input
+            type="range"
+            min={0.1}
+            max={1.0}
+            step={0.05}
+            value={tracker().target_smoothing_alpha}
+            onInput={(e) =>
+              setTracker({
+                ...tracker(),
+                target_smoothing_alpha: Number(e.currentTarget.value),
+              })
+            }
+          />
+        </label>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={tracker().flip_x}
+              onChange={(e) => setTracker({ ...tracker(), flip_x: e.currentTarget.checked })}
+            />
+            Flip X
+          </label>
+          <label style="margin-left:1em">
+            <input
+              type="checkbox"
+              checked={tracker().flip_y}
+              onChange={(e) => setTracker({ ...tracker(), flip_y: e.currentTarget.checked })}
+            />
+            Flip Y
+          </label>
+        </div>
+      </div>
+      <div class="btn-row">
+        <button type="button" onClick={() => void saveTracker()}>
+          Save tracker
+        </button>
+        <button type="button" onClick={() => void loadSettings()}>
+          Reload
+        </button>
+      </div>
+
+      <h3>Head offsets</h3>
+      <div class="grid grid-2">
+        <label>
+          Yaw offset: <span>{offsets().yaw_offset_deg.toFixed(1)}°</span>
+          <input
+            type="range"
+            min={-30}
+            max={30}
+            step={0.5}
+            value={offsets().yaw_offset_deg}
+            onInput={(e) =>
+              setOffsets({ ...offsets(), yaw_offset_deg: Number(e.currentTarget.value) })
+            }
+          />
+        </label>
+        <label>
+          Tilt offset: <span>{offsets().tilt_offset_deg.toFixed(1)}°</span>
+          <input
+            type="range"
+            min={-30}
+            max={30}
+            step={0.5}
+            value={offsets().tilt_offset_deg}
+            onInput={(e) =>
+              setOffsets({ ...offsets(), tilt_offset_deg: Number(e.currentTarget.value) })
+            }
+          />
+        </label>
+      </div>
+      <div class="btn-row">
+        <button type="button" onClick={() => void saveOffsets()}>
+          Save offsets
+        </button>
+        <button type="button" onClick={() => void loadOffsets()}>
+          Reload
+        </button>
+      </div>
+
+      <small>
+        FOV: place a target at a known angle, POST /look-at, see if the head over- or
+        under-rotates; scale the FOV proportionally. Flips: move the target left of centre and
+        check the head turns left too — if it goes the wrong way, toggle Flip X. Same for
+        vertical with Flip Y. Smoothing α: 1.0 is pass-through (most responsive); lower values
+        add EMA inertia. Head offsets: command pan = 0 / tilt = 0, eyeball whether the head is
+        pointing dead ahead, then nudge the offsets so it does.
+      </small>
+    </section>
+  );
+}

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -1,7 +1,15 @@
 import { createSignal, onMount } from "solid-js";
 import { authedFetch, setAuthToken } from "../auth";
 import { showToast, snapshot } from "../store";
-import type { Settings as SettingsType } from "../types";
+import type { Settings as SettingsType, Tracker } from "../types";
+
+const TRACKER_DEFAULT: Tracker = {
+  fov_h_deg: 62.0,
+  fov_v_deg: 49.0,
+  target_smoothing_alpha: 1.0,
+  flip_x: false,
+  flip_y: false,
+};
 
 export function Settings() {
   const [ssid, setSsid] = createSignal("");
@@ -11,6 +19,11 @@ export function Settings() {
   const [sntp, setSntp] = createSignal("");
   const [token, setToken] = createSignal("");
   const [tz, setTz] = createSignal("UTC");
+  // Tracker is round-tripped opaquely — the Calibration component
+  // owns the editing UI. Without this preservation, every Save
+  // here would reset tracker to firmware defaults via the
+  // `unwrap_or_default()` in the bare_json parser.
+  const [tracker, setTracker] = createSignal<Tracker>(TRACKER_DEFAULT);
 
   const load = async () => {
     try {
@@ -31,8 +44,9 @@ export function Settings() {
       setSntp(c.time.sntp_servers.join(", "));
       setToken(c.auth.token);
       setTz(c.time.tz);
+      setTracker(c.tracker);
     } catch (e) {
-      showToast((e as Error).message, true);
+      showToast(e instanceof Error ? e.message : String(e), true);
     }
   };
 
@@ -53,6 +67,7 @@ export function Settings() {
       },
       auth: { token: token() },
       audio,
+      tracker: tracker(),
     };
     const newToken = body.auth.token;
     try {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -31,12 +31,26 @@ export type AvatarSnapshot = {
   camera_mode: boolean;
 };
 
+export type Tracker = {
+  fov_h_deg: number;
+  fov_v_deg: number;
+  target_smoothing_alpha: number;
+  flip_x: boolean;
+  flip_y: boolean;
+};
+
+export type HeadOffsets = {
+  yaw_offset_deg: number;
+  tilt_offset_deg: number;
+};
+
 export type Settings = {
   wifi: { ssid: string; psk: string; country: string };
   mdns: { hostname: string };
   time: { tz: string; sntp_servers: string[] };
   auth: { token: string };
   audio: AudioState;
+  tracker: Tracker;
 };
 
 export type Imu = {


### PR DESCRIPTION
## Summary

- New **Calibration** dashboard panel that bundles the camera, tracker config, and head-offset surfaces operators reach for during a fresh kit setup. Includes a Capture-and-view loop (with optional 2 s auto-capture) so the operator can see what the camera sees while tweaking flips / FOV.
- **Bug fix (round-trip clobber)**: `Settings.tsx` was silently dropping the persisted tracker config on every Save — the form's PUT body never included the `tracker` block, and the parser at `crates/stackchan-net/src/bare_json.rs:377` falls back to `TrackerConfig::default()` on a missing field. Every dashboard Save reset fov / smoothing / flips. Fixed by loading the block on GET and round-tripping it opaquely on PUT, in the same shape the Calibration panel does for the inverse direction.
- **Doc drift cleanup**: routes table in `docs/http.md` now lists `/sensors`, `/head/offsets`, and `/palette` which were missing.

## Test plan

- [x] `npm run build` — TypeScript typecheck + Vite build clean
- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just clippy-firmware` — strict clippy on `xtensa-esp32s3-none-elf`
- [ ] On-device verification via `just fmr`:
  - [ ] Open dashboard, confirm Calibration panel renders
  - [ ] Place a target ~30° to the side; trigger Capture & view; confirm canvas paints
  - [ ] Toggle Auto-capture, confirm it stops cleanly when un-toggled
  - [ ] Move FOV sliders, click Save tracker, reboot, confirm values stuck
  - [ ] Drag head-offset sliders, click Save offsets, command `/look-at` to (0, 0), confirm offsets applied
  - [ ] **Round-trip regression check**: edit Wi-Fi settings + Save, then check `/settings` shows tracker config preserved (this is the bug this PR fixes)

## Notes

- Other dashboard routes still missing from `docs/http.md`'s routes table: `/sleep`, `/wake`, `/look-at-point`, `/face-target`, `/camera/mode`, `/camera/capture`, `/restart`, `/factory-reset`, `/settings/backup`. Those drift fixes belong in a focused docs cleanup PR.
- The new component does **not** overlay tracker centroid on the snapshot — that would require exposing the centroid via `/sensors` or a new endpoint and is bigger than this scope. For v1, calibration is operator-eyeball-driven: place target → POST /look-at → see if head goes there.