### PR TITLE
feat(firmware): GET /state/ws — WebSocket avatar push (RFC 6455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,16 @@ section summarises the milestone work in human terms.
 - Time configuration honours the `time.tz` field at boot — a small
   catalog of named IANA zones plus `Etc/GMT±N` is enough for the
   desk-toy use case without pulling in a real timezone library.
+- `GET /state/ws` — WebSocket transport (RFC 6455) parallel to the
+  existing `/state/stream` Server-Sent Events path. Same snapshot
+  payload; same publisher; operators pick whichever transport
+  their dashboard library speaks. Server-push only (handshake +
+  text frames + a 15 s ping); client-sent frames are ignored.
+  Bidirectional support, binary opcodes, and per-frame masking
+  are out of scope for v1. RFC 6455 handshake + frame primitives
+  in `net/websocket.rs` cover handshake-key SHA-1 / base64,
+  case-insensitive header lookup, and short / extended-length
+  frame headers.
 
 ### Stability + plumbing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,6 +4764,7 @@ dependencies = [
  "mipidsi",
  "py32",
  "scservo",
+ "sha1_smol",
  "si12t",
  "stackchan-core",
  "stackchan-net",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -149,6 +149,15 @@ static_cell = "2.1.1"
 # dB mapping; sharing the dep keeps the workspace libm-free.
 micromath = "2"
 
+# WebSocket handshake (`GET /state/ws`) hashes the client-supplied
+# `Sec-WebSocket-Key` + RFC 6455 GUID with SHA-1 to produce the
+# `Sec-WebSocket-Accept` echo. `sha1_smol` is a pure-Rust `no_std`
+# SHA-1; we disable its default features to keep `std` out of the
+# firmware build. Base64 of the 20-byte digest is hand-rolled in
+# `net/websocket.rs` to avoid pulling another version of `base64`
+# into the dep graph alongside the one trouble-host already brings.
+sha1_smol = { version = "1.0", default-features = false }
+
 [features]
 # Default: zero-overhead production build. The `tracking_trace`
 # module's no-op `TraceState` ZST + empty methods compile to nothing.

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -431,6 +431,9 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         ("GET", "/health") => write_json(socket, 200, &health_body()).await,
         ("GET", "/state") => write_json(socket, 200, &state_body(snapshot::read())).await,
         ("GET", "/state/stream") => handle_state_stream(socket).await,
+        ("GET", "/state/ws") => {
+            handle_state_websocket(socket, &buf[line_end + 2..header_end]).await
+        }
         ("GET", "/sensors") => {
             write_json(socket, 200, &sensors_body(snapshot::read_sensors())).await
         }
@@ -563,6 +566,97 @@ async fn write_heartbeat(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
         .await
         .map_err(|_| HttpError::Write)?;
     socket.flush().await.map_err(|_| HttpError::Write)
+}
+
+/// WebSocket ping interval. Same 15 s cadence as the SSE heartbeat
+/// for the same reason — keeps proxy / NAT idle timers from
+/// tearing the connection down.
+const WS_PING_INTERVAL_SECS: u64 = 15;
+
+/// `GET /state/ws` — upgrade the connection to a WebSocket and
+/// push [`AvatarSnapshot`] events as text frames.
+///
+/// Mirrors [`handle_state_stream`] (SSE) over RFC 6455 framing.
+/// Operators choose the transport their dashboard speaks; both
+/// subscribe to the same [`super::snapshot::SNAPSHOT_PUBSUB`] so
+/// payloads are bit-identical.
+///
+/// Pre-handshake the request body is empty (`Content-Length: 0`),
+/// so the bearer-token gate higher up doesn't apply — `GET` reads
+/// stay LAN-open regardless of `auth.token`.
+async fn handle_state_websocket(
+    socket: &mut TcpSocket<'_>,
+    headers: &[u8],
+) -> Result<(), HttpError> {
+    use core::fmt::Write as _;
+
+    use super::websocket;
+
+    let Some(key) = websocket::parse_websocket_key(headers) else {
+        return write_text(socket, 400, "missing Sec-WebSocket-Key\n").await;
+    };
+    let Ok(mut subscriber) = snapshot::SNAPSHOT_PUBSUB.subscriber() else {
+        return write_text(socket, 503, "stream slots exhausted\n").await;
+    };
+
+    // The handshake response is small; build it in a heapless
+    // buffer so the 101 + Upgrade + Accept header lines never
+    // touch the allocator.
+    let accept = websocket::compute_accept_key(key);
+    let mut response: heapless::String<160> = heapless::String::new();
+    if write!(
+        &mut response,
+        "HTTP/1.1 101 Switching Protocols\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Accept: {}\r\n\r\n",
+        accept.as_str(),
+    )
+    .is_err()
+    {
+        return Err(HttpError::Write);
+    }
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|_| HttpError::Write)?;
+    socket.flush().await.map_err(|_| HttpError::Write)?;
+
+    // After the upgrade the connection is server-push only; the
+    // per-request inactivity timeout would tear a healthy
+    // long-lived stream down.
+    socket.set_timeout(None);
+
+    // Initial snapshot so freshly-connected clients don't wait
+    // for the next render tick to render their first frame.
+    let body = state_body(snapshot::read());
+    websocket::write_text_frame(socket, body.trim_end_matches('\n').as_bytes())
+        .await
+        .map_err(|()| HttpError::Write)?;
+
+    loop {
+        match select(
+            subscriber.next_message(),
+            embassy_time::Timer::after(Duration::from_secs(WS_PING_INTERVAL_SECS)),
+        )
+        .await
+        {
+            Either::First(WaitResult::Message(snap)) => {
+                let body = state_body(snap);
+                websocket::write_text_frame(socket, body.trim_end_matches('\n').as_bytes())
+                    .await
+                    .map_err(|()| HttpError::Write)?;
+            }
+            // `Lagged` means we missed N publishes. Same as SSE
+            // — the next snapshot is more useful than backfilling.
+            Either::First(WaitResult::Lagged(_)) => {}
+            Either::Second(()) => {
+                websocket::write_ping_frame(socket)
+                    .await
+                    .map_err(|()| HttpError::Write)?;
+            }
+        }
+    }
 }
 
 /// `GET /settings` — render the current snapshot with `wifi.psk`

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -592,6 +592,22 @@ async fn handle_state_websocket(
 
     use super::websocket;
 
+    // RFC 6455 § 4.2.1: the server must validate `Upgrade:
+    // websocket`, `Sec-WebSocket-Version: 13`, and presence of
+    // `Sec-WebSocket-Key` before issuing `101`. Without the
+    // version gate a client on an older draft would receive a
+    // `101` with framing it doesn't understand and silently
+    // break — a clean `400` lets the client fall back.
+    let upgrade_ok = websocket::parse_header_value(headers, b"upgrade")
+        .is_some_and(|v| v.eq_ignore_ascii_case(b"websocket"));
+    if !upgrade_ok {
+        return write_text(socket, 400, "Upgrade: websocket required\n").await;
+    }
+    let version_ok =
+        websocket::parse_header_value(headers, b"sec-websocket-version") == Some(b"13" as &[u8]);
+    if !version_ok {
+        return write_text(socket, 400, "Sec-WebSocket-Version: 13 required\n").await;
+    }
     let Some(key) = websocket::parse_websocket_key(headers) else {
         return write_text(socket, 400, "missing Sec-WebSocket-Key\n").await;
     };

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -17,4 +17,5 @@ pub mod mdns;
 pub mod snapshot;
 pub mod sntp;
 pub mod stack;
+pub mod websocket;
 pub mod wifi;

--- a/crates/stackchan-firmware/src/net/websocket.rs
+++ b/crates/stackchan-firmware/src/net/websocket.rs
@@ -1,0 +1,295 @@
+//! WebSocket primitives for the live-state push path.
+//!
+//! Implements just enough of RFC 6455 to run a server-only push
+//! stream over `GET /state/ws`:
+//!
+//! - [`compute_accept_key`] hashes the client's
+//!   `Sec-WebSocket-Key` with the RFC 6455 GUID and base64-encodes
+//!   the SHA-1 digest. This is the value the handshake echoes back
+//!   in `Sec-WebSocket-Accept`.
+//! - [`parse_websocket_key`] locates the `Sec-WebSocket-Key`
+//!   header value inside the raw header byte slice. Case-
+//!   insensitive on the header name, whitespace-tolerant on the
+//!   value.
+//! - [`write_text_frame`] emits one unfragmented server-side
+//!   text frame (FIN = 1, opcode = 0x1, mask bit = 0).
+//! - [`write_ping_frame`] emits a zero-payload ping (opcode = 0x9)
+//!   so reverse-proxy and NAT idle timers don't tear long-lived
+//!   connections down.
+//!
+//! Client-to-server frames, fragmentation, binary opcodes, and
+//! per-frame masking aren't implemented because the live-state
+//! endpoint never reads from the client after the handshake.
+//! Adding bidirectional support is a follow-up — the primitives
+//! here cover everything `GET /state/ws` needs today.
+
+use embassy_net::tcp::TcpSocket;
+use embedded_io_async::Write as _;
+use sha1_smol::Sha1;
+
+/// Magic GUID concatenated with the client key before hashing.
+/// Defined in RFC 6455 § 4.2.2.
+const WS_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/// Length of the base64 encoding of a 20-byte SHA-1 digest. 20
+/// bytes → ceil(20/3) × 4 = 28 chars (with one trailing `=`).
+pub const ACCEPT_KEY_LEN: usize = 28;
+
+/// Compute the value of the server's `Sec-WebSocket-Accept`
+/// header from the client's `Sec-WebSocket-Key`.
+///
+/// Per RFC 6455 § 4.2.2: `base64(sha1(key + GUID))`. The output
+/// length is fixed at [`ACCEPT_KEY_LEN`] bytes.
+#[must_use]
+pub fn compute_accept_key(key: &[u8]) -> heapless::String<ACCEPT_KEY_LEN> {
+    let mut sha = Sha1::new();
+    sha.update(key);
+    sha.update(WS_GUID);
+    let digest = sha.digest().bytes();
+    base64_encode_20(&digest)
+}
+
+/// Find the `Sec-WebSocket-Key` header value in a raw header
+/// byte slice. Case-insensitive on the header name.
+///
+/// Returns the trimmed value bytes, or `None` if the header
+/// isn't present or its line is malformed (no `:` separator).
+#[must_use]
+pub fn parse_websocket_key(headers: &[u8]) -> Option<&[u8]> {
+    parse_header_value(headers, b"sec-websocket-key")
+}
+
+/// Generic case-insensitive header value lookup. Pulled out so
+/// the `Upgrade` / `Connection` / `Sec-WebSocket-Version` gates
+/// can layer on later without rewriting the scan.
+#[must_use]
+pub fn parse_header_value<'a>(headers: &'a [u8], name_lower: &[u8]) -> Option<&'a [u8]> {
+    for line in headers.split(|&b| b == b'\n') {
+        // Strip optional trailing `\r` from `\r\n` splits.
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let colon = line.iter().position(|&b| b == b':')?;
+        let (raw_name, raw_value) = line.split_at(colon);
+        if raw_name.len() != name_lower.len() {
+            continue;
+        }
+        if !raw_name
+            .iter()
+            .zip(name_lower.iter())
+            .all(|(a, b)| a.to_ascii_lowercase() == *b)
+        {
+            continue;
+        }
+        // Strip the `:` and surrounding whitespace.
+        let value = raw_value
+            .strip_prefix(b":")
+            .unwrap_or(raw_value)
+            .iter()
+            .position(|&b| b != b' ' && b != b'\t')
+            .map_or(&raw_value[..0], |start| {
+                let v = &raw_value[1..][start..];
+                // Trim trailing whitespace.
+                let end = v
+                    .iter()
+                    .rposition(|&b| b != b' ' && b != b'\t' && b != b'\r')
+                    .map_or(0, |e| e + 1);
+                &v[..end]
+            });
+        return Some(value);
+    }
+    None
+}
+
+/// Write one unfragmented server-side WebSocket text frame
+/// (opcode = 0x1, FIN = 1, mask = 0).
+///
+/// Encodes the payload-length prefix per RFC 6455 § 5.2 — 7-bit
+/// inline for ≤125 bytes, 7 + 16-bit for ≤65 535, 7 + 64-bit
+/// otherwise. The send is two `write_all` calls (header bytes +
+/// payload bytes) so the framing stays trivially correct vs.
+/// constructing one large staging buffer.
+///
+/// # Errors
+///
+/// Propagates a socket write failure as a unit-error `()`. The
+/// caller's outer loop logs and rebinds — same shape as
+/// `handle_state_stream`'s SSE path.
+pub async fn write_text_frame(socket: &mut TcpSocket<'_>, payload: &[u8]) -> Result<(), ()> {
+    let mut header = [0_u8; 10];
+    let header_len = encode_text_frame_header(payload.len(), &mut header);
+    socket
+        .write_all(&header[..header_len])
+        .await
+        .map_err(|_| ())?;
+    socket.write_all(payload).await.map_err(|_| ())?;
+    socket.flush().await.map_err(|_| ())
+}
+
+/// Write a zero-payload server-side WebSocket ping frame
+/// (opcode = 0x9, FIN = 1, mask = 0, length = 0).
+///
+/// # Errors
+///
+/// Propagates a socket write failure as a unit-error `()`.
+pub async fn write_ping_frame(socket: &mut TcpSocket<'_>) -> Result<(), ()> {
+    socket.write_all(&[0x89, 0x00]).await.map_err(|_| ())?;
+    socket.flush().await.map_err(|_| ())
+}
+
+/// Fill `header` with the frame prefix for an unfragmented
+/// server-side text frame carrying `payload_len` bytes, returning
+/// the prefix length.
+///
+/// Layout per RFC 6455 § 5.2:
+///   - byte 0: `0x81` (FIN = 1, opcode = 0x1)
+///   - byte 1 low 7 bits: `len_field` (`< 126`, `126`, or `127`)
+///   - byte 1 high bit (mask): `0` — server-to-client never masks
+///   - extended length (0 / 2 / 8 bytes, big-endian) if the
+///     `len_field` is `126` or `127`.
+fn encode_text_frame_header(payload_len: usize, header: &mut [u8; 10]) -> usize {
+    header[0] = 0x81;
+    if payload_len < 126 {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "payload_len < 126 fits in u8 by construction"
+        )]
+        {
+            header[1] = payload_len as u8;
+        }
+        2
+    } else if let Ok(len) = u16::try_from(payload_len) {
+        header[1] = 126;
+        header[2..4].copy_from_slice(&len.to_be_bytes());
+        4
+    } else {
+        header[1] = 127;
+        let len = payload_len as u64;
+        header[2..10].copy_from_slice(&len.to_be_bytes());
+        10
+    }
+}
+
+/// Base64-encode exactly 20 bytes into 28 chars (one trailing
+/// `=` pad).
+///
+/// Hand-rolled for the WebSocket handshake's fixed-size SHA-1
+/// digest so we don't pull a `base64` crate version into the dep
+/// graph alongside whatever trouble-host transitively brought in.
+/// Not exported — the only caller is [`compute_accept_key`].
+fn base64_encode_20(bytes: &[u8; 20]) -> heapless::String<ACCEPT_KEY_LEN> {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = heapless::String::<ACCEPT_KEY_LEN>::new();
+    // Six full triplets cover the first 18 bytes.
+    let mut i = 0;
+    while i + 3 <= 18 {
+        let b0 = bytes[i];
+        let b1 = bytes[i + 1];
+        let b2 = bytes[i + 2];
+        let _ = out.push(ALPHABET[(b0 >> 2) as usize] as char);
+        let _ = out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize] as char);
+        let _ = out.push(ALPHABET[(((b1 & 0x0F) << 2) | (b2 >> 6)) as usize] as char);
+        let _ = out.push(ALPHABET[(b2 & 0x3F) as usize] as char);
+        i += 3;
+    }
+    // Two trailing bytes → 3 chars + 1 pad.
+    let b0 = bytes[18];
+    let b1 = bytes[19];
+    let _ = out.push(ALPHABET[(b0 >> 2) as usize] as char);
+    let _ = out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize] as char);
+    let _ = out.push(ALPHABET[((b1 & 0x0F) << 2) as usize] as char);
+    let _ = out.push('=');
+    out
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "tests assert RFC 6455 fixtures; .expect / .unwrap is the standard test idiom"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accept_key_matches_rfc6455_example() {
+        // From RFC 6455 § 1.3:
+        //   key:    "dGhlIHNhbXBsZSBub25jZQ=="
+        //   accept: "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+        let accept = compute_accept_key(b"dGhlIHNhbXBsZSBub25jZQ==");
+        assert_eq!(accept.as_str(), "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    }
+
+    #[test]
+    fn parse_websocket_key_case_insensitive_header_name() {
+        let headers =
+            b"Host: 192.168.1.1\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nUpgrade: websocket\r\n";
+        let key = parse_websocket_key(headers).unwrap();
+        assert_eq!(key, b"dGhlIHNhbXBsZSBub25jZQ==");
+    }
+
+    #[test]
+    fn parse_websocket_key_lowercase_header_works_too() {
+        let headers = b"sec-websocket-key: dGhlIHNhbXBsZSBub25jZQ==\r\n";
+        let key = parse_websocket_key(headers).unwrap();
+        assert_eq!(key, b"dGhlIHNhbXBsZSBub25jZQ==");
+    }
+
+    #[test]
+    fn parse_websocket_key_returns_none_when_absent() {
+        let headers = b"Host: x\r\nConnection: keep-alive\r\n";
+        assert!(parse_websocket_key(headers).is_none());
+    }
+
+    #[test]
+    fn parse_websocket_key_tolerates_extra_whitespace() {
+        let headers = b"Sec-WebSocket-Key:    dGhlIHNhbXBsZSBub25jZQ==   \r\n";
+        let key = parse_websocket_key(headers).unwrap();
+        assert_eq!(key, b"dGhlIHNhbXBsZSBub25jZQ==");
+    }
+
+    #[test]
+    fn frame_header_encodes_short_payload_in_two_bytes() {
+        let mut h = [0_u8; 10];
+        let n = encode_text_frame_header(5, &mut h);
+        assert_eq!(n, 2);
+        assert_eq!(h[0], 0x81);
+        assert_eq!(h[1], 5);
+    }
+
+    #[test]
+    fn frame_header_encodes_125_byte_payload_in_two_bytes() {
+        let mut h = [0_u8; 10];
+        let n = encode_text_frame_header(125, &mut h);
+        assert_eq!(n, 2);
+        assert_eq!(h[1], 125);
+    }
+
+    #[test]
+    fn frame_header_encodes_126_byte_payload_with_16bit_length() {
+        let mut h = [0_u8; 10];
+        let n = encode_text_frame_header(126, &mut h);
+        assert_eq!(n, 4);
+        assert_eq!(h[1], 126);
+        assert_eq!(u16::from_be_bytes([h[2], h[3]]), 126);
+    }
+
+    #[test]
+    fn frame_header_encodes_64k_payload_with_16bit_length() {
+        let mut h = [0_u8; 10];
+        let n = encode_text_frame_header(usize::from(u16::MAX), &mut h);
+        assert_eq!(n, 4);
+        assert_eq!(h[1], 126);
+        assert_eq!(u16::from_be_bytes([h[2], h[3]]), u16::MAX);
+    }
+
+    #[test]
+    fn frame_header_encodes_oversize_payload_with_64bit_length() {
+        let mut h = [0_u8; 10];
+        let n = encode_text_frame_header(usize::from(u16::MAX) + 1, &mut h);
+        assert_eq!(n, 10);
+        assert_eq!(h[1], 127);
+        assert_eq!(
+            u64::from_be_bytes([h[2], h[3], h[4], h[5], h[6], h[7], h[8], h[9]]),
+            u64::from(u16::MAX) + 1
+        );
+    }
+}

--- a/crates/stackchan-firmware/src/net/websocket.rs
+++ b/crates/stackchan-firmware/src/net/websocket.rs
@@ -67,7 +67,15 @@ pub fn parse_header_value<'a>(headers: &'a [u8], name_lower: &[u8]) -> Option<&'
     for line in headers.split(|&b| b == b'\n') {
         // Strip optional trailing `\r` from `\r\n` splits.
         let line = line.strip_suffix(b"\r").unwrap_or(line);
-        let colon = line.iter().position(|&b| b == b':')?;
+        // `?` here would abort the whole scan on any colon-less
+        // line — including the empty trailing element that
+        // splitting a `\n`-terminated header block always produces.
+        // Skip to the next line instead so a malformed line before
+        // the target header doesn't make the caller spuriously
+        // 400 the request.
+        let Some(colon) = line.iter().position(|&b| b == b':') else {
+            continue;
+        };
         let (raw_name, raw_value) = line.split_at(colon);
         if raw_name.len() != name_lower.len() {
             continue;
@@ -242,6 +250,17 @@ mod tests {
     #[test]
     fn parse_websocket_key_tolerates_extra_whitespace() {
         let headers = b"Sec-WebSocket-Key:    dGhlIHNhbXBsZSBub25jZQ==   \r\n";
+        let key = parse_websocket_key(headers).unwrap();
+        assert_eq!(key, b"dGhlIHNhbXBsZSBub25jZQ==");
+    }
+
+    #[test]
+    fn parse_websocket_key_skips_colon_less_lines() {
+        // A colon-less line before the target header used to abort
+        // the scan via the trailing `?` and surface as a spurious
+        // 400 at the handler. The `continue` path must keep
+        // scanning so the target header still gets found.
+        let headers = b"garbage-line-no-colon\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n";
         let key = parse_websocket_key(headers).unwrap();
         assert_eq!(key, b"dGhlIHNhbXBsZSBub25jZQ==");
     }

--- a/docs/http.md
+++ b/docs/http.md
@@ -27,6 +27,7 @@ beats pulling a full HTTP framework into the firmware target.
 | GET    | `/sensors`       | Live IMU / ambient / audio-RMS / body-touch sample   |
 | GET    | `/camera/snapshot` | Most recent `/sd/CAPTURE.565` frame as raw QVGA RGB565 BE |
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
+| GET    | `/state/ws`      | WebSocket stream of state changes (RFC 6455)        |
 | GET    | `/head/offsets`  | Current yaw + tilt zero-point offsets               |
 | POST   | `/head/offsets`  | Update yaw + tilt zero-point offsets; persisted to SD |
 | GET    | `/crash`         | Most recent panic log (404 if none recorded)        |
@@ -83,6 +84,25 @@ underlying render loop ticks at 30 Hz.
 
 The HTTP layer accepts on a pool of worker tasks, so a long-lived
 SSE stream doesn't block other requests on the same port.
+
+`GET /state/ws` opens an RFC 6455 WebSocket carrying the same
+snapshot payload as `/state/stream`, framed as text frames
+instead of `data:` lines. Operators choose whichever transport
+their dashboard library speaks; both subscribe to the same
+publisher so payloads are bit-identical. A 15 s ping frame keeps
+proxies and NAT idle timers from closing the connection.
+
+```
+$ wscat -c ws://stackchan.local/state/ws
+< {"emotion":"Neutral", ...}
+< {"emotion":"Happy", ...}
+```
+
+Only server→client traffic is implemented today — the firmware
+accepts the handshake, sends the initial snapshot, then pushes
+text frames whenever the snapshot changes. Client-sent frames
+are ignored; binary frames, fragmentation, and per-frame
+masking are out of scope for this v1.
 
 ## Manual control
 


### PR DESCRIPTION
## Summary

Arc 3b. Adds a WebSocket transport parallel to the existing SSE path on `GET /state/stream` — same snapshot payload, same publisher, operators pick whichever their dashboard library speaks. Both transports can run side by side.

- **`net/websocket.rs`** — RFC 6455 primitives. `compute_accept_key` (SHA-1 + base64 of client key + § 4.2.2 magic GUID), `parse_websocket_key` / `parse_header_value` (case-insensitive header lookup), `write_text_frame` / `write_ping_frame`, and the three frame-header length encodings (7-bit inline, 7 + 16-bit, 7 + 64-bit). `sha1_smol` (pure-Rust `no_std`, `default-features = false`) handles the digest; base64 of the fixed 20-byte SHA-1 output is hand-rolled to avoid pulling another `base64` major version into the dep graph alongside the one trouble-host already brought.
- **`handle_state_websocket`** in `net/http.rs` mirrors `handle_state_stream`: parse the key, return `101 Switching Protocols` with the accept echo, send the initial snapshot, then `select(next_message, ping_timer)` in the same shape SSE uses. 15 s ping cadence matches the SSE heartbeat for the same reason — proxy / NAT idle timer.
- **12 host tests** in `net/websocket.rs` cover the RFC 6455 § 1.3 fixture (`dGhlIHNhbXBsZSBub25jZQ==` → `s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`), case-insensitive header matching, whitespace tolerance, and the four frame-header length boundaries (125 / 126 / u16::MAX / u16::MAX + 1).

## Out of scope (deliberate v1 limits)

- **Server-push only.** Client→server frames are ignored after the handshake. The use case is dashboard push; bidirectional command sends already have the existing `POST` routes.
- **No fragmentation, binary opcodes, or per-frame masking on TX** (server frames are unmasked per RFC § 5.1). Adding these is mechanical when a real use case appears.
- **No dashboard migration.** The embedded operator dashboard still uses `EventSource` / SSE. Operators with a Node / Python / browser-side dashboard that prefers WS can use the new transport directly.

## Test plan

- [x] `cargo test -p stackchan-firmware` — N/A (firmware crate is `no_std`, host tests don't compile against it; the WS module tests live there as inline specs matching the `audio_debug` precedent)
- [x] `just check` — fmt + workspace clippy + host tests (`stackchan-net` round-trips still green; no schema change)
- [x] `cargo +esp clippy --release -p stackchan-firmware -- -D warnings` — strict clippy on the firmware target with the new module
- [x] `just ci` — adds `cargo deny` + the rustdoc-warnings gate
- [ ] On-device smoke: `wscat -c ws://<device-ip>/state/ws` should show the initial snapshot + each subsequent change as JSON text frames. Deferred to the next on-device session.