### PR TITLE
feat(firmware): crash recovery — RTC-RAM panic latch + /sd/CRASH.LOG + dashboard banner

### DIFF
--- a/crates/stackchan-firmware/src/crash.rs
+++ b/crates/stackchan-firmware/src/crash.rs
@@ -1,0 +1,157 @@
+//! Persistent crash latch in RTC fast RAM + boot-time SD save.
+//!
+//! The default `#[panic_handler]` for a `no_std` firmware is "log
+//! over defmt and `loop {}`" — which strands the device with no
+//! record once it's plugged into a wall and the defmt console isn't
+//! attached. This module captures the panic message + location into
+//! RTC fast RAM (preserved across software resets, watchdog
+//! timeouts, and the bootloader handoff via
+//! `#[esp_hal::ram(unstable(rtc_fast, persistent))]`), reboots the
+//! chip, and on the *next* boot copies the latch contents into
+//! `/sd/CRASH.LOG` so the operator can fetch them via `GET /crash`
+//! or the dashboard.
+//!
+//! ## Lifecycle
+//!
+//! 1. Panic handler calls [`record_panic`], which serialises
+//!    [`PanicInfo`] into [`CRASH_LATCH`] (the persistent RAM buffer)
+//!    via [`stackchan_net::crash_latch::encode`].
+//! 2. Panic handler calls `esp_hal::system::software_reset()`. The
+//!    chip restarts; RTC fast RAM is preserved across the reset.
+//! 3. On the next boot, [`consume_latch`] validates magic +
+//!    checksum and returns the snapshot, atomically clearing the
+//!    magic so the same crash isn't replayed every subsequent boot.
+//! 4. The boot path in `main.rs` writes the snapshot to
+//!    `/sd/CRASH.LOG` once SD is mounted; `GET /crash` returns it,
+//!    `POST /crash/clear` deletes it.
+//!
+//! ## Why RTC fast RAM and not flash?
+//!
+//! Flash writes from a panic context are dangerous: the SPI flash
+//! controller may be mid-operation, the heap may be poisoned, and a
+//! partial write could brick the running firmware image. RTC fast
+//! RAM is a small dedicated SRAM region the CPU writes atomically
+//! without involving any peripheral driver. The `persistent` mode of
+//! `#[ram]` skips the zero-init that runs on every boot, so the
+//! latch survives `software_reset` even though the rest of the SRAM
+//! is reinitialised.
+//!
+//! Byte layout + encode / decode helpers live in
+//! [`stackchan_net::crash_latch`] so they're host-testable. This
+//! module keeps the `static mut` and the `#[panic_handler]` glue.
+
+// Reaches the `static mut CRASH_LATCH` directly. The two `unsafe`
+// blocks below are the only places the latch buffer is touched at
+// runtime: once from the panic handler (every other CPU activity is
+// suspended; `RECORDING` serialises re-entrant panics) and once
+// from `main` before any task has spawned (single-threaded by
+// construction). No async path or interrupt handler touches the
+// latch, so there's no observable aliasing.
+#![allow(unsafe_code)]
+
+use core::panic::PanicInfo;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use stackchan_net::crash_latch::{LATCH_SIZE, clear_magic, decode, encode, format_into};
+
+pub use stackchan_net::crash_latch::CrashSnapshot;
+
+/// Persistent crash-latch buffer. RTC fast RAM is preserved across
+/// `software_reset` thanks to the `persistent` mode of
+/// `#[esp_hal::ram]`, which skips the zero-init normally performed
+/// at every boot.
+#[esp_hal::ram(unstable(rtc_fast, persistent))]
+pub static mut CRASH_LATCH: [u8; LATCH_SIZE] = [0u8; LATCH_SIZE];
+
+/// Re-entrancy guard — flips to `true` on the first call to
+/// [`record_panic`]. A panic that happens *inside* the panic handler
+/// (e.g. a recursive call through a corrupt formatter) becomes a
+/// no-op, so the original snapshot survives instead of being
+/// overwritten with garbage.
+static RECORDING: AtomicBool = AtomicBool::new(false);
+
+/// Capture `info` into [`CRASH_LATCH`]. Idempotent against
+/// re-entrant panics — the first call wins.
+///
+/// # Safety
+///
+/// Touches the `static mut CRASH_LATCH`. Panic handlers run with
+/// every other CPU activity suspended, and [`RECORDING`] serialises
+/// re-entrant calls.
+pub fn record_panic(info: &PanicInfo<'_>) {
+    if RECORDING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    // Render the panic message into a stack buffer. `format!`
+    // requires a working allocator, which is exactly what may have
+    // just panicked, so we route through a fixed-size truncating
+    // sink instead.
+    let mut msg_buf = [0u8; stackchan_net::crash_latch::MSG_CAP];
+    let msg_len = format_into(&mut msg_buf, format_args!("{}", info.message()));
+
+    let (file_bytes, file_len, line) =
+        info.location()
+            .map_or(([0u8; stackchan_net::crash_latch::FILE_CAP], 0, 0), |loc| {
+                let mut buf = [0u8; stackchan_net::crash_latch::FILE_CAP];
+                let bytes = loc.file().as_bytes();
+                let n = bytes.len().min(stackchan_net::crash_latch::FILE_CAP);
+                buf[..n].copy_from_slice(&bytes[..n]);
+                (buf, n, loc.line())
+            });
+
+    // SAFETY: `CRASH_LATCH` is `static mut`. The panic handler runs
+    // with every other CPU activity suspended; `RECORDING`
+    // serialises re-entrant calls.
+    unsafe {
+        let latch = &mut *core::ptr::addr_of_mut!(CRASH_LATCH);
+        encode(latch, &msg_buf[..msg_len], &file_bytes[..file_len], line);
+    }
+}
+
+/// Read [`CRASH_LATCH`], validate magic + checksum, and return the
+/// decoded snapshot if both pass. Atomically zeroes the magic after
+/// a successful read so the caller never sees the same crash twice.
+///
+/// # Safety
+///
+/// Touches the `static mut CRASH_LATCH`. Called once on boot before
+/// any other task spawns; safe by single-threaded construction.
+#[must_use]
+pub fn consume_latch() -> Option<CrashSnapshot> {
+    // SAFETY: called from `main` before any task spawn. No other
+    // executor is running concurrently.
+    unsafe {
+        let latch = &mut *core::ptr::addr_of_mut!(CRASH_LATCH);
+        let snap = decode(latch);
+        if snap.is_some() {
+            // Mark consumed so subsequent boots don't replay.
+            clear_magic(latch);
+        } else if u32::from_le_bytes([latch[0], latch[1], latch[2], latch[3]])
+            == stackchan_net::crash_latch::MAGIC
+        {
+            // Magic survived but the checksum didn't — clear the
+            // magic so we don't keep tripping on a corrupt latch.
+            clear_magic(latch);
+        }
+        snap
+    }
+}
+
+/// Render a [`CrashSnapshot`] into a human-readable, line-delimited
+/// log entry suitable for writing to `/sd/CRASH.LOG`. Schema is
+/// stable: `key=value` pairs, one per line, blank trailer.
+///
+/// Operators read this directly via `GET /crash` or by mounting the
+/// SD card. Future versions may add fields (boot count, reset
+/// reason, firmware version) — readers tolerate unknown keys.
+#[must_use]
+pub fn render_log_entry(snap: &CrashSnapshot, reset_reason: &str) -> alloc::string::String {
+    use core::fmt::Write as _;
+    let mut out = alloc::string::String::new();
+    let _ = writeln!(out, "reset_reason={reset_reason}");
+    let _ = writeln!(out, "file={}", snap.file_str());
+    let _ = writeln!(out, "line={}", snap.line);
+    let _ = writeln!(out, "message={}", snap.message_str());
+    out
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -26,6 +26,7 @@ pub mod button;
 pub mod camera;
 pub mod chime;
 pub mod clock;
+pub mod crash;
 pub mod event_log;
 pub mod framebuffer;
 pub mod head;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -113,12 +113,21 @@ esp_bootloader_esp_idf::esp_app_desc!();
 #[used]
 static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
 
-/// Panic handler. Halts the core; esp-rtos emits the trace over RTT
-/// before we arrive here (via `--catch-hardfault` on the probe-rs side).
+/// Panic handler. Records the panic into the persistent crash latch
+/// and triggers a software reset so the device recovers without
+/// human intervention. The next boot's main loop reads the latch
+/// and writes it to `/sd/CRASH.LOG` for post-mortem fetch via
+/// `GET /crash`.
+///
+/// `loop {}` is the fallback if the latch write returns (it
+/// shouldn't — `record_panic` is `fn () -> ()`, but the safety
+/// guard against re-entrant panics may early-return without
+/// resetting). The watchdog will catch us either way.
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     defmt::error!("panic: {}", defmt::Display2Format(info));
-    loop {}
+    stackchan_firmware::crash::record_panic(info);
+    esp_hal::system::software_reset();
 }
 
 /// Internal SRAM heap, registered first so short-lived allocations (embassy
