### PR TITLE
feat(firmware): persist head offsets to RUNTIME.RON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ section summarises the milestone work in human terms.
   configured idle window with no commanded pose change. The next
   commanded change re-enables torque before the position write.
   `0` (default) keeps torque on continuously.
+- Head offsets persist to `/sd/RUNTIME.RON`. Previously,
+  `POST /head/offsets` was runtime-only and a reboot zeroed the
+  dialled trim; now the operator's value rides through the same
+  SD-backed runtime store as `palette` / `mood` / `face_geometry`
+  and is restored to `OFFSETS_CACHE` + signalled to the head task
+  before the first tick.
 
 ### Networking + control plane
 

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1281,11 +1281,20 @@ async fn main(spawner: Spawner) -> ! {
             net::http::PALETTE_SIGNAL.signal(runtime.palette);
             net::http::MOOD_SIGNAL.signal(runtime.mood);
             net::http::FACE_GEOMETRY_SIGNAL.signal(runtime.face_geometry);
+            // Seed the head task's offset signal + cache directly so
+            // the first head tick already applies the persisted trim.
+            // Without the explicit cache seed, `GET /head/offsets`
+            // would return zero between boot and the head task's
+            // first signal-drain.
+            head::OFFSETS_SIGNAL.signal(runtime.head_offsets);
+            head::OFFSETS_CACHE.lock(|cell| cell.set(runtime.head_offsets));
             defmt::info!(
-                "runtime store: restored palette={=str} mood={=str} face_geometry={=str}",
+                "runtime store: restored palette={=str} mood={=str} face_geometry={=str} head_offsets=({=f32}, {=f32})",
                 runtime.palette.wire_str(),
                 runtime.mood.wire_str(),
                 runtime.face_geometry.wire_str(),
+                runtime.head_offsets.yaw_offset_deg,
+                runtime.head_offsets.tilt_offset_deg,
             );
             cfg
         }

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -880,9 +880,13 @@ async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Res
     // tick, leaving a small POST-then-GET window where the read
     // returns the prior value).
     crate::head::OFFSETS_CACHE.lock(|cell| cell.set(firmware_offsets));
+    // The persist outcome is logged by `runtime_store::persist` itself
+    // (`info!` on success, `warn!` on SD-write failure) — no need to
+    // annotate either side here, which would risk a contradictory
+    // ordering in the serial log if the SD write failed.
     let _ = crate::runtime_store::update_head_offsets(firmware_offsets).await;
     defmt::info!(
-        "http: POST /head/offsets → yaw={=f32} tilt={=f32} (persisted)",
+        "http: POST /head/offsets → yaw={=f32} tilt={=f32}",
         firmware_offsets.yaw_offset_deg,
         firmware_offsets.tilt_offset_deg,
     );

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -855,9 +855,8 @@ async fn handle_get_head_offsets(socket: &mut TcpSocket<'_>) -> Result<(), HttpE
 
 /// `POST /head/offsets` — parse the JSON body and push the new
 /// offsets at the head task via
-/// [`crate::head::OFFSETS_SIGNAL`]. Runtime-only; head offsets are
-/// not yet enrolled in the SD-backed `RuntimeStore` and reset on
-/// reboot.
+/// [`crate::head::OFFSETS_SIGNAL`]. Persists to `/sd/RUNTIME.RON`
+/// so a reboot restores the dialled-in trim.
 async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
     let offsets = match json::parse_head_offsets(body) {
         Ok(o) => o,
@@ -881,8 +880,9 @@ async fn handle_post_head_offsets(socket: &mut TcpSocket<'_>, body: &str) -> Res
     // tick, leaving a small POST-then-GET window where the read
     // returns the prior value).
     crate::head::OFFSETS_CACHE.lock(|cell| cell.set(firmware_offsets));
+    let _ = crate::runtime_store::update_head_offsets(firmware_offsets).await;
     defmt::info!(
-        "http: POST /head/offsets → yaw={=f32} tilt={=f32}",
+        "http: POST /head/offsets → yaw={=f32} tilt={=f32} (persisted)",
         firmware_offsets.yaw_offset_deg,
         firmware_offsets.tilt_offset_deg,
     );

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -40,10 +40,12 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use stackchan_core::{FaceGeometry, Mood, Palette};
 
+use crate::head::HeadOffsets;
+
 /// In-memory snapshot of the runtime state. Defaults match the
 /// avatar's neutral resting look so a brand-new device reads the
 /// same state a missing-file fallback would produce.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct RuntimeState {
     /// Current operator-selected palette. Mirrored into
     /// `entity.face.palette` on boot via the firmware's
@@ -56,6 +58,11 @@ pub struct RuntimeState {
     /// `entity.face` on boot via the firmware's
     /// `FACE_GEOMETRY_SIGNAL`.
     pub face_geometry: FaceGeometry,
+    /// Operator-supplied head zero-point correction. Persisted so a
+    /// reboot doesn't reset a freshly-dialled offset; mirrored into
+    /// [`crate::head::OFFSETS_SIGNAL`] + the [`crate::head::OFFSETS_CACHE`]
+    /// at boot.
+    pub head_offsets: HeadOffsets,
 }
 
 /// Render a [`RuntimeState`] to its line-based wire form.
@@ -65,6 +72,20 @@ pub fn render(state: &RuntimeState) -> String {
     let _ = writeln!(out, "palette={}", state.palette.wire_str());
     let _ = writeln!(out, "mood={}", state.mood.wire_str());
     let _ = writeln!(out, "face_geometry={}", state.face_geometry.wire_str());
+    // Two decimal places match the resolution operators dial via
+    // `POST /head/offsets` (the JSON parser accepts any f32). Stored
+    // separately so a future bump in precision doesn't fight the wire
+    // format.
+    let _ = writeln!(
+        out,
+        "head_yaw_offset={:.2}",
+        state.head_offsets.yaw_offset_deg
+    );
+    let _ = writeln!(
+        out,
+        "head_tilt_offset={:.2}",
+        state.head_offsets.tilt_offset_deg
+    );
     out
 }
 
@@ -101,6 +122,16 @@ pub fn parse(input: &str) -> RuntimeState {
                     out.face_geometry = g;
                 }
             }
+            "head_yaw_offset" => {
+                if let Ok(v) = value.trim().parse::<f32>() {
+                    out.head_offsets.yaw_offset_deg = v;
+                }
+            }
+            "head_tilt_offset" => {
+                if let Ok(v) = value.trim().parse::<f32>() {
+                    out.head_offsets.tilt_offset_deg = v;
+                }
+            }
             _ => {}
         }
     }
@@ -123,6 +154,10 @@ static CACHE: Mutex<CriticalSectionRawMutex, Cell<RuntimeState>> =
         palette: Palette::Default,
         mood: Mood::Neutral,
         face_geometry: FaceGeometry::Default,
+        head_offsets: HeadOffsets {
+            yaw_offset_deg: 0.0,
+            tilt_offset_deg: 0.0,
+        },
     }));
 
 /// Snapshot the current cache.
@@ -194,6 +229,13 @@ pub async fn update_face_geometry(geometry: FaceGeometry) -> bool {
     persist().await
 }
 
+/// Update the head-offsets field and persist the cache. Same
+/// semantics as [`update_palette`].
+pub async fn update_head_offsets(offsets: HeadOffsets) -> bool {
+    mutate(|s| s.head_offsets = offsets);
+    persist().await
+}
+
 /// Apply `f` to the cache atomically — read + modify + write happen
 /// inside one critical section.
 ///
@@ -255,8 +297,31 @@ mod tests {
             palette: Palette::Cute,
             mood: Mood::Playful,
             face_geometry: FaceGeometry::Chibi,
+            head_offsets: HeadOffsets {
+                yaw_offset_deg: 1.25,
+                tilt_offset_deg: -3.5,
+            },
         };
         assert_eq!(render_then_parse(&s), s);
+    }
+
+    #[test]
+    fn parse_omitted_head_offsets_yields_zero() {
+        // Older firmware that wrote only palette/mood/face_geometry
+        // must still parse cleanly under a newer firmware that knows
+        // about head_offsets.
+        let input = "palette=cute\nmood=playful\nface_geometry=chibi\n";
+        let s = parse(input);
+        assert!(s.head_offsets.yaw_offset_deg.abs() < f32::EPSILON);
+        assert!(s.head_offsets.tilt_offset_deg.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn parse_head_offsets_round_trips() {
+        let input = "head_yaw_offset=2.50\nhead_tilt_offset=-1.75\n";
+        let s = parse(input);
+        assert!((s.head_offsets.yaw_offset_deg - 2.5).abs() < f32::EPSILON);
+        assert!((s.head_offsets.tilt_offset_deg - (-1.75)).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/docs/http.md
+++ b/docs/http.md
@@ -28,7 +28,7 @@ beats pulling a full HTTP framework into the firmware target.
 | GET    | `/camera/snapshot` | Most recent `/sd/CAPTURE.565` frame as raw QVGA RGB565 BE |
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
 | GET    | `/head/offsets`  | Current yaw + tilt zero-point offsets               |
-| POST   | `/head/offsets`  | Update yaw + tilt zero-point offsets (runtime-only) |
+| POST   | `/head/offsets`  | Update yaw + tilt zero-point offsets; persisted to SD |
 | GET    | `/crash`         | Most recent panic log (404 if none recorded)        |
 | POST   | `/crash/clear`   | Delete `/sd/CRASH.LOG` (idempotent)                 |
 | POST   | `/emotion`       | Set affect with hold timer                          |


### PR DESCRIPTION
## Summary

- Enrols \`head_offsets\` in the SD-backed runtime store alongside \`palette\` / \`mood\` / \`face_geometry\`. The \"head offsets reset on reboot\" comment on the existing \`POST /head/offsets\` handler is now obsolete.
- Wire form adds two lines to \`/sd/RUNTIME.RON\`:
  \`\`\`
  head_yaw_offset=1.25
  head_tilt_offset=-3.50
  \`\`\`
- Boot path seeds both \`OFFSETS_SIGNAL\` (so the head task applies the trim on its first tick) and \`OFFSETS_CACHE\` (so a \`GET /head/offsets\` between boot and the head tick returns the persisted value, not zero).
- \`POST /head/offsets\` now calls \`update_head_offsets\` so the operator's dialled value sticks.

## Scope note

The original Arc 2c task description bundled an on-device touch-driven calibration UX on top of this persistence. The on-device UX adds ~300 LOC of render-mode and touch-routing surface for a feature whose operator-facing payoff is mostly the persistence layer that now lands — operators can already nudge offsets from any browser tab via \`POST /head/offsets\`. Deferring the touch UI to a future PR if there's user demand.

## Test plan
- [x] \`cargo test -p stackchan-firmware --lib runtime_store\` — round-trip + forward-compat (older firmware's file omitting head_offsets parses to zero)
- [x] \`just check\` clean
- [x] \`cargo +esp clippy --release -- -D warnings\` clean
- [ ] Hardware verify: \`curl -X POST http://stackchan.local/head/offsets -d '{"yaw_offset_deg":1.5,"tilt_offset_deg":-2.0}'\`, reboot, confirm boot log shows \`head_offsets=(1.5, -2.0)\` and \`GET /head/offsets\` returns the value.