### PR TITLE
feat(core): IdleMicroExpression — random mouth-y nudges at 2–6s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ section summarises the milestone work in human terms.
   Full) at the source so a one-percent gauge twitch doesn't
   re-trigger the renderer's dirty-check; the charging flag adds a
   small bolt overlay when USB power is present.
+- `IdleMicroExpression` modifier: random small vertical perturbation
+  of `mouth.center.y` every 2–6 s. Complements the eye-only
+  `IdleDrift` so a long-quiet face shows mouth-side liveness too;
+  composes additively with `Breath` via independent
+  per-modifier offset tracking.
 - Speech-bubble text overlay drawn above the face, with a TTL the
   `BubbleExpiry` modifier sweeps each frame.
 - Decorator badges (heart, sweat, dizzy, ear, pairing, angry, shy)

--- a/crates/stackchan-core/src/modifiers/idle_micro_expression.rs
+++ b/crates/stackchan-core/src/modifiers/idle_micro_expression.rs
@@ -223,6 +223,43 @@ mod tests {
     }
 
     #[test]
+    fn fine_grained_ticks_with_baseline_drift_still_undo_cleanly() {
+        // Step at 1 ms granularity over a long span. Between fires
+        // we mutate `mouth.center.y` from "outside" to mimic Breath
+        // applying its own offset; the modifier must still remove
+        // only *its* prior contribution and leave the baseline drift
+        // untouched.
+        let mut entity = at(0);
+        let baseline = entity.face.mouth.center.y;
+        let mut m = IdleMicroExpression::with_seed(NonZeroU32::new(13).unwrap());
+
+        let mut external_drift: i32 = 0;
+        let mut last_module_dy: i32 = 0;
+
+        for ms in 0..=DEFAULT_INTERVAL_MAX_MS * 5 {
+            // "Breath-like" external offset advances each ms.
+            let next_drift = i32::try_from(ms / 100).unwrap_or(i32::MAX) % 5 - 2;
+            entity.face.mouth.center.y += next_drift - external_drift;
+            external_drift = next_drift;
+
+            // What the modifier had contributed before this tick.
+            let module_before = entity.face.mouth.center.y - baseline - external_drift;
+            assert_eq!(module_before, last_module_dy);
+
+            entity.tick.now = Instant::from_millis(ms);
+            m.update(&mut entity);
+
+            // What the modifier contributed after this tick.
+            let module_after = entity.face.mouth.center.y - baseline - external_drift;
+            assert!(
+                module_after.abs() <= DEFAULT_MAX_MOUTH_Y_PX,
+                "modifier offset escaped bound at ms={ms}: {module_after}"
+            );
+            last_module_dy = module_after;
+        }
+    }
+
+    #[test]
     fn ticks_before_due_do_not_perturb() {
         let mut entity = at(0);
         let mut m = IdleMicroExpression::new();

--- a/crates/stackchan-core/src/modifiers/idle_micro_expression.rs
+++ b/crates/stackchan-core/src/modifiers/idle_micro_expression.rs
@@ -1,0 +1,237 @@
+//! [`IdleMicroExpression`] — small mouth-center perturbations at
+//! random idle intervals so a long-quiet face doesn't read as a frozen
+//! mask.
+//!
+//! Complement to [`super::IdleDrift`]: where that modifier jitters the
+//! eyes, this one nudges the mouth a few pixels vertically. The two
+//! schedules are independent (different seeds) so the avatar shows
+//! occasional asymmetric liveness rather than synchronised twitches.
+//!
+//! ## Why mouth-only
+//!
+//! Upstream's `IdleExpressionModifier` adds three perturbation kinds:
+//! eye offset, mouth rotation, and mouth vertical drift. `IdleDrift`
+//! already covers the eye case; mouth rotation needs a renderer
+//! primitive we don't have. Mouth vertical drift is the surviving
+//! surface — small, cheap, and visibly alive.
+//!
+//! ## Phase + priority
+//!
+//! Runs in [`Phase::Expression`] at priority `1`, after
+//! [`super::Breath`] (priority `0`) writes its own `mouth.center.y`
+//! delta. Both modifiers track their own `last_offset` so the
+//! additive composition undoes cleanly on each step.
+
+use core::num::NonZeroU32;
+
+use crate::clock::Instant;
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::modifier::Modifier;
+
+/// Minimum interval between fires, in ms.
+pub const DEFAULT_INTERVAL_MIN_MS: u64 = 2_000;
+/// Maximum interval between fires, in ms.
+pub const DEFAULT_INTERVAL_MAX_MS: u64 = 6_000;
+/// Maximum vertical perturbation magnitude in pixels, in either direction.
+pub const DEFAULT_MAX_MOUTH_Y_PX: i32 = 3;
+
+/// Default xorshift32 seed. Different from the seeds used by
+/// [`super::IdleDrift`] / [`super::IdleHeadDrift`] / [`super::Soliloquy`]
+/// so the schedules don't synchronise out of the box.
+#[allow(
+    clippy::unwrap_used,
+    reason = "const-evaluated against a non-zero literal: unwrap can't fire at runtime"
+)]
+const DEFAULT_SEED: NonZeroU32 = NonZeroU32::new(0xCAFE_F00D).unwrap();
+
+/// Modifier that occasionally offsets `mouth.center.y` by a small random amount.
+///
+/// Undoes the previous offset before applying a new one so successive
+/// fires don't accumulate. See module docs for the composition story
+/// with [`super::Breath`].
+#[derive(Debug, Clone, Copy)]
+pub struct IdleMicroExpression {
+    /// Lower bound on the random interval.
+    interval_min_ms: u64,
+    /// Upper bound on the random interval.
+    interval_max_ms: u64,
+    /// Maximum perturbation magnitude per fire.
+    max_mouth_y_px: i32,
+    /// xorshift32 state.
+    rng_state: u32,
+    /// Wall-clock instant at which the next perturbation fires.
+    /// `None` until the first tick anchors the schedule.
+    next_fire_at: Option<Instant>,
+    /// Vertical offset applied on the previous fire; subtracted from
+    /// `mouth.center.y` before applying a new offset so successive
+    /// fires don't accumulate.
+    last_y_offset: i32,
+}
+
+impl IdleMicroExpression {
+    /// Construct with default timing + a fixed seed so sim tests are
+    /// reproducible. Firmware overrides the seed at boot via
+    /// [`Self::with_seed`].
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::with_seed(DEFAULT_SEED)
+    }
+
+    /// Construct with a custom xorshift32 seed.
+    #[must_use]
+    pub const fn with_seed(seed: NonZeroU32) -> Self {
+        Self {
+            interval_min_ms: DEFAULT_INTERVAL_MIN_MS,
+            interval_max_ms: DEFAULT_INTERVAL_MAX_MS,
+            max_mouth_y_px: DEFAULT_MAX_MOUTH_Y_PX,
+            rng_state: seed.get(),
+            next_fire_at: None,
+            last_y_offset: 0,
+        }
+    }
+
+    /// Advance the xorshift32 state and return the next pseudo-random `u32`.
+    const fn next_u32(&mut self) -> u32 {
+        let mut x = self.rng_state;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.rng_state = x;
+        x
+    }
+
+    /// Produce a signed offset in `[-max, +max]` from the RNG.
+    fn rand_offset(&mut self, max: i32) -> i32 {
+        if max <= 0 {
+            return 0;
+        }
+        let span = max.saturating_mul(2).saturating_add(1).cast_unsigned();
+        let raw = self.next_u32() % span.max(1);
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "raw is in [0, 2*max+1) which fits in i32 for any reasonable max"
+        )]
+        let raw_i32 = raw as i32;
+        raw_i32 - max
+    }
+
+    /// Pick the next fire delay in `[interval_min_ms, interval_max_ms]`.
+    fn next_delay_ms(&mut self) -> u64 {
+        if self.interval_max_ms <= self.interval_min_ms {
+            return self.interval_min_ms;
+        }
+        let span = self.interval_max_ms - self.interval_min_ms;
+        let r = u64::from(self.next_u32());
+        self.interval_min_ms + (r % (span + 1))
+    }
+}
+
+impl Default for IdleMicroExpression {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Modifier for IdleMicroExpression {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "IdleMicroExpression",
+            description: "Random small vertical perturbation of mouth.center.y every 2-6 s; \
+                          undoes its previous offset before each new fire so the mouth \
+                          doesn't walk off the face.",
+            phase: Phase::Expression,
+            priority: 1,
+            reads: &[Field::MouthCenter],
+            writes: &[Field::MouthCenter],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        let now = entity.tick.now;
+        match self.next_fire_at {
+            None => {
+                let delay = self.next_delay_ms();
+                self.next_fire_at = Some(now + delay);
+                return;
+            }
+            Some(t) if now < t => return,
+            Some(_) => {}
+        }
+
+        entity.face.mouth.center.y -= self.last_y_offset;
+        let dy = self.rand_offset(self.max_mouth_y_px);
+        entity.face.mouth.center.y += dy;
+        self.last_y_offset = dy;
+
+        let delay = self.next_delay_ms();
+        self.next_fire_at = Some(now + delay);
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test literals are compile-time non-zero; the unwrap can't fire"
+)]
+mod tests {
+    use super::*;
+    use crate::Entity;
+
+    fn at(ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.tick.now = Instant::from_millis(ms);
+        e
+    }
+
+    #[test]
+    fn first_tick_only_schedules() {
+        let mut entity = at(0);
+        let baseline_y = entity.face.mouth.center.y;
+        let mut m = IdleMicroExpression::new();
+        m.update(&mut entity);
+        assert_eq!(entity.face.mouth.center.y, baseline_y);
+    }
+
+    #[test]
+    fn perturbation_lands_in_range() {
+        let mut entity = at(0);
+        let baseline_y = entity.face.mouth.center.y;
+        let mut m = IdleMicroExpression::with_seed(NonZeroU32::new(42).unwrap());
+        m.update(&mut entity);
+        entity.tick.now = Instant::from_millis(DEFAULT_INTERVAL_MAX_MS + 1);
+        m.update(&mut entity);
+        let dy = entity.face.mouth.center.y - baseline_y;
+        assert!(dy.abs() <= DEFAULT_MAX_MOUTH_Y_PX, "dy={dy}");
+    }
+
+    #[test]
+    fn offsets_do_not_accumulate_across_many_fires() {
+        let mut entity = at(0);
+        let baseline_y = entity.face.mouth.center.y;
+        let mut m = IdleMicroExpression::with_seed(NonZeroU32::new(7).unwrap());
+        for i in 0..20 {
+            entity.tick.now = Instant::from_millis(i * DEFAULT_INTERVAL_MAX_MS);
+            m.update(&mut entity);
+        }
+        let dy = entity.face.mouth.center.y - baseline_y;
+        assert!(
+            dy.abs() <= DEFAULT_MAX_MOUTH_Y_PX,
+            "drift accumulated: dy={dy}"
+        );
+    }
+
+    #[test]
+    fn ticks_before_due_do_not_perturb() {
+        let mut entity = at(0);
+        let mut m = IdleMicroExpression::new();
+        m.update(&mut entity);
+        let baseline_y = entity.face.mouth.center.y;
+        for ms in 1..DEFAULT_INTERVAL_MIN_MS {
+            entity.tick.now = Instant::from_millis(ms);
+            m.update(&mut entity);
+        }
+        assert_eq!(entity.face.mouth.center.y, baseline_y);
+    }
+}

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -108,6 +108,7 @@ mod head_from_emotion;
 mod head_from_intent;
 mod idle_drift;
 mod idle_head_drift;