@@ -1094,6 +1103,22 @@ async fn main(spawner: Spawner) -> ! {
             // first request — and so the SSE stream stays consistent
             // with what the amp actually applies at boot.
             net::snapshot::update_audio(cfg.audio);
+            // If the previous boot panicked, the crash latch in RTC
+            // fast RAM still holds the message + location. Drain it
+            // now (clears the magic atomically) and write the
+            // rendered log to /sd/CRASH.LOG so `GET /crash` can
+            // surface it to the operator. A failed SD write is
+            // logged but not fatal — defmt still has the panic line
+            // for anyone watching the console.
+            if let Some(snap) = stackchan_firmware::crash::consume_latch() {
+                defmt::warn!(
+                    "crash recovery: previous boot panicked at {=str}:{=u32} — saving to SD",
+                    snap.file_str(),
+                    snap.line,
+                );
+                let log = stackchan_firmware::crash::render_log_entry(&snap, "panic");
+                let _ = storage::with_storage(|s| s.write_crash(&log)).await;
+            }
             // Restore the operator-tuned palette + mood from the
             // SD-backed runtime store. Tolerant of a missing /
             // malformed file: any failure leaves the cache (and the

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -460,6 +460,8 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/mood") => handle_post_mood(socket, body).await,
         ("POST", "/palette") => handle_post_palette(socket, body).await,
         ("POST", "/face-geometry") => handle_post_face_geometry(socket, body).await,
+        ("GET", "/crash") => handle_get_crash(socket).await,
+        ("POST", "/crash/clear") => handle_post_crash_clear(socket).await,
         ("POST", "/sleep") => handle_post_sleep(socket).await,
         ("POST", "/wake") => handle_post_wake(socket).await,
         ("GET", "/head/offsets") => handle_get_head_offsets(socket).await,
@@ -905,6 +907,44 @@ async fn handle_post_face_geometry(
     let _ = crate::runtime_store::update_face_geometry(geometry).await;
     defmt::info!("http: POST /face-geometry → {}", geometry.wire_str());
     write_no_content(socket).await
+}
+
+/// `GET /crash` — return the most recent panic log written by the
+/// boot path from the persistent RTC crash latch.
+///
+/// Body is the raw rendered log entry — line-delimited `key=value`
+/// pairs (`reset_reason`, `file`, `line`, `message`). Returns 404
+/// if no crash has been recorded since the last clear, 503 if the
+/// SD card is absent or unreadable.
+async fn handle_get_crash(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let outcome = crate::storage::with_storage(crate::storage::FirmwareStorage::read_crash).await;
+    match outcome {
+        Some(Ok(Some(text))) => write_text(socket, 200, &text).await,
+        Some(Ok(None)) => write_text(socket, 404, "no crash recorded\n").await,
+        Some(Err(e)) => {
+            defmt::warn!("http: GET /crash read failed ({})", defmt::Debug2Format(&e));
+            write_text(socket, 500, "crash log read failed\n").await
+        }
+        None => write_text(socket, 503, "no SD card mounted\n").await,
+    }
+}
+
+/// `POST /crash/clear` — empty body. Deletes `/sd/CRASH.LOG` so
+/// subsequent `GET /crash` calls return 404. Idempotent: clearing
+/// when no log exists returns 204.
+async fn handle_post_crash_clear(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
+    let outcome = crate::storage::with_storage(crate::storage::FirmwareStorage::delete_crash).await;
+    match outcome {
+        Some(Ok(())) => write_no_content(socket).await,
+        Some(Err(e)) => {
+            defmt::warn!(
+                "http: POST /crash/clear failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            write_text(socket, 500, "crash log delete failed\n").await
+        }
+        None => write_text(socket, 503, "no SD card mounted\n").await,
+    }
 }
 
 /// `POST /sleep` — empty body. Drops eyes shut, head limp, LED ring

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -148,6 +148,21 @@ const MAX_BONDS_BYTES: u32 = 1024;
 /// 153 600 bytes; convertible with a one-line numpy reshape.
 const CAPTURE_FILE: &str = "CAPTURE.565";
 
+/// Filename for the most recent crash log. Written by the boot path
+/// when the persistent latch in RTC fast RAM contains a valid panic
+/// snapshot. Single-slot — each new crash overwrites the prior log,
+/// matching the operator workflow ("device rebooted unexpectedly,
+/// what happened?"); a multi-entry archive would force log rotation
+/// and partition planning that's out of scope at v1.
+const CRASH_FILE: &str = "CRASH.LOG";
+
+/// Cap on the crash log we'll read back. The renderer in
+/// [`crate::crash::render_log_entry`] currently emits ~400 bytes for
+/// a max-truncated panic (4 fields × ~MSG/FILE caps). 2 KiB leaves
+/// headroom for future fields (boot count, reset reason variants,
+/// firmware version) without unbounded SRAM growth at read time.
+const MAX_CRASH_BYTES: u32 = 2048;
+
 /// Storage / FAT errors. Logged via `defmt::Format` at the firmware
 /// boundary; the operator triages from the boot log.
 #[derive(Debug, defmt::Format)]
@@ -386,6 +401,69 @@ where
         self.write_file(CAPTURE_FILE, frame)
     }
 
+    /// Truncate-write a rendered crash-log entry into
+    /// `/sd/CRASH.LOG`. No staging dance — the operator workflow is
+    /// "boot saw a previous crash, write the latest"; partial
+    /// writes get overwritten by the next reboot or the operator
+    /// clearing it via `POST /crash/clear`.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying SPI / FAT failure.
+    pub fn write_crash(&mut self, rendered: &str) -> Result<(), StorageError> {
+        self.write_file(CRASH_FILE, rendered.as_bytes())
+    }
+
+    /// Read `/sd/CRASH.LOG` as raw UTF-8 text. Returns `Ok(None)` if
+    /// the file is absent — that's the steady-state "no recent
+    /// crash" condition, not an error.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Read`] on a partial / failed read,
+    /// [`StorageError::TooLarge`] if the file exceeds
+    /// [`MAX_CRASH_BYTES`], [`StorageError::NotUtf8`] if the bytes
+    /// don't decode as UTF-8.
+    pub fn read_crash(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(file) = root.open_file_in_dir(CRASH_FILE, Mode::ReadOnly) else {
+            return Ok(None);
+        };
+        let len = file.length();
+        if len > MAX_CRASH_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = len as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+        let text = alloc::string::String::from_utf8(buf).map_err(|_| StorageError::NotUtf8)?;
+        Ok(Some(text))
+    }
+
+    /// Delete `/sd/CRASH.LOG`. `Ok(())` if the file is absent
+    /// (idempotent). Used by `POST /crash/clear`.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying SPI / FAT failure
+    /// other than the file-not-found case.
+    pub fn delete_crash(&mut self) -> Result<(), StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        match root.delete_file_in_dir(CRASH_FILE) {
+            Ok(()) | Err(embedded_sdmmc::Error::NotFound) => Ok(()),
+            Err(_) => Err(StorageError::Write),
+        }
+    }
+
     /// Read the most recent camera capture from `/sd/CAPTURE.565`.
     /// Returns `Ok(None)` if no capture exists yet — that's the
     /// before-first-capture state, not an error.
