### PR TITLE
feat(firmware): toast log overlay (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ section summarises the milestone work in human terms.
   `IdleDrift` so a long-quiet face shows mouth-side liveness too;
   composes additively with `Breath` via independent
   per-modifier offset tracking.
+- Toast overlay (firmware-only): opt-in via
+  `behavior.toast_overlay_enabled`, with a `crate::toast::push` API
+  any task can call to surface a 3-second warn / error band at the
+  bottom of the LCD. Operator-driven verification path exposed at
+  `POST /toast` (`{level, message}`).
 - Speech-bubble text overlay drawn above the face, with a TTL the
   `BubbleExpiry` modifier sweeps each frame.
 - Decorator badges (heart, sweat, dizzy, ear, pairing, angry, shy)

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -41,6 +41,7 @@ pub mod runtime_store;
 pub mod sd_spi;
 pub mod sleep;
 pub mod storage;
+pub mod toast;
 pub mod touch;
 pub mod tracking_trace;
 pub mod wallclock;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -831,7 +831,12 @@ fn draw_toast_overlay(fb: &mut Framebuffer, toast: &toast::ToastDisplay) {
         clippy::cast_possible_wrap,
         reason = "framebuffer dimensions are well under i32::MAX"
     )]
-    let center = EgPoint::new(FB_WIDTH as i32 / 2, top_y + 13);
+    // FONT_10X20 baseline sits 16 px below the cell top (4 px
+    // descender below). For the 24 px toast band, anchoring the
+    // baseline at top_y + 18 leaves 2 px of margin above and below
+    // the alphabetic glyph extent — same arithmetic the 32 px
+    // passkey banner uses at y=22.
+    let center = EgPoint::new(FB_WIDTH as i32 / 2, top_y + 18);
     let style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
     let _ = Text::with_alignment(toast.text.as_str(), center, style, Alignment::Center).draw(fb);
 }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -26,7 +26,7 @@ extern crate alloc;
 
 use stackchan_firmware::{
     ambient, audio, ble, board, body_touch, button, camera, clock, event_log, framebuffer, head,
-    imu, ir, leds, net, power, sleep, storage, touch, tracking_trace, wallclock, watchdog,
+    imu, ir, leds, net, power, sleep, storage, toast, touch, tracking_trace, wallclock, watchdog,
 };
 
 use board::{HeadDriverImpl, SharedI2c};
@@ -283,11 +283,19 @@ async fn render_task(
             .is_some_and(|c| c.behavior.battery_icon_enabled);
         BatteryOverlayFromPerception::with_enabled(enabled)
     };
+    let toast_overlay_enabled = stackchan_firmware::storage::CONFIG_SNAPSHOT
+        .lock()
+        .await
+        .as_ref()
+        .is_some_and(|c| c.behavior.toast_overlay_enabled);
     let mut last_rendered: Option<Face> = None;
     // Last on-screen pairing passkey. Tracked separately from
     // `last_rendered` so a passkey transition forces a redraw even
     // when the avatar face is bit-equal across frames.
     let mut last_passkey: Option<u32> = None;
+    // Last on-screen toast. Same dirty-check escape as `last_passkey`:
+    // a toast push needs to redraw even when the face hasn't changed.
+    let mut last_toast: Option<toast::ToastDisplay> = None;
     // Last instant TX was observed playing. Drives the post-playback
     // tail of the audio_rms gate so the mic doesn't pick up the
     // speaker's residual response immediately after a chirp ends.
