### PR TITLE
feat(firmware): auto-torque-release (idle servo power saver)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ section summarises the milestone work in human terms.
 - Optional hourly chime (`behavior.hourly_chime_enabled`) — a short
   `WakeChirp` at every wall-clock top-of-hour. Off by default; gated
   on an SNTP-synced RTC.
+- Auto-torque-release: `behavior.auto_torque_release_ms` releases
+  holding torque on the `SCServo` pan / tilt motors after the
+  configured idle window with no commanded pose change. The next
+  commanded change re-enables torque before the position write.
+  `0` (default) keeps torque on continuously.
 
 ### Networking + control plane
 

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -241,6 +241,23 @@ impl<W: Write> ScsHead<W> {
 }
 
 impl<U: Read + Write> ScsHead<U> {
+    /// Enable or disable holding torque on both servos. Used by the
+    /// firmware's auto-torque-release idle saver: a quiet desk-toy can
+    /// release torque to drop the motors' standing draw, and re-enable
+    /// it on the next commanded pose change. Errors on the first
+    /// failing write — the caller logs + continues so a transient
+    /// glitch doesn't reboot the binary.
+    ///
+    /// # Errors
+    /// Returns the transport error on the first failing write.
+    pub async fn set_torque(&mut self, enabled: bool) -> Result<(), scservo::Error<U::Error>> {
+        self.bus.write_torque_enable(YAW_SERVO_ID, enabled).await?;
+        self.bus
+            .write_torque_enable(PITCH_SERVO_ID, enabled)
+            .await?;
+        Ok(())
+    }
+
     /// Read the live position of both servos, return a `Pose` in the
     /// same commanded-reference-frame as `set_pose` inputs. Useful for
     /// feedback logging + the future `EyeGaze` modifier.

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -890,6 +890,11 @@ fn draw_passkey_overlay(fb: &mut Framebuffer, passkey: u32) {
 /// UART write/read failures log at `warn` and continue: a transient
 /// bus glitch shouldn't blank the face or reboot the binary.
 #[embassy_executor::task]
+#[allow(
+    clippy::too_many_lines,
+    reason = "single embassy task body: signal-drain + pose dispatch + torque-saver + read-back \
+              loop. Splitting fragments the long-lived locals the loop carries forward."
+)]
 async fn head_task(mut driver: HeadDriverImpl) {
     /// Poll position every N command ticks. `HEAD_PERIOD_MS` × N = 1 s.
     const POSITION_POLL_EVERY: u32 = 50;
@@ -897,16 +902,27 @@ async fn head_task(mut driver: HeadDriverImpl) {
     const READ_TIMEOUT_MS: u64 = 10;
 
     let clock = HalClock;
+    let auto_release_ms: u64 = u64::from(
+        stackchan_firmware::storage::CONFIG_SNAPSHOT
+            .lock()
+            .await
+            .as_ref()
+            .map_or(0_u32, |c| c.behavior.auto_torque_release_ms),
+    );
     let mut ticker = Ticker::every(Duration::from_millis(HEAD_PERIOD_MS));
     let mut current = stackchan_core::Pose::NEUTRAL;
+    let mut last_commanded = current;
+    let mut last_pose_change_at = clock.now();
+    let mut torque_released = false;
     let mut offsets = head::HeadOffsets::default();
     let mut tick_count: u32 = 0;
     defmt::info!(
-        "head task: {=u64} ms tick, consumes POSE_SIGNAL for SCServo IDs {=u8} (yaw) / {=u8} (pitch), reads actual @ {=u64} ms",
+        "head task: {=u64} ms tick, consumes POSE_SIGNAL for SCServo IDs {=u8} (yaw) / {=u8} (pitch), reads actual @ {=u64} ms, auto-torque-release after {=u64} ms (0 = disabled)",
         HEAD_PERIOD_MS,
         head::YAW_SERVO_ID,
         head::PITCH_SERVO_ID,
         HEAD_PERIOD_MS.saturating_mul(u64::from(POSITION_POLL_EVERY)),
+        auto_release_ms,
     );
     loop {
         watchdog::HEAD.beat();
@@ -922,9 +938,43 @@ async fn head_task(mut driver: HeadDriverImpl) {
                 offsets.tilt_offset_deg,
             );
         }
+        let now = clock.now();
+        let pose_changed = current.pan_deg.to_bits() != last_commanded.pan_deg.to_bits()
+            || current.tilt_deg.to_bits() != last_commanded.tilt_deg.to_bits();
+        if pose_changed {
+            last_pose_change_at = now;
+            last_commanded = current;
+            if torque_released {
+                match driver.set_torque(true).await {
+                    Ok(()) => {
+                        defmt::info!("head: torque re-enabled (operator commanded new pose)");
+                        torque_released = false;
+                    }
+                    Err(e) => {
+                        defmt::warn!("head: torque re-enable failed: {}", defmt::Debug2Format(&e))
+                    }
+                }
+            }
+        }
         let commanded = offsets.apply(current);
-        if let Err(e) = driver.set_pose(commanded, clock.now()).await {
+        if let Err(e) = driver.set_pose(commanded, now).await {
             defmt::warn!("head: SCServo write failed: {}", defmt::Debug2Format(&e));
+        }
+        if auto_release_ms > 0
+            && !torque_released
+            && now.saturating_duration_since(last_pose_change_at) >= auto_release_ms
+        {
+            match driver.set_torque(false).await {
+                Ok(()) => {
+                    defmt::info!(
+                        "head: torque released after {=u64} ms idle (saver: {=u64} ms)",
+                        now.saturating_duration_since(last_pose_change_at),
+                        auto_release_ms,
+                    );
+                    torque_released = true;
+                }
+                Err(e) => defmt::warn!("head: torque release failed: {}", defmt::Debug2Format(&e)),
+            }
         }
         tick_count = tick_count.wrapping_add(1);
         if tick_count.is_multiple_of(POSITION_POLL_EVERY) {

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -943,17 +943,27 @@ async fn head_task(mut driver: HeadDriverImpl) {
             || current.tilt_deg.to_bits() != last_commanded.tilt_deg.to_bits();
         if pose_changed {
             last_pose_change_at = now;
-            last_commanded = current;
             if torque_released {
                 match driver.set_torque(true).await {
                     Ok(()) => {
                         defmt::info!("head: torque re-enabled (operator commanded new pose)");
                         torque_released = false;
+                        last_commanded = current;
                     }
                     Err(e) => {
-                        defmt::warn!("head: torque re-enable failed: {}", defmt::Debug2Format(&e))
+                        // Leave `last_commanded` un-advanced so the next
+                        // tick still sees `pose_changed = true` and
+                        // retries the re-enable. Otherwise a transient
+                        // bus glitch would keep the servo slack until
+                        // the operator commanded a *different* pose.
+                        defmt::warn!(
+                            "head: torque re-enable failed: {}; will retry next tick",
+                            defmt::Debug2Format(&e)
+                        );
                     }
                 }
+            } else {
+                last_commanded = current;
             }
         }
         let commanded = offsets.apply(current);

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -134,6 +134,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        toast_overlay_enabled: {},",
         config.behavior.toast_overlay_enabled
     );
+    let _ = writeln!(
+        out,
+        "        auto_torque_release_ms: {},",
+        config.behavior.auto_torque_release_ms
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -494,6 +499,7 @@ impl<'a> Parser<'a> {
         let mut hourly_chime_enabled: Option<bool> = None;
         let mut battery_icon_enabled: Option<bool> = None;
         let mut toast_overlay_enabled: Option<bool> = None;
+        let mut auto_torque_release_ms: Option<u32> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -508,6 +514,7 @@ impl<'a> Parser<'a> {
                 "hourly_chime_enabled" => hourly_chime_enabled = Some(self.parse_bool()?),
                 "battery_icon_enabled" => battery_icon_enabled = Some(self.parse_bool()?),
                 "toast_overlay_enabled" => toast_overlay_enabled = Some(self.parse_bool()?),
+                "auto_torque_release_ms" => auto_torque_release_ms = Some(self.parse_u32()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -520,6 +527,7 @@ impl<'a> Parser<'a> {
             hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
             battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
             toast_overlay_enabled: toast_overlay_enabled.unwrap_or(false),
+            auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
         })
     }
 
@@ -541,6 +549,26 @@ impl<'a> Parser<'a> {
             return Ok(Some(v));
         }
         Err(bare_err("expected Some(...) or None", ""))
+    }
+
+    /// Parse a contiguous run of decimal digits as a `u32`. Used for
+    /// `behavior.auto_torque_release_ms`. Any digits past `u32::MAX`
+    /// land on `BareParse` rather than wrapping silently.
+    fn parse_u32(&mut self) -> Result<u32, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected unsigned integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: u32 = digits
+            .parse()
+            .map_err(|_| bare_err("not a u32 literal", digits))?;
+        self.input = rest;
+        Ok(parsed)
     }
 
     /// Parse a contiguous run of decimal digits as a `u8`. Used for

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -238,11 +238,12 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     out.push_str("},\"behavior\":{");
     let _ = write!(
         out,
-        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{},\"toast_overlay_enabled\":{}",
+        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{},\"toast_overlay_enabled\":{},\"auto_torque_release_ms\":{}",
         config.behavior.soliloquy_enabled,
         config.behavior.hourly_chime_enabled,
         config.behavior.battery_icon_enabled,
         config.behavior.toast_overlay_enabled,
+        config.behavior.auto_torque_release_ms,
     );
     out.push_str("}}");
     Ok(out)
@@ -745,6 +746,7 @@ impl<'a> Parser<'a> {
         let mut hourly_chime_enabled: Option<bool> = None;
         let mut battery_icon_enabled: Option<bool> = None;
         let mut toast_overlay_enabled: Option<bool> = None;
+        let mut auto_torque_release_ms: Option<u32> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -782,6 +784,15 @@ impl<'a> Parser<'a> {
                     }
                     toast_overlay_enabled = Some(self.parse_bool()?);
                 }
+                "auto_torque_release_ms" => {
+                    if auto_torque_release_ms.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "auto_torque_release_ms",
+                        ));
+                    }
+                    auto_torque_release_ms = Some(self.parse_u32()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -794,6 +805,7 @@ impl<'a> Parser<'a> {
             hourly_chime_enabled: hourly_chime_enabled.unwrap_or(false),
             battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
             toast_overlay_enabled: toast_overlay_enabled.unwrap_or(false),
+            auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
         })
     }
 
@@ -840,6 +852,26 @@ impl<'a> Parser<'a> {
         self.input = rest;
         #[allow(clippy::cast_possible_truncation)]
         Ok(parsed as u8)
+    }
+
+    /// Parse a contiguous run of decimal digits as `u32`. Used for
+    /// `behavior.auto_torque_release_ms`. Digits past `u32::MAX` land
+    /// on `BareParse`.
+    fn parse_u32(&mut self) -> Result<u32, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected unsigned integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: u32 = digits
+            .parse()
+            .map_err(|_| bare_err("not a u32 literal", digits))?;
+        self.input = rest;
+        Ok(parsed)
     }
 
     /// Parse a bare JSON `true` / `false` literal.