@@ -452,6 +530,7 @@ where
             BONDS_FILE,
             BONDS_STAGING_FILE,
             CAPTURE_FILE,
+            CRASH_FILE,
         ] {
             // FileNotFound is the expected case for any file the
             // operator never wrote — keep going. Anything else is a

--- a/crates/stackchan-net/src/crash_latch.rs
+++ b/crates/stackchan-net/src/crash_latch.rs
@@ -1,0 +1,387 @@
+//! Encoder / decoder for the firmware's persistent crash latch.
+//!
+//! The firmware captures panic info into a fixed-size byte buffer
+//! placed in RTC fast RAM (preserved across `software_reset`,
+//! watchdog timeouts, and the bootloader handoff via
+//! `#[esp_hal::ram(unstable(rtc_fast, persistent))]`). On the next
+//! boot, the same buffer is decoded back into a [`CrashSnapshot`]
+//! and saved to `/sd/CRASH.LOG`.
+//!
+//! This module owns the byte-level layout and the magic / checksum
+//! validation. The firmware crate is `xtensa-esp32s3-none-elf`-only,
+//! so the actual `static mut [u8; LATCH_SIZE]` and the
+//! `#[panic_handler]` glue live there. Putting the codec here keeps
+//! it host-testable — the panic / boot pair is non-trivial enough
+//! that a layout typo would silently lose every crash report.
+//!
+//! ## Layout
+//!
+//! ```text
+//! offset  size  field
+//!  0       4    magic       `u32` little-endian, [`MAGIC`]
+//!  4       4    line        `u32` panic location line number
+//!  8       2    msg_len     `u16` little-endian, bytes of `message` to read
+//! 10       2    file_len    `u16` little-endian, bytes of `file` to read
+//! 12     256    message     `[u8; 256]` truncated panic message
+//! 268    112    file        `[u8; 112]` truncated source file path
+//! 380      4    checksum    `u32` sum-of-bytes XOR over [0, 380)
+//! ```
+
+use core::fmt::Write as _;
+
+/// Magic header — the bit pattern that distinguishes a real crash
+/// snapshot from random RTC RAM contents on first boot. Spelled
+/// `0xC1A5_DEAD` (`CrAS Dead`) so a hex dump of the latch is
+/// self-describing.
+pub const MAGIC: u32 = 0xC1A5_DEAD;
+
+/// Maximum panic-message bytes captured. Longer messages are
+/// silently truncated.
+pub const MSG_CAP: usize = 256;
+
+/// Maximum source-file-path bytes captured. Same truncation policy
+/// as [`MSG_CAP`].
+pub const FILE_CAP: usize = 112;
+
+/// Total latch size in bytes. Layout described in the module-level
+/// docs.
+pub const LATCH_SIZE: usize = 384;
+
+/// Byte offset of the magic header within the latch buffer.
+const MAGIC_OFFSET: usize = 0;
+/// Byte offset of the panic-location line number.
+const LINE_OFFSET: usize = 4;
+/// Byte offset of the message-length word (little-endian `u16`).
+const MSG_LEN_OFFSET: usize = 8;
+/// Byte offset of the file-length word (little-endian `u16`).
+const FILE_LEN_OFFSET: usize = 10;
+/// Byte offset where the message content begins.
+const MSG_OFFSET: usize = 12;
+/// Byte offset where the source-file-path content begins.
+const FILE_OFFSET: usize = MSG_OFFSET + MSG_CAP;
+/// Byte offset of the trailing checksum word.
+const CHECKSUM_OFFSET: usize = FILE_OFFSET + FILE_CAP;
+
+const _: () = {
+    assert!(CHECKSUM_OFFSET + 4 == LATCH_SIZE);
+};
+
+/// Decoded crash snapshot returned from [`decode`]. Owns its strings
+/// via fixed-size buffers so the consumer doesn't need to allocate.
+#[derive(Debug, Clone, Copy)]
+pub struct CrashSnapshot {
+    /// Panic message bytes (UTF-8 best-effort; truncated to fit
+    /// [`MSG_CAP`]).
+    pub message: [u8; MSG_CAP],
+    /// Number of valid bytes in [`Self::message`].
+    pub message_len: usize,
+    /// Source file path bytes (UTF-8 best-effort; truncated to fit
+    /// [`FILE_CAP`]).
+    pub file: [u8; FILE_CAP],
+    /// Number of valid bytes in [`Self::file`].
+    pub file_len: usize,
+    /// Source line number, or `0` if `PanicInfo::location()` was
+    /// `None` at the time of the panic.
+    pub line: u32,
+}
+
+impl CrashSnapshot {
+    /// Borrow the panic message as a string slice. Returns the
+    /// canonical placeholder when the bytes don't decode as UTF-8 —
+    /// callers can still surface the bytes via the raw `message`
+    /// field if they need to.
+    #[must_use]
+    pub fn message_str(&self) -> &str {
+        core::str::from_utf8(&self.message[..self.message_len]).unwrap_or("<non-utf8>")
+    }
+
+    /// Borrow the source file path as a string slice; same fallback
+    /// as [`Self::message_str`].
+    #[must_use]
+    pub fn file_str(&self) -> &str {
+        core::str::from_utf8(&self.file[..self.file_len]).unwrap_or("<non-utf8>")
+    }
+}
+
+/// Write the message + location + checksum into `latch`. Truncates
+/// silently if `message` or `file` exceed [`MSG_CAP`] / [`FILE_CAP`].
+///
+/// Used by the firmware's `#[panic_handler]`. Splitting the
+/// formatter from the byte writer is intentional — the panic
+/// handler renders `core::fmt::Arguments` into a stack buffer via
+/// [`format_into`], then calls this with the resulting slice.
+pub fn encode(latch: &mut [u8; LATCH_SIZE], message: &[u8], file: &[u8], line: u32) {
+    latch[MAGIC_OFFSET..MAGIC_OFFSET + 4].copy_from_slice(&MAGIC.to_le_bytes());
+    latch[LINE_OFFSET..LINE_OFFSET + 4].copy_from_slice(&line.to_le_bytes());
+
+    let msg_n = message.len().min(MSG_CAP);
+    let file_n = file.len().min(FILE_CAP);
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "msg_n / file_n are clamped to MSG_CAP / FILE_CAP, both <= u16::MAX"
+    )]
+    {
+        latch[MSG_LEN_OFFSET..MSG_LEN_OFFSET + 2].copy_from_slice(&(msg_n as u16).to_le_bytes());
+        latch[FILE_LEN_OFFSET..FILE_LEN_OFFSET + 2].copy_from_slice(&(file_n as u16).to_le_bytes());
+    }
+
+    latch[MSG_OFFSET..MSG_OFFSET + MSG_CAP].fill(0);
+    latch[MSG_OFFSET..MSG_OFFSET + msg_n].copy_from_slice(&message[..msg_n]);
+
+    latch[FILE_OFFSET..FILE_OFFSET + FILE_CAP].fill(0);
+    latch[FILE_OFFSET..FILE_OFFSET + file_n].copy_from_slice(&file[..file_n]);
+
+    let cs = compute_checksum(&latch[..CHECKSUM_OFFSET]);
+    latch[CHECKSUM_OFFSET..CHECKSUM_OFFSET + 4].copy_from_slice(&cs.to_le_bytes());
+}
+
+/// Validate magic + checksum and decode `latch` into a snapshot.
+///
+/// Returns `None` if the magic doesn't match (cold boot, RTC RAM
+/// uninitialised) or if the checksum doesn't validate (partial
+/// corruption between panic and read-back). The caller is
+/// responsible for clearing the magic after a successful read so
+/// the same crash isn't replayed on the next boot.
+#[must_use]
+pub fn decode(latch: &[u8; LATCH_SIZE]) -> Option<CrashSnapshot> {
+    let mut magic_bytes = [0u8; 4];
+    magic_bytes.copy_from_slice(&latch[MAGIC_OFFSET..MAGIC_OFFSET + 4]);
+    if u32::from_le_bytes(magic_bytes) != MAGIC {
+        return None;
+    }
+
+    let mut cs_bytes = [0u8; 4];
+    cs_bytes.copy_from_slice(&latch[CHECKSUM_OFFSET..CHECKSUM_OFFSET + 4]);
+    if u32::from_le_bytes(cs_bytes) != compute_checksum(&latch[..CHECKSUM_OFFSET]) {
+        return None;
+    }
+
+    let mut msg_len_bytes = [0u8; 2];
+    msg_len_bytes.copy_from_slice(&latch[MSG_LEN_OFFSET..MSG_LEN_OFFSET + 2]);
+    let msg_len = (u16::from_le_bytes(msg_len_bytes) as usize).min(MSG_CAP);
+    let mut file_len_bytes = [0u8; 2];
+    file_len_bytes.copy_from_slice(&latch[FILE_LEN_OFFSET..FILE_LEN_OFFSET + 2]);
+    let file_len = (u16::from_le_bytes(file_len_bytes) as usize).min(FILE_CAP);
+    let mut line_bytes = [0u8; 4];
+    line_bytes.copy_from_slice(&latch[LINE_OFFSET..LINE_OFFSET + 4]);
+
+    let mut message = [0u8; MSG_CAP];
+    message.copy_from_slice(&latch[MSG_OFFSET..MSG_OFFSET + MSG_CAP]);
+    let mut file = [0u8; FILE_CAP];
+    file.copy_from_slice(&latch[FILE_OFFSET..FILE_OFFSET + FILE_CAP]);
+
+    Some(CrashSnapshot {
+        message,
+        message_len: msg_len,
+        file,
+        file_len,
+        line: u32::from_le_bytes(line_bytes),
+    })
+}
+
+/// Zero out the magic so the next [`decode`] call returns `None`.
+/// Used after a successful read to avoid replaying the same crash
+/// on every subsequent boot.
+pub fn clear_magic(latch: &mut [u8; LATCH_SIZE]) {
+    latch[MAGIC_OFFSET..MAGIC_OFFSET + 4].copy_from_slice(&[0u8; 4]);
+}
+
+/// Sum-of-bytes XOR'd into a `u32` with byte-position rotation.
+///
+/// Strong enough to flag single-byte corruption — any flipped bit
+/// shifts the rotated XOR away from the stored value. Not a
+/// cryptographic hash; the expected failure mode is "RTC RAM kept
+/// the magic across reset but the body got partially overwritten by
+/// the bootloader scratchpad."
+#[must_use]
+pub fn compute_checksum(bytes: &[u8]) -> u32 {
+    let mut acc: u32 = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "the rotation amount is `i % 32`; the cast to u32 \
+                      cannot lose information"
+        )]
+        let shifted = u32::from(b).rotate_left((i % 32) as u32);
+        acc ^= shifted;
+    }
+    acc
+}
+
+/// Render `args` into `buf`, silently truncating past the buffer's
+/// capacity. Returns the number of bytes actually written.
+///
+/// The firmware's panic handler uses this to flatten
+/// `PanicInfo::message()` into a stack buffer suitable for
+/// [`encode`] without allocating — `format!` requires a working
+/// allocator, which is exactly what may have just panicked.
+pub fn format_into(buf: &mut [u8], args: core::fmt::Arguments<'_>) -> usize {
+    let mut sink = Truncate { buf, len: 0 };
+    let _ = sink.write_fmt(args);
+    sink.len
+}
+
+/// `core::fmt::Write` sink that captures bytes into a fixed
+/// caller-owned slice, silently dropping anything past the slice's
+/// capacity. Backs [`format_into`].
+struct Truncate<'a> {
+    /// Output slice; bytes are written from the start.
+    buf: &'a mut [u8],
+    /// Number of bytes written so far. Read by [`format_into`] to
+    /// return the captured length.
+    len: usize,
+}
+
+impl core::fmt::Write for Truncate<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let cap = self.buf.len();
+        for &b in s.as_bytes() {
+            if self.len < cap {
+                self.buf[self.len] = b;
+                self.len += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::missing_docs_in_private_items,
+    reason = "test-only: fixtures are constructed in-line and assertions \
+              guarantee the unwrap branch is unreachable for valid inputs"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_short_message() {
+        let mut buf = [0u8; LATCH_SIZE];
+        encode(&mut buf, b"boom", b"src/main.rs", 42);
+        let snap = decode(&buf).expect("valid latch decodes");
+        assert_eq!(snap.message_str(), "boom");
+        assert_eq!(snap.file_str(), "src/main.rs");
+        assert_eq!(snap.line, 42);
+    }
+
+    #[test]
+    fn round_trip_no_location() {
+        // A panic with `info.location() == None` writes line=0 and
+        // file_len=0; decode returns those values verbatim so the
+        // SD-side logger can render `<unknown>:0` deliberately.
+        let mut buf = [0u8; LATCH_SIZE];
+        encode(&mut buf, b"oops", b"", 0);
+        let snap = decode(&buf).expect("valid latch decodes");
+        assert_eq!(snap.message_str(), "oops");
+        assert_eq!(snap.file_str(), "");
+        assert_eq!(snap.line, 0);
+    }
+
+    #[test]
+    fn empty_buffer_is_rejected() {
+        let buf = [0u8; LATCH_SIZE];
+        assert!(decode(&buf).is_none());
+    }
+
+    #[test]
+    fn random_bytes_with_wrong_magic_rejected() {
+        let mut buf = [0u8; LATCH_SIZE];
+        for (i, slot) in buf.iter_mut().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                *slot = (i & 0xFF) as u8;
+            }
+        }
+        // Even though the body has data, the magic header almost
+        // certainly doesn't match — guards against treating
+        // pre-init RAM as a valid crash snapshot.
+        assert!(decode(&buf).is_none());
+    }
+
+    #[test]
+    fn corrupt_body_after_valid_magic_rejected() {
+        let mut buf = [0u8; LATCH_SIZE];
+        encode(&mut buf, b"boom", b"src/main.rs", 42);
+        buf[MSG_OFFSET] ^= 0x01;
+        assert!(decode(&buf).is_none());
+    }
+
+    #[test]
+    fn message_longer_than_cap_is_silently_truncated() {
+        let mut buf = [0u8; LATCH_SIZE];
+        let long = vec![b'x'; MSG_CAP * 2];
+        encode(&mut buf, &long, b"src/main.rs", 1);
+        let snap = decode(&buf).expect("valid latch decodes");
+        assert_eq!(snap.message_len, MSG_CAP);
+        assert!(snap.message_str().bytes().all(|b| b == b'x'));
+    }
+
+    #[test]
+    fn file_longer_than_cap_is_silently_truncated() {
+        let mut buf = [0u8; LATCH_SIZE];
+        let long = vec![b'p'; FILE_CAP * 2];
+        encode(&mut buf, b"boom", &long, 1);
+        let snap = decode(&buf).expect("valid latch decodes");
+        assert_eq!(snap.file_len, FILE_CAP);
+    }
+
+    #[test]
+    fn format_into_truncates_silently() {
+        let mut buf = [0u8; 8];
+        let n = format_into(&mut buf, format_args!("hello world!"));
+        assert_eq!(n, 8);
+        assert_eq!(&buf, b"hello wo");
+    }
+
+    #[test]
+    fn format_into_handles_full_args() {
+        let mut buf = [0u8; 64];
+        let n = format_into(&mut buf, format_args!("panic at {}:{}", "src/main.rs", 42));
+        assert_eq!(&buf[..n], b"panic at src/main.rs:42");
+    }
+
+    #[test]
+    fn checksum_changes_when_any_byte_changes() {
+        let mut buf = [0u8; LATCH_SIZE];
+        encode(&mut buf, b"boom", b"src/main.rs", 42);
+        let original_cs = compute_checksum(&buf[..CHECKSUM_OFFSET]);
+        for offset in [
+            MSG_OFFSET,
+            MSG_OFFSET + 1,
+            FILE_OFFSET,
+            LINE_OFFSET,
+            MAGIC_OFFSET,
+        ] {
+            let saved = buf[offset];
+            buf[offset] ^= 0x01;
+            assert_ne!(
+                compute_checksum(&buf[..CHECKSUM_OFFSET]),
+                original_cs,
+                "checksum collision when flipping byte at offset {offset}",
+            );
+            buf[offset] = saved;
+        }
+    }
+
+    #[test]
+    fn clear_magic_makes_subsequent_decode_return_none() {
+        let mut buf = [0u8; LATCH_SIZE];
+        encode(&mut buf, b"boom", b"src/main.rs", 42);
+        assert!(decode(&buf).is_some());
+        clear_magic(&mut buf);
+        assert!(decode(&buf).is_none());
+    }
+
+    #[test]
+    fn re_encode_after_clear_round_trips() {
+        let mut buf = [0u8; LATCH_SIZE];
+        encode(&mut buf, b"first", b"a.rs", 1);
+        clear_magic(&mut buf);
+        encode(&mut buf, b"second", b"b.rs", 2);
+        let snap = decode(&buf).expect("valid latch decodes");
+        assert_eq!(snap.message_str(), "second");
+        assert_eq!(snap.file_str(), "b.rs");
+        assert_eq!(snap.line, 2);
+    }
+}

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -52,6 +52,7 @@ pub mod bare;
 pub mod bare_json;
 pub mod ble_command;
 pub mod config;