@@ -762,11 +770,17 @@ async fn render_task(
             // `motor.head_pose`, which is invisible to this dirty
             // check by construction.
             let current_passkey = ble::read_passkey();
+            let current_toast = if toast_overlay_enabled {
+                toast::current(now)
+            } else {
+                None
+            };
             let face_changed = last_rendered
                 .as_ref()
                 .is_none_or(|prev| *prev != entity.face);
             let passkey_changed = current_passkey != last_passkey;
-            if face_changed || passkey_changed {
+            let toast_changed = current_toast != last_toast;
+            if face_changed || passkey_changed || toast_changed {
                 // Draw is Infallible on `Framebuffer`; the `let _ =`
                 // discards the `Result<(), Infallible>` without
                 // triggering unwrap lints.
@@ -774,10 +788,14 @@ async fn render_task(
                 if let Some(passkey) = current_passkey {
                     draw_passkey_overlay(&mut fb, passkey);
                 }
+                if let Some(t) = current_toast.as_ref() {
+                    draw_toast_overlay(&mut fb, t);
+                }
                 match display.fill_contiguous(&canvas, fb.as_slice().iter().copied()) {
                     Ok(()) => {
                         last_rendered = Some(entity.face);
                         last_passkey = current_passkey;
+                        last_toast = current_toast;
                     }
                     Err(e) => defmt::error!("render: blit failed: {}", defmt::Debug2Format(&e)),
                 }
@@ -786,6 +804,36 @@ async fn render_task(
 
         ticker.next().await;
     }
+}
+
+/// Draw a short toast band across the bottom of the framebuffer.
+/// Colour matches the toast severity (warn = amber, error = red);
+/// text is centred in white `FONT_10X20`.
+fn draw_toast_overlay(fb: &mut Framebuffer, toast: &toast::ToastDisplay) {
+    use embedded_graphics::pixelcolor::RgbColor;
+    let height: u32 = 24;
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "framebuffer dimensions are well under i32::MAX"
+    )]
+    let top_y = FB_HEIGHT as i32 - height as i32;
+    let band = Rectangle::new(EgPoint::new(0, top_y), Size::new(FB_WIDTH, height));
+    let bg = PrimitiveStyleBuilder::new()
+        .fill_color(match toast.level {
+            toast::ToastLevel::Warn => Rgb565::new(31, 40, 0),
+            toast::ToastLevel::Error => Rgb565::new(31, 8, 4),
+        })
+        .build();
+    if band.into_styled(bg).draw(fb).is_err() {
+        return;
+    }
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "framebuffer dimensions are well under i32::MAX"
+    )]
+    let center = EgPoint::new(FB_WIDTH as i32 / 2, top_y + 13);
+    let style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+    let _ = Text::with_alignment(toast.text.as_str(), center, style, Alignment::Center).draw(fb);
 }
 
 /// Draw a transient pairing-passkey banner across the top of the

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -128,7 +128,7 @@ use embassy_sync::pubsub::WaitResult;
 use embassy_sync::signal::Signal;
 use embassy_time::Duration;
 use embedded_io_async::Write as AsyncWrite;
