### PR TITLE
fix(firmware): WIFI_LINK_SIGNAL multi-consumer race — replace with Watch

### DIFF
--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -2,7 +2,7 @@
 //! advertising for `_stackchan._tcp.local.`.
 //!
 //! Joins the IPv4 mDNS multicast group `224.0.0.251:5353` and emits an
-//! unsolicited announcement on every `WIFI_LINK_SIGNAL::Connected`
+//! unsolicited announcement on every `WIFI_LINK_WATCH::Connected`
 //! transition so phones / laptops / Bonjour browsers pick up the
 //! device without an explicit query. Inbound A queries for
 //! `<hostname>.local` and PTR queries for the service type are
@@ -43,7 +43,7 @@ use stackchan_core::Pose;
 use stackchan_net::mdns_pose::{POSE_PUBLISH_MIN_INTERVAL_MS, PoseAnnouncer, format_pose_kv};
 
 use super::snapshot;
-use super::wifi::{WIFI_LINK_SIGNAL, WifiLinkState};
+use super::wifi::{WIFI_LINK_WATCH, WifiLinkState};
 
 /// IPv4 mDNS multicast group + port.
 const MDNS_MULTICAST: embassy_net::IpAddress =
@@ -90,11 +90,16 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
     let mut tx_meta = [PacketMetadata::EMPTY; 4];
     let mut tx_buf = [0u8; MAX_DNS_BYTES];
 