+pub mod crash_latch;
 pub mod dance;
 pub mod error;
 pub mod esp_now;

--- a/docs/http.md
+++ b/docs/http.md
@@ -29,6 +29,8 @@ beats pulling a full HTTP framework into the firmware target.
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
 | GET    | `/head/offsets`  | Current yaw + tilt zero-point offsets               |
 | POST   | `/head/offsets`  | Update yaw + tilt zero-point offsets (runtime-only) |
+| GET    | `/crash`         | Most recent panic log (404 if none recorded)        |
+| POST   | `/crash/clear`   | Delete `/sd/CRASH.LOG` (idempotent)                 |
 | POST   | `/emotion`       | Set affect with hold timer                          |
 | POST   | `/look-at`       | Aim head + eyes with hold timer                     |
 | POST   | `/reset`         | Clear active emotion / look-at hold                 |

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { onCleanup, onMount } from "solid-js";
 import { connectStream } from "./store";
 import { ConnStatus } from "./components/ConnStatus";
+import { CrashBanner } from "./components/CrashBanner";
 import { State } from "./components/State";
 import { Emotion } from "./components/Emotion";
 import { Listen } from "./components/Listen";
@@ -51,6 +52,7 @@ export function App() {
           <h1>Stack-chan</h1>
           <ConnStatus />
         </header>
+        <CrashBanner />
         <State />
         <Emotion />
         <Mood />

--- a/web/src/components/CrashBanner.tsx
+++ b/web/src/components/CrashBanner.tsx
@@ -1,0 +1,76 @@
+import { Show, createSignal, onMount } from "solid-js";
+import { authedFetch } from "../auth";
+import { showToast } from "../store";
+
+// Top-of-dashboard banner that surfaces the firmware's most recent
+// panic log. Backed by the persistent crash latch in RTC fast RAM
+// (firmware/src/crash.rs) → /sd/CRASH.LOG → GET /crash.
+//
+// Lifecycle:
+// - Mount: GET /crash. 200 → render banner with the log body.
+//   404/503 → silent (no recent crash, or no SD).
+// - Operator clicks Dismiss → POST /crash/clear, then 204 → hide.
+export function CrashBanner() {
+  const [body, setBody] = createSignal<string | null>(null);
+
+  const load = async () => {
+    try {
+      const res = await fetch("/crash");
+      if (res.status === 200) {
+        const text = await res.text();
+        setBody(text);
+      } else {
+        setBody(null);
+      }
+    } catch {
+      // Best-effort surface; absent /crash isn't a UI error.
+      setBody(null);
+    }
+  };
+
+  const dismiss = async () => {
+    try {
+      const res = await authedFetch("/crash/clear", { method: "POST" });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${text || res.statusText}`);
+      }
+      setBody(null);
+      showToast("crash log cleared");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  onMount(() => void load());
+
+  return (
+    <Show when={body()}>
+      <section
+        style={{
+          "border-left": "4px solid #d33",
+          "background-color": "rgba(221, 51, 51, 0.08)",
+          padding: "8px 12px",
+          "margin-bottom": "12px",
+        }}
+      >
+        <div style={{ display: "flex", "justify-content": "space-between", gap: "8px" }}>
+          <strong>Previous boot crashed</strong>
+          <button type="button" onClick={() => void dismiss()}>
+            Dismiss
+          </button>
+        </div>
+        <pre
+          style={{
+            "white-space": "pre-wrap",
+            "font-size": "0.85em",
+            "margin-top": "6px",
+            "margin-bottom": "0",
+          }}
+        >
+          {body()}
+        </pre>
+      </section>
+    </Show>
+  );
+}


### PR DESCRIPTION
## Summary

The default `no_std` panic handler was "log over defmt and `loop {}`" — which strands a deployed device with no record once the defmt console isn't attached. This PR replaces it with a panic → persistent latch → reset → SD save → operator-fetchable log loop.

### Architecture

- Persistent latch lives in RTC fast RAM via `#[esp_hal::ram(unstable(rtc_fast, persistent))]`. The `persistent` mode skips the zero-init that runs on every boot, so the buffer survives `software_reset`, watchdog timeouts, and the bootloader handoff.
- Encode / decode + checksum factored out into `stackchan-net::crash_latch` so they're host-testable. The firmware crate is xtensa-only; without the split, a layout typo would silently lose every crash report.
- Panic handler renders `PanicInfo` into a fixed-size stack buffer (no allocator — that's exactly what may have just panicked) and writes the latch under a re-entrancy guard, then triggers `software_reset()`.
- Boot path reads the latch right after SD mount, copies to `/sd/CRASH.LOG`, and clears the magic so the same crash isn't replayed on every subsequent boot.

### HTTP surface

- `GET /crash` — returns the rendered log (`404` if none, `503` if no SD).
- `POST /crash/clear` — deletes `/sd/CRASH.LOG` (idempotent, auth-gated).

### Dashboard

- `CrashBanner.tsx` fetches `/crash` on mount; if present, shows a red top-of-page banner with the panic body + Dismiss button.

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just ci` — adds cargo-deny + workspace doc-lint
- [x] `just clippy-firmware` — strict clippy on `xtensa-esp32s3-none-elf`
- [x] **12 host tests** in `stackchan-net::crash_latch::tests` cover encode round-trip, missing-location case, empty-buffer rejection, random-bytes-with-wrong-magic rejection, checksum-sensitivity (every byte position flips it), MSG_CAP / FILE_CAP truncation, format_into truncation, clear-magic, re-encode after clear.
- [ ] On-device verification via `just fmr`:
  - [ ] Inject `panic!("test crash {}", 42)` somewhere late-init, flash → device should reset → next boot logs `crash recovery: previous boot panicked at <path>:<line>` and writes `/sd/CRASH.LOG`
  - [ ] `curl http://stackchan.local/crash` returns the rendered log
  - [ ] Open dashboard → red banner appears with panic body
  - [ ] Click Dismiss → `POST /crash/clear` succeeds, banner disappears, subsequent `GET /crash` returns 404
  - [ ] Reboot without panic → no banner, no SD log
  - [ ] Force a watchdog reset (long-block in a task) → reset happens but no panic latch, so no crash log (correct — only `panic!()` writes the latch)

## Notes

- The latch survives across multiple boots, so if SD mount fails on the first reboot, the snapshot persists for the next boot's attempt — only `consume_latch()` (called inside the SD-mounted branch) clears the magic.
- Schema deliberately includes a `reset_reason` field placeholder; for v1 it's hardcoded to `"panic"` since that's the only path that writes the latch. A follow-up could distinguish panic / WDT / brownout via `esp_hal::system::reset_reason()`.
- `unsafe` blocks gated behind a per-module `#![allow(unsafe_code)]` with a safety argument in the module comment. Matches the existing `sd_spi.rs` convention.