-use stackchan_core::RemoteCommand;
+use stackchan_core::{Clock as _, RemoteCommand};
 use stackchan_net::http_command::{self as json, JsonError};
 use stackchan_net::http_parse::{
     ct_eq, find_subsequence, parse_bearer_token, parse_content_length,
@@ -464,6 +464,7 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("POST", "/crash/clear") => handle_post_crash_clear(socket).await,
         ("POST", "/sleep") => handle_post_sleep(socket).await,
         ("POST", "/wake") => handle_post_wake(socket).await,
+        ("POST", "/toast") => handle_post_toast(socket, body).await,
         ("GET", "/head/offsets") => handle_get_head_offsets(socket).await,
         ("POST", "/head/offsets") => handle_post_head_offsets(socket, body).await,
         ("POST", "/mcp") => handle_post_mcp(socket, body).await,
@@ -960,6 +961,46 @@ async fn handle_post_sleep(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> 
 async fn handle_post_wake(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
     crate::sleep::SLEEP_SIGNAL.signal(crate::sleep::SleepState::Awake);
     defmt::info!("http: POST /wake → exiting sleep");
+    write_no_content(socket).await
+}
+
+/// `POST /toast` — JSON `{"level":"warn"|"error","message":"..."}`.
+/// Pushes a toast onto the firmware's render-side overlay. Useful for
+/// operator-driven verification when the overlay is enabled via
+/// `behavior.toast_overlay_enabled`.
+///
+/// Returns 400 on a body that fails to parse, 204 otherwise. The
+/// overlay still requires `toast_overlay_enabled = true` in the boot
+/// config for the toast to actually render.
+async fn handle_post_toast(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
+    use stackchan_net::mcp::find_string_field;
+    let level = match find_string_field(body, "level") {
+        Ok(Some("warn")) => crate::toast::ToastLevel::Warn,
+        Ok(Some("error")) => crate::toast::ToastLevel::Error,
+        Ok(Some(other)) => {
+            defmt::warn!("http: POST /toast unknown level={=str}", other);
+            return write_text(socket, 400, "level must be \"warn\" or \"error\"\n").await;
+        }
+        Ok(None) => {
+            return write_text(socket, 400, "missing level field\n").await;
+        }
+        Err(_) => {
+            return write_text(socket, 400, "malformed JSON body\n").await;
+        }
+    };
+    let message = match find_string_field(body, "message") {
+        Ok(Some(m)) => m,
+        Ok(None) => "",
+        Err(_) => {
+            return write_text(socket, 400, "malformed JSON body\n").await;
+        }
+    };
+    crate::toast::push(level, message, crate::clock::HalClock.now());
+    defmt::info!(
+        "http: POST /toast level={=?} msg={=str}",
+        defmt::Debug2Format(&level),
+        message
+    );
     write_no_content(socket).await
 }
 

--- a/crates/stackchan-firmware/src/toast.rs
+++ b/crates/stackchan-firmware/src/toast.rs
@@ -1,0 +1,125 @@
+//! Toast overlay — short on-screen warn/error notifications.
+//!
+//! Opt-in via `BehaviorConfig::toast_overlay_enabled`. When enabled,
+//! the render task paints the most recently pushed toast in a
+//! horizontal band at the bottom of the LCD for [`TOAST_TTL_MS`]
+//! after it was pushed. The slot is single-deep — a fresh push
+//! overwrites the previous toast, so a burst of failures shows the
+//! most recent rather than a cycling backlog.
+//!
+//! ## Why a separate slot instead of `Face::bubble`
+//!
+//! The bubble lives in `stackchan-core` and is part of the avatar's
+//! emotional surface — set by skills, decorators, and the
+//! soliloquy modifier. The toast is a *debug aid*: warning the
+//! operator that something is wrong with the firmware itself, not
+//! something the avatar is saying. Keeping it firmware-side means
+//! it can fire from any task (Wi-Fi failure, panic recovery, BLE
+//! bond eviction, audio underrun) without dragging a
+//! firmware-specific notion into the host-side domain model.
+//!
+//! ## Tasks can push from any context
+//!
+//! `push` takes a critical-section lock on the slot and returns
+//! immediately. It is safe to call from interrupts and async
+//! contexts. The render task is the sole reader (via
+//! [`current`]); it never blocks waiting for a toast.
+
+use core::cell::Cell;
+use core::fmt::Write as _;
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use stackchan_core::Instant;
+
+/// How long a toast stays visible after being pushed, in ms. Long
+/// enough to read a six-word message; short enough that a burst of
+/// warnings doesn't keep occluding the lower-third of the face.
+pub const TOAST_TTL_MS: u64 = 3_000;
+
+/// Maximum byte length of a toast message. Picked to fit one line of
+/// `FONT_8X13` across the 320-px framebuffer with margin to spare.
+pub const MAX_TOAST_LEN: usize = 40;
+
+/// Severity tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToastLevel {
+    /// Yellow band — non-fatal warning.
+    Warn,
+    /// Red band — error worth the operator's attention.
+    Error,
+}
+
+/// One toast snapshot — what the renderer needs to paint a single
+/// frame. Implements `PartialEq` so the render task can dirty-check
+/// against the previous frame's toast cheaply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToastDisplay {
+    /// Severity tier.
+    pub level: ToastLevel,
+    /// Bounded-length message text.
+    pub text: heapless::String<MAX_TOAST_LEN>,
+    /// Wall-clock instant after which this toast stops being drawn.
+    pub expires_at: Instant,
+}
+
+/// In-memory slot for the active toast, or `None` for the
+/// no-toast steady state. Held in a critical-section mutex so any
+/// task — including interrupt handlers — can push without yielding.
+static SLOT: Mutex<CriticalSectionRawMutex, Cell<Option<ToastDisplay>>> =
+    Mutex::new(Cell::new(None));
+
+/// Push a toast. Overwrites any active toast — the render path
+/// shows the most recent only.
+pub fn push(level: ToastLevel, message: &str, now: Instant) {
+    let mut text: heapless::String<MAX_TOAST_LEN> = heapless::String::new();
+    for ch in message.chars() {
+        if text.push(ch).is_err() {
+            break;
+        }
+    }
+    let display = ToastDisplay {
+        level,
+        text,
+        expires_at: Instant::from_millis(now.as_millis() + TOAST_TTL_MS),
+    };
+    SLOT.lock(|cell| cell.set(Some(display)));
+}
+
+/// Push a toast using a `core::fmt::Write` builder. Convenient when
+/// the caller has a `Debug2Format` value or wants to compose a
+/// short structured message without allocating.
+pub fn push_fmt(level: ToastLevel, now: Instant, args: core::fmt::Arguments<'_>) {
+    let mut buf: heapless::String<MAX_TOAST_LEN> = heapless::String::new();
+    let _ = buf.write_fmt(args);
+    let display = ToastDisplay {
+        level,
+        text: buf,
+        expires_at: Instant::from_millis(now.as_millis() + TOAST_TTL_MS),
+    };
+    SLOT.lock(|cell| cell.set(Some(display)));
+}
+
+/// Read the active toast if one exists and `now` is before its
+/// expiry. Returns `None` (and clears the slot) once the TTL has
+/// passed so the next render skips the overlay.
+#[must_use]
+pub fn current(now: Instant) -> Option<ToastDisplay> {
+    SLOT.lock(|cell| {
+        let current = cell.take();
+        match current {
+            Some(display) if now < display.expires_at => {
+                // Put it back; it's still live.
+                cell.set(Some(display.clone()));
+                Some(display)
+            }
+            _ => None,
+        }
+    })
+}
+
+/// Clear the slot. Test helper + a hook the operator dashboard can
+/// call via `POST /toast/clear` if a future route exposes one.
+pub fn clear() {
+    SLOT.lock(|cell| cell.set(None));
+}