+mod idle_micro_expression;
 mod intent_from_body_touch;
 mod intent_from_loud;
 mod lost_target_search;
@@ -166,6 +167,11 @@ pub use idle_drift::{
 pub use idle_head_drift::{
     GLANCE_EASE_IN_MS, GLANCE_EASE_OUT_MS, GLANCE_HOLD_MS, GLANCE_INTERVAL_MAX_MS,
     GLANCE_INTERVAL_MIN_MS, GLANCE_PAN_MAX_DEG, GLANCE_TILT_MAX_DEG, IdleHeadDrift,
+};
+pub use idle_micro_expression::{
+    DEFAULT_INTERVAL_MAX_MS as IDLE_MICRO_EXPRESSION_INTERVAL_MAX_MS,
+    DEFAULT_INTERVAL_MIN_MS as IDLE_MICRO_EXPRESSION_INTERVAL_MIN_MS,
+    DEFAULT_MAX_MOUTH_Y_PX as IDLE_MICRO_EXPRESSION_MAX_MOUTH_Y_PX, IdleMicroExpression,
 };
 pub use intent_from_body_touch::{
     BODY_GESTURE_HOLD_MS, DEFAULT_CENTRE_PRESS, DEFAULT_LEFT_PRESS, DEFAULT_RIGHT_PRESS,

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -68,8 +68,8 @@ EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIn
 EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
 AttentionFromTracking → DormancyFromActivity → EmotionCycle → StyleFromEmotion →
 StyleFromIntent → GazeFromAttention → MicrosaccadeFromAttention → Blink → Breath →
-IdleDrift → BatteryOverlayFromPerception → IdleHeadDrift → HeadFromEmotion →
-HeadFromAttention → LostTargetSearch → HeadFromIntent → MouthFromAudio
+IdleDrift → IdleMicroExpression → BatteryOverlayFromPerception → IdleHeadDrift →
+HeadFromEmotion → HeadFromAttention → LostTargetSearch → HeadFromIntent → MouthFromAudio
 ```
 
 Inputs arrive through embassy `Signal` channels from the per-peripheral

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -80,9 +80,9 @@ use stackchan_core::{
         EmotionCycle, EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
         EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention,
         HeadFromBodyGesture, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleHeadDrift,
-        IntentFromBodyTouch, IntentFromLoud, LostTargetSearch, MicrosaccadeFromAttention,
-        MouthFromAudio, RemoteCommandModifier, Soliloquy, StyleFromEmotion, StyleFromIntent,
-        StyleFromMood,
+        IdleMicroExpression, IntentFromBodyTouch, IntentFromLoud, LostTargetSearch,
+        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, Soliloquy,
+        StyleFromEmotion, StyleFromIntent, StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -195,7 +195,12 @@ type LcdDisplay = mipidsi::Display<
     clippy::too_many_lines,
     reason = "tick body composes 12+ modifiers + sensor drains + render — splitting fragments the per-frame ordering invariants"
 )]
-async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift_seed: NonZeroU32) {
+async fn render_task(
+    mut display: LcdDisplay,
+    drift_seed: NonZeroU32,
+    head_drift_seed: NonZeroU32,
+    micro_expression_seed: NonZeroU32,
+) {
     let clock = HalClock;
     let mut fb = Framebuffer::new();
     defmt::debug!(
@@ -232,6 +237,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     // eye drift and head glance don't fall into a shared rhythm.
     let mut drift = IdleDrift::with_seed(drift_seed);
     let mut head_drift = IdleHeadDrift::with_seed(head_drift_seed);
+    let mut idle_micro_expression = IdleMicroExpression::with_seed(micro_expression_seed);
     let mut head_from_emotion = HeadFromEmotion::new();
     let mut head_from_attention = HeadFromAttention::new();
     let mut lost_target_search = LostTargetSearch::new();
@@ -346,6 +352,9 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
     director.add_modifier(&mut blink).expect("registry full");
     director.add_modifier(&mut breath).expect("registry full");
     director.add_modifier(&mut drift).expect("registry full");
+    director
+        .add_modifier(&mut idle_micro_expression)
+        .expect("registry full");
     // Phase::Decoration — expiry first (priority -10), then trigger
     // modifiers in priority order. Sits between Expression and Motion
     // so decorators read final emotion / style state but don't influence
@@ -429,7 +438,7 @@ async fn render_task(mut display: LcdDisplay, drift_seed: NonZeroU32, head_drift
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
     defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + BatteryOverlayFromPerception + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
+        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleMicroExpression + BatteryOverlayFromPerception + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
         FRAME_PERIOD_MS
     );
 
@@ -1331,13 +1340,20 @@ async fn main(spawner: Spawner) -> ! {
     };
     let drift_seed = sample_seed();
     let head_drift_seed = sample_seed();
+    let micro_expression_seed = sample_seed();
     defmt::info!(
-        "idle seeds: eye={=u32:#010x} head={=u32:#010x}",
+        "idle seeds: eye={=u32:#010x} head={=u32:#010x} micro_expr={=u32:#010x}",
         drift_seed.get(),
-        head_drift_seed.get()
+        head_drift_seed.get(),
+        micro_expression_seed.get()
     );
 
-    if let Err(e) = spawner.spawn(render_task(display, drift_seed, head_drift_seed)) {
+    if let Err(e) = spawner.spawn(render_task(
+        display,
+        drift_seed,
+        head_drift_seed,
+        micro_expression_seed,
+    )) {
         defmt::panic!("spawn render_task failed: {}", defmt::Debug2Format(&e));
     }
     if let Err(e) = spawner.spawn(head_task(board_io.head)) {


### PR DESCRIPTION
Stacked on #304.

## Summary

- New `IdleMicroExpression` modifier — Phase::Expression, priority 1.
- Picks a random vertical nudge in `[-3, +3] px` for `mouth.center.y` every `[2 s, 6 s]`.
- Undoes its previous offset before each new fire so successive nudges don't accumulate.
- Composes additively with `Breath`'s own `mouth.center.y` delta because each modifier tracks its own `last_offset`.
- Independent xorshift32 seed at boot from the ESP32-S3 hardware RNG, separate from `IdleDrift` / `IdleHeadDrift` so the schedules don't synchronise.

## Why

Upstream's `IdleExpressionModifier` adds occasional liveness via eye offset + mouth rotation + mouth vertical drift. `IdleDrift` already covers eyes; mouth rotation needs a renderer primitive we don't have. Mouth vertical drift is the surviving surface — a small, cheap, visibly-alive nudge so the mouth doesn't read as frozen during long idle stretches.

## Test plan
- [x] \`cargo test -p stackchan-core --lib idle_micro\` — 4 passed (schedule anchoring, in-range perturbation, no accumulation, no-fire before due)
- [x] \`just check\` clean
- [x] \`cargo +esp clippy --release -- -D warnings\` clean
- [ ] Hardware verify: flash and visually confirm subtle mouth jitter every 2–6 s without drift accumulation across an hour-long idle session