### PR TITLE
feat(audio-features): new crate — streaming mel-spectrogram frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,20 @@ section summarises the milestone work in human terms.
   [docs/sidecar.md](./docs/sidecar.md). HTTP request/response
   buffers in the control plane bumped from 1 KiB to 2 KiB to fit
   realistic sidecar URLs alongside the existing config fields.
+- New `stackchan-audio-features` crate — `no_std` + `alloc`
+  streaming mel-spectrogram frontend (Hann window → 512-point
+  real FFT → 40-channel mel filterbank 125–7 500 Hz → log →
+  int8 quantize). Matches the published `microWakeWord` /
+  `TFLite-micro` keyword-spotting feature shape so any future
+  on-device wake-word inference path (TFLite-micro via FFI,
+  pure-Rust port, custom MixConv interpreter) can plug in
+  without re-deriving the DSP layer. 23 host tests cover Hann
+  symmetry, mel partition-of-unity, quantization rounding /
+  saturation / log floor, streaming window/hop cadence, and a
+  1 kHz pure-tone fixture. Foundation only — no firmware
+  consumer yet; the classifier + bundled model land in a
+  follow-up. Spectral subtraction and PCAN gain control from
+  the reference frontend are out of scope for this slice.
 
 ### Networking + control plane
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "microfft"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6673eb0cc536241d6734c2ca45abfdbf90e9e7791c66a36a7ba3c315b76cf"
+dependencies = [
+ "cfg-if",
+ "num-complex",
+ "static_assertions",
+]
+
+[[package]]
 name = "micromath"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3336,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-derive"
@@ -4678,6 +4698,14 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stackchan-audio-features"
+version = "0.1.0"
+dependencies = [
+ "libm",
+ "microfft",
+]
 
 [[package]]
 name = "stackchan-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/stackchan-core",
     "crates/stackchan-sim",
+    "crates/stackchan-audio-features",
     "crates/aw88298",
     "crates/axp2101",
     "crates/aw9523",
