### PR TITLE
docs: add known-limitations section + tighten README framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,24 @@ section summarises the milestone work in human terms.
   dispatcher no longer starves under inbound traffic and no longer
   latches a NaN pose into the delta-comparison cache.
 
+### Documentation
+
+- README gains a `Known limitations` section spelling out
+  single-unit hardware test scope (BMM150 bench-only), LAN-only
+  HTTP control plane with no TLS, Experimental-until-v2.x API
+  contract, and the best-effort single-maintainer cadence. Pairs
+  with the existing `Non-goals` section so a 30-second-rubric
+  reader sees both what the firmware won't do by design and where
+  the present implementation has gaps.
+- README `Why` section trimmed of unverified competitive
+  framings; the factual contrast against the upstream `xiaozhi`
+  firmware (cloud-dependent LLM agent in C++) stays.
+- Self-applied `unsafe denied` shield removed from the README
+  header; the same claim already appears under `Features`, and
+  the remaining badges (`CI`, `Release`, `License`, `Rust 1.88+`)
+  are independently validated by GitHub Actions, GitHub Releases,
+  the `LICENSE` files, and `rust-toolchain.toml`.
+
 ## [0.1.0] — 2026-04-23
 
 First release. CoreS3 boots to a double-buffered 320×240 face that blinks,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Release](https://img.shields.io/github/v/release/andymai/stackchan-kai)](https://github.com/andymai/stackchan-kai/releases)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org/)
-[![unsafe denied](https://img.shields.io/badge/unsafe-workspace--denied-success.svg)]()
 
 [Stability](./STABILITY.md) · [Changelog](./CHANGELOG.md) · [Justfile](./justfile) · [Handbook](https://andymai.github.io/stackchan-kai/)
 
@@ -29,9 +28,8 @@ sensor bench examples).
 
 ## Why
 
-M5Stack ships Stack-chan with an xiaozhi firmware stack: a Chinese
-LLM-agent pipeline with cloud dependencies, questionable security posture, and
-a C++ codebase that's hard to audit. stackchan-kai rebuilds just the local
+M5Stack ships Stack-chan with the `xiaozhi` firmware stack: a cloud-dependent
+LLM-agent pipeline written in C++. `stackchan-kai` rebuilds just the local
 desk-toy surface — animated face, head motion, local sensors — in `no_std`
 Rust on top of [`esp-hal`](https://github.com/esp-rs/esp-hal) and
 [embassy](https://embassy.dev/). The engine is modeled as data and the render
@@ -116,6 +114,13 @@ Discovery and inter-device:
 Without an SD card the firmware boots offline and the desk-toy surface works
 the same. See [HTTP control plane](https://andymai.github.io/stackchan-kai/http)
 for the full reference.
+
+## Known limitations
+
+- Tested on a single CoreS3 unit. The BMM150 magnetometer on this kit is bench-only — chassis-side interference makes the in-enclosure reading unusable; other sensors are exercised regularly.
+- LAN-only HTTP plane, no TLS. The bearer-token gate is a soft check against accidental drive-by writes — not a hardened auth surface for an untrusted network.
+- All public APIs are Experimental until at least v2.x per [STABILITY.md](./STABILITY.md). Minor releases will break things.
+- Single-maintainer project. Issue and PR response is best-effort; nothing is on a cadence.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- New `Known limitations` section in the README sits alongside the existing `Non-goals` section, surfacing the hard-truth gaps a 30-second-rubric reader would otherwise have to discover themselves: single CoreS3 unit tested (BMM150 bench-only on this kit), LAN-only HTTP plane with no TLS, Experimental-until-v2.x API contract per [STABILITY.md](./STABILITY.md), and the best-effort single-maintainer issue / PR cadence.
- `Why` section trimmed of unverified competitive framings ("Chinese", "questionable security posture", "hard to audit"). The load-bearing technical contrast — cloud-dependent LLM agent in C++ — stays.
- Self-applied `unsafe denied` shield removed from the header. The same claim already appears under `Features` ("`unsafe` denied workspace-wide"), and the remaining badges are all independently validated: CI by GitHub Actions, Release by GitHub Releases, License by the `LICENSE-*` files, Rust version by `rust-toolchain.toml`.
- CHANGELOG entry under `[Unreleased] — v0.2.0 parity push` in a new `Documentation` subsection.

## Test plan

- [x] `git diff` reviewed — three targeted edits, no structural churn
- [x] Pre-commit hook passed (fmt + clippy + host tests + doctests + workspace check + lock-drift)
- [x] Local repo render of the README via a markdown previewer confirms the new section sits between `Networking` and `Non-goals`
- [x] Anchor links in the new section (`STABILITY.md`) resolve to existing files