### PR TITLE
chore(crash-recovery): address greptile findings on #297

### DIFF
--- a/crates/stackchan-firmware/src/crash.rs
+++ b/crates/stackchan-firmware/src/crash.rs
@@ -145,6 +145,11 @@ pub fn consume_latch() -> Option<CrashSnapshot> {
 /// Operators read this directly via `GET /crash` or by mounting the
 /// SD card. Future versions may add fields (boot count, reset
 /// reason, firmware version) — readers tolerate unknown keys.
+///
+/// Embedded newlines in the panic message are escaped to `\n` so
+/// each key occupies exactly one line — otherwise a `panic!("a\nb")`
+/// would split the `message=` value across two lines and break any
+/// downstream parser that splits on `\n`.
 #[must_use]
 pub fn render_log_entry(snap: &CrashSnapshot, reset_reason: &str) -> alloc::string::String {
     use core::fmt::Write as _;
@@ -152,6 +157,7 @@ pub fn render_log_entry(snap: &CrashSnapshot, reset_reason: &str) -> alloc::stri
     let _ = writeln!(out, "reset_reason={reset_reason}");
     let _ = writeln!(out, "file={}", snap.file_str());
     let _ = writeln!(out, "line={}", snap.line);
-    let _ = writeln!(out, "message={}", snap.message_str());
+    let escaped = snap.message_str().replace('\n', r"\n");
+    let _ = writeln!(out, "message={escaped}");
     out
 }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -119,10 +119,10 @@ static _APP_DESC_ANCHOR: &esp_bootloader_esp_idf::EspAppDesc = &ESP_APP_DESC;
 /// and writes it to `/sd/CRASH.LOG` for post-mortem fetch via
 /// `GET /crash`.
 ///
-/// `loop {}` is the fallback if the latch write returns (it
-/// shouldn't — `record_panic` is `fn () -> ()`, but the safety
-/// guard against re-entrant panics may early-return without
-/// resetting). The watchdog will catch us either way.
+/// `software_reset()` is the diverging terminator — it returns `!`,
+/// so the compiler sees a complete `!` path. The watchdog fires as
+/// a belt-and-suspenders backstop if the reset peripheral itself
+/// were to stall.
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     defmt::error!("panic: {}", defmt::Display2Format(info));
@@ -1117,7 +1117,21 @@ async fn main(spawner: Spawner) -> ! {
                     snap.line,
                 );
                 let log = stackchan_firmware::crash::render_log_entry(&snap, "panic");
-                let _ = storage::with_storage(|s| s.write_crash(&log)).await;
+                // Match the SD-write outcome so a failure logs the
+                // panic body to defmt; without this the message
+                // disappears across the reboot if SD write fails.
+                match storage::with_storage(|s| s.write_crash(&log)).await {
+                    Some(Ok(())) => {}
+                    Some(Err(e)) => defmt::warn!(
+                        "crash recovery: SD write failed ({}); message={=str}",
+                        defmt::Debug2Format(&e),
+                        snap.message_str(),
+                    ),
+                    None => defmt::warn!(
+                        "crash recovery: storage not mounted; message={=str}",
+                        snap.message_str(),
+                    ),
+                }
             }
             // Restore the operator-tuned palette + mood from the
             // SD-backed runtime store. Tolerant of a missing /


### PR DESCRIPTION
## Summary

Three Greptile findings on PR #297, all real and worth fixing.

### P2 — newline-in-message breaks `key=value` schema

`render_log_entry` now escapes embedded `\n` in the panic message to the literal `\n` so each `key=value` pair occupies exactly one line. Without this, `panic!(\"a\\nb\")` would split the `message=` value across two lines and break any downstream parser that splits on `\n` (grep, JSON-line readers, the dashboard's `<pre>` block).

### P2 — silent SD write failure loses the panic message

The boot path used `let _ = storage::with_storage(...).await` to discard the result. The `defmt::warn!` above only logged file/line; the message body lived only in the SD write that just failed — so on SD failure the message disappeared everywhere. Now matches the outcome and logs the message on both failure paths (write failed, storage not mounted).

### P2 — stale doc comment on `#[panic_handler]`

Comment claimed `loop {}` is the fallback but the body now ends in `software_reset()` which returns `!`. Leftover from the pre-fix version. Updated to describe `software_reset()` as the diverging terminator + watchdog as a belt-and-suspenders backstop.

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just clippy-firmware` — strict clippy on `xtensa-esp32s3-none-elf`