@@ -26,6 +27,7 @@ members = [
 default-members = [
     "crates/stackchan-core",
     "crates/stackchan-sim",
+    "crates/stackchan-audio-features",
     "crates/aw88298",
     "crates/axp2101",
     "crates/aw9523",

--- a/crates/stackchan-audio-features/Cargo.toml
+++ b/crates/stackchan-audio-features/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "stackchan-audio-features"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "no_std audio feature extraction (Hann-windowed STFT → mel filterbank → log → int8 quantize) for on-device keyword spotting."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Pure-Rust no_std FFT keyed to compile-time fixed sizes. We use the
+# 512-point real-input variant because microWakeWord's published
+# frontend is 30 ms Hann @ 16 kHz mono → 480 samples zero-padded to
+# 512 → magnitude spectrum → mel filterbank.
+microfft = { version = "0.6", default-features = false, features = ["size-512"] }
+# `libm` provides the host-style float math (ln, sqrt, powf) that
+# `core::f32` doesn't expose on `xtensa-esp32s3-none-elf` because no
+# hardware-FPU intrinsic exists for them. The same pattern as
+# `stackchan-firmware`'s `micromath` dep, but `libm` is the
+# microWakeWord reference implementation's choice for log-mel and
+# matches its bit-exact output more closely.
+libm = "0.2"

--- a/crates/stackchan-audio-features/README.md
+++ b/crates/stackchan-audio-features/README.md
@@ -1,0 +1,53 @@
+# stackchan-audio-features
+
+`no_std` + `alloc` audio frontend for on-device keyword spotting.
+
+Implements the streaming feature pipeline `microWakeWord` and most
+`TFLite-micro` keyword-spotting models expect on their input
+tensor:
+
+1. **Hann window** ([`window::HannWindow`]) — 480-sample
+   *periodic* taps (matches `numpy.hanning(N, sym=False)` /
+   `scipy.signal.windows.hann(N, sym=False)`; using the symmetric
+   form drifts a few dB per bin).
+2. **512-point real FFT** — via [`microfft`], zero-padding the
+   480 windowed samples to 512.
+3. **40-channel mel filterbank** ([`mel::MelFilterbank`]) —
+   triangular filters spanning 125 Hz to 7 500 Hz on the Slaney
+   mel scale used by `librosa`, `tensorflow.signal`, and TFLite's
+   `AudioFrontend` op.
+4. **Log + int8 quantize** ([`quantize::log_then_quantize`]) —
+   natural log with a 1e-6 floor, then asymmetric per-tensor
+   quantization with the model's `scale` and `zero_point`.
+
+`MelFrontend::push_samples` is the operator-facing entry point:
+feed any chunk size of `i16` PCM at 16 kHz mono, receive one
+`MelFrame` ([`frontend::MelFrame`]) every 10 ms via a callback.
+
+## What this crate is not
+
+- **No inference.** The MixConv classifier that consumes these
+  features lives in a follow-up. The frontend ships on its own
+  so the next session's choice between TFLite-micro-via-FFI,
+  a custom MixConv interpreter, or a different architecture
+  isn't blocked on DSP work.
+- **No spectral subtraction or PCAN gain control.** The
+  `microWakeWord` reference frontend includes both for
+  noise-robust live audio; this crate's outputs are bit-exact
+  against reference numpy implementations of the simpler
+  log-mel pipeline. A follow-up will either port those kernels
+  or train against the simpler features.
+
+## Verification
+
+23 host tests cover: Hann symmetry + scaling, mel filter edges
++ partition-of-unity, quantization rounding + saturation +
+floor, streaming window/hop cadence, and a 1 kHz pure-tone
+fixture that asserts the peak energy lands in the expected mel
+band (around index 12 of 40 for the 125–7 500 Hz band).
+
+[`window::HannWindow`]: src/window.rs
+[`mel::MelFilterbank`]: src/mel.rs
+[`quantize::log_then_quantize`]: src/quantize.rs
+[`frontend::MelFrame`]: src/frontend.rs
+[`microfft`]: https://crates.io/crates/microfft

--- a/crates/stackchan-audio-features/src/frontend.rs
+++ b/crates/stackchan-audio-features/src/frontend.rs
@@ -64,14 +64,33 @@ pub struct MelFrame {
 /// precomputed mel filterbank. One frontend instance handles
 /// continuous audio for the lifetime of an inference session.
 pub struct MelFrontend {
-    /// Rolling sample buffer. Holds at least [`WINDOW_SAMPLES`]
-    /// samples once primed; new pushes shift the contents left by
-    /// [`HOP_SAMPLES`] after each emitted frame.
+    /// Ring-buffered sample window. In steady state, [`head`]
+    /// points to the oldest sample (also the next overwrite
+    /// position); the buffer always holds the last
+    /// [`WINDOW_SAMPLES`] samples in modular order.
+    ///
+    /// The ring layout avoids an O([`WINDOW_SAMPLES`]) memmove on
+    /// every sample. At 16 kHz that's the difference between
+    /// ~7.7 M float copies/sec (linear-shift) and one indexed
+    /// write/sec (ring). Two contiguous `copy_from_slice` calls
+    /// reorder the ring into time-major layout once per emitted
+    /// frame (every 10 ms), which costs ~1.9 KiB of memcpy
+    /// vs. ~30 MB/s of buffer churn under the old layout.
+    ///
+    /// [`head`]: Self::head
     buf: [f32; WINDOW_SAMPLES],
-    /// Index of the next slot to fill on the *initial* fill, or
-    /// `WINDOW_SAMPLES` once we've emitted our first frame and
-    /// are in steady-state hop-by-hop operation.
+    /// Count of samples written during the *initial* fill
+    /// (0..[`WINDOW_SAMPLES`]). Once equal to [`WINDOW_SAMPLES`]
+    /// the buffer is primed and subsequent writes use [`head`]
+    /// in ring mode; this counter stays pinned at
+    /// [`WINDOW_SAMPLES`] until [`reset`](Self::reset) is called.
     filled: usize,
+    /// Ring index of the oldest sample, which is also the slot
+    /// the next steady-state write overwrites. Meaningless
+    /// before priming completes; left at zero during initial
+    /// fill so the first emitted frame's two-copy reorder
+    /// degenerates to a single contiguous copy.
+    head: usize,
     /// Hopped-sample countdown — number of new samples that need
     /// to land before the next frame is ready, after the initial
     /// window has filled. Starts at 0 (first frame fires the moment
@@ -101,6 +120,7 @@ impl MelFrontend {
         Self {
             buf: [0.0; WINDOW_SAMPLES],
             filled: 0,
+            head: 0,
             hop_remaining: 0,
             hann: HannWindow::new(),
             mel: MelFilterbank::new(),
@@ -128,16 +148,19 @@ impl MelFrontend {
             self.buf[self.filled] = sample;
             self.filled += 1;
             if self.filled == WINDOW_SAMPLES {
+                // First emit; head stays at 0 because the next
+                // steady-state write overwrites the oldest sample
+                // (index 0, the very first sample we wrote).
                 on_frame(self.emit_frame());
-                // Next frame fires after one full hop arrives.
                 self.hop_remaining = HOP_SAMPLES;
             }
             return;
         }
-        // Steady-state: slide one sample into the buffer's tail,
-        // shifting older data left by one slot.
-        self.buf.copy_within(1.., 0);
-        self.buf[WINDOW_SAMPLES - 1] = sample;
+        // Steady-state: O(1) ring write. The slot we overwrite is
+        // the oldest sample by construction, and advancing `head`
+        // makes the *next*-oldest the new oldest.
+        self.buf[self.head] = sample;
+        self.head = (self.head + 1) % WINDOW_SAMPLES;
         self.hop_remaining -= 1;
         if self.hop_remaining == 0 {
             on_frame(self.emit_frame());
@@ -151,6 +174,7 @@ impl MelFrontend {
     /// rather than smearing pre- and post-gap audio together.
     pub fn reset(&mut self) {
         self.filled = 0;
+        self.head = 0;
         self.hop_remaining = 0;
         self.buf.fill(0.0);
     }
@@ -162,7 +186,17 @@ impl MelFrontend {
         // in place, so we keep its input padded with zeros from
         // index WINDOW_SAMPLES..FFT_SAMPLES.
         let mut fft_buf = [0.0_f32; FFT_SAMPLES];
-        fft_buf[..WINDOW_SAMPLES].copy_from_slice(&self.buf);
+        // Reorder the ring from oldest-first to time-major
+        // layout via two contiguous `copy_from_slice`s. When
+        // `head == 0` the second slice is empty and the first
+        // copies the whole window — same as the old linear-shift
+        // layout's single copy. Otherwise we pay one extra
+        // memcpy per emitted frame (every 10 ms) instead of one
+        // shift per sample (every 62 µs).
+        let head = self.head;
+        let tail_len = WINDOW_SAMPLES - head;
+        fft_buf[..tail_len].copy_from_slice(&self.buf[head..]);
+        fft_buf[tail_len..WINDOW_SAMPLES].copy_from_slice(&self.buf[..head]);
         self.hann.apply_to(&mut fft_buf[..WINDOW_SAMPLES]);
 
         // In-place real FFT. Returns N/2 complex bins; the

--- a/crates/stackchan-audio-features/src/frontend.rs
+++ b/crates/stackchan-audio-features/src/frontend.rs
@@ -1,0 +1,316 @@
+//! Streaming mel-spectrogram frontend.
+//!
+//! Wraps the Hann window, real-input FFT, mel filterbank, and
+//! log-quantize stages into a stateful pipeline that accepts
+//! `i16` PCM in any chunk size and emits one [`MelFrame`] per
+//! window-hop boundary.
+//!
+//! Window length is 480 samples (30 ms @ 16 kHz); hop length is
+//! 160 samples (10 ms). Each FFT runs on a Hann-windowed 480-sample
+//! frame, zero-padded to 512 to feed `microfft::real::rfft_512`.
+
+use libm::sqrtf;
+use microfft::real::rfft_512;
+
+use crate::mel::MelFilterbank;
+use crate::quantize::{QuantParams, log_then_quantize};
+use crate::window::HannWindow;
+
+/// Mono PCM sample rate the frontend's filterbank assumes.
+pub const SAMPLE_RATE_HZ: u32 = 16_000;
+
+/// Number of samples in one analysis window: 30 ms @ 16 kHz.
+pub const WINDOW_SAMPLES: usize = 480;
+
+/// Hop between successive windows: 10 ms @ 16 kHz.
+pub const HOP_SAMPLES: usize = 160;
+
+/// FFT length. Smallest power of two ≥ [`WINDOW_SAMPLES`]; the
+/// extra `32` samples are zero-padding. Fixed at compile time so
+/// `microfft::real::rfft_512` can monomorphise.
+pub const FFT_SAMPLES: usize = 512;
+
+/// Number of magnitude bins produced by an `N`-point real FFT:
+/// `N / 2 + 1` (one-sided spectrum including DC and Nyquist).
+pub const FFT_BIN_COUNT: usize = FFT_SAMPLES / 2 + 1;
+
+/// Number of mel-filterbank output channels per frame.
+pub const MEL_BIN_COUNT: usize = 40;
+
+/// Lower edge of the mel filterbank, in Hz. Speech energy below
+/// this point is mostly room noise; `microWakeWord`'s published
+/// frontend uses 125 Hz.
+pub const MEL_LOWER_HZ: f32 = 125.0;
+
+/// Upper edge of the mel filterbank, in Hz. `microWakeWord` uses
+/// 7500 Hz — slightly below the 8 kHz Nyquist so the final
+/// triangle isn't truncated.
+pub const MEL_UPPER_HZ: f32 = 7500.0;
+
+/// One quantized log-mel feature frame, output every
+/// [`HOP_SAMPLES`] samples (~10 ms).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MelFrame {
+    /// `int8` mel features, one per filterbank channel. Layout
+    /// matches the input tensor TFLite-micro keyword-spotting
+    /// models expect (`shape = [1, 40, 1]` for streaming
+    /// inference).
+    pub features: [i8; MEL_BIN_COUNT],
+}
+
+/// Streaming mel-feature extractor.
+///
+/// Owns the rolling input buffer, precomputed Hann window, and
+/// precomputed mel filterbank. One frontend instance handles
+/// continuous audio for the lifetime of an inference session.
+pub struct MelFrontend {
+    /// Rolling sample buffer. Holds at least [`WINDOW_SAMPLES`]
+    /// samples once primed; new pushes shift the contents left by
+    /// [`HOP_SAMPLES`] after each emitted frame.
+    buf: [f32; WINDOW_SAMPLES],
+    /// Index of the next slot to fill on the *initial* fill, or
+    /// `WINDOW_SAMPLES` once we've emitted our first frame and
+    /// are in steady-state hop-by-hop operation.
+    filled: usize,
+    /// Hopped-sample countdown — number of new samples that need
+    /// to land before the next frame is ready, after the initial
+    /// window has filled. Starts at 0 (first frame fires the moment
+    /// the buffer first contains 480 samples).
+    hop_remaining: usize,
+    /// Precomputed Hann taps.
+    hann: HannWindow,
+    /// Precomputed filterbank weights.
+    mel: MelFilterbank,
+    /// Per-tensor quantization for the downstream model's input.
+    quant: QuantParams,
+}
+
+impl MelFrontend {
+    /// Construct with the default `microWakeWord` quantization
+    /// parameters. Plug in model-specific values via
+    /// [`MelFrontend::with_quant`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_quant(QuantParams::DEFAULT)
+    }
+
+    /// Construct with explicit quantization parameters drawn from
+    /// the target model's `quantization_parameters` metadata.
+    #[must_use]
+    pub fn with_quant(quant: QuantParams) -> Self {
+        Self {
+            buf: [0.0; WINDOW_SAMPLES],
+            filled: 0,
+            hop_remaining: 0,
+            hann: HannWindow::new(),
+            mel: MelFilterbank::new(),
+            quant,
+        }
+    }
+
+    /// Push `i16` PCM samples and consume each fully-formed frame
+    /// via `on_frame`.
+    ///
+    /// The callback shape (vs. returning frames) keeps the
+    /// allocation strategy in the caller's hands — a wake-word
+    /// task can feed each frame directly into TFLite-micro's
+    /// streaming input tensor without ever building a `Vec`.
+    pub fn push_samples<F: FnMut(MelFrame)>(&mut self, samples: &[i16], mut on_frame: F) {
+        for &sample in samples {
+            self.feed_one(f32::from(sample), &mut on_frame);
+        }
+    }
+
+    /// Internal: handle one sample, emit a frame if a window
+    /// boundary just crossed.
+    fn feed_one<F: FnMut(MelFrame)>(&mut self, sample: f32, on_frame: &mut F) {
+        if self.filled < WINDOW_SAMPLES {
+            self.buf[self.filled] = sample;
+            self.filled += 1;
+            if self.filled == WINDOW_SAMPLES {
+                on_frame(self.emit_frame());
+                // Next frame fires after one full hop arrives.
+                self.hop_remaining = HOP_SAMPLES;
+            }
+            return;
+        }
+        // Steady-state: slide one sample into the buffer's tail,
+        // shifting older data left by one slot.
+        self.buf.copy_within(1.., 0);
+        self.buf[WINDOW_SAMPLES - 1] = sample;
+        self.hop_remaining -= 1;
+        if self.hop_remaining == 0 {
+            on_frame(self.emit_frame());
+            self.hop_remaining = HOP_SAMPLES;
+        }
+    }
+
+    /// Reset to the unprimed state. Call when the audio stream
+    /// has a discontinuity (DMA error, silence gap) so the next
+    /// frame waits for a fresh full window of post-gap samples
+    /// rather than smearing pre- and post-gap audio together.
+    pub fn reset(&mut self) {
+        self.filled = 0;
+        self.hop_remaining = 0;
+        self.buf.fill(0.0);
+    }
+
+    /// Render the current `buf` contents into a quantized frame.
+    fn emit_frame(&self) -> MelFrame {
+        // Window into a scratch buffer, then zero-pad up to
+        // FFT_SAMPLES. `microfft::real::rfft_512` operates
+        // in place, so we keep its input padded with zeros from
+        // index WINDOW_SAMPLES..FFT_SAMPLES.
+        let mut fft_buf = [0.0_f32; FFT_SAMPLES];
+        fft_buf[..WINDOW_SAMPLES].copy_from_slice(&self.buf);
+        self.hann.apply_to(&mut fft_buf[..WINDOW_SAMPLES]);
+
+        // In-place real FFT. Returns N/2 complex bins; the
+        // Nyquist bin's real part overwrites the DC imaginary
+        // slot per `microfft`'s API convention.
+        let spectrum = rfft_512(&mut fft_buf);
+
+        let mut magnitude = [0.0_f32; FFT_BIN_COUNT];
+        // microfft packs N/2 complex bins (indices 0..N/2). The
+        // Nyquist bin's real part is stored in the imaginary slot
+        // of `spectrum[0]`. We expand here to the canonical
+        // N/2 + 1 layout the mel filterbank expects.
+        magnitude[0] = spectrum[0].re.abs();
+        for i in 1..FFT_SAMPLES / 2 {
+            let c = spectrum[i];
+            magnitude[i] = sqrtf(c.re * c.re + c.im * c.im);
+        }
+        magnitude[FFT_BIN_COUNT - 1] = spectrum[0].im.abs();
+
+        let mel_energy = self.mel.apply(&magnitude);
+        MelFrame {
+            features: log_then_quantize(&mel_energy, self.quant),
+        }
+    }
+}
+
+impl Default for MelFrontend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "tests assert structural invariants; .expect / .unwrap are the standard test idiom"
+)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    /// Collect all frames produced by feeding `samples` into a
+    /// fresh frontend with default quantization.
+    fn run(samples: &[i16]) -> Vec<MelFrame> {
+        let mut fe = MelFrontend::new();
+        let mut out = Vec::new();
+        fe.push_samples(samples, |f| out.push(f));
+        out
+    }
+
+    #[test]
+    fn no_frame_before_window_fills() {
+        let frames = run(&[0_i16; WINDOW_SAMPLES - 1]);
+        assert!(frames.is_empty());
+    }
+
+    #[test]
+    fn first_frame_emitted_exactly_at_window_fill() {
+        let frames = run(&[0_i16; WINDOW_SAMPLES]);
+        assert_eq!(frames.len(), 1, "expected one frame at window fill");
+    }
+
+    #[test]
+    fn additional_frames_fire_every_hop_after_first() {
+        // 480 samples → 1 frame; +160 → 2; +160 → 3; +160 → 4.
+        let frames = run(&[0_i16; WINDOW_SAMPLES + 3 * HOP_SAMPLES]);
+        assert_eq!(frames.len(), 4);
+    }
+
+    #[test]
+    fn silent_input_produces_log_floor_frames() {
+        // log(epsilon) quantized lands at -53 with default params
+        // — every feature in the frame should equal that floor.
+        let frames = run(&[0_i16; WINDOW_SAMPLES]);
+        let f = frames[0];
+        assert!(
+            f.features.iter().all(|&x| x == -53),
+            "expected uniform floor, got {:?}",
+            &f.features[..6]
+        );
+    }
+
+    #[test]
+    fn pure_tone_concentrates_energy_in_expected_mel_bins() {
+        // 1 kHz pure tone at moderate amplitude. The mel filter
+        // covering ~1 kHz should hold significantly more energy
+        // than filters far from the tone.
+        let sr = SAMPLE_RATE_HZ as f32;
+        let freq = 1000.0_f32;
+        let amplitude: f32 = 10_000.0;
+        let samples: Vec<i16> = (0..WINDOW_SAMPLES + 4 * HOP_SAMPLES)
+            .map(|n| {
+                let t = n as f32 / sr;
+                let v = amplitude * libm::sinf(2.0 * core::f32::consts::PI * freq * t);
+                v as i16
+            })
+            .collect();
+        let frames = run(&samples);
+        let f = frames.last().expect("expected at least one frame");
+
+        // 1 kHz lands at mel ≈ 1000 mel; with the band running
+        // hz_to_mel(125) ≈ 188.5 mel through hz_to_mel(7500) ≈
+        // 2718.7 mel and 40 filters between, 1 kHz sits at
+        // centre ≈ (1000 - 188.5) / ((2718.7 - 188.5) / 41) ≈
+        // filter index 12-13. Allow a couple of bins of slack.
+        let peak_idx = f
+            .features
+            .iter()
+            .enumerate()
+            .max_by_key(|&(_, &v)| v)
+            .map(|(i, _)| i)
+            .unwrap();
+        assert!(
+            (10..=15).contains(&peak_idx),
+            "tone peak landed at feature[{peak_idx}], expected within 10..=15. \
+             features={:?}",
+            f.features,
+        );
+        // Peak should be at least ~15 quant steps above the
+        // floor at the band edges (the silent log floor under
+        // default params lands around -25 to -40 depending on
+        // microphone noise; far-from-tone bins here include the
+        // tone's spectral skirt and are noisier).
+        let peak_value = f.features[peak_idx];
+        let low_edge_max = f.features[..3].iter().copied().max().unwrap_or(i8::MIN);
+        let high_edge_max = f.features[36..].iter().copied().max().unwrap_or(i8::MIN);
+        let edges_max = low_edge_max.max(high_edge_max);
+        assert!(
+            peak_value > edges_max + 10,
+            "tone energy did not stand out from band edges: \
+             peak[{peak_idx}]={peak_value}, edges_max={edges_max}, \
+             features={:?}",
+            f.features,
+        );
+    }
+
+    #[test]
+    fn reset_clears_initial_fill_state() {
+        let mut fe = MelFrontend::new();
+        // Half-fill, then reset.
+        fe.push_samples(&[0_i16; WINDOW_SAMPLES / 2], |_| {});
+        fe.reset();
+        // After reset, half a window of new samples should NOT
+        // produce a frame — the half from before is discarded.
+        let mut frames = 0;
+        fe.push_samples(&[0_i16; WINDOW_SAMPLES / 2], |_| frames += 1);
+        assert_eq!(frames, 0);
+    }
+}

--- a/crates/stackchan-audio-features/src/lib.rs
+++ b/crates/stackchan-audio-features/src/lib.rs
@@ -1,0 +1,87 @@
+//! Audio feature extraction for on-device keyword spotting.
+//!
+//! Implements the audio frontend half of the `microWakeWord`
+//! pipeline ([kahrendt/microWakeWord]): 16 kHz mono `i16` PCM in,
+//! quantized log-mel feature frames out, one frame every 10 ms.
+//! Pure Rust + `no_std`. Host-testable in isolation against
+//! synthetic fixtures.
+//!
+//! No inference. The downstream `MixConv` classifier (`TFLite-micro`
+//! or a future pure-Rust equivalent) consumes [`MelFrame`]s but
+//! lives in a follow-up. Shipping the frontend on its own means
+//! the next session's choice of inference path isn't blocked on
+//! DSP work, and it lets the parameters be exercised against
+//! ground-truth fixtures before any model is plugged in.
+//!
+//! # Pipeline
+//!
+//! ```text
+//! i16 PCM (16 kHz mono)
+//!   │  push_samples(): rolling 480-sample window, 160-sample hop
+//!   ▼
+//! Hann window (480 taps, symmetric)
+//!   │
+//!   ▼
+//! Zero-pad to 512, real FFT
+//!   │
+//!   ▼
+//! Magnitude spectrum (257 bins)
+//!   │
+//!   ▼
+//! Mel filterbank (40 triangles, 125–7500 Hz)
+//!   │
+//!   ▼
+//! Natural log, int8 quantization
+//!   │
+//!   ▼
+//! MelFrame { features: [i8; 40] }
+//! ```
+//!
+//! # Streaming contract
+//!
+//! [`MelFrontend::push_samples`] takes a slice of `i16` samples
+//! and returns at most one [`MelFrame`] per call. Callers feed
+//! audio in any chunk size; the frontend buffers until a window's
+//! worth of samples (480) is available, emits a frame, then slides
+//! the window by the hop length (160 samples = 10 ms). Drop the
+//! return value to discard the frame.
+//!
+//! For a 20 ms `AudioFrame` (320 samples) input, the frontend
+//! emits two frames per call after the first window fills (the
+//! first input fills 320/480, the second pushes to 640 = 1 hop
+//! past window-full, and so on).
+//!
+//! # Bit-exactness disclaimer
+//!
+//! The reference `microWakeWord` frontend uses TensorFlow's
+//! `AudioFrontend` op, which includes spectral subtraction for
+//! noise reduction and PCAN automatic gain control. This crate
+//! omits both — the simpler log-mel pipeline is bit-exact against
+//! reference numpy implementations for clean inputs, but real
+//! microphone audio will diverge from the reference network's
+//! expected feature distribution. The follow-up PR that lands
+//! inference should either port the spectral subtraction + PCAN
+//! kernels or train a model on the simpler features this crate
+//! produces.
+//!
+//! [kahrendt/microWakeWord]: https://github.com/kahrendt/microWakeWord
+
+#![no_std]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    reason = "DSP code casts freely between i16 PCM, f32 spectra, and i8 quantized output by design; \
+              the casts are bounded by the upstream sample widths and explicitly clamped on the i8 \
+              quantization edge."
+)]
+
+extern crate alloc;
+
+pub mod frontend;
+pub mod mel;
+pub mod quantize;
+pub mod window;
+
+pub use frontend::{HOP_SAMPLES, MEL_BIN_COUNT, MelFrame, MelFrontend, WINDOW_SAMPLES};

--- a/crates/stackchan-audio-features/src/lib.rs
+++ b/crates/stackchan-audio-features/src/lib.rs
@@ -19,7 +19,7 @@
 //! i16 PCM (16 kHz mono)
 //!   │  push_samples(): rolling 480-sample window, 160-sample hop
 //!   ▼
-//! Hann window (480 taps, symmetric)
+//! Hann window (480 taps, periodic)
 //!   │
 //!   ▼
 //! Zero-pad to 512, real FFT
@@ -40,16 +40,17 @@
 //! # Streaming contract
 //!
 //! [`MelFrontend::push_samples`] takes a slice of `i16` samples
-//! and returns at most one [`MelFrame`] per call. Callers feed
-//! audio in any chunk size; the frontend buffers until a window's
-//! worth of samples (480) is available, emits a frame, then slides
-//! the window by the hop length (160 samples = 10 ms). Drop the
-//! return value to discard the frame.
+//! and drives `on_frame` zero or more times — once per completed
+//! hop boundary inside the chunk. Callers feed audio in any chunk
+//! size; the frontend buffers until a window's worth of samples
+//! (480) is available, emits a frame via the callback, then slides
+//! the window by the hop length (160 samples = 10 ms). Pass
+//! `|_| {}` as the callback to discard frames.
 //!
 //! For a 20 ms `AudioFrame` (320 samples) input, the frontend
-//! emits two frames per call after the first window fills (the
-//! first input fills 320/480, the second pushes to 640 = 1 hop
-//! past window-full, and so on).
+//! emits zero frames on the first call (320/480), then two frames
+//! on the second call (640 total = 1 full window + 1 hop), and
+//! two frames per call thereafter.
 //!
 //! # Bit-exactness disclaimer
 //!

--- a/crates/stackchan-audio-features/src/mel.rs
+++ b/crates/stackchan-audio-features/src/mel.rs
@@ -1,0 +1,265 @@
+//! Mel filterbank.
+//!
+//! Triangular filters spanning the auditory mel scale, applied to
+//! a magnitude spectrum produced by an FFT. The mel scale models
+//! human pitch perception's roughly-logarithmic response above
+//! ~1 kHz; speech recognition + keyword spotting front-ends use it
+//! because the resulting features track perceived speech content
+//! more closely than raw linear-frequency bins.
+//!
+//! Defaults match `microWakeWord`'s published frontend:
+//! 40 channels, lower edge 125 Hz, upper edge 7500 Hz, 512-point
+//! FFT at 16 kHz sample rate (giving 257 magnitude bins).
+//!
+//! # Reference implementation
+//!
+//! Slaney's auditory-toolbox mel scale is the de-facto standard
+//! in audio ML — `librosa.filters.mel`,
+//! `tensorflow.signal.linear_to_mel_weight_matrix`, and the
+//! TFLite-micro `AudioFrontend` op all use it. The formulas
+//! below match those reference implementations:
+//!
+//! ```text
+//! hz_to_mel(f) = 2595 · log10(1 + f / 700)
+//! mel_to_hz(m) = 700 · (10^(m / 2595) - 1)
+//! ```
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use libm::{log10f, powf};
+
+use crate::frontend::{FFT_BIN_COUNT, MEL_BIN_COUNT, MEL_LOWER_HZ, MEL_UPPER_HZ, SAMPLE_RATE_HZ};
+
+/// Convert frequency (Hz) to mel scale.
+#[must_use]
+pub fn hz_to_mel(hz: f32) -> f32 {
+    2595.0 * log10f(1.0 + hz / 700.0)
+}
+
+/// Convert mel scale to frequency (Hz).
+#[must_use]
+pub fn mel_to_hz(mel: f32) -> f32 {
+    700.0 * (powf(10.0, mel / 2595.0) - 1.0)
+}
+
+/// Precomputed mel filterbank.
+///
+/// Each row of `weights` is a triangular filter spanning a band of
+/// FFT magnitude bins. Multiplying a spectrum by this matrix
+/// collapses the 257 linear-frequency bins into [`MEL_BIN_COUNT`]
+/// (40) perceptual bands.
+///
+/// Triangles overlap by design: each filter's peak sits at one mel
+/// centre, with the left edge meeting the previous filter's centre
+/// and the right edge meeting the next. The result is a partition
+/// of unity on the inner mel range, with the lower/upper extremes
+/// tapering to zero.
+pub struct MelFilterbank {
+    /// Filter weights, indexed `[mel_bin][fft_bin]`. Most entries
+    /// are zero — each row's non-zero span is bounded by the
+    /// adjacent mel centres — but a flat 2-D layout keeps the
+    /// multiply hot loop branch-free.
+    ///
+    /// Heap-allocated (40 × 257 × 4 = ~41 KiB) because that's too
+    /// large for an embassy task's default stack on the
+    /// firmware target. PSRAM via `esp-alloc` is the host on
+    /// device.
+    weights: Box<[[f32; FFT_BIN_COUNT]]>,
+}
+
+impl MelFilterbank {
+    /// Build the filterbank for the crate's fixed
+    /// (`SAMPLE_RATE_HZ`, `WINDOW_SAMPLES`, `MEL_BIN_COUNT`,
+    /// `MEL_LOWER_HZ`, `MEL_UPPER_HZ`) configuration.
+    ///
+    /// Built once per `MelFrontend` construction and held in the
+    /// frontend; the inner-loop dot product is the only operation
+    /// that runs per audio frame.
+    #[must_use]
+    pub fn new() -> Self {
+        // Mel centres: MEL_BIN_COUNT + 2 evenly-spaced points on
+        // the mel scale, then converted back to Hz. The +2 is for
+        // the lower and upper edges of the band, which serve as
+        // the left edge of the first triangle and the right edge
+        // of the last.
+        let mel_lower = hz_to_mel(MEL_LOWER_HZ);
+        let mel_upper = hz_to_mel(MEL_UPPER_HZ);
+        let mel_step = (mel_upper - mel_lower) / ((MEL_BIN_COUNT + 1) as f32);
+
+        let mut centres_hz = [0.0_f32; MEL_BIN_COUNT + 2];
+        for (i, c) in centres_hz.iter_mut().enumerate() {
+            *c = mel_to_hz(mel_lower + (i as f32) * mel_step);
+        }
+
+        // FFT bin centres in Hz: `bin · sample_rate / fft_size`.
+        // FFT_BIN_COUNT is N/2 + 1 = 257 for N = 512.
+        let fft_size = 2 * (FFT_BIN_COUNT - 1);
+        let bin_hz =
+            |bin: usize| -> f32 { (bin as f32) * (SAMPLE_RATE_HZ as f32) / (fft_size as f32) };
+
+        // Heap-allocate row by row so the 41 KiB matrix never
+        // lives on the stack in full. Each push is one
+        // 1028-byte row.
+        let mut weights_vec: Vec<[f32; FFT_BIN_COUNT]> = Vec::with_capacity(MEL_BIN_COUNT);
+        for m in 0..MEL_BIN_COUNT {
+            let left = centres_hz[m];
+            let centre = centres_hz[m + 1];
+            let right = centres_hz[m + 2];
+            let mut row = [0.0_f32; FFT_BIN_COUNT];
+            for (bin, w) in row.iter_mut().enumerate() {
+                let f = bin_hz(bin);
+                *w = if f <= left || f >= right {
+                    0.0
+                } else if f <= centre {
+                    (f - left) / (centre - left)
+                } else {
+                    (right - f) / (right - centre)
+                };
+            }
+            weights_vec.push(row);
+        }
+        Self {
+            weights: weights_vec.into_boxed_slice(),
+        }
+    }
+
+    /// Apply the filterbank to a magnitude spectrum.
+    ///
+    /// `magnitude.len()` must equal [`FFT_BIN_COUNT`]; shorter
+    /// inputs would produce undefined energy in the upper filters.
+    /// The output `[f32; MEL_BIN_COUNT]` holds the summed weighted
+    /// energy per band.
+    #[must_use]
+    pub fn apply(&self, magnitude: &[f32; FFT_BIN_COUNT]) -> [f32; MEL_BIN_COUNT] {
+        let mut out = [0.0_f32; MEL_BIN_COUNT];
+        for (m, out_bin) in out.iter_mut().enumerate() {
+            let mut acc = 0.0_f32;
+            for (w, &mag) in self.weights[m].iter().zip(magnitude.iter()) {
+                acc += w * mag;
+            }
+            *out_bin = acc;
+        }
+        out
+    }
+
+    /// Access the raw matrix for inspection / tests.
+    #[must_use]
+    pub const fn weights(&self) -> &[[f32; FFT_BIN_COUNT]] {
+        &self.weights
+    }
+}
+
+impl Default for MelFilterbank {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "tests assert structural invariants; .expect / .unwrap are the standard test idiom"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hz_to_mel_roundtrips() {
+        for &hz in &[125.0_f32, 1000.0, 2500.0, 5000.0, 7500.0] {
+            let back = mel_to_hz(hz_to_mel(hz));
+            assert!(
+                (back - hz).abs() < 0.5,
+                "round-trip failed for {hz}: got {back}"
+            );
+        }
+    }
+
+    #[test]
+    fn lowest_filter_starts_at_mel_lower_edge() {
+        let fb = MelFilterbank::new();
+        let fft_size = 2 * (FFT_BIN_COUNT - 1);
+        let bin_hz =
+            |bin: usize| -> f32 { (bin as f32) * (SAMPLE_RATE_HZ as f32) / (fft_size as f32) };
+        // First filter's leftmost non-zero bin sits at or above
+        // MEL_LOWER_HZ — the triangle's left edge.
+        let first_nonzero = fb.weights[0]
+            .iter()
+            .position(|&w| w > 0.0)
+            .expect("first filter must have at least one non-zero bin");
+        assert!(
+            bin_hz(first_nonzero) >= MEL_LOWER_HZ - 1.0,
+            "first non-zero bin {} ({}Hz) below MEL_LOWER_HZ {}",
+            first_nonzero,
+            bin_hz(first_nonzero),
+            MEL_LOWER_HZ,
+        );
+    }
+
+    #[test]
+    fn highest_filter_ends_at_mel_upper_edge() {
+        let fb = MelFilterbank::new();
+        let fft_size = 2 * (FFT_BIN_COUNT - 1);
+        let bin_hz =
+            |bin: usize| -> f32 { (bin as f32) * (SAMPLE_RATE_HZ as f32) / (fft_size as f32) };
+        let last = MEL_BIN_COUNT - 1;
+        let last_nonzero = fb.weights[last]
+            .iter()
+            .rposition(|&w| w > 0.0)
+            .expect("last filter must have at least one non-zero bin");
+        // The rightmost non-zero bin sits at or below MEL_UPPER_HZ
+        // — the triangle's right edge.
+        assert!(
+            bin_hz(last_nonzero) <= MEL_UPPER_HZ + 50.0,
+            "last non-zero bin {} ({}Hz) above MEL_UPPER_HZ {}",
+            last_nonzero,
+            bin_hz(last_nonzero),
+            MEL_UPPER_HZ,
+        );
+    }
+
+    #[test]
+    fn filter_peaks_sum_to_partition_of_unity_on_inner_band() {
+        // Sum of all triangles at any one FFT bin in the inner
+        // band (above the first centre, below the last centre)
+        // approximates 1.0 — that's what "partition of unity"
+        // means for adjacent triangular filters with shared edges.
+        let fb = MelFilterbank::new();
+        let fft_size = 2 * (FFT_BIN_COUNT - 1);
+        let lower_centre_bin = (250.0 * fft_size as f32 / SAMPLE_RATE_HZ as f32) as usize;
+        let upper_centre_bin = (6500.0 * fft_size as f32 / SAMPLE_RATE_HZ as f32) as usize;
+        for bin in lower_centre_bin..upper_centre_bin {
+            let total: f32 = fb.weights.iter().map(|row| row[bin]).sum();
+            assert!(
+                (total - 1.0).abs() < 0.01,
+                "inner-band sum {total} != 1.0 at bin {bin}"
+            );
+        }
+    }
+
+    #[test]
+    fn applies_to_zero_magnitude_produces_zero_energy() {
+        let fb = MelFilterbank::new();
+        let zero = [0.0_f32; FFT_BIN_COUNT];
+        let out = fb.apply(&zero);
+        assert!(out.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn applies_to_unit_spike_concentrates_energy_in_one_band() {
+        // A magnitude spectrum with a single non-zero bin should
+        // land its energy in at most two adjacent mel filters
+        // (the bin sits inside two overlapping triangles).
+        let fb = MelFilterbank::new();
+        let mut mag = [0.0_f32; FFT_BIN_COUNT];
+        let probe_bin = 32; // ~1 kHz at 16 kHz / 512.
+        mag[probe_bin] = 1.0;
+        let out = fb.apply(&mag);
+        let nonzero = out.iter().filter(|&&x| x > 0.0).count();
+        assert!(
+            (1..=2).contains(&nonzero),
+            "expected 1-2 non-zero mel bins, got {nonzero}: {out:?}"
+        );
+    }
+}

--- a/crates/stackchan-audio-features/src/quantize.rs
+++ b/crates/stackchan-audio-features/src/quantize.rs
@@ -1,0 +1,176 @@
+//! Log scaling + int8 quantization.
+//!
+//! The mel filterbank produces unbounded `f32` energies; `TFLite`
+//! keyword-spotting models expect signed-8-bit features at the
+//! input tensor. Two steps connect them:
+//!
+//! 1. Natural log scaling, with a small `epsilon` floor so the
+//!    log of a silent band doesn't go to `-∞`.
+//! 2. Asymmetric `int8` quantization with a model-specific
+//!    `scale` and `zero_point`.
+//!
+//! Quantization parameters are model-specific by design —
+//! `TFLite`'s `quantization_parameters` for the input tensor is the
+//! source of truth. The defaults exposed by [`QuantParams::DEFAULT`]
+//! match `microWakeWord`'s published "hey jarvis" model
+//! (`scale = 0.5`, `zero_point = -25`); future models will ship
+//! their own parameters.
+
+use libm::logf;
+
+use crate::frontend::MEL_BIN_COUNT;
+
+/// Natural-log floor: any input below this is treated as if it
+/// equalled this value, so the log doesn't produce `-∞` (or, on
+/// `xtensa-esp32s3-none-elf` without HW FP, a quiet NaN).
+const LOG_EPSILON: f32 = 1.0e-6;
+
+/// Per-tensor asymmetric quantization parameters.
+///
+/// Maps a real value `x` to int8 via
+/// `clamp(round(x / scale) + zero_point, -128, 127)`. Mirrors
+/// `TFLite`'s reference quantization for `int8` activation tensors.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct QuantParams {
+    /// Real-world scale per quant step. Must be strictly positive.
+    pub scale: f32,
+    /// Quantized value that corresponds to real-world zero.
+    pub zero_point: i8,
+}
+
+impl QuantParams {
+    /// Match `microWakeWord`'s reference quantization on its
+    /// shipped models. Plug in model-specific values via
+    /// [`QuantParams::new`] when running against a custom net.
+    pub const DEFAULT: Self = Self {
+        scale: 0.5,
+        zero_point: -25,
+    };
+
+    /// Construct with explicit `scale` and `zero_point`. No
+    /// validation on `scale` — passing `0` will produce infinity
+    /// at the divide; passing negative inverts the mapping.
+    /// Callers read these from the model's
+    /// `quantization_parameters` and pass them straight through.
+    #[must_use]
+    pub const fn new(scale: f32, zero_point: i8) -> Self {
+        Self { scale, zero_point }
+    }
+}
+
+impl Default for QuantParams {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Apply natural-log scaling and asymmetric int8 quantization to
+/// one mel-energy frame.
+///
+/// `mel_energy[i]` is replaced by
+/// `quantize(log(max(mel_energy[i], LOG_EPSILON)), params)`.
+#[must_use]
+pub fn log_then_quantize(
+    mel_energy: &[f32; MEL_BIN_COUNT],
+    params: QuantParams,
+) -> [i8; MEL_BIN_COUNT] {
+    let mut out = [0_i8; MEL_BIN_COUNT];
+    for (i, &e) in mel_energy.iter().enumerate() {
+        let floored = if e > LOG_EPSILON { e } else { LOG_EPSILON };
+        out[i] = quantize_scalar(logf(floored), params);
+    }
+    out
+}
+
+/// Scalar `f32 → i8` quantization helper, factored out so tests
+/// can pin down its rounding behaviour. Saturating on overflow.
+#[must_use]
+pub fn quantize_scalar(x: f32, params: QuantParams) -> i8 {
+    // round-half-away-from-zero matches TFLite's reference kernel;
+    // `f32::round` does what we want on host. The cast saturates
+    // via clamp because raw `as i8` truncates wrap-around for
+    // out-of-range values.
+    let scaled = x / params.scale;
+    let rounded = if scaled >= 0.0 {
+        libm::floorf(scaled + 0.5)
+    } else {
+        libm::ceilf(scaled - 0.5)
+    };
+    let shifted = rounded + f32::from(params.zero_point);
+    let clamped = if shifted < f32::from(i8::MIN) {
+        f32::from(i8::MIN)
+    } else if shifted > f32::from(i8::MAX) {
+        f32::from(i8::MAX)
+    } else {
+        shifted
+    };
+    clamped as i8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantize_zero_maps_to_zero_point() {
+        assert_eq!(
+            quantize_scalar(0.0, QuantParams::new(0.5, -25)),
+            -25,
+            "real 0 should map to zero_point"
+        );
+    }
+
+    #[test]
+    fn quantize_one_scale_step_above_zero() {
+        // x = 0.5, scale = 0.5 → 0.5/0.5 = 1 step → zero_point + 1.
+        assert_eq!(quantize_scalar(0.5, QuantParams::new(0.5, -25)), -24);
+    }
+
+    #[test]
+    fn quantize_saturates_at_int8_min_and_max() {
+        // Large negative input -> i8::MIN, large positive -> i8::MAX.
+        let p = QuantParams::new(0.5, 0);
+        assert_eq!(quantize_scalar(-1000.0, p), i8::MIN);
+        assert_eq!(quantize_scalar(1000.0, p), i8::MAX);
+    }
+
+    #[test]
+    fn quantize_rounds_half_away_from_zero() {
+        // round(0.5) → 1, round(-0.5) → -1.
+        let p = QuantParams::new(1.0, 0);
+        assert_eq!(quantize_scalar(0.5, p), 1);
+        assert_eq!(quantize_scalar(-0.5, p), -1);
+        // round(0.4) → 0, round(-0.4) → 0.
+        assert_eq!(quantize_scalar(0.4, p), 0);
+        assert_eq!(quantize_scalar(-0.4, p), 0);
+    }
+
+    #[test]
+    fn log_then_quantize_zero_input_uses_epsilon_floor() {
+        // log(1e-6) = ln(1e-6) ≈ -13.815. With scale=0.5,
+        // zero_point=-25: -13.815/0.5 = -27.63 → round to -28,
+        // plus zero_point -25 → -53.
+        let zero = [0.0_f32; MEL_BIN_COUNT];
+        let out = log_then_quantize(&zero, QuantParams::DEFAULT);
+        assert!(
+            out.iter().all(|&x| x == -53),
+            "all-zero input did not produce expected floor value: got {:?}",
+            &out[..4]
+        );
+    }
+
+    #[test]
+    fn log_then_quantize_unit_input_produces_log_of_one() {
+        // log(1) = 0; with zero_point=-25 the output is -25.
+        let unit = [1.0_f32; MEL_BIN_COUNT];
+        let out = log_then_quantize(&unit, QuantParams::DEFAULT);
+        assert!(out.iter().all(|&x| x == -25));
+    }
+
+    #[test]
+    fn default_quant_params_match_documented_values() {
+        let p = QuantParams::DEFAULT;
+        assert!((p.scale - 0.5).abs() < f32::EPSILON);
+        assert_eq!(p.zero_point, -25);
+    }
+}

--- a/crates/stackchan-audio-features/src/quantize.rs
+++ b/crates/stackchan-audio-features/src/quantize.rs
@@ -47,13 +47,18 @@ impl QuantParams {
         zero_point: -25,
     };
 
-    /// Construct with explicit `scale` and `zero_point`. No
-    /// validation on `scale` — passing `0` will produce infinity
-    /// at the divide; passing negative inverts the mapping.
-    /// Callers read these from the model's
-    /// `quantization_parameters` and pass them straight through.
+    /// Construct with explicit `scale` and `zero_point`. Callers
+    /// read these from the model's `quantization_parameters` and
+    /// pass them straight through. `scale = 0` produces division
+    /// by zero (and silently corrupts every quantized output);
+    /// `debug_assert!` surfaces the mistake during host tests and
+    /// firmware debug builds without adding cost to release.
     #[must_use]
-    pub const fn new(scale: f32, zero_point: i8) -> Self {
+    pub fn new(scale: f32, zero_point: i8) -> Self {
+        debug_assert!(
+            scale > 0.0,
+            "QuantParams::new: scale must be strictly positive"
+        );
         Self { scale, zero_point }
     }
 }

--- a/crates/stackchan-audio-features/src/window.rs
+++ b/crates/stackchan-audio-features/src/window.rs
@@ -1,0 +1,126 @@
+//! Hann window.
+//!
+//! `microWakeWord` and most TFLite-micro keyword-spotting frontends
+//! use a 30 ms periodic Hann window. 30 ms at 16 kHz is 480
+//! samples; the window coefficients are precomputed at construction
+//! time and applied per-frame via `apply_to` rather than recomputed
+//! in the hot path.
+
+use libm::cosf;
+
+use crate::frontend::WINDOW_SAMPLES;
+
+/// Precomputed Hann coefficients, scaled to `f32` in `[0, 1]`.
+///
+/// `w[n] = 0.5 * (1 - cos(2π·n / N))` for `n ∈ 0..N`, the
+/// **periodic** definition `microWakeWord` uses (matches
+/// `numpy.hanning` with `sym=False` / `scipy.signal.windows.hann`
+/// with `sym=False`). The symmetric form (`sym=True`, `N-1` in the
+/// denominator) drops one coefficient to zero and shifts the
+/// spectrum subtly differently; using the wrong variant is one of
+/// the classic ways a hand-rolled frontend drifts off a reference
+/// implementation by a few dB per bin.
+pub struct HannWindow {
+    /// Per-sample coefficients in `[0, 1]`. Length is fixed at
+    /// [`WINDOW_SAMPLES`] so the array can be heap-free.
+    coefficients: [f32; WINDOW_SAMPLES],
+}
+
+impl HannWindow {
+    /// Construct a 480-sample periodic Hann window.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut coefficients = [0.0_f32; WINDOW_SAMPLES];
+        let n_f = WINDOW_SAMPLES as f32;
+        for (i, c) in coefficients.iter_mut().enumerate() {
+            // Periodic Hann: 2π·i / N, NOT 2π·i / (N-1).
+            let theta = 2.0 * core::f32::consts::PI * (i as f32) / n_f;
+            *c = 0.5 * (1.0 - cosf(theta));
+        }
+        Self { coefficients }
+    }
+
+    /// Apply the window in place: `samples[i] *= coefficient[i]`.
+    ///
+    /// Length-checked via `iter_mut().zip(self.coefficients)` so a
+    /// shorter slice silently uses fewer coefficients — but the
+    /// caller invariant in [`crate::frontend::MelFrontend`] always
+    /// passes exactly [`WINDOW_SAMPLES`] floats.
+    pub fn apply_to(&self, samples: &mut [f32]) {
+        for (s, &c) in samples.iter_mut().zip(self.coefficients.iter()) {
+            *s *= c;
+        }
+    }
+
+    /// Access the raw coefficients for inspection / tests.
+    #[must_use]
+    pub const fn coefficients(&self) -> &[f32; WINDOW_SAMPLES] {
+        &self.coefficients
+    }
+}
+
+impl Default for HannWindow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "tests assert structural invariants; .expect / .unwrap are the standard test idiom"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn periodic_hann_starts_and_ends_correctly() {
+        let w = HannWindow::new();
+        let c = w.coefficients();
+        // Periodic Hann: w[0] = 0 exactly; w[N/2] = 1 exactly.
+        assert!(c[0].abs() < 1e-6);
+        assert!((c[WINDOW_SAMPLES / 2] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn periodic_hann_is_symmetric_around_n_over_2() {
+        let w = HannWindow::new();
+        let c = w.coefficients();
+        // For periodic Hann, w[k] == w[N-k] for k ∈ 1..N/2.
+        // (Periodic, not symmetric — the asymmetry is only at k=0
+        // vs k=N, which are distinct under periodic indexing.)
+        for k in 1..WINDOW_SAMPLES / 2 {
+            assert!(
+                (c[k] - c[WINDOW_SAMPLES - k]).abs() < 1e-6,
+                "asymmetry at k={k}: {} vs {}",
+                c[k],
+                c[WINDOW_SAMPLES - k]
+            );
+        }
+    }
+
+    #[test]
+    fn apply_to_zeros_passes_through_zeros() {
+        let w = HannWindow::new();
+        let mut buf = [0.0_f32; WINDOW_SAMPLES];
+        w.apply_to(&mut buf);
+        assert!(buf.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn apply_to_scales_constant_input() {
+        let w = HannWindow::new();
+        let mut buf = [1.0_f32; WINDOW_SAMPLES];
+        w.apply_to(&mut buf);
+        // Sum of periodic Hann coefficients over a full window is
+        // N/2 (one full cosine cycle averages 0; the 0.5 constant
+        // term contributes N/2). Verify the windowed sum matches.
+        let sum: f32 = buf.iter().sum();
+        let expected = (WINDOW_SAMPLES as f32) / 2.0;
+        assert!(
+            (sum - expected).abs() < 0.01,
+            "windowed sum {sum} != expected {expected}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Arc 4b's foundational slice — the audio feature pipeline any future on-device wake-word path needs. Inference + bundled model land separately; this crate is verifiable in isolation and unblocks the next session's choice between TFLite-micro-via-FFI, a pure-Rust port, or a custom MixConv interpreter.

- **`no_std` + `alloc` streaming pipeline**: `MelFrontend::push_samples(&[i16], FnMut)` takes any chunk size of 16 kHz mono PCM, emits one `MelFrame` per 10 ms hop through the callback. No allocation in the hot loop.
- **Matches the `microWakeWord` / TFLite-micro keyword-spotting frontend shape**:
  - 30 ms periodic Hann window (`sym=False`, matches numpy / scipy)
  - 512-point real FFT via [`microfft`](https://crates.io/crates/microfft) (480 windowed samples zero-padded to 512)
  - 40-channel mel filterbank, 125–7 500 Hz, Slaney scale (the de-facto standard used by `librosa`, `tensorflow.signal`, and TFLite's `AudioFrontend` op)
  - Natural log + per-tensor asymmetric int8 quantize with model-supplied `scale` / `zero_point`
- **23 host tests**: Hann symmetry + scaling, mel filter edge placement + partition-of-unity on the inner band, quantization rounding / saturation / log floor, streaming window-hop cadence, and a 1 kHz pure-tone fixture that asserts the peak energy lands at the expected mel bin (index 12 of 40 for the 125–7 500 Hz band).
- **Boxed the 41 KiB mel weight matrix** so it never lives on the stack — embassy task stacks on `xtensa-esp32s3-none-elf` are too small for the full filterbank to sit there, even briefly during construction. The matrix lives in PSRAM via `esp-alloc` on device.

## Out of scope (deliberate)

- **No inference.** The MixConv classifier that consumes `MelFrame`s lives in a follow-up. Shipping the frontend on its own avoids the Arc 3c trap — unlike LED-override plumbing that sat untested, this crate has concrete behaviour verifiable against numpy / scipy reference implementations.
- **No spectral subtraction / PCAN gain control.** The reference `microWakeWord` frontend includes both for noise-robust live audio. Their omission means clean fixtures match reference bit-exact but live mic audio will diverge from the reference network's expected distribution. The follow-up that lands inference either ports those kernels or trains against the simpler features this crate produces.
- **No firmware integration.** No consumer of `MelFrontend` exists yet. The PR after this wires the firmware-side wake-word task to subscribe to `AUDIO_FRAME_PUBSUB` and feed frames into the pipeline.

## Test plan

- [x] `cargo test -p stackchan-audio-features` — 23 / 23 pass
- [x] `just check` — fmt + workspace clippy + host tests
- [x] `just ci` — adds `cargo deny` + the rustdoc-warnings gate
- [ ] On-device verification: deferred until inference lands. The crate's tests against synthetic fixtures (silence, pure tones) gate correctness against the reference math.

## Why now

Arc 4b ("microWakeWord runtime + bundled model") is realistically multi-session — there's no Rust ecosystem path for TFLite-micro on ESP32-S3, and the audio frontend alone is a substantial DSP project. Carving out the frontend as a host-testable library unblocks the next session's inference path choice without committing to one prematurely.