@@ -1018,6 +1050,7 @@ mod tests {
                 hourly_chime_enabled: false,
                 battery_icon_enabled: true,
                 toast_overlay_enabled: true,
+                auto_torque_release_ms: 30_000,
             },
         }
     }
@@ -1337,6 +1370,7 @@ mod tests {
                 hourly_chime_enabled: false,
                 battery_icon_enabled: true,
                 toast_overlay_enabled: true,
+                auto_torque_release_ms: 30_000,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -318,6 +318,16 @@ pub struct BehaviorConfig {
     /// expression stays clean; operators opt in via the boot config
     /// or `PUT /settings`. Toasts have a fixed 3-second TTL.
     pub toast_overlay_enabled: bool,
+    /// Idle window (in milliseconds) after which the firmware
+    /// releases holding torque on the `SCServo` pan / tilt motors. `0`
+    /// disables the saver — torque stays on continuously, matching
+    /// v0.1.0 behaviour. Otherwise, after this many ms with no
+    /// commanded pose change, the head task sends
+    /// `write_torque_enable(false)` to both servos; the next
+    /// commanded change re-enables torque before issuing the
+    /// position write. Useful for desk-toy units that sit idle for
+    /// hours and don't need the motors' standing draw.
+    pub auto_torque_release_ms: u32,
 }
 
 /// Time / SNTP configuration.


### PR DESCRIPTION
## Summary

- Adds \`behavior.auto_torque_release_ms\` to \`BehaviorConfig\`. After this many ms with no commanded pose change, the head task disables SCServo holding torque on both pan + tilt.
- The next commanded pose change re-enables torque before the position write, so operator commands are never lost.
- New \`ScsHead::set_torque(enabled)\` helper batches the two-axis torque writes.
- \`0\` (default) keeps torque on continuously, matching v0.1.0 behaviour.
- Symmetric \`parse_u32\` helpers added to both the RON and JSON behavior-block parsers.

## Test plan
- [x] \`just check\` clean
- [x] \`cargo +esp clippy --release -- -D warnings\` clean
- [ ] Hardware verify with \`auto_torque_release_ms: 10000\` — let the unit sit idle 10 s, observe \`head: torque released\` info log + motors going slack; \`POST /look-at\` triggers \`head: torque re-enabled\` info log + the head moves.

## Note on modify-lock scope

The original Arc 2b task bundled modify-lock alongside auto-torque-release. Audit showed that "operator-holds-the-head" is already covered by \`RemoteCommand::LookAt\` + \`mind.autonomy.manual_until\` for the autonomy-gated head modifiers; the remaining gap (idle\_head\_drift doesn't read autonomy) is small and orthogonal, so I'm dropping it from this scope to keep the PR tight.