### PR TITLE
chore(calibration): address greptile findings on #293

### DIFF
--- a/web/src/components/Calibration.tsx
+++ b/web/src/components/Calibration.tsx
@@ -1,18 +1,11 @@
 import { Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import { authedFetch, postJson } from "../auth";
 import { showToast, snapshot } from "../store";
+import { TRACKER_DEFAULT } from "../types";
 import type { HeadOffsets, Settings as SettingsType, Tracker } from "../types";
 
 const FRAME_WIDTH = 320;
 const FRAME_HEIGHT = 240;
-
-const TRACKER_DEFAULT: Tracker = {
-  fov_h_deg: 62.0,
-  fov_v_deg: 49.0,
-  target_smoothing_alpha: 1.0,
-  flip_x: false,
-  flip_y: false,
-};
 
 const HEAD_OFFSETS_DEFAULT: HeadOffsets = {
   yaw_offset_deg: 0,
@@ -46,10 +39,6 @@ export function Calibration() {
   const [offsets, setOffsets] = createSignal<HeadOffsets>(HEAD_OFFSETS_DEFAULT);
   const [autoCapture, setAutoCapture] = createSignal(false);
   const [hasSnapshot, setHasSnapshot] = createSignal(false);
-  // Cached opaque copy of the rest of /settings so we can PUT just
-  // the tracker block without clobbering wifi / mdns / time / auth.
-  // The Settings component does the same thing in reverse.
-  const [settingsCache, setSettingsCache] = createSignal<SettingsType | null>(null);
   let canvasRef: HTMLCanvasElement | undefined;
   let captureTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -65,7 +54,6 @@ export function Calibration() {
         return;
       }
       const c = (await res.json()) as SettingsType;
-      setSettingsCache(c);
       setTracker(c.tracker);
     } catch (e) {
       showToast(e instanceof Error ? e.message : String(e), true);
@@ -92,13 +80,20 @@ export function Calibration() {
   });
 
   const saveTracker = async () => {
-    const cache = settingsCache();
-    if (!cache) {
-      showToast("reload settings first", true);
-      return;
-    }
-    const body: SettingsType = { ...cache, tracker: tracker() };
     try {
+      // Re-fetch immediately before PUT so we merge against the
+      // latest persisted state, not a snapshot captured at mount.
+      // Without this, a Settings save mid-session would clobber the
+      // tracker change we're about to make — and vice versa.
+      const freshRes = await fetch("/settings");
+      if (!freshRes.ok) {
+        if (freshRes.status === 503) {
+          throw new Error("settings unavailable (no SD card)");
+        }
+        throw new Error(`GET /settings: ${freshRes.status}`);
+      }
+      const fresh = (await freshRes.json()) as SettingsType;
+      const body: SettingsType = { ...fresh, tracker: tracker() };
       const res = await authedFetch("/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -110,8 +105,6 @@ export function Calibration() {
       }
       const reply = (await res.json().catch(() => ({}))) as { reboot_required?: boolean };
       showToast(reply.reboot_required ? "tracker saved — reboot to apply" : "tracker saved");
-      // Refresh the cache so the next save sees the persisted state.
-      setSettingsCache(body);
     } catch (e) {
       showToast(e instanceof Error ? e.message : String(e), true);
     }

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -1,15 +1,7 @@
 import { createSignal, onMount } from "solid-js";
 import { authedFetch, setAuthToken } from "../auth";
 import { showToast, snapshot } from "../store";
-import type { Settings as SettingsType, Tracker } from "../types";
-
-const TRACKER_DEFAULT: Tracker = {
-  fov_h_deg: 62.0,
-  fov_v_deg: 49.0,
-  target_smoothing_alpha: 1.0,
-  flip_x: false,
-  flip_y: false,
-};
+import type { Settings as SettingsType } from "../types";
 
 export function Settings() {
   const [ssid, setSsid] = createSignal("");
@@ -19,11 +11,6 @@ export function Settings() {
   const [sntp, setSntp] = createSignal("");
   const [token, setToken] = createSignal("");
   const [tz, setTz] = createSignal("UTC");
-  // Tracker is round-tripped opaquely — the Calibration component
-  // owns the editing UI. Without this preservation, every Save
-  // here would reset tracker to firmware defaults via the
-  // `unwrap_or_default()` in the bare_json parser.
-  const [tracker, setTracker] = createSignal<Tracker>(TRACKER_DEFAULT);
 
   const load = async () => {
     try {
@@ -44,7 +31,6 @@ export function Settings() {
       setSntp(c.time.sntp_servers.join(", "));
       setToken(c.auth.token);
       setTz(c.time.tz);
-      setTracker(c.tracker);
     } catch (e) {
       showToast(e instanceof Error ? e.message : String(e), true);
     }
@@ -54,23 +40,36 @@ export function Settings() {
 
   const submit = async (ev: Event) => {
     ev.preventDefault();
-    const audio = snapshot()?.audio ?? { volume_pct: 50, muted: false };
-    const body: SettingsType = {
-      wifi: { ssid: ssid(), psk: psk(), country: country().toUpperCase() },
-      mdns: { hostname: hostname() },
-      time: {
-        tz: tz(),
-        sntp_servers: sntp()
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean),
-      },
-      auth: { token: token() },
-      audio,
-      tracker: tracker(),
-    };
-    const newToken = body.auth.token;
     try {
+      // Re-fetch immediately before PUT so we merge against the
+      // latest persisted state, not the snapshot captured at mount.
+      // Without this, a Calibration "Save tracker" mid-session would
+      // be clobbered when the operator subsequently saves through
+      // this form — the form would PUT the stale tracker block.
+      const freshRes = await fetch("/settings");
+      if (!freshRes.ok) {
+        if (freshRes.status === 503) {
+          throw new Error("settings unavailable (no SD card)");
+        }
+        throw new Error(`GET /settings: ${freshRes.status}`);
+      }
+      const fresh = (await freshRes.json()) as SettingsType;
+      const audio = snapshot()?.audio ?? fresh.audio;
+      const body: SettingsType = {
+        wifi: { ssid: ssid(), psk: psk(), country: country().toUpperCase() },
+        mdns: { hostname: hostname() },
+        time: {
+          tz: tz(),
+          sntp_servers: sntp()
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+        },
+        auth: { token: token() },
+        audio,
+        tracker: fresh.tracker,
+      };
+      const newToken = body.auth.token;
       const res = await authedFetch("/settings", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -99,7 +98,7 @@ export function Settings() {
           : "saved — applied without reboot",
       );
     } catch (e) {
-      showToast((e as Error).message, true);
+      showToast(e instanceof Error ? e.message : String(e), true);
     }
   };
 
@@ -126,7 +125,7 @@ export function Settings() {
       setTimeout(() => URL.revokeObjectURL(url), 0);
       showToast("backup downloaded");
     } catch (e) {
-      showToast((e as Error).message, true);
+      showToast(e instanceof Error ? e.message : String(e), true);
     }
   };
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -39,6 +39,18 @@ export type Tracker = {
   flip_y: boolean;
 };
 
+// Mirrors `stackchan_net::config::TrackerSettings::DEFAULT`. The
+// dashboard only consults this as a fallback when /settings is
+// unreachable (e.g. SD card absent); on a healthy device the values
+// always come from the firmware's GET /settings response.
+export const TRACKER_DEFAULT: Tracker = {
+  fov_h_deg: 62.0,
+  fov_v_deg: 49.0,
+  target_smoothing_alpha: 1.0,
+  flip_x: false,
+  flip_y: false,
+};
+
 export type HeadOffsets = {
   yaw_offset_deg: number;
   tilt_offset_deg: number;


### PR DESCRIPTION
## Summary

Four Greptile findings on PR #293; the P1 was a real within-session round-trip clobber that #293 inadvertently introduced (and that I flagged in my own insight comment but didn't actually fix — Greptile caught the gap).

### P1 — tracker stomp across panels

`Calibration` and `Settings` were both mounted simultaneously and each cached `/settings` on its own `onMount`. Operator path:

1. Calibration: tweak FOV, click *Save tracker* → PUTs new tracker
2. Settings: edit Wi-Fi, click *Save* → PUTs the **stale** tracker captured at mount time, clobbering step 1

Fix: both submit handlers now re-fetch `/settings` immediately before constructing the PUT body, so each merge runs against the latest persisted state. Per-component caches (`settingsCache`, `Settings.tracker` signal) deleted — they were the staleness vector.

### P2 — `TRACKER_DEFAULT` duplicated

Hoisted to `types.ts` beside the `Tracker` type. Single source of truth.

### P2 — `(e as Error)` casts in Settings.tsx

Two remaining catch blocks switched to `instanceof Error` narrowing.

## Test plan

- [x] `npm run build` — TypeScript typecheck + Vite build clean
- [x] `just check` — fmt + clippy + host tests + doctests
- [ ] On-device verification:
  - [ ] Open dashboard, edit FOV in Calibration → Save tracker
  - [ ] Without reloading: edit Wi-Fi SSID in Settings → Save
  - [ ] Reload page, confirm both FOV and SSID survived (pre-fix: SSID survives, FOV reverts)
  - [ ] Reverse direction: edit Wi-Fi → Save, then edit FOV → Save tracker, reload, confirm both survive

## Notes

- The 18 other dashboard components still use the unsafe `(e as Error).message` cast — that's a separate audit PR. Worth flipping `useUnknownInCatchVariables: true` in `tsconfig.json` and fixing the resulting type errors in one pass.