+    let Some(mut link) = WIFI_LINK_WATCH.receiver() else {
+        defmt::error!("mdns: WIFI_LINK_WATCH receiver slot exhausted; parking");
+        park_forever().await;
+    };
+
     loop {
         // Wait for a Connected link before binding the socket.
         // embassy-net needs the IPv4 address to encode A-record
         // answers, and join_multicast_group needs the link up.
-        if !matches!(WIFI_LINK_SIGNAL.wait().await, WifiLinkState::Connected) {
+        if !matches!(link.changed().await, WifiLinkState::Connected) {
             continue;
         }
 

--- a/crates/stackchan-firmware/src/net/sntp.rs
+++ b/crates/stackchan-firmware/src/net/sntp.rs
@@ -16,7 +16,7 @@ use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_time::{Duration, Timer, with_timeout};
 use embedded_hal_async::i2c::I2c as AsyncI2c;
 
-use super::wifi::{WIFI_LINK_SIGNAL, WifiLinkState};
+use super::wifi::{WIFI_LINK_WATCH, WifiLinkState};
 
 /// SNTP / NTP epoch is 1900-01-01; Unix is 1970-01-01. Difference in
 /// seconds — used to fold the transmit-timestamp seconds field into a
@@ -29,7 +29,7 @@ const PER_SERVER_TIMEOUT_SECS: u64 = 5;
 
 /// Re-sync cadence after a successful sync. Hourly is enough — the
 /// BM8563's stock crystal drifts <30 s/day. Re-syncs also fire on every
-/// `WIFI_LINK_SIGNAL::Connected` transition (handled by the outer loop).
+/// `WIFI_LINK_WATCH::Connected` transition (handled by the outer loop).
 const RESYNC_INTERVAL_SECS: u64 = 3_600;
 
 /// Concrete shared-I²C handle the firmware threads through every async
@@ -65,11 +65,17 @@ pub async fn sntp_task(stack: Stack<'static>, rtc_bus: SharedI2cBus, servers: Ve
         );
     }
 
+    let Some(mut link) = WIFI_LINK_WATCH.receiver() else {
+        defmt::error!("sntp: WIFI_LINK_WATCH receiver slot exhausted; parking");
+        park_forever().await;
+    };
+
     loop {
-        // Wait for an active link before each sync attempt. `wait()`
-        // returns whatever the wifi task last published — including the
-        // initial `Disconnected`, so we re-check before dispatching.
-        if !matches!(WIFI_LINK_SIGNAL.wait().await, WifiLinkState::Connected) {
+        // Wait for an active link before each sync attempt. `changed()`
+        // returns the next published value (including the first one if
+        // wifi_task already published before this task spawned), so we
+        // still re-check the variant before dispatching.
+        if !matches!(link.changed().await, WifiLinkState::Connected) {
             continue;
         }
         // Give DHCP a moment to settle once the link is up. Without an

--- a/crates/stackchan-firmware/src/net/wifi.rs
+++ b/crates/stackchan-firmware/src/net/wifi.rs
@@ -21,26 +21,41 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use embassy_futures::select::{Either, select};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
+use embassy_sync::watch::Watch;
 use embassy_time::{Duration, Timer};
 use esp_radio::wifi::{ClientConfig, ModeConfig, WifiController, WifiEvent};
 
-/// Public link-state signal — downstream tasks (SNTP, HTTP, mDNS)
-/// `wait()` on it to gate their own startup against the connect.
+/// Number of independent receivers the [`WIFI_LINK_WATCH`] supports.
 ///
-/// `Signal` is single-consumer: it stores one waker, so multiple
-/// concurrent `.wait().await` callers will lose all but the
-/// last-registered. SNTP and mDNS each have a single instance and
-/// loop on the signal, so this works for them. Multi-instance
-/// consumers (the HTTP worker pool) must use [`LINK_READY`] instead.
-pub static WIFI_LINK_SIGNAL: Signal<CriticalSectionRawMutex, WifiLinkState> = Signal::new();
+/// Sized for the current consumers (SNTP + mDNS) plus headroom for a
+/// future BLE link-state characteristic or HTTP worker subscription
+/// without re-touching this constant. Each slot is cheap (one
+/// generation counter), so over-provisioning here is fine.
+pub const WIFI_LINK_WATCH_RECEIVERS: usize = 4;
+
+/// Public link-state watch — downstream tasks (SNTP, mDNS, …) take a
+/// receiver each and loop on `.changed()` to gate their own work.
+///
+/// Was a `Signal<…, WifiLinkState>` until 2026-05; embassy's `Signal`
+/// stores only one waker, so two tasks awaiting the same `Signal`
+/// race — whichever registers second overwrites the first task's
+/// waker, and the first task starves until something else wakes it.
+/// In practice that meant either SNTP never time-synced or mDNS never
+/// advertised, depending on spawn order. `Watch` is the multi-consumer
+/// equivalent: each receiver tracks its own last-seen generation, so
+/// every consumer wakes on every transition.
+pub static WIFI_LINK_WATCH: Watch<
+    CriticalSectionRawMutex,
+    WifiLinkState,
+    WIFI_LINK_WATCH_RECEIVERS,
+> = Watch::new();
 
 /// Latched "link has been up at least once" flag.
 ///
 /// Set the first time [`wifi_task`] observes a [`WifiLinkState::Connected`]
-/// transition; never cleared. Multiple consumers can read this
-/// concurrently without the single-waker contention that
-/// [`WIFI_LINK_SIGNAL`] has — used by the HTTP worker pool to gate
-/// each worker's first accept call.
+/// transition; never cleared. Used by the HTTP worker pool to gate
+/// each worker's first accept call without consuming a
+/// [`WIFI_LINK_WATCH`] receiver slot per worker.
 pub static LINK_READY: AtomicBool = AtomicBool::new(false);
 
 /// Soft-reconfig signal — replace the active Wi-Fi credentials.
@@ -107,7 +122,7 @@ pub async fn wifi_task(
     loop {
         if creds.ssid.trim().is_empty() {
             defmt::info!("wifi: no SSID configured, idle");
-            WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+            WIFI_LINK_WATCH.sender().send(WifiLinkState::Disconnected);
             creds = WIFI_RECONFIG.wait().await;
             continue;
         }
@@ -120,7 +135,7 @@ pub async fn wifi_task(
                 "wifi: set_config rejected ({}); waiting for next provisioning",
                 defmt::Debug2Format(&e)
             );
-            WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+            WIFI_LINK_WATCH.sender().send(WifiLinkState::Disconnected);
             creds = WIFI_RECONFIG.wait().await;
             continue;
         }
@@ -159,14 +174,14 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
     let mut backoff_idx: usize = 0;
     loop {
         defmt::info!("wifi: connecting to ssid={=str}", ssid);
-        WIFI_LINK_SIGNAL.signal(WifiLinkState::Connecting);
+        WIFI_LINK_WATCH.sender().send(WifiLinkState::Connecting);
 
         let connect_outcome = select(controller.connect_async(), WIFI_RECONFIG.wait()).await;
         match connect_outcome {
             Either::First(Ok(())) => {
                 defmt::info!("wifi: connected");
                 crate::event_log::record(crate::event_log::Kind::Lifecycle, "wifi: connected");
-                WIFI_LINK_SIGNAL.signal(WifiLinkState::Connected);
+                WIFI_LINK_WATCH.sender().send(WifiLinkState::Connected);
                 LINK_READY.store(true, Ordering::Release);
                 backoff_idx = 0;
 
@@ -182,7 +197,7 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
                             crate::event_log::Kind::Warn,
                             "wifi: link dropped",
                         );
-                        WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+                        WIFI_LINK_WATCH.sender().send(WifiLinkState::Disconnected);
                     }
                     Either::Second(new_creds) => {
                         defmt::info!(
@@ -190,7 +205,7 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
                             new_creds.ssid.as_str()
                         );
                         let _ = controller.disconnect_async().await;
-                        WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+                        WIFI_LINK_WATCH.sender().send(WifiLinkState::Disconnected);
                         return new_creds;
                     }
                 }
@@ -202,7 +217,7 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
                     defmt::Debug2Format(&e),
                     backoff_ms
                 );
-                WIFI_LINK_SIGNAL.signal(WifiLinkState::Disconnected);
+                WIFI_LINK_WATCH.sender().send(WifiLinkState::Disconnected);
 
                 let wait_outcome = select(
                     Timer::after(Duration::from_millis(backoff_ms)),


### PR DESCRIPTION
## Summary

Real, deterministic single-waker race: `sntp_task` and `mdns_task` both call `WIFI_LINK_SIGNAL.wait().await` at the top of their loops. embassy's `Signal` stores a single waker, so the second task to register overwrites the first. Whichever spawns later wins all subsequent wake events; the other starves on Wi-Fi state transitions.

Symptom in production: depending on spawn order, **either SNTP never time-syncs *or* mDNS never advertises** after the first link-up. The wifi.rs doc comment at line 30-34 claimed "this works for them" — it doesn't.

Fix: replace `WIFI_LINK_SIGNAL: Signal<…>` with `WIFI_LINK_WATCH: Watch<…, 4>`. `Watch` is the multi-consumer broadcast pattern in `embassy_sync` — each receiver tracks its own last-seen generation, so every consumer wakes on every transition.

## Notes

- Capacity 4 leaves headroom for a future BLE link-state characteristic or a third subscriber without re-touching the cap. Each slot is one generation counter — cheap to over-provision.
- `LINK_READY: AtomicBool` is unchanged — used by the HTTP worker pool to gate first-accept. `HTTP_WORKER_COUNT × 4` receiver slots would blow the budget, and a latched "ever-connected" bool is the right shape for that single check anyway.
- Slot exhaustion (more receivers than `WIFI_LINK_WATCH_RECEIVERS`) is handled with a `let-else` that logs `defmt::error!` and parks the task. Project rule denies `expect()` in firmware, so this is the graceful path.
- Found via the `feedback_round_trip_audit.md` memory pattern: "Signal single-waker race when N tasks await the same signal." Audit also turned up no other multi-consumer Signal — every other `*_SIGNAL` has exactly one consumer (canonical drain in render_task or owning task).

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just clippy-firmware` — strict clippy on `xtensa-esp32s3-none-elf`
- [ ] On-device verification via `just fmr` with `STACKCHAN.RON` configured for Wi-Fi:
  - [ ] Boot, observe both `sntp:` and `mdns:` log lines fire after Wi-Fi connect (pre-fix: only one would, depending on spawn order)
  - [ ] Reconnect Wi-Fi (drop AP / restore), confirm both tasks log re-entry to their post-Connected branches
  - [ ] `dig @stackchan.local stackchan.local A` returns the lease IP — confirms mDNS responder is alive
  - [ ] System time matches host within seconds — confirms SNTP synced