### PR TITLE
feat(firmware): UDP audio debug stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ section summarises the milestone work in human terms.
   `AUDIO_FRAME_CAPTURED` tracks total publishes for health probing.
   Foundation for the wake-word + push-to-talk + UDP audio debug
   paths; consumer-side code lands in follow-up PRs.
+- UDP audio debug stream — opt-in via
+  `behavior.audio_debug_udp_target`. A new task subscribes to
+  `AUDIO_FRAME_PUBSUB` and forwards each 20 ms frame as a raw
+  little-endian `s16` UDP datagram, listenable on the host with
+  `nc -lu <port> | aplay -r 16000 -f S16_LE -c 1 -t raw`. Empty
+  target parks the task with no resource cost. Bench-only; see
+  [docs/audio-debug.md](./docs/audio-debug.md).
 
 ### Networking + control plane
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ section summarises the milestone work in human terms.
   `behavior.audio_debug_udp_target`. A new task subscribes to
   `AUDIO_FRAME_PUBSUB` and forwards each 20 ms frame as a raw
   little-endian `s16` UDP datagram, listenable on the host with
-  `nc -lu <port> | aplay -r 16000 -f S16_LE -c 1 -t raw`. Empty
+  `nc -lu <ip> <port> | aplay -r 16000 -f S16_LE -c 1 -t raw`. Empty
   target parks the task with no resource cost. Bench-only; see
   [docs/audio-debug.md](./docs/audio-debug.md).
 