--- a/crates/stackchan-firmware/src/toast.rs
+++ b/crates/stackchan-firmware/src/toast.rs
@@ -37,9 +37,10 @@ use stackchan_core::Instant;
 /// warnings doesn't keep occluding the lower-third of the face.
 pub const TOAST_TTL_MS: u64 = 3_000;
 
-/// Maximum byte length of a toast message. Picked to fit one line of
-/// `FONT_8X13` across the 320-px framebuffer with margin to spare.
-pub const MAX_TOAST_LEN: usize = 40;
+/// Maximum byte length of a toast message. Sized for one line of
+/// `FONT_10X20` across the 320-px framebuffer (10 px/char × 32 chars
+/// = 320 px), the font the render path uses for the toast band.
+pub const MAX_TOAST_LEN: usize = 32;
 
 /// Severity tier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,10 +87,12 @@ pub fn push(level: ToastLevel, message: &str, now: Instant) {
     SLOT.lock(|cell| cell.set(Some(display)));
 }
 
-/// Push a toast using a `core::fmt::Write` builder. Convenient when
-/// the caller has a `Debug2Format` value or wants to compose a
-/// short structured message without allocating.
-pub fn push_fmt(level: ToastLevel, now: Instant, args: core::fmt::Arguments<'_>) {
+/// Push a toast using a `core::fmt::Write` builder.
+///
+/// Convenient when the caller has a `Debug2Format` value or wants to
+/// compose a short structured message without allocating. Argument
+/// order mirrors [`push`] (level, payload, timestamp).
+pub fn push_fmt(level: ToastLevel, args: core::fmt::Arguments<'_>, now: Instant) {
     let mut buf: heapless::String<MAX_TOAST_LEN> = heapless::String::new();
     let _ = buf.write_fmt(args);
     let display = ToastDisplay {

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -129,6 +129,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        battery_icon_enabled: {},",
         config.behavior.battery_icon_enabled
     );
+    let _ = writeln!(
+        out,
+        "        toast_overlay_enabled: {},",
+        config.behavior.toast_overlay_enabled
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -488,6 +493,7 @@ impl<'a> Parser<'a> {
         let mut soliloquy_enabled: Option<bool> = None;
         let mut hourly_chime_enabled: Option<bool> = None;
         let mut battery_icon_enabled: Option<bool> = None;
+        let mut toast_overlay_enabled: Option<bool> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -501,6 +507,7 @@ impl<'a> Parser<'a> {
                 "soliloquy_enabled" => soliloquy_enabled = Some(self.parse_bool()?),
                 "hourly_chime_enabled" => hourly_chime_enabled = Some(self.parse_bool()?),
                 "battery_icon_enabled" => battery_icon_enabled = Some(self.parse_bool()?),
+                "toast_overlay_enabled" => toast_overlay_enabled = Some(self.parse_bool()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -512,6 +519,7 @@ impl<'a> Parser<'a> {
             soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
             hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
             battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
+            toast_overlay_enabled: toast_overlay_enabled.unwrap_or(false),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -238,10 +238,11 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     out.push_str("},\"behavior\":{");
     let _ = write!(
         out,
-        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{}",
+        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{},\"toast_overlay_enabled\":{}",
         config.behavior.soliloquy_enabled,
         config.behavior.hourly_chime_enabled,
         config.behavior.battery_icon_enabled,
+        config.behavior.toast_overlay_enabled,
     );
     out.push_str("}}");
     Ok(out)
@@ -743,6 +744,7 @@ impl<'a> Parser<'a> {
         let mut soliloquy_enabled: Option<bool> = None;
         let mut hourly_chime_enabled: Option<bool> = None;
         let mut battery_icon_enabled: Option<bool> = None;
+        let mut toast_overlay_enabled: Option<bool> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -771,6 +773,15 @@ impl<'a> Parser<'a> {
                     }
                     battery_icon_enabled = Some(self.parse_bool()?);
                 }
+                "toast_overlay_enabled" => {
+                    if toast_overlay_enabled.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "toast_overlay_enabled",
+                        ));
+                    }
+                    toast_overlay_enabled = Some(self.parse_bool()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -782,6 +793,7 @@ impl<'a> Parser<'a> {
             soliloquy_enabled: soliloquy_enabled.unwrap_or(false),
             hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
             battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
+            toast_overlay_enabled: toast_overlay_enabled.unwrap_or(false),
         })
     }
 
@@ -1005,6 +1017,7 @@ mod tests {
                 soliloquy_enabled: true,
                 hourly_chime_enabled: false,
                 battery_icon_enabled: true,
+                toast_overlay_enabled: true,
             },
         }
     }
@@ -1323,6 +1336,7 @@ mod tests {
                 soliloquy_enabled: true,
                 hourly_chime_enabled: false,
                 battery_icon_enabled: true,
+                toast_overlay_enabled: true,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -285,6 +285,11 @@ impl Default for EspNowConfig {
 /// editing `STACKCHAN.RON` directly.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "each flag gates a distinct opt-in behavior; consolidating into bitflags \
+              hides the wire-format key names that operators edit in STACKCHAN.RON"
+)]
 pub struct BehaviorConfig {
     /// When `true`, the firmware writes a randomly-picked
     /// soliloquy line to `face.bubble` at random intervals
@@ -307,6 +312,12 @@ pub struct BehaviorConfig {
     /// at the source so a one-percent change does not re-trigger a
     /// frame redraw.
     pub battery_icon_enabled: bool,
+    /// When `true`, the firmware renders a short toast band at the
+    /// bottom of the screen for any warn / error events posted via
+    /// `crate::toast::push`. Off by default so the avatar's resting
+    /// expression stays clean; operators opt in via the boot config
+    /// or `PUT /settings`. Toasts have a fixed 3-second TTL.
+    pub toast_overlay_enabled: bool,
 }
 
 /// Time / SNTP configuration.

--- a/docs/http.md
+++ b/docs/http.md
@@ -44,6 +44,7 @@ beats pulling a full HTTP framework into the firmware target.
 | POST   | `/mcp`           | JSON-RPC 2.0 / MCP endpoint (initialize, tools/list, tools/call) |
 | POST   | `/volume`        | Set output volume (0–100); persisted to SD           |
 | POST   | `/mute`          | Mute / un-mute output stage; persisted to SD         |
+| POST   | `/toast`         | Push a short toast band (warn / error); 3-second TTL |
 | GET    | `/settings`      | Persisted config (PSK + token redacted)             |
 | PUT    | `/settings`      | Replace persisted config; atomic SD writeback        |
 


### PR DESCRIPTION
Stacked on #305 (which stacks on #304).

## Summary

- New `crate::toast` module: critical-section-safe `push` from any task, `current(now)` reader for the render task.
- `behavior.toast_overlay_enabled` boot flag (default off).
- Render task picks up active toast each frame, paints a 24 px band at the bottom with severity-coloured background + white \`FONT_10X20\` text, and tracks it in the dirty-check so a push forces a redraw even when the face hasn't changed.
- New \`POST /toast\` route — JSON \`{level, message}\` — for operator-driven verification.
- TTL is 3 s; slot is single-deep so a burst shows the most recent.

## Design notes

The toast state lives in firmware (not on \`Face\`) because it's a debug aid rather than part of the avatar's emotional surface. Keeping it firmware-side also means any task (interrupt, async, render) can push without dragging the notion into the host-side domain model.

## Test plan

- [x] \`just check\` clean
- [x] \`cargo +esp clippy --release -- -D warnings\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --all-features\` clean
- [ ] Hardware verify: flash with \`behavior.toast_overlay_enabled: true\`, hit \`POST /toast {"level":"warn","message":"hi"}\` from curl, confirm the band paints for 3 s then disappears without lingering pixels.