### PR TITLE
fix(firmware): WIFI_LINK_WATCH cold-boot race — seed via get() then loop on changed()

### DIFF
--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -85,21 +85,27 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
         park_forever().await;
     }
 
-    let mut rx_meta = [PacketMetadata::EMPTY; 4];
-    let mut rx_buf = [0u8; MAX_DNS_BYTES];
-    let mut tx_meta = [PacketMetadata::EMPTY; 4];
-    let mut tx_buf = [0u8; MAX_DNS_BYTES];
-
+    // Acquire the receiver before any await; `Watch::receiver()`
+    // initialises the receiver's generation counter to the watch's
+    // *current* generation, so a publish that lands between task
+    // spawn and this line would be invisible to a subsequent
+    // `.changed().await`. The first read uses `.get()` instead,
+    // which returns the stored value (or waits for the first
+    // publish) regardless of when this receiver was created.
     let Some(mut link) = WIFI_LINK_WATCH.receiver() else {
         defmt::error!("mdns: WIFI_LINK_WATCH receiver slot exhausted; parking");
         park_forever().await;
     };
 
+    let mut rx_meta = [PacketMetadata::EMPTY; 4];
+    let mut rx_buf = [0u8; MAX_DNS_BYTES];
+    let mut tx_meta = [PacketMetadata::EMPTY; 4];
+    let mut tx_buf = [0u8; MAX_DNS_BYTES];
+
+    let mut state = link.get().await;
     loop {
-        // Wait for a Connected link before binding the socket.
-        // embassy-net needs the IPv4 address to encode A-record
-        // answers, and join_multicast_group needs the link up.
-        if !matches!(link.changed().await, WifiLinkState::Connected) {
+        if !matches!(state, WifiLinkState::Connected) {
+            state = link.changed().await;
             continue;
         }
 
@@ -108,6 +114,7 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
         if let Err(e) = socket.bind(MDNS_PORT) {
             defmt::warn!("mdns: bind failed ({:?})", e);
             Timer::after(Duration::from_secs(5)).await;
+            state = link.changed().await;
             continue;
         }
         if let Err(e) = stack.join_multicast_group(MDNS_MULTICAST) {
@@ -117,6 +124,7 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
             // back to waiting for the next link transition rather
             // than busy-looping.
             Timer::after(Duration::from_secs(60)).await;
+            state = link.changed().await;
             continue;
         }
 
@@ -124,6 +132,7 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
             defmt::warn!("mdns: no IPv4 lease yet; will retry");
             socket.close();
             Timer::after(Duration::from_secs(2)).await;
+            state = link.changed().await;
             continue;
         };
 
@@ -149,6 +158,9 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
 
         let _ = stack.leave_multicast_group(MDNS_MULTICAST);
         socket.close();
+        // serve_loop returned (link dropped or socket failure) —
+        // wait for the next state transition before re-binding.
+        state = link.changed().await;
     }
 }
 

--- a/crates/stackchan-firmware/src/net/sntp.rs
+++ b/crates/stackchan-firmware/src/net/sntp.rs
@@ -51,6 +51,18 @@ pub async fn sntp_task(stack: Stack<'static>, rtc_bus: SharedI2cBus, servers: Ve
         park_forever().await;
     }
 
+    // Acquire the receiver before any await. `Watch::receiver()`
+    // initialises the receiver's generation counter to the watch's
+    // *current* generation; if `wifi_task` ever publishes between
+    // task spawn and this line, that publish becomes invisible to a
+    // subsequent `.changed().await`. The first read uses `.get()`
+    // which returns the stored value (or waits for the first
+    // publish) regardless of when this receiver was created.
+    let Some(mut link) = WIFI_LINK_WATCH.receiver() else {
+        defmt::error!("sntp: WIFI_LINK_WATCH receiver slot exhausted; parking");
+        park_forever().await;
+    };
+
     let mut rx_meta = [PacketMetadata::EMPTY; 4];
     let mut rx_buf = [0u8; 256];
     let mut tx_meta = [PacketMetadata::EMPTY; 4];
@@ -65,40 +77,40 @@ pub async fn sntp_task(stack: Stack<'static>, rtc_bus: SharedI2cBus, servers: Ve
         );
     }
 
-    let Some(mut link) = WIFI_LINK_WATCH.receiver() else {
-        defmt::error!("sntp: WIFI_LINK_WATCH receiver slot exhausted; parking");
-        park_forever().await;
-    };
-
+    // Seed with the current value (or wait for the first publish);
+    // every subsequent iteration waits on `.changed()` for the next
+    // transition, matching the original "sync once per link cycle"
+    // design.
+    let mut state = link.get().await;
     loop {
-        // Wait for an active link before each sync attempt. `changed()`
-        // returns the next published value (including the first one if
-        // wifi_task already published before this task spawned), so we
-        // still re-check the variant before dispatching.
-        if !matches!(link.changed().await, WifiLinkState::Connected) {
-            continue;
-        }
-        // Give DHCP a moment to settle once the link is up. Without an
-        // assigned address the UDP socket can't route the request.
-        Timer::after(Duration::from_secs(1)).await;
+        if matches!(state, WifiLinkState::Connected) {
+            // Give DHCP a moment to settle once the link is up.
+            // Without an assigned address the UDP socket can't
+            // route the request.
+            Timer::after(Duration::from_secs(1)).await;
 
-        let mut socket =
-            UdpSocket::new(stack, &mut rx_meta, &mut rx_buf, &mut tx_meta, &mut tx_buf);
-        if let Err(e) = socket.bind(0) {
-            defmt::warn!("sntp: bind failed ({:?})", e);
-            sleep_until_resync().await;
-            continue;
+            let mut socket =
+                UdpSocket::new(stack, &mut rx_meta, &mut rx_buf, &mut tx_meta, &mut tx_buf);
+            match socket.bind(0) {
+                Ok(()) => {
+                    let synced = try_sync_once(&stack, &socket, &servers, &mut rtc).await;
+                    socket.close();
+                    if synced {
+                        sleep_until_resync().await;
+                    } else {
+                        // No server answered — back off briefly
+                        // before the next attempt rather than
+                        // busy-looping the link signal.
+                        Timer::after(Duration::from_secs(30)).await;
+                    }
+                }
+                Err(e) => {
+                    defmt::warn!("sntp: bind failed ({:?})", e);
+                    sleep_until_resync().await;
+                }
+            }
         }
-
-        let synced = try_sync_once(&stack, &socket, &servers, &mut rtc).await;
-        socket.close();
-        if synced {
-            sleep_until_resync().await;
-        } else {
-            // No server answered — back off briefly before the next
-            // attempt rather than busy-looping the link signal.
-            Timer::after(Duration::from_secs(30)).await;
-        }
+        state = link.changed().await;
     }
 }
 


### PR DESCRIPTION
## Summary

Greptile P1 on #294. The `Watch::receiver()` → `loop-on-changed()` pattern that fix introduced has the same shape of bug it was supposed to *solve*, just subtler.

`Watch::receiver()` initialises the receiver's generation counter to the watch's **current** generation, so `.changed()` only fires on sends that happen *after* the receiver was created. It does NOT return values already stored.

### Concrete failure mode

- `main.rs:1191` spawns `wifi_task` *before* `main.rs:1209` spawns `sntp_task`
- `wifi_task` body hits a synchronous `.signal(Disconnected)` at line 110 before its first `await`
- By the time `sntp_task` runs and calls `.receiver()`, the watch is already at gen 1
- `sntp_task`'s first `.changed().await` blocks until the *next* transition — so SNTP silently skips its first sync window

Same hazard applies to `mdns_task`. The doc comment in #294 claiming "first one if wifi_task already published" was wrong about `Watch` semantics — it described `get()` behaviour, not `changed()`.

### Fix

Verified `Receiver::poll_get` source at `embassy-sync-0.7.2/src/watch.rs`: returns `Poll::Ready(data.clone())` if any value is stored, regardless of the receiver's `id`, and marks it seen.

- Move `.receiver()` to the top of each task, before any await.
- Seed the loop with `let mut state = link.get().await` — returns the currently-stored value regardless of the receiver's generation.
- Loop body explicitly re-fetches `state = link.changed().await` at every continuation point. Slightly more verbose but the control flow is explicit about when we wait for the next transition.

Both `sntp_task` and `mdns_task` updated identically.

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just clippy-firmware` — strict clippy on `xtensa-esp32s3-none-elf`
- [ ] On-device verification via `just fmr`:
  - [ ] Boot with Wi-Fi configured — observe **both** `sntp:` and `mdns:` log lines fire after the first connect (no spawn-order dependence)
  - [ ] Reboot with Wi-Fi already up — both should still trigger their post-Connected branches via `.get()`
  - [ ] Reconnect cycle (drop AP / restore) — confirm both tasks re-trigger their work
  - [ ] `dig @stackchan.local stackchan.local A` returns the lease IP — confirms mDNS responder is alive on first boot
  - [ ] System time matches host within seconds within ~10s of boot — confirms SNTP synced on first boot