### PR TITLE
feat(core): on-screen battery overlay (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ section summarises the milestone work in human terms.
 
 ### Avatar surface
 
+- On-screen battery indicator drawn in the top-left corner; opt-in
+  via `behavior.battery_icon_enabled`. The percent reading is
+  quantised into five buckets (Critical / Low / Medium / High /
+  Full) at the source so a one-percent gauge twitch doesn't
+  re-trigger the renderer's dirty-check; the charging flag adds a
+  small bolt overlay when USB power is present.
 - Speech-bubble text overlay drawn above the face, with a TTL the
   `BubbleExpiry` modifier sweeps each frame.
-- Decorator badges (heart, sweat, sleep, anger, shy) sit on top of
-  the base face. Emotion edges trigger `Angry` / `Shy` automatically;
-  the existing reactive triggers still fire `Heart` / `Sweat` / `Sleep`.
+- Decorator badges (heart, sweat, dizzy, ear, pairing, angry, shy)
+  sit on top of the base face. Emotion edges trigger `Angry` / `Shy`
+  automatically; reactive triggers still fire `Heart` / `Sweat` /
+  `Dizzy` / `Ear` / `Pairing`.
 - Runtime color palette swap through named presets (`default` / `dark`
   / `cute` / `dog`) — affects the four "skin" colours of the avatar
   while symbolic overlays keep their dedicated colours.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ for the details.
 ## Features
 
 - **Animated face** — eased transitions across the m5stack-avatar emotion palette, blink / breath / idle-drift at double-buffered 30 FPS
-- **Symbolic overlays** — speech-bubble text and decorator badges (heart, sweat, sleep, anger, shy) layered on top of the base face
+- **Symbolic overlays** — speech-bubble text and decorator badges (heart, sweat, dizzy, ear, pairing, angry, shy) layered on top of the base face
+- **Battery indicator** — opt-in corner overlay; the percent reading is quantised into segment buckets so per-percent jitter doesn't churn the renderer's dirty-check
 - **Color palette swap** — runtime theme switch through a small set of named presets (default / dark / cute / dog) without disturbing the symbolic-overlay layer's distinctness
 - **Head motion** — Feetech SCServo pan/tilt with a calibration bench (`just bench`) and a runtime zero-point correction surface for day-of mounting drift
 - **9-axis sensing** — BMI270 accel + gyro, BMM150 magnetometer (compensated µT, live bench via `just mag-bench`)

--- a/crates/stackchan-core/src/director.rs
+++ b/crates/stackchan-core/src/director.rs
@@ -162,6 +162,8 @@ pub enum Field {
     Decorator,
     /// `entity.face.bubble`
     Bubble,
+    /// `entity.face.battery_overlay`
+    BatteryOverlay,
 
     // ---- Motor ----
     /// `entity.motor.head_pose`
@@ -254,6 +256,7 @@ impl Field {
         Self::BreathDepthScale,
         Self::Decorator,
         Self::Bubble,
+        Self::BatteryOverlay,
         Self::HeadPose,
         Self::HeadPoseActual,
         Self::AccelG,
@@ -302,7 +305,8 @@ impl Field {
             | Self::BlinkRateScale
             | Self::BreathDepthScale
             | Self::Decorator
-            | Self::Bubble => FieldGroup::Face,
+            | Self::Bubble
+            | Self::BatteryOverlay => FieldGroup::Face,
             Self::HeadPose | Self::HeadPoseActual => FieldGroup::Motor,
             Self::AccelG
             | Self::GyroDps
@@ -373,6 +377,7 @@ impl Field {
             }
             Self::Decorator => before.face.decorator != after.face.decorator,
             Self::Bubble => before.face.bubble != after.face.bubble,
+            Self::BatteryOverlay => before.face.battery_overlay != after.face.battery_overlay,
             Self::HeadPose => {
                 before.motor.head_pose.pan_deg.to_bits() != after.motor.head_pose.pan_deg.to_bits()
                     || before.motor.head_pose.tilt_deg.to_bits()
@@ -857,7 +862,7 @@ mod tests {
         }
         assert_eq!(
             Field::ALL.len(),
-            43,
+            44,
             "update Field::ALL when adding variants"
         );
     }

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -40,7 +40,7 @@ use embedded_graphics::{
 
 use crate::bubble::BubbleState;
 use crate::decorator::{Decorator, DecoratorState};
-use crate::face::{Eye, EyePhase, Face, Mouth, SCALE_DEFAULT};
+use crate::face::{BatteryBucket, BatteryOverlay, Eye, EyePhase, Face, Mouth, SCALE_DEFAULT};
 use crate::palette::PaletteColors;
 
 /// Heart decorator pink — slightly more saturated than the `Default`
@@ -141,6 +141,9 @@ impl Face {
         }
         if let Some(state) = self.bubble {
             draw_bubble(state, target)?;
+        }
+        if let Some(overlay) = self.battery_overlay {
+            draw_battery(overlay, target)?;
         }
         Ok(())
     }
@@ -902,6 +905,131 @@ const fn stroke(color: Rgb565, width: u32) -> PrimitiveStyle<Rgb565> {
         .build()
 }
 
+/// Battery indicator top-left anchor.
+const BATTERY_X: i32 = 8;
+/// Battery indicator top anchor.
+const BATTERY_Y: i32 = 8;
+/// Battery indicator outer width (excludes the terminal nub).
+const BATTERY_BODY_W: u32 = 28;
+/// Battery indicator outer height.
+const BATTERY_BODY_H: u32 = 12;
+/// Stroke width of the battery outline.
+const BATTERY_STROKE: u32 = 2;
+/// Padding from the outline to each segment fill, in pixels per side.
+const BATTERY_INNER_PAD: i32 = 2;
+/// Width of the terminal nub on the right of the body.
+const BATTERY_NUB_W: u32 = 3;
+/// Height of the terminal nub.
+const BATTERY_NUB_H: u32 = 6;
+/// Battery outline / segment colour — black so it reads against the
+/// (typically white) palette background. The corner anchor sits above
+/// the eye area so the outline never overlaps the rendered face at
+/// any geometry preset.
+const BATTERY_COLOR: Rgb565 = Rgb565::BLACK;
+/// Critical-bucket fill — red so 0..=9 % reads as urgent regardless of
+/// charging state.
+const BATTERY_CRITICAL_COLOR: Rgb565 = Rgb565::new(31, 8, 4);
+/// Charging-bolt overlay colour — same saturated green used elsewhere
+/// for "all good" signals.
+const BATTERY_CHARGING_COLOR: Rgb565 = Rgb565::new(4, 50, 8);
+
+/// Draw the battery indicator in the upper-left corner.
+///
+/// Outline + terminal nub render in [`BATTERY_COLOR`]. Inside the body
+/// the bucket selects 0..=4 filled segments (Critical = no segments
+/// plus a red body fill; Full = four segments). The charging flag
+/// renders a thin green vertical bolt centred over the segments — a
+/// minimal, integer-coordinate stand-in for the lightning glyph that
+/// stays legible at this scale.
+fn draw_battery<D>(overlay: BatteryOverlay, target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let body_top_left = EgPoint::new(BATTERY_X, BATTERY_Y);
+    let body_size = Size::new(BATTERY_BODY_W, BATTERY_BODY_H);
+
+    if matches!(overlay.bucket, BatteryBucket::Critical) {
+        Rectangle::new(body_top_left, body_size)
+            .into_styled(fill(BATTERY_CRITICAL_COLOR))
+            .draw(target)?;
+    }
+    Rectangle::new(body_top_left, body_size)
+        .into_styled(stroke(BATTERY_COLOR, BATTERY_STROKE))
+        .draw(target)?;
+
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "constants are well under i32::MAX"
+    )]
+    let nub_x = BATTERY_X + BATTERY_BODY_W as i32;
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "constants are well under i32::MAX"
+    )]
+    let nub_y = BATTERY_Y + (BATTERY_BODY_H as i32 - BATTERY_NUB_H as i32) / 2;
+    Rectangle::new(
+        EgPoint::new(nub_x, nub_y),
+        Size::new(BATTERY_NUB_W, BATTERY_NUB_H),
+    )
+    .into_styled(fill(BATTERY_COLOR))
+    .draw(target)?;
+
+    let segments = segment_count(overlay.bucket);
+    if segments > 0 {
+        let inner_top = BATTERY_Y + BATTERY_INNER_PAD;
+        let inner_left = BATTERY_X + BATTERY_INNER_PAD;
+        #[allow(clippy::cast_possible_wrap, reason = "constants well under i32::MAX")]
+        let inner_w = BATTERY_BODY_W as i32 - 2 * BATTERY_INNER_PAD;
+        #[allow(clippy::cast_possible_wrap, reason = "constants well under i32::MAX")]
+        let inner_h_i32 = BATTERY_BODY_H as i32 - 2 * BATTERY_INNER_PAD;
+        let segment_gap: i32 = 1;
+        let total_gap = segment_gap * 3;
+        let segment_w = ((inner_w - total_gap) / 4).max(1);
+        #[allow(
+            clippy::cast_sign_loss,
+            reason = "segment_w guarded with max(1); inner_h_i32 is positive by construction"
+        )]
+        let seg_size = Size::new(segment_w as u32, inner_h_i32.max(1) as u32);
+        for i in 0..segments {
+            let x = inner_left + i32::from(i) * (segment_w + segment_gap);
+            Rectangle::new(EgPoint::new(x, inner_top), seg_size)
+                .into_styled(fill(BATTERY_COLOR))
+                .draw(target)?;
+        }
+    }
+
+    if overlay.charging {
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "constants are well under i32::MAX"
+        )]
+        let mid_x = BATTERY_X + BATTERY_BODY_W as i32 / 2;
+        let top_y = BATTERY_Y + BATTERY_INNER_PAD;
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "constants are well under i32::MAX"
+        )]
+        let bottom_y = BATTERY_Y + BATTERY_BODY_H as i32 - BATTERY_INNER_PAD;
+        Line::new(EgPoint::new(mid_x, top_y), EgPoint::new(mid_x, bottom_y))
+            .into_styled(stroke(BATTERY_CHARGING_COLOR, 2))
+            .draw(target)?;
+    }
+    Ok(())
+}
+
+/// How many filled segments to draw for each bucket. Critical renders
+/// zero segments (the body fill conveys the urgency); Full renders all
+/// four.
+const fn segment_count(bucket: BatteryBucket) -> u8 {
+    match bucket {
+        BatteryBucket::Critical => 0,
+        BatteryBucket::Low => 1,
+        BatteryBucket::Medium => 2,
+        BatteryBucket::High => 3,
+        BatteryBucket::Full => 4,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -924,6 +1052,15 @@ mod tests {
     fn scale_radius_scales_up_and_down() {
         assert_eq!(scale_radius(25, 64), 12);
         assert_eq!(scale_radius(25, 255), 49);
+    }
+
+    #[test]
+    fn battery_segment_count_matches_bucket() {
+        assert_eq!(segment_count(BatteryBucket::Critical), 0);
+        assert_eq!(segment_count(BatteryBucket::Low), 1);
+        assert_eq!(segment_count(BatteryBucket::Medium), 2);
+        assert_eq!(segment_count(BatteryBucket::High), 3);
+        assert_eq!(segment_count(BatteryBucket::Full), 4);
     }
 
     #[test]

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -333,6 +333,59 @@ impl FaceGeometry {
     }
 }
 
+/// Coarse battery-level bucket for the on-screen indicator.
+///
+/// Quantising the percent reading at the source keeps the dirty-check
+/// rare: a per-percent flicker doesn't re-render. Each bucket maps
+/// to a distinct glyph (segment count).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+#[non_exhaustive]
+pub enum BatteryBucket {
+    /// `0..=9` — empty cell, urgent.
+    Critical,
+    /// `10..=24` — one segment.
+    Low,
+    /// `25..=49` — two segments.
+    Medium,
+    /// `50..=74` — three segments.
+    High,
+    /// `75..=100` — four segments (full).
+    #[default]
+    Full,
+}
+
+impl BatteryBucket {
+    /// Map a raw `0..=100` percent reading to its rendered bucket.
+    /// Out-of-range inputs saturate to [`Self::Full`] — the AXP2101
+    /// gauge can briefly report >100 during a fresh charge, and the
+    /// renderer should keep showing a full cell rather than blank.
+    #[must_use]
+    pub const fn from_percent(p: u8) -> Self {
+        match p {
+            0..=9 => Self::Critical,
+            10..=24 => Self::Low,
+            25..=49 => Self::Medium,
+            50..=74 => Self::High,
+            _ => Self::Full,
+        }
+    }
+}
+
+/// On-screen battery indicator state.
+///
+/// `None` on [`Face::battery_overlay`] means the renderer skips the
+/// indicator. Set by [`crate::modifiers::BatteryOverlayFromPerception`]
+/// when the operator has opted in and a battery reading has landed
+/// at least once. The bucket field is quantised so frame-to-frame
+/// percent jitter doesn't trip the renderer's dirty-check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BatteryOverlay {
+    /// Quantised battery level for rendering.
+    pub bucket: BatteryBucket,
+    /// `true` while USB power is reported present by the AXP2101.
+    pub charging: bool,
+}
+
 /// The visual surface of the entity. Owns everything the renderer reads
 /// to produce a frame — both the geometric primitives ([`Eye`], [`Mouth`])
 /// and the emotion-driven modulators ([`Style`]).
@@ -361,6 +414,10 @@ pub struct Face {
     /// firmware-side MCP `speak` short-circuit) populate this field;
     /// [`crate::modifiers::BubbleExpiry`] clears it on deadline.
     pub bubble: Option<crate::bubble::BubbleState>,
+    /// On-screen battery indicator, drawn in the top-left corner. `None`
+    /// is the steady state (operator has not enabled the overlay, or no
+    /// battery reading has landed yet).
+    pub battery_overlay: Option<BatteryOverlay>,
     /// Active colour palette. Picks the background / eye / mouth /
     /// cheek colours used by the renderer. Decorator and bubble
     /// overlays keep their own dedicated colours so a palette swap
@@ -435,6 +492,7 @@ impl Default for Face {
             style: Style::default(),
             decorator: None,
             bubble: None,
+            battery_overlay: None,
             palette: crate::palette::Palette::Default,
             geometry: FaceGeometry::Default,
         }
@@ -556,6 +614,31 @@ mod tests {
         assert_eq!(face.left_eye.weight, 100);
         assert_eq!(face.mouth.weight, 0);
         assert!(face.mouth.mouth_open.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn battery_bucket_boundaries_are_inclusive_low_and_exclusive_high() {
+        assert_eq!(BatteryBucket::from_percent(0), BatteryBucket::Critical);
+        assert_eq!(BatteryBucket::from_percent(9), BatteryBucket::Critical);
+        assert_eq!(BatteryBucket::from_percent(10), BatteryBucket::Low);
+        assert_eq!(BatteryBucket::from_percent(24), BatteryBucket::Low);
+        assert_eq!(BatteryBucket::from_percent(25), BatteryBucket::Medium);
+        assert_eq!(BatteryBucket::from_percent(49), BatteryBucket::Medium);
+        assert_eq!(BatteryBucket::from_percent(50), BatteryBucket::High);
+        assert_eq!(BatteryBucket::from_percent(74), BatteryBucket::High);
+        assert_eq!(BatteryBucket::from_percent(75), BatteryBucket::Full);
+        assert_eq!(BatteryBucket::from_percent(100), BatteryBucket::Full);
+    }
+
+    #[test]
+    fn battery_bucket_out_of_range_saturates_to_full() {
+        assert_eq!(BatteryBucket::from_percent(101), BatteryBucket::Full);
+        assert_eq!(BatteryBucket::from_percent(u8::MAX), BatteryBucket::Full);
+    }
+
+    #[test]
+    fn default_face_has_no_battery_overlay() {
+        assert!(Face::default().battery_overlay.is_none());
     }
 
     #[test]

--- a/crates/stackchan-core/src/modifiers/battery_overlay.rs
+++ b/crates/stackchan-core/src/modifiers/battery_overlay.rs
@@ -1,0 +1,165 @@
+//! [`BatteryOverlayFromPerception`] — renders the on-screen battery
+//! indicator when the operator has opted in via
+//! `BehaviorConfig::battery_icon_enabled`.
+//!
+//! Quantises [`crate::perception::Perception::battery_percent`] into a
+//! [`BatteryBucket`] at the source so frame-to-frame percent jitter
+//! doesn't keep flipping the renderer's dirty-check; the bucket
+//! changes only when the indicator's visual state actually differs.
+//! The charging flag mirrors `perception.usb_power_present`.
+//!
+//! ## Phase + priority
+//!
+//! Runs in [`Phase::Decoration`] at priority `5`. The decorator
+//! pipeline (expiry at `-10`, triggers at `0`) lives in the same
+//! phase, but the battery overlay writes a disjoint field
+//! ([`Field::BatteryOverlay`]) so order against the decorator
+//! triggers is immaterial.
+
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::face::{BatteryBucket, BatteryOverlay};
+use crate::modifier::Modifier;
+
+/// Modifier that maps perception's battery percent + USB-power flag
+/// into the quantised on-screen indicator. Opt-in via
+/// [`Self::with_enabled`].
+#[derive(Debug, Clone, Copy)]
+pub struct BatteryOverlayFromPerception {
+    /// `true` once the operator has opted into the overlay via
+    /// `BehaviorConfig::battery_icon_enabled`; mirrored at boot.
+    /// `false` short-circuits [`Modifier::update`] to a no-op and
+    /// clears any stale overlay.
+    enabled: bool,
+}
+
+impl BatteryOverlayFromPerception {
+    /// Construct with the operator-set enable flag baked in. The
+    /// firmware mirrors `BehaviorConfig::battery_icon_enabled` into
+    /// the `bool` at boot.
+    #[must_use]
+    pub const fn with_enabled(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    /// Construct disabled. Equivalent to `with_enabled(false)`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::with_enabled(false)
+    }
+}
+
+impl Default for BatteryOverlayFromPerception {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for BatteryOverlayFromPerception {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "BatteryOverlayFromPerception",
+            description: "Maps perception.battery_percent + usb_power_present to \
+                          face.battery_overlay; opt-in via \
+                          BehaviorConfig::battery_icon_enabled.",
+            phase: Phase::Decoration,
+            priority: 5,
+            reads: &[Field::BatteryPercent, Field::UsbPowerPresent],
+            writes: &[Field::BatteryOverlay],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        if !self.enabled {
+            if entity.face.battery_overlay.is_some() {
+                entity.face.battery_overlay = None;
+            }
+            return;
+        }
+        let next = entity
+            .perception
+            .battery_percent
+            .map(|percent| BatteryOverlay {
+                bucket: BatteryBucket::from_percent(percent),
+                charging: entity.perception.usb_power_present.unwrap_or(false),
+            });
+        if entity.face.battery_overlay != next {
+            entity.face.battery_overlay = next;
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only: Option::expect on values just written by the \
+              modifier-under-test"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_clears_overlay_and_writes_none_when_already_none() {
+        let mut e = Entity::default();
+        e.face.battery_overlay = Some(BatteryOverlay {
+            bucket: BatteryBucket::Full,
+            charging: false,
+        });
+        let mut m = BatteryOverlayFromPerception::with_enabled(false);
+        m.update(&mut e);
+        assert!(e.face.battery_overlay.is_none());
+
+        m.update(&mut e);
+        assert!(e.face.battery_overlay.is_none());
+    }
+
+    #[test]
+    fn enabled_without_perception_keeps_overlay_none() {
+        let mut e = Entity::default();
+        let mut m = BatteryOverlayFromPerception::with_enabled(true);
+        m.update(&mut e);
+        assert!(e.face.battery_overlay.is_none());
+    }
+
+    #[test]
+    fn enabled_with_perception_writes_quantised_overlay() {
+        let mut e = Entity::default();
+        e.perception.battery_percent = Some(42);
+        e.perception.usb_power_present = Some(true);
+        let mut m = BatteryOverlayFromPerception::with_enabled(true);
+        m.update(&mut e);
+        let o = e.face.battery_overlay.expect("overlay should be Some");
+        assert_eq!(o.bucket, BatteryBucket::Medium);
+        assert!(o.charging);
+    }
+
+    #[test]
+    fn percent_jitter_within_bucket_keeps_overlay_stable() {
+        let mut e = Entity::default();
+        e.perception.usb_power_present = Some(false);
+        let mut m = BatteryOverlayFromPerception::with_enabled(true);
+        e.perception.battery_percent = Some(50);
+        m.update(&mut e);
+        let first = e.face.battery_overlay.expect("set");
+        e.perception.battery_percent = Some(73);
+        m.update(&mut e);
+        let second = e.face.battery_overlay.expect("set");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn charging_flag_follows_usb_power_present() {
+        let mut e = Entity::default();
+        e.perception.battery_percent = Some(80);
+        e.perception.usb_power_present = Some(true);
+        let mut m = BatteryOverlayFromPerception::with_enabled(true);
+        m.update(&mut e);
+        assert!(e.face.battery_overlay.expect("set").charging);
+
+        e.perception.usb_power_present = Some(false);
+        m.update(&mut e);
+        assert!(!e.face.battery_overlay.expect("set").charging);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -82,6 +82,7 @@
 //! [`crate::director::Phase::Output`].
 
 mod attention_from_tracking;
+mod battery_overlay;
 mod blink;
 mod breath;
 mod bubble_expiry;
@@ -122,6 +123,7 @@ pub use attention_from_tracking::{
     AttentionFromTracking, FACE_LOCK_HITS, FACE_RELEASE_MISSES, TRACKING_LOCK_TICKS,
     TRACKING_RELEASE_MS,
 };
+pub use battery_overlay::BatteryOverlayFromPerception;
 pub use blink::Blink;
 pub use breath::Breath;
 pub use bubble_expiry::BubbleExpiry;

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -68,7 +68,7 @@ EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIn
 EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
 AttentionFromTracking → DormancyFromActivity → EmotionCycle → StyleFromEmotion →
 StyleFromIntent → GazeFromAttention → MicrosaccadeFromAttention → Blink → Breath →
-IdleDrift → IdleHeadDrift → BatteryOverlayFromPerception → HeadFromEmotion →
+IdleDrift → BatteryOverlayFromPerception → IdleHeadDrift → HeadFromEmotion →
 HeadFromAttention → LostTargetSearch → HeadFromIntent → MouthFromAudio
 ```
 

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -68,8 +68,8 @@ EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIn
 EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
 AttentionFromTracking → DormancyFromActivity → EmotionCycle → StyleFromEmotion →
 StyleFromIntent → GazeFromAttention → MicrosaccadeFromAttention → Blink → Breath →
-IdleDrift → IdleHeadDrift → HeadFromEmotion → HeadFromAttention →
-LostTargetSearch → HeadFromIntent → MouthFromAudio
+IdleDrift → IdleHeadDrift → BatteryOverlayFromPerception → HeadFromEmotion →
+HeadFromAttention → LostTargetSearch → HeadFromIntent → MouthFromAudio
 ```
 
 Inputs arrive through embassy `Signal` channels from the per-peripheral

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -74,14 +74,15 @@ use mipidsi::{
 use stackchan_core::{
     Attention, Clock, Director, Entity, Face, HeadDriver, LedFrame, RemoteCommand,
     modifiers::{
-        AttentionFromTracking, Blink, Breath, BubbleExpiry, DancePlayer, DecoratorExpiry,
-        DecoratorFromBodyTouch, DecoratorFromEmotion, DecoratorFromListening, DecoratorFromLoud,
-        DecoratorFromShake, DormancyFromActivity, EmotionCycle, EmotionFromAmbient,
-        EmotionFromBattery, EmotionFromIntent, EmotionFromRemote, EmotionFromTouch,
-        EmotionFromVoice, GazeFromAttention, HeadFromAttention, HeadFromBodyGesture,
-        HeadFromEmotion, HeadFromIntent, IdleDrift, IdleHeadDrift, IntentFromBodyTouch,
-        IntentFromLoud, LostTargetSearch, MicrosaccadeFromAttention, MouthFromAudio,
-        RemoteCommandModifier, Soliloquy, StyleFromEmotion, StyleFromIntent, StyleFromMood,
+        AttentionFromTracking, BatteryOverlayFromPerception, Blink, Breath, BubbleExpiry,
+        DancePlayer, DecoratorExpiry, DecoratorFromBodyTouch, DecoratorFromEmotion,
+        DecoratorFromListening, DecoratorFromLoud, DecoratorFromShake, DormancyFromActivity,
+        EmotionCycle, EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
+        EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention,
+        HeadFromBodyGesture, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleHeadDrift,
+        IntentFromBodyTouch, IntentFromLoud, LostTargetSearch, MicrosaccadeFromAttention,
+        MouthFromAudio, RemoteCommandModifier, Soliloquy, StyleFromEmotion, StyleFromIntent,
+        StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -262,6 +263,14 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut decorator_from_listening = DecoratorFromListening::new();
     let mut decorator_from_loud = DecoratorFromLoud::new();
     let mut decorator_from_shake = DecoratorFromShake::new();
+    let mut battery_overlay = {
+        let enabled = stackchan_firmware::storage::CONFIG_SNAPSHOT
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|c| c.behavior.battery_icon_enabled);
+        BatteryOverlayFromPerception::with_enabled(enabled)
+    };
     let mut last_rendered: Option<Face> = None;
     // Last on-screen pairing passkey. Tracked separately from
     // `last_rendered` so a passkey transition forces a redraw even
@@ -361,6 +370,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
         .add_modifier(&mut decorator_from_listening)
         .expect("registry full");
     director
+        .add_modifier(&mut battery_overlay)
+        .expect("registry full");
+    director
         .add_modifier(&mut head_drift)
         .expect("registry full");
     director
@@ -411,7 +423,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + BatteryOverlayFromPerception + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -263,6 +263,12 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     let mut decorator_from_listening = DecoratorFromListening::new();
     let mut decorator_from_loud = DecoratorFromLoud::new();
     let mut decorator_from_shake = DecoratorFromShake::new();
+    // `behavior.battery_icon_enabled` flips at boot via STACKCHAN.RON;
+    // if the operator later toggles it via PUT /settings, the change
+    // takes effect on the next reboot (same as soliloquy_enabled
+    // above). The modifier is always constructed; `enabled = false`
+    // short-circuits its `update` to a no-op so there's no cost when
+    // disabled.
     let mut battery_overlay = {
         let enabled = stackchan_firmware::storage::CONFIG_SNAPSHOT
             .lock()
@@ -423,7 +429,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleHeadDrift + BatteryOverlayFromPerception + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + BatteryOverlayFromPerception + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -124,6 +124,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        hourly_chime_enabled: {},",
         config.behavior.hourly_chime_enabled
     );
+    let _ = writeln!(
+        out,
+        "        battery_icon_enabled: {},",
+        config.behavior.battery_icon_enabled
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -476,12 +481,13 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse the `behavior: (soliloquy_enabled, hourly_chime_enabled)`
-    /// block. Both fields default to `false` if absent.
+    /// Parse the `behavior: (...)` block. All fields default to
+    /// `false` if absent.
     fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
         self.expect_char('(')?;
         let mut soliloquy_enabled: Option<bool> = None;
         let mut hourly_chime_enabled: Option<bool> = None;
+        let mut battery_icon_enabled: Option<bool> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -494,6 +500,7 @@ impl<'a> Parser<'a> {
             match key {
                 "soliloquy_enabled" => soliloquy_enabled = Some(self.parse_bool()?),
                 "hourly_chime_enabled" => hourly_chime_enabled = Some(self.parse_bool()?),
+                "battery_icon_enabled" => battery_icon_enabled = Some(self.parse_bool()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -504,6 +511,7 @@ impl<'a> Parser<'a> {
         Ok(BehaviorConfig {
             soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
             hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
+            battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -238,8 +238,10 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     out.push_str("},\"behavior\":{");
     let _ = write!(
         out,
-        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{}",
-        config.behavior.soliloquy_enabled, config.behavior.hourly_chime_enabled
+        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{}",
+        config.behavior.soliloquy_enabled,
+        config.behavior.hourly_chime_enabled,
+        config.behavior.battery_icon_enabled,
     );
     out.push_str("}}");
     Ok(out)
@@ -733,13 +735,14 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse the optional `"behavior"` object. Both fields default
+    /// Parse the optional `"behavior"` object. All fields default
     /// to `false` if absent so a JSON body that pre-dates a flag's
     /// introduction round-trips cleanly.
     fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
         self.expect_char('{')?;
         let mut soliloquy_enabled: Option<bool> = None;
         let mut hourly_chime_enabled: Option<bool> = None;
+        let mut battery_icon_enabled: Option<bool> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -762,6 +765,12 @@ impl<'a> Parser<'a> {
                     }
                     hourly_chime_enabled = Some(self.parse_bool()?);
                 }
+                "battery_icon_enabled" => {
+                    if battery_icon_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "battery_icon_enabled"));
+                    }
+                    battery_icon_enabled = Some(self.parse_bool()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -772,6 +781,7 @@ impl<'a> Parser<'a> {
         Ok(BehaviorConfig {
             soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
             hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
+            battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
         })
     }
 
@@ -994,6 +1004,7 @@ mod tests {
             behavior: BehaviorConfig {
                 soliloquy_enabled: true,
                 hourly_chime_enabled: false,
+                battery_icon_enabled: true,
             },
         }
     }
@@ -1311,6 +1322,7 @@ mod tests {
             behavior: BehaviorConfig {
                 soliloquy_enabled: true,
                 hourly_chime_enabled: false,
+                battery_icon_enabled: true,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -300,6 +300,13 @@ pub struct BehaviorConfig {
     /// each chime so a mid-day clock correction doesn't drift the
     /// next-fire time.
     pub hourly_chime_enabled: bool,
+    /// When `true`, the firmware renders a small battery indicator
+    /// in the top-left corner of the face. Off by default so the
+    /// avatar's resting expression stays clean; operators opt in via
+    /// the boot config or `PUT /settings`. The bucket is quantised
+    /// at the source so a one-percent change does not re-trigger a
+    /// frame redraw.
+    pub battery_icon_enabled: bool,
 }
 
 /// Time / SNTP configuration.


### PR DESCRIPTION
## Summary

- Adds a corner battery indicator gated by `behavior.battery_icon_enabled` in `STACKCHAN.RON`.
- Quantises the percent reading into five buckets at the source (`BatteryBucket::{Critical,Low,Medium,High,Full}`) so a one-percent gauge twitch doesn't churn the renderer's dirty-check.
- Mirrors `perception.usb_power_present` into the overlay's charging flag (renders as a small green bolt).
- Refreshes the stale decorator list in README + CHANGELOG (the shipped set is `heart/sweat/dizzy/ear/pairing/angry/shy`; the v0.1 draft said `heart/sweat/sleep/anger/shy`).

## Test plan
- [x] \`cargo test -p stackchan-core --lib bucket\` — 5 passed (bucket boundaries, segment counts, jitter stability)
- [x] \`cargo test -p stackchan-core --lib battery_overlay\` — 6 passed (modifier disabled/enabled/jitter/charging paths)
- [x] \`just check\` — fmt + workspace clippy + host tests clean
- [x] \`cargo +esp clippy --release -- -D warnings\` — strict firmware clippy clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features\` — rustdoc gate clean
- [ ] Hardware verify: flash to CoreS3 with \`behavior.battery_icon_enabled: true\`, confirm corner overlay tracks battery + USB-power state