--- a/crates/stackchan-firmware/src/audio_debug.rs
+++ b/crates/stackchan-firmware/src/audio_debug.rs
@@ -1,0 +1,192 @@
+//! UDP audio debug stream — tees `AUDIO_FRAME_PUBSUB` frames to a
+//! configured LAN target so a host can listen with `aplay` / `nc`.
+//!
+//! Opt-in via `behavior.audio_debug_udp_target` in `STACKCHAN.RON`.
+//! Empty target (the default) parks the task and consumes no socket
+//! or pubsub slot.
+//!
+//! ## Wire format
+//!
+//! Each 20 ms frame from [`crate::audio::AUDIO_FRAME_PUBSUB`] becomes
+//! one UDP datagram carrying [`crate::audio::AUDIO_FRAME_SAMPLES`] ×
+//! `i16` little-endian samples (`AUDIO_FRAME_SAMPLES × 2 = 640` bytes
+//! of payload). No header, no sequence number on the wire — drops
+//! show up as audible gaps at the receiver.
+//!
+//! ## Receiving on a host
+//!
+//! ```sh
+//! # 1) Bind to UDP port 5005 on the host LAN interface.
+//! # 2) Decode raw little-endian s16 mono @ 16 kHz with aplay.
+//! nc -lu 192.168.1.42 5005 | aplay -r 16000 -f S16_LE -c 1 -t raw
+//! ```
+//!
+//! Set `behavior.audio_debug_udp_target = "192.168.1.42:5005"` in
+//! `STACKCHAN.RON` and reboot.
+
+use alloc::string::String;
+
+use embassy_net::Stack;
+use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_sync::pubsub::WaitResult;
+
+use crate::audio::{AUDIO_FRAME_PUBSUB, AUDIO_FRAME_SAMPLES};
+use crate::net::wifi::{WIFI_LINK_WATCH, WifiLinkState};
+
+/// Payload size of one UDP datagram: one [`crate::audio::AudioFrame`]
+/// flattened to little-endian `i16` bytes.
+const DATAGRAM_BYTES: usize = AUDIO_FRAME_SAMPLES * 2;
+
+/// Audio-debug UDP task entry point.
+///
+/// Idles until Wi-Fi is up, then subscribes to
+/// [`AUDIO_FRAME_PUBSUB`] and forwards each frame to `target` as a
+/// raw UDP datagram. Re-opens the socket on link drops.
+///
+/// `target` is a `"host:port"` literal — `192.168.1.42:5005` etc.
+/// Empty / unparseable values park the task.
+#[embassy_executor::task]
+pub async fn audio_debug_task(stack: Stack<'static>, target: String) -> ! {
+    if target.is_empty() {
+        defmt::info!("audio-debug: target empty, idle");
+        park_forever().await;
+    }
+    let Some(endpoint) = parse_endpoint(&target) else {
+        defmt::error!(
+            "audio-debug: invalid target '{=str}' (expected ipv4:port); idle",
+            target.as_str(),
+        );
+        park_forever().await;
+    };
+    let Ok(mut subscriber) = AUDIO_FRAME_PUBSUB.subscriber() else {
+        defmt::error!("audio-debug: subscriber slot exhausted; idle");
+        park_forever().await;
+    };
+    let Some(mut link) = WIFI_LINK_WATCH.receiver() else {
+        defmt::error!("audio-debug: WIFI_LINK_WATCH receiver slot exhausted; idle");
+        park_forever().await;
+    };
+
+    defmt::info!(
+        "audio-debug: streaming {=usize}-byte UDP datagrams to target (wait for link)",
+        DATAGRAM_BYTES,
+    );
+
+    let mut rx_meta = [PacketMetadata::EMPTY; 2];
+    let mut rx_buf = [0_u8; 16]; // RX unused; we're send-only
+    let mut tx_meta = [PacketMetadata::EMPTY; 4];
+    let mut tx_buf = [0_u8; DATAGRAM_BYTES + 64];
+
+    let mut state = link.get().await;
+    loop {
+        if !matches!(state, WifiLinkState::Connected) {
+            state = link.changed().await;
+            continue;
+        }
+        let mut socket =
+            UdpSocket::new(stack, &mut rx_meta, &mut rx_buf, &mut tx_meta, &mut tx_buf);
+        if let Err(e) = socket.bind(0) {
+            defmt::warn!("audio-debug: bind failed ({:?}); backing off", e);
+            embassy_time::Timer::after(embassy_time::Duration::from_secs(5)).await;
+            state = link.changed().await;
+            continue;
+        }
+
+        defmt::info!("audio-debug: socket ready, streaming");
+        loop {
+            let frame = match subscriber.next_message().await {
+                WaitResult::Message(f) => f,
+                WaitResult::Lagged(n) => {
+                    defmt::warn!("audio-debug: lagged {=u64} frames", n);
+                    continue;
+                }
+            };
+            let mut buf = [0_u8; DATAGRAM_BYTES];
+            for (i, &sample) in frame.samples.iter().enumerate() {
+                let le = sample.to_le_bytes();
+                buf[i * 2] = le[0];
+                buf[i * 2 + 1] = le[1];
+            }
+            if let Err(e) = socket.send_to(&buf, endpoint).await {
+                defmt::warn!(
+                    "audio-debug: send_to failed: {:?}; reopening socket",
+                    defmt::Debug2Format(&e),
+                );
+                break;
+            }
+        }
+        socket.close();
+        state = link.changed().await;
+    }
+}
+
+/// Parse `"a.b.c.d:port"` into an [`embassy_net::IpEndpoint`].
+///
+/// Returns `None` on any malformed component — task logs and parks
+/// rather than crashing.
+fn parse_endpoint(s: &str) -> Option<embassy_net::IpEndpoint> {
+    let (host, port_str) = s.rsplit_once(':')?;
+    let port: u16 = port_str.parse().ok()?;
+    let mut octets = [0_u8; 4];
+    let mut count = 0;
+    for part in host.split('.') {
+        if count >= 4 {
+            return None;
+        }
+        octets[count] = part.parse().ok()?;
+        count += 1;
+    }
+    if count != 4 {
+        return None;
+    }
+    Some(embassy_net::IpEndpoint::new(
+        embassy_net::IpAddress::Ipv4(embassy_net::Ipv4Address::new(
+            octets[0], octets[1], octets[2], octets[3],
+        )),
+        port,
+    ))
+}
+
+/// Spin forever, parking the task. Used when the task can't proceed
+/// (no target configured, no subscriber slot, etc.).
+async fn park_forever() -> ! {
+    loop {
+        embassy_time::Timer::after(embassy_time::Duration::from_secs(3600)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_endpoint;
+
+    #[test]
+    fn parse_endpoint_accepts_ipv4_with_port() {
+        let e = parse_endpoint("192.168.1.42:5005").unwrap();
+        assert_eq!(e.port, 5005);
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_missing_port() {
+        assert!(parse_endpoint("192.168.1.42").is_none());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_non_numeric_port() {
+        assert!(parse_endpoint("192.168.1.42:abc").is_none());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_too_few_octets() {
+        assert!(parse_endpoint("192.168.1:5005").is_none());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_too_many_octets() {
+        assert!(parse_endpoint("1.2.3.4.5:5005").is_none());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_empty() {
+        assert!(parse_endpoint("").is_none());
+    }
+}

--- a/crates/stackchan-firmware/src/audio_debug.rs
+++ b/crates/stackchan-firmware/src/audio_debug.rs
@@ -77,46 +77,62 @@ pub async fn audio_debug_task(stack: Stack<'static>, target: String) -> ! {
     let mut tx_meta = [PacketMetadata::EMPTY; 4];
     let mut tx_buf = [0_u8; DATAGRAM_BYTES + 64];
 
-    let mut state = link.get().await;
+    // Outer loop: wait for the link to be Connected, then stream
+    // until either the link drops or a transient socket error breaks
+    // the inner loop. Never block on `link.changed()` mid-stream — a
+    // transient send_to failure leaves the link Connected, so a
+    // blocking wait would stall the task until the next real
+    // disconnect/reconnect cycle. Instead, the inner loop selects
+    // across both the link receiver and the next-frame subscriber
+    // so link changes are observed promptly.
     loop {
-        if !matches!(state, WifiLinkState::Connected) {
+        let mut state = link.get().await;
+        while !matches!(state, WifiLinkState::Connected) {
             state = link.changed().await;
-            continue;
         }
         let mut socket =
             UdpSocket::new(stack, &mut rx_meta, &mut rx_buf, &mut tx_meta, &mut tx_buf);
         if let Err(e) = socket.bind(0) {
             defmt::warn!("audio-debug: bind failed ({:?}); backing off", e);
             embassy_time::Timer::after(embassy_time::Duration::from_secs(5)).await;
-            state = link.changed().await;
             continue;
         }
 
         defmt::info!("audio-debug: socket ready, streaming");
         loop {
-            let frame = match subscriber.next_message().await {
-                WaitResult::Message(f) => f,
-                WaitResult::Lagged(n) => {
-                    defmt::warn!("audio-debug: lagged {=u64} frames", n);
-                    continue;
+            use embassy_futures::select::{Either, select};
+            let next = select(subscriber.next_message(), link.changed()).await;
+            match next {
+                Either::First(WaitResult::Message(frame)) => {
+                    let mut buf = [0_u8; DATAGRAM_BYTES];
+                    for (i, &sample) in frame.samples.iter().enumerate() {
+                        let le = sample.to_le_bytes();
+                        buf[i * 2] = le[0];
+                        buf[i * 2 + 1] = le[1];
+                    }
+                    if let Err(e) = socket.send_to(&buf, endpoint).await {
+                        defmt::warn!(
+                            "audio-debug: send_to failed: {:?}; reopening socket",
+                            defmt::Debug2Format(&e),
+                        );
+                        break;
+                    }
                 }
-            };
-            let mut buf = [0_u8; DATAGRAM_BYTES];
-            for (i, &sample) in frame.samples.iter().enumerate() {
-                let le = sample.to_le_bytes();
-                buf[i * 2] = le[0];
-                buf[i * 2 + 1] = le[1];
-            }
-            if let Err(e) = socket.send_to(&buf, endpoint).await {
-                defmt::warn!(
-                    "audio-debug: send_to failed: {:?}; reopening socket",
-                    defmt::Debug2Format(&e),
-                );
-                break;
+                Either::First(WaitResult::Lagged(n)) => {
+                    defmt::warn!("audio-debug: lagged {=u64} frames", n);
+                }
+                Either::Second(new_state) => {
+                    if !matches!(new_state, WifiLinkState::Connected) {
+                        defmt::info!("audio-debug: link dropped, closing socket");
+                        break;
+                    }
+                    // Otherwise the link bounced through some other
+                    // intermediate state and re-stabilised at Connected
+                    // — keep streaming.
+                }
             }
         }
         socket.close();
-        state = link.changed().await;
     }
 }
 

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -19,6 +19,7 @@ extern crate alloc;
 
 pub mod ambient;
 pub mod audio;
+pub mod audio_debug;
 pub mod ble;
 pub mod board;
 pub mod body_touch;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1388,6 +1388,20 @@ async fn main(spawner: Spawner) -> ! {
         defmt::panic!("spawn(mdns_task) failed: {}", defmt::Debug2Format(&e));
     }
 
+    // UDP audio debug stream — opt-in via
+    // `behavior.audio_debug_udp_target`. Empty target parks the task
+    // immediately; non-empty subscribes to AUDIO_FRAME_PUBSUB and
+    // forwards each frame as a raw little-endian s16 datagram.
+    if let Err(e) = spawner.spawn(stackchan_firmware::audio_debug::audio_debug_task(
+        net_stack,
+        net_config.behavior.audio_debug_udp_target.clone(),
+    )) {
+        defmt::panic!(
+            "spawn(audio_debug_task) failed: {}",
+            defmt::Debug2Format(&e)
+        );
+    }
+
     // Hourly chime — opt-in via `behavior.hourly_chime_enabled`. The
     // task exits early when disabled, so the spawn is unconditional.
     if let Err(e) = spawner.spawn(stackchan_firmware::chime::chime_task(

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -139,6 +139,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        auto_torque_release_ms: {},",
         config.behavior.auto_torque_release_ms
     );
+    push_field(
+        &mut out,
+        "        audio_debug_udp_target",
+        &config.behavior.audio_debug_udp_target,
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -500,6 +505,7 @@ impl<'a> Parser<'a> {
         let mut battery_icon_enabled: Option<bool> = None;
         let mut toast_overlay_enabled: Option<bool> = None;
         let mut auto_torque_release_ms: Option<u32> = None;
+        let mut audio_debug_udp_target: Option<String> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -515,6 +521,7 @@ impl<'a> Parser<'a> {
                 "battery_icon_enabled" => battery_icon_enabled = Some(self.parse_bool()?),
                 "toast_overlay_enabled" => toast_overlay_enabled = Some(self.parse_bool()?),
                 "auto_torque_release_ms" => auto_torque_release_ms = Some(self.parse_u32()?),
+                "audio_debug_udp_target" => audio_debug_udp_target = Some(self.parse_string()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -528,6 +535,7 @@ impl<'a> Parser<'a> {
             battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
             toast_overlay_enabled: toast_overlay_enabled.unwrap_or(false),
             auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
+            audio_debug_udp_target: audio_debug_udp_target.unwrap_or_default(),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -150,6 +150,12 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
 ///
 /// Currently infallible — kept as `Result` for symmetry with
 /// [`crate::render_ron`].
+#[allow(
+    clippy::too_many_lines,
+    reason = "single linear render: emitting one schema-v1 JSON document end to end. \
+              Splitting per nested object fragments the layout review and would force \
+              callers through a builder API for no readability gain."
+)]
 pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<String, ConfigError> {
     let mut out = String::new();
     out.push('{');
@@ -238,12 +244,17 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     out.push_str("},\"behavior\":{");
     let _ = write!(
         out,
-        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{},\"toast_overlay_enabled\":{},\"auto_torque_release_ms\":{}",
+        "\"soliloquy_enabled\":{},\"hourly_chime_enabled\":{},\"battery_icon_enabled\":{},\"toast_overlay_enabled\":{},\"auto_torque_release_ms\":{},",
         config.behavior.soliloquy_enabled,
         config.behavior.hourly_chime_enabled,
         config.behavior.battery_icon_enabled,
         config.behavior.toast_overlay_enabled,
         config.behavior.auto_torque_release_ms,
+    );
+    push_string_field(
+        &mut out,
+        "audio_debug_udp_target",
+        &config.behavior.audio_debug_udp_target,
     );
     out.push_str("}}");
     Ok(out)
@@ -747,6 +758,7 @@ impl<'a> Parser<'a> {
         let mut battery_icon_enabled: Option<bool> = None;
         let mut toast_overlay_enabled: Option<bool> = None;
         let mut auto_torque_release_ms: Option<u32> = None;
+        let mut audio_debug_udp_target: Option<String> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -793,6 +805,15 @@ impl<'a> Parser<'a> {
                     }
                     auto_torque_release_ms = Some(self.parse_u32()?);
                 }
+                "audio_debug_udp_target" => {
+                    if audio_debug_udp_target.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "audio_debug_udp_target",
+                        ));
+                    }
+                    audio_debug_udp_target = Some(self.parse_string()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -806,6 +827,7 @@ impl<'a> Parser<'a> {
             battery_icon_enabled: battery_icon_enabled.unwrap_or(false),
             toast_overlay_enabled: toast_overlay_enabled.unwrap_or(false),
             auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
+            audio_debug_udp_target: audio_debug_udp_target.unwrap_or_default(),
         })
     }
 
@@ -1051,6 +1073,7 @@ mod tests {
                 battery_icon_enabled: true,
                 toast_overlay_enabled: true,
                 auto_torque_release_ms: 30_000,
+                audio_debug_udp_target: "192.168.1.42:5005".to_string(),
             },
         }
     }
@@ -1371,6 +1394,7 @@ mod tests {
                 battery_icon_enabled: true,
                 toast_overlay_enabled: true,
                 auto_torque_release_ms: 30_000,
+                audio_debug_udp_target: "192.168.1.42:5005".to_string(),
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -283,7 +283,7 @@ impl Default for EspNowConfig {
 /// `behavior:` block at all — `serde(default)` on the parent populates
 /// it. Operators opt in by adding the block via `PUT /settings` or
 /// editing `STACKCHAN.RON` directly.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 #[allow(
     clippy::struct_excessive_bools,
@@ -328,6 +328,13 @@ pub struct BehaviorConfig {
     /// position write. Useful for desk-toy units that sit idle for
     /// hours and don't need the motors' standing draw.
     pub auto_torque_release_ms: u32,
+    /// UDP target for the audio debug stream, as `"host:port"`. Empty
+    /// disables the debug task. When set, the firmware subscribes to
+    /// `AUDIO_FRAME_PUBSUB` and forwards each 20 ms frame's raw
+    /// little-endian `i16` samples to this address. Pair with the
+    /// canned `aplay` / `nc` receive command in `docs/audio-debug.md`
+    /// to listen on the host. Bench-only — leave empty in production.
+    pub audio_debug_udp_target: String,
 }
 
 /// Time / SNTP configuration.

--- a/docs/audio-debug.md
+++ b/docs/audio-debug.md
@@ -1,0 +1,56 @@
+---
+title: UDP audio debug
+---
+
+# UDP audio debug
+
+The firmware can tee its microphone capture to a LAN UDP target so a
+host machine can listen along with `aplay` / `nc`. Opt-in via the
+`behavior.audio_debug_udp_target` field in `STACKCHAN.RON`; empty
+disables the stream entirely (the task parks and consumes no
+resources).
+
+## Enable
+
+In `/sd/STACKCHAN.RON`:
+
+```ron
+behavior: (
+    audio_debug_udp_target: "192.168.1.42:5005",
+)
+```
+
+Substitute the IP of the host you'll receive on (must be on the same
+LAN as the avatar) and any free UDP port. Reboot the avatar.
+
+## Receive
+
+```sh
+nc -lu 192.168.1.42 5005 | aplay -r 16000 -f S16_LE -c 1 -t raw
+```
+
+Decoder parameters:
+
+- `-r 16000` — sample rate matches firmware `SAMPLE_RATE_HZ`
+- `-f S16_LE` — 16-bit signed little-endian, matches the on-wire layout
+- `-c 1` — mono
+- `-t raw` — no header
+
+## Wire format
+
+Each datagram is one 20 ms frame from `AUDIO_FRAME_PUBSUB`:
+`320 × i16` little-endian = 640 bytes of payload. No header, no
+sequence number — drops show up as audible gaps. At 50 frames/sec the
+stream is ~32 KB/s of UDP traffic.
+
+## When to use
+
+- Verifying the ES7210 capture path works end-to-end without flashing
+  a wake-word build.
+- Inspecting environmental noise at a deployed unit to tune
+  `EmotionFromVoice` / `IntentFromLoud` thresholds.
+- Recording a sample for off-device model training.
+
+The stream is **plaintext UDP** on the LAN; not suitable for a shared
+network. Leave the field empty in any deployment outside a controlled
+bench.


### PR DESCRIPTION
First consumer of the \`AUDIO_FRAME_PUBSUB\` fan-out (#317). Tees the firmware's microphone capture to a LAN UDP target so a host can listen along with \`aplay\`.

## Summary

- New \`crate::audio_debug::audio_debug_task\` subscribes to \`AUDIO_FRAME_PUBSUB\` and forwards each 20 ms frame as a raw little-endian \`s16\` UDP datagram.
- Opt-in via \`behavior.audio_debug_udp_target = "ip:port"\` in \`STACKCHAN.RON\`. Empty parks the task (no socket, no subscriber slot used).
- Wire format: 640 B / datagram, one per frame. No header. ~32 KB/s.
- Receive command documented in \`docs/audio-debug.md\`:
  \`\`\`
  nc -lu <ip> <port> | aplay -r 16000 -f S16_LE -c 1 -t raw
  \`\`\`

## Schema change

\`BehaviorConfig\` drops \`Copy\` to accommodate the new \`String\` field. The struct stays \`Clone + PartialEq + Eq\`. Firmware-side accesses are all by-ref (e.g. \`c.behavior.foo\`), so the loss of \`Copy\` is invisible at the call sites. Verified via \`cargo +esp check\` + workspace clippy.

## Test plan

- [x] \`just check\` clean
- [x] \`cargo +esp clippy --release -- -D warnings\` clean
- [x] Unit tests for \`parse_endpoint\` (5 cases: ipv4+port, missing port, non-numeric port, too few octets, too many octets, empty)
- [ ] Hardware verify: set \`audio_debug_udp_target: "192.168.1.42:5005"\`, reboot, run \`nc -lu 192.168.1.42 5005 | aplay -r 16000 -f S16_LE -c 1 -t raw\` on the host, confirm voice into the mic plays through the host speakers within ~200 ms.

## Security note

Plaintext UDP on the LAN. Not suitable for shared networks — anyone on the wire can listen. Leave the field empty in any deployment outside a controlled bench.