### PR TITLE
chore(core): drop Mind::memory placeholder — TODO sweep

### DIFF
--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -2,8 +2,7 @@
 //!
 //! [`Mind`] holds [`Affect`] (current emotion), [`Autonomy`]
 //! (manual-override gating), [`Intent`] (current goal), and
-//! [`Attention`] (current focus). [`Memory`] is a marker type
-//! reserved for future cross-boot persistence. Modifiers in
+//! [`Attention`] (current focus). Modifiers in
 //! [`Phase::Affect`] write `mind.affect.emotion` and
 //! `mind.autonomy.manual_until`; skills write `mind.intent` and
 //! `mind.attention`; modifiers in [`Phase::Expression`] and
@@ -346,14 +345,9 @@ pub enum BodyGesture {
     Release,
 }
 
-/// Persistent facts the entity remembers across boots. Placeholder
-/// marker type; not yet populated.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct Memory;
-
 /// The cognitive layer of the entity. Sub-component shape is stable;
-/// new fields land on `Affect` / `Autonomy` / `Intent` / `Attention` /
-/// `Memory` without breaking modifiers that read `Mind`.
+/// new fields land on `Affect` / `Autonomy` / `Intent` / `Attention`
+/// without breaking modifiers that read `Mind`.
 ///
 /// `PartialEq` only — [`Attention::Tracking`] holds a [`Pose`] with
 /// f32 fields, which leak through here.
@@ -390,6 +384,4 @@ pub struct Mind {
     /// a head-pet motion modifier ignores anything older than its
     /// own reaction window). `None` until the first gesture lands.
     pub last_gesture: Option<(BodyGesture, Instant)>,
-    /// Persistent facts.
-    pub memory: Memory,
 }


### PR DESCRIPTION
## Summary

Closes the fourth and final v1.0 polish milestone from `STABILITY.md` (RON-configurable appearance + host-side calibration tooling + crash recovery + **codebase TODO sweep**).

The workspace turned up:
- Zero `TODO` / `FIXME` / `HACK` comment markers
- Zero `todo!()` / `unimplemented!()` macros
- Zero `#[ignore]`'d tests

The no-meta-commentary convention (CLAUDE.md: "TODOs require a concrete trigger condition") has held up across recent feature churn. Every "future" mention in comments is *defensive* (explaining why something IS done a certain way to absorb a future change) rather than aspirational.

The only soft TODO surfaced was `Mind::memory`:

- `pub` field of type `Memory` (an empty unit struct) on `Mind`
- Never read or written anywhere in the workspace (verified via grep — only the field declaration matches)
- Doc comment was honest: "Placeholder marker type; not yet populated."

Per the project's anti-aspirational stance ("Don't add features, refactor, or introduce abstractions beyond what the task requires. Don't design for hypothetical future requirements") this was dead code. Removed. If cross-boot persistent facts ever land, the field can be re-added against a concrete trigger then.

## Test plan

- [x] `just check` — fmt + clippy + host tests + doctests
- [x] `just clippy-firmware` — strict clippy on `xtensa-esp32s3-none-elf`

No behavior change — `Memory` was unused, and removing it from `Mind` doesn't affect anyone's `Default` derive or `PartialEq`.