### PR TITLE
feat(firmware): mimic-follower — apply a leader's mDNS pose locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,17 @@ section summarises the milestone work in human terms.
   in `net/websocket.rs` cover handshake-key SHA-1 / base64,
   case-insensitive header lookup, and short / extended-length
   frame headers.
+- Mimic-follower — opt-in via `behavior.follower_leader_hostname`.
+  The firmware already advertises live `yaw` / `pitch` on its own
+  mDNS TXT record (the leader half of the meganetaaan `mimic_main`
+  protocol); this PR closes the loop by inspecting every inbound
+  mDNS multicast packet and applying any TXT record from the
+  configured leader as a 1.5 s `RemoteCommand::LookAt` hold. No
+  HTTP round-trip; both devices must share a multicast LAN
+  segment. `parse_response_pose` in `stackchan-net::mdns_pose` is
+  the host-testable parser — 11 host tests cover synthetic
+  fixtures, case-insensitive matching, compression pointers, and
+  a one-cycle pointer-loop bail-out.
 
 ### Stability + plumbing
 

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1395,8 +1395,23 @@ async fn main(spawner: Spawner) -> ! {
     if let Err(e) = spawner.spawn(net::mdns::mdns_task(
         net_stack,
         net_config.mdns.hostname.clone(),
+        net_config.behavior.follower_leader_hostname.clone(),
     )) {
         defmt::panic!("spawn(mdns_task) failed: {}", defmt::Debug2Format(&e));
+    }
+
+    // Mimic-follower — opt-in via
+    // `behavior.follower_leader_hostname`. Empty hostname parks
+    // the task; non-empty drains LEADER_POSE_SIGNAL (set by
+    // mdns_task's serve_loop when an inbound TXT matches) into
+    // RemoteCommand::LookAt holds.
+    if let Err(e) = spawner.spawn(net::mdns_follower::follower_task(
+        net_config.behavior.follower_leader_hostname.clone(),
+    )) {
+        defmt::panic!(
+            "spawn(mdns_follower::follower_task) failed: {}",
+            defmt::Debug2Format(&e)
+        );
     }
 
     // UDP audio debug stream — opt-in via

--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -38,12 +38,31 @@ use alloc::string::String;
 use embassy_futures::select::{Either, select};
 use embassy_net::Stack;
 use embassy_net::udp::{PacketMetadata, UdpSocket};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Instant as EmbassyInstant, Timer};
 use stackchan_core::Pose;
-use stackchan_net::mdns_pose::{POSE_PUBLISH_MIN_INTERVAL_MS, PoseAnnouncer, format_pose_kv};
+use stackchan_net::mdns_pose::{
+    POSE_PUBLISH_MIN_INTERVAL_MS, PoseAnnouncer, format_pose_kv, parse_response_pose,
+};
 
 use super::snapshot;
 use super::wifi::{WIFI_LINK_WATCH, WifiLinkState};
+
+/// Latest-wins pose lifted from a leader's mDNS TXT record.
+///
+/// Set by [`serve_loop`] whenever an inbound multicast packet
+/// carries a TXT record matching the configured
+/// `behavior.follower_leader_hostname`. Drained by the follower
+/// task ([`crate::net::mdns_follower::follower_task`]) which
+/// fires a `RemoteCommand::LookAt` hold so the local head tracks
+/// the leader without an HTTP round-trip.
+///
+/// Latest-wins semantics match the use case: a follower that
+/// missed an intermediate update should still snap to the
+/// freshest pose on the next tick rather than catching up
+/// through a backlog.
+pub static LEADER_POSE_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Signal::new();
 
 /// IPv4 mDNS multicast group + port.
 const MDNS_MULTICAST: embassy_net::IpAddress =
@@ -79,7 +98,7 @@ const SERVICE_LABELS: [&[u8]; 3] = [b"_stackchan", b"_tcp", b"local"];
 /// Rebinds on each `Connected` transition so a Wi-Fi reconnect
 /// doesn't strand the listener on a stale lease.
 #[embassy_executor::task]
-pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
+pub async fn mdns_task(stack: Stack<'static>, hostname: String, leader_hostname: String) -> ! {
     if hostname.is_empty() {
         defmt::info!("mdns: empty hostname, idle");
         park_forever().await;
@@ -154,7 +173,7 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String) -> ! {
 
         // Serve queries + periodic pose updates until the link drops
         // or anything errors out.
-        serve_loop(&socket, &hostname, our_ip, &mut announcer).await;
+        serve_loop(&socket, &hostname, &leader_hostname, our_ip, &mut announcer).await;
 
         let _ = stack.leave_multicast_group(MDNS_MULTICAST);
         socket.close();
@@ -186,6 +205,7 @@ async fn park_forever() -> ! {
 async fn serve_loop(
     socket: &UdpSocket<'_>,
     hostname: &str,
+    leader_hostname: &str,
     our_ip: embassy_net::Ipv4Address,
     announcer: &mut PoseAnnouncer,
 ) {
@@ -204,6 +224,13 @@ async fn serve_loop(
                 }
                 let kind = classify_query(&buf[..n], hostname);
                 if matches!(kind, QueryKind::None) {
+                    // Not a query directed at us. Could still be
+                    // a leader's TXT announcement worth following.
+                    if !leader_hostname.is_empty()
+                        && let Some(pose) = parse_response_pose(&buf[..n], leader_hostname)
+                    {
+                        LEADER_POSE_SIGNAL.signal(pose);
+                    }
                     continue;
                 }
                 // Both A and service-type queries are answered with

--- a/crates/stackchan-firmware/src/net/mdns_follower.rs
+++ b/crates/stackchan-firmware/src/net/mdns_follower.rs
@@ -1,0 +1,83 @@
+//! Mimic-follower task — apply a leader's head pose locally.
+//!
+//! `serve_loop` in [`super::mdns`] inspects every inbound mDNS
+//! multicast packet; when one carries a TXT record from the
+//! configured `behavior.follower_leader_hostname`, the leader's
+//! commanded `yaw` / `pitch` are signalled on
+//! [`super::mdns::LEADER_POSE_SIGNAL`]. This task drains the
+//! signal and converts each pose into a
+//! [`RemoteCommand::LookAt`] hold long enough to bridge a missed
+//! leader update.
+//!
+//! ## Hold duration
+//!
+//! The leader's [`PoseAnnouncer`] beats at most every
+//! [`POSE_HEARTBEAT_INTERVAL_MS`] (1 s) even when stationary, so
+//! a 1.5 s hold guarantees the follower never falls back to
+//! autonomy mid-stream from a single dropped multicast packet.
+//! A longer hold would stomp on operator-driven HTTP
+//! `POST /look-at` commands; shorter would let one missed packet
+//! return the head to autonomy.
+//!
+//! ## Empty leader → idle
+//!
+//! Empty `behavior.follower_leader_hostname` parks the task. No
+//! signal source ever fires (the producer in `serve_loop` also
+//! gates on a non-empty hostname), but the task still spawns —
+//! this matches the pattern other opt-in tasks use
+//! (`audio_debug`, `agent_sidecar`), so the boot-time spawn list
+//! stays consistent regardless of config.
+
+use alloc::string::String;
+
+use embassy_time::{Duration, Timer};
+use stackchan_core::input::RemoteCommand;
+use stackchan_net::mdns_pose::POSE_HEARTBEAT_INTERVAL_MS;
+
+use super::http::REMOTE_COMMAND_SIGNAL;
+use super::mdns::LEADER_POSE_SIGNAL;
+
+/// `LookAt` hold per signalled leader update. 1.5 × the leader's
+/// 1 s heartbeat so a single dropped multicast packet doesn't
+/// drop the follower back to autonomy mid-stream. The
+/// `POSE_HEARTBEAT_INTERVAL_MS` source constant is a `u64` for
+/// arithmetic in milliseconds, but `RemoteCommand::LookAt`'s
+/// `hold_ms` is `u32`; the constant fits in `u32` comfortably
+/// (~12 days at 1 ms resolution before overflow).
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "POSE_HEARTBEAT_INTERVAL_MS = 1000 is well below u32::MAX; the truncation is unreachable"
+)]
+const FOLLOWER_HOLD_MS: u32 = (POSE_HEARTBEAT_INTERVAL_MS as u32) * 3 / 2;
+
+/// Follower task entry point.
+///
+/// Empty `leader_hostname` parks the task — there's no producer
+/// for the signal in that case, so the loop would never advance.
+#[embassy_executor::task]
+pub async fn follower_task(leader_hostname: String) -> ! {
+    if leader_hostname.is_empty() {
+        defmt::info!("mdns-follower: no leader configured, idle");
+        park_forever().await;
+    }
+    defmt::info!(
+        "mdns-follower: tracking leader '{=str}' (hold {=u32}ms per update)",
+        leader_hostname.as_str(),
+        FOLLOWER_HOLD_MS,
+    );
+    loop {
+        let pose = LEADER_POSE_SIGNAL.wait().await;
+        REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::LookAt {
+            target: pose,
+            hold_ms: FOLLOWER_HOLD_MS,
+        });
+    }
+}
+
+/// Spin forever, parking the task. Used when no leader is
+/// configured.
+async fn park_forever() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(3600)).await;
+    }
+}

--- a/crates/stackchan-firmware/src/net/mod.rs
+++ b/crates/stackchan-firmware/src/net/mod.rs
@@ -14,6 +14,7 @@
 pub mod esp_now;
 pub mod http;
 pub mod mdns;
+pub mod mdns_follower;
 pub mod snapshot;
 pub mod sntp;
 pub mod stack;

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -149,6 +149,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        agent_sidecar_url",
         &config.behavior.agent_sidecar_url,
     );
+    push_field(
+        &mut out,
+        "        follower_leader_hostname",
+        &config.behavior.follower_leader_hostname,
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -512,6 +517,7 @@ impl<'a> Parser<'a> {
         let mut auto_torque_release_ms: Option<u32> = None;
         let mut audio_debug_udp_target: Option<String> = None;
         let mut agent_sidecar_url: Option<String> = None;
+        let mut follower_leader_hostname: Option<String> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -529,6 +535,9 @@ impl<'a> Parser<'a> {
                 "auto_torque_release_ms" => auto_torque_release_ms = Some(self.parse_u32()?),
                 "audio_debug_udp_target" => audio_debug_udp_target = Some(self.parse_string()?),
                 "agent_sidecar_url" => agent_sidecar_url = Some(self.parse_string()?),
+                "follower_leader_hostname" => {
+                    follower_leader_hostname = Some(self.parse_string()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -544,6 +553,7 @@ impl<'a> Parser<'a> {
             auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
             audio_debug_udp_target: audio_debug_udp_target.unwrap_or_default(),
             agent_sidecar_url: agent_sidecar_url.unwrap_or_default(),
+            follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -262,6 +262,12 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         "agent_sidecar_url",
         &config.behavior.agent_sidecar_url,
     );
+    out.push(',');
+    push_string_field(
+        &mut out,
+        "follower_leader_hostname",
+        &config.behavior.follower_leader_hostname,
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -766,6 +772,7 @@ impl<'a> Parser<'a> {
         let mut auto_torque_release_ms: Option<u32> = None;
         let mut audio_debug_udp_target: Option<String> = None;
         let mut agent_sidecar_url: Option<String> = None;
+        let mut follower_leader_hostname: Option<String> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -827,6 +834,15 @@ impl<'a> Parser<'a> {
                     }
                     agent_sidecar_url = Some(self.parse_string()?);
                 }
+                "follower_leader_hostname" => {
+                    if follower_leader_hostname.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "follower_leader_hostname",
+                        ));
+                    }
+                    follower_leader_hostname = Some(self.parse_string()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -842,6 +858,7 @@ impl<'a> Parser<'a> {
             auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
             audio_debug_udp_target: audio_debug_udp_target.unwrap_or_default(),
             agent_sidecar_url: agent_sidecar_url.unwrap_or_default(),
+            follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
         })
     }
 
@@ -1089,6 +1106,7 @@ mod tests {
                 auto_torque_release_ms: 30_000,
                 audio_debug_udp_target: "192.168.1.42:5005".to_string(),
                 agent_sidecar_url: "http://192.168.1.42:8080/v1/listen".to_string(),
+                follower_leader_hostname: "kitchen-cat".to_string(),
             },
         }
     }
@@ -1411,6 +1429,7 @@ mod tests {
                 auto_torque_release_ms: 30_000,
                 audio_debug_udp_target: "192.168.1.42:5005".to_string(),
                 agent_sidecar_url: "http://192.168.1.42:8080/v1/listen".to_string(),
+                follower_leader_hostname: "kitchen-cat".to_string(),
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -347,6 +347,18 @@ pub struct BehaviorConfig {
     /// `docs/sidecar.md`. Hostname-only URLs are not resolved —
     /// use a raw IPv4 literal (mirrors `audio_debug_udp_target`).
     pub agent_sidecar_url: String,
+    /// mDNS hostname of another Stack-chan to mimic, as the bare
+    /// first label (`"kitchen-cat"`, not the fully-qualified
+    /// `"kitchen-cat.local"`). Empty disables follower mode.
+    /// When set, the firmware inspects every inbound mDNS
+    /// multicast packet for the leader's TXT record and applies
+    /// its `yaw` / `pitch` to the local head as a 1.5 s
+    /// `RemoteCommand::LookAt` hold — long enough to bridge a
+    /// single dropped multicast packet, short enough that
+    /// operator-driven `POST /look-at` commands still feel
+    /// snappy. Both devices must be on the same LAN multicast
+    /// segment.
+    pub follower_leader_hostname: String,
 }
 
 /// Time / SNTP configuration.

--- a/crates/stackchan-net/src/mdns_pose.rs
+++ b/crates/stackchan-net/src/mdns_pose.rs
@@ -218,10 +218,19 @@ fn extract_pose_from_txt_rdata(rdata: &[u8]) -> Option<Pose> {
             return None;
         }
         if let Ok(s) = core::str::from_utf8(&rdata[i..i + len]) {
-            if let Some(v) = s.strip_prefix("yaw=") {
-                yaw = v.parse().ok();
-            } else if let Some(v) = s.strip_prefix("pitch=") {
-                pitch = v.parse().ok();
+            // First-valid-wins on duplicate keys. A naive
+            // `yaw = v.parse().ok()` would let a malformed
+            // second `yaw=` entry clobber a valid first reading
+            // and surface as a follower stall on otherwise-good
+            // leader traffic.
+            if let Some(v) = s.strip_prefix("yaw=")
+                && let Ok(val) = v.parse()
+            {
+                yaw.get_or_insert(val);
+            } else if let Some(v) = s.strip_prefix("pitch=")
+                && let Ok(val) = v.parse()
+            {
+                pitch.get_or_insert(val);
             }
         }
         i += len;
@@ -576,5 +585,85 @@ mod tests {
         // not hang.
         let msg = [0xC0_u8, 0x00];
         assert!(read_name(&msg, 0).is_none());
+    }
+
+    /// Build a response with a filler `A` record before the TXT
+    /// to exercise the answer-walking loop's `off = rdata_end`
+    /// advance. Mirrors the shape of a real kai announcement
+    /// (PTR + SRV + TXT + A in order; TXT is the third answer)
+    /// without reimplementing every record type — one preceding
+    /// record is enough to catch a fixed-header miscount.
+    fn build_txt_response_with_filler(hostname: &str, txt_strings: &[&str]) -> alloc::vec::Vec<u8> {
+        let mut msg = alloc::vec::Vec::new();
+        // Header: QR=1 AA=1, ancount=2.
+        msg.extend_from_slice(&[
+            0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        // Filler answer #1: A `filler.local.` → 1.2.3.4.
+        for label in ["filler", "local"] {
+            #[allow(clippy::cast_possible_truncation, reason = "test labels are short")]
+            msg.push(label.len() as u8);
+            msg.extend_from_slice(label.as_bytes());
+        }
+        msg.push(0x00);
+        msg.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // type A, class IN
+        msg.extend_from_slice(&[0x00, 0x00, 0x00, 0x78]); // TTL
+        msg.extend_from_slice(&[0x00, 0x04]); // rdlength = 4
+        msg.extend_from_slice(&[1, 2, 3, 4]); // a.b.c.d
+        // Target answer: TXT `<hostname>._stackchan._tcp.local.`.
+        for label in [hostname, "_stackchan", "_tcp", "local"] {
+            #[allow(clippy::cast_possible_truncation, reason = "test labels are short")]
+            msg.push(label.len() as u8);
+            msg.extend_from_slice(label.as_bytes());
+        }
+        msg.push(0x00);
+        msg.extend_from_slice(&[0x00, 0x10, 0x00, 0x01]); // type TXT
+        msg.extend_from_slice(&[0x00, 0x00, 0x00, 0x78]); // TTL
+        let mut rdata = alloc::vec::Vec::new();
+        for s in txt_strings {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "test TXT strings are short"
+            )]
+            rdata.push(s.len() as u8);
+            rdata.extend_from_slice(s.as_bytes());
+        }
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "test rdata length is bounded by short inputs"
+        )]
+        let rdlen = rdata.len() as u16;
+        msg.extend_from_slice(&rdlen.to_be_bytes());
+        msg.extend_from_slice(&rdata);
+        msg
+    }
+
+    #[test]
+    fn parse_response_pose_finds_txt_after_filler_answer() {
+        // Real kai announcements emit four answers (PTR + SRV +
+        // TXT + A) so the parser must skip past preceding records
+        // before reaching the TXT. A miscount in the
+        // `off = rdata_end` advance would pass every single-
+        // answer test but fail on every live announcement.
+        let msg = build_txt_response_with_filler(
+            "kitchen-cat",
+            &["txtvers=1", "kai=1", "yaw=7.5", "pitch=-2.5"],
+        );
+        let pose = parse_response_pose(&msg, "kitchen-cat").unwrap();
+        assert!((pose.pan_deg - 7.5).abs() < 0.01);
+        assert!((pose.tilt_deg + 2.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_response_pose_keeps_first_valid_value_on_duplicate_key() {
+        // A malformed second entry must not clobber a valid
+        // first reading — `yaw = v.parse().ok()` would let
+        // `yaw=bad` overwrite `Some(12.3)` with `None` and
+        // surface as a follower stall on otherwise-good leader
+        // traffic.
+        let msg = build_txt_response("kitchen-cat", &["yaw=12.3", "yaw=bad", "pitch=4.5"]);
+        let pose = parse_response_pose(&msg, "kitchen-cat").unwrap();
+        assert!((pose.pan_deg - 12.3).abs() < 0.01);
+        assert!((pose.tilt_deg - 4.5).abs() < 0.01);
     }
 }

--- a/crates/stackchan-net/src/mdns_pose.rs
+++ b/crates/stackchan-net/src/mdns_pose.rs
@@ -131,6 +131,168 @@ pub fn format_pose_kv(key: &str, value_deg: f32) -> Option<heapless::String<POSE
     Some(buf)
 }
 
+/// Walk a DNS response packet for the leader's TXT record and
+/// extract its commanded head pose.
+///
+/// Inverse of the [`PoseAnnouncer`] producer side: a follower
+/// inspects inbound mDNS multicast packets and lifts the leader's
+/// `yaw=` / `pitch=` keys straight off the TXT record without an
+/// HTTP round-trip.
+///
+/// `leader_hostname` is the local-name first label (e.g.
+/// `"kitchen-cat"`); the parser builds the expected fully-qualified
+/// record name `<leader_hostname>._stackchan._tcp.local` and
+/// matches it case-insensitively against each answer record's
+/// owner.
+///
+/// Returns `Some(Pose)` only when:
+///
+/// - The message has the QR bit set (it's a response, not a query).
+/// - At least one answer record's name matches the leader's TXT name.
+/// - That record's RDATA contains both `yaw=<f32>` and `pitch=<f32>`.
+///
+/// Returns `None` otherwise. Malformed packets, compression loops,
+/// and partial-key records all short-circuit safely — the follower
+/// either gets a clean pose or no pose, never a half-applied one.
+#[must_use]
+pub fn parse_response_pose(msg: &[u8], leader_hostname: &str) -> Option<Pose> {
+    if msg.len() < 12 {
+        return None;
+    }
+    // QR bit lives in the high bit of byte 2.
+    if msg[2] & 0x80 == 0 {
+        return None;
+    }
+    let qdcount = u16::from_be_bytes([msg[4], msg[5]]) as usize;
+    let ancount = u16::from_be_bytes([msg[6], msg[7]]) as usize;
+    if ancount == 0 {
+        return None;
+    }
+    let mut off = 12;
+    // Skip the question section. Each question is `name + qtype +
+    // qclass` (the name uses the same compression scheme as
+    // answers, so reuse `read_name`).
+    for _ in 0..qdcount {
+        let (_name, after) = read_name(msg, off)?;
+        off = after.checked_add(4)?;
+        if off > msg.len() {
+            return None;
+        }
+    }
+    for _ in 0..ancount {
+        let (name, after) = read_name(msg, off)?;
+        if after.checked_add(10)? > msg.len() {
+            return None;
+        }
+        let rtype = u16::from_be_bytes([msg[after], msg[after + 1]]);
+        let rdlength = u16::from_be_bytes([msg[after + 8], msg[after + 9]]) as usize;
+        let rdata_start = after + 10;
+        let rdata_end = rdata_start.checked_add(rdlength)?;
+        if rdata_end > msg.len() {
+            return None;
+        }
+        if rtype == 16 && is_leader_txt_name(name.as_str(), leader_hostname) {
+            return extract_pose_from_txt_rdata(&msg[rdata_start..rdata_end]);
+        }
+        off = rdata_end;
+    }
+    None
+}
+
+/// Pull `yaw=` and `pitch=` out of a TXT record's RDATA.
+///
+/// RDATA is one or more length-prefixed strings concatenated per
+/// RFC 1035 § 3.3.14. Each string is `<len:u8><bytes>`. Strings
+/// the follower doesn't recognise are skipped — kai's TXT also
+/// carries `txtvers` / `version` / `path` / `mcp` / `kai`, and
+/// upstream stackchan may add others, so a tolerant scan keeps
+/// us forward-compatible.
+fn extract_pose_from_txt_rdata(rdata: &[u8]) -> Option<Pose> {
+    let mut yaw: Option<f32> = None;
+    let mut pitch: Option<f32> = None;
+    let mut i = 0;
+    while i < rdata.len() {
+        let len = rdata[i] as usize;
+        i += 1;
+        if i.checked_add(len)? > rdata.len() {
+            return None;
+        }
+        if let Ok(s) = core::str::from_utf8(&rdata[i..i + len]) {
+            if let Some(v) = s.strip_prefix("yaw=") {
+                yaw = v.parse().ok();
+            } else if let Some(v) = s.strip_prefix("pitch=") {
+                pitch = v.parse().ok();
+            }
+        }
+        i += len;
+    }
+    Some(Pose::new(yaw?, pitch?))
+}
+
+/// Case-insensitive match for `<leader_hostname>._stackchan._tcp.local`.
+fn is_leader_txt_name(name: &str, leader_hostname: &str) -> bool {
+    let mut parts = name.splitn(2, '.');
+    let host = parts.next().unwrap_or("");
+    let suffix = parts.next().unwrap_or("");
+    host.eq_ignore_ascii_case(leader_hostname)
+        && suffix.eq_ignore_ascii_case("_stackchan._tcp.local")
+}
+
+/// Walk DNS labels starting at `start`, returning the dotted name
+/// and the offset just past the last label byte in the original
+/// stream (NOT past any followed compression pointers).
+///
+/// Supports the RFC 1035 § 4.1.4 compression scheme — a label byte
+/// whose high two bits are `11` is a 14-bit pointer into the
+/// message. We follow pointers (with a small loop budget so a
+/// cyclic packet can't hang the parser) but only record the
+/// "end offset in the original stream" up to the first pointer
+/// follow, so the caller's record-walking arithmetic still lines
+/// up.
+fn read_name(msg: &[u8], start: usize) -> Option<(heapless::String<128>, usize)> {
+    let mut out: heapless::String<128> = heapless::String::new();
+    let mut off = start;
+    let mut end_off: Option<usize> = None;
+    let mut hops: u8 = 0;
+    loop {
+        if off >= msg.len() {
+            return None;
+        }
+        let b = msg[off];
+        if b == 0 {
+            return Some((out, end_off.unwrap_or(off + 1)));
+        }
+        if b & 0xC0 == 0xC0 {
+            if off + 1 >= msg.len() {
+                return None;
+            }
+            hops = hops.checked_add(1)?;
+            if hops > 8 {
+                return None;
+            }
+            if end_off.is_none() {
+                end_off = Some(off + 2);
+            }
+            off = (usize::from(b & 0x3F) << 8) | usize::from(msg[off + 1]);
+            continue;
+        }
+        if b & 0xC0 != 0 {
+            return None;
+        }
+        let len = b as usize;
+        if off.checked_add(1 + len)? > msg.len() {
+            return None;
+        }
+        if !out.is_empty() {
+            out.push('.').ok()?;
+        }
+        for &ch in &msg[off + 1..off + 1 + len] {
+            out.push(ch as char).ok()?;
+        }
+        off += 1 + len;
+    }
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -249,5 +411,170 @@ mod tests {
             s.as_str() == "pitch=-60.0" || s.as_str() == "pitch=-59.9",
             "unexpected format: {s:?}"
         );
+    }
+
+    /// Build a synthetic mDNS response packet carrying exactly one
+    /// answer: a TXT record at `<hostname>._stackchan._tcp.local`
+    /// whose RDATA is the concatenation of the given key=value
+    /// strings (each prefixed with its single-byte length).
+    fn build_txt_response(hostname: &str, txt_strings: &[&str]) -> alloc::vec::Vec<u8> {
+        let mut msg = alloc::vec::Vec::new();
+        // Header: ID 0, flags QR=1 AA=1, qdcount=0, ancount=1.
+        msg.extend_from_slice(&[
+            0x00, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        // Answer NAME: <hostname>._stackchan._tcp.local.
+        for label in [hostname, "_stackchan", "_tcp", "local"] {
+            #[allow(clippy::cast_possible_truncation, reason = "test labels are short")]
+            msg.push(label.len() as u8);
+            msg.extend_from_slice(label.as_bytes());
+        }
+        msg.push(0x00); // root
+        // TYPE 16 (TXT), CLASS 1 (IN).
+        msg.extend_from_slice(&[0x00, 0x10, 0x00, 0x01]);
+        // TTL 120.
+        msg.extend_from_slice(&[0x00, 0x00, 0x00, 0x78]);
+        // RDLENGTH + RDATA.
+        let mut rdata = alloc::vec::Vec::new();
+        for s in txt_strings {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "test TXT strings are short"
+            )]
+            rdata.push(s.len() as u8);
+            rdata.extend_from_slice(s.as_bytes());
+        }
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "test rdata length is bounded by short inputs"
+        )]
+        let rdlen = rdata.len() as u16;
+        msg.extend_from_slice(&rdlen.to_be_bytes());
+        msg.extend_from_slice(&rdata);
+        msg
+    }
+
+    #[test]
+    fn parse_response_pose_extracts_yaw_and_pitch() {
+        let msg = build_txt_response(
+            "kitchen-cat",
+            &["txtvers=1", "kai=1", "yaw=12.3", "pitch=-4.5"],
+        );
+        let pose = parse_response_pose(&msg, "kitchen-cat").unwrap();
+        assert!((pose.pan_deg - 12.3).abs() < 0.01);
+        assert!((pose.tilt_deg - -4.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_response_pose_is_case_insensitive_on_hostname() {
+        let msg = build_txt_response("Kitchen-Cat", &["yaw=1.0", "pitch=2.0"]);
+        assert!(parse_response_pose(&msg, "kitchen-cat").is_some());
+        assert!(parse_response_pose(&msg, "KITCHEN-CAT").is_some());
+    }
+
+    #[test]
+    fn parse_response_pose_rejects_wrong_hostname() {
+        let msg = build_txt_response("kitchen-cat", &["yaw=1.0", "pitch=2.0"]);
+        assert!(parse_response_pose(&msg, "living-room-cat").is_none());
+    }
+
+    #[test]
+    fn parse_response_pose_rejects_query_with_qr_clear() {
+        // Same packet shape but flags byte 2 = 0x00 (QR cleared).
+        let mut msg = build_txt_response("kitchen-cat", &["yaw=1.0", "pitch=2.0"]);
+        msg[2] = 0x00;
+        assert!(parse_response_pose(&msg, "kitchen-cat").is_none());
+    }
+
+    #[test]
+    fn parse_response_pose_returns_none_when_pose_keys_partial() {
+        // Only yaw, no pitch — extractor returns None because both
+        // are required to drive a useful follower update.
+        let msg = build_txt_response("kitchen-cat", &["yaw=12.3"]);
+        assert!(parse_response_pose(&msg, "kitchen-cat").is_none());
+    }
+
+    #[test]
+    fn parse_response_pose_ignores_unrelated_keys() {
+        let msg = build_txt_response(
+            "kitchen-cat",
+            &[
+                "txtvers=1",
+                "version=0.2.0",
+                "path=/",
+                "mcp=/mcp",
+                "kai=1",
+                "yaw=10.0",
+                "pitch=0.0",
+            ],
+        );
+        let pose = parse_response_pose(&msg, "kitchen-cat").unwrap();
+        assert!((pose.pan_deg - 10.0).abs() < 0.01);
+        assert!(pose.tilt_deg.abs() < 0.01);
+    }
+
+    #[test]
+    fn parse_response_pose_rejects_too_short_msg() {
+        assert!(parse_response_pose(&[0_u8; 4], "x").is_none());
+        assert!(parse_response_pose(&[], "x").is_none());
+    }
+
+    #[test]
+    fn parse_response_pose_rejects_no_answers() {
+        let mut msg = build_txt_response("kitchen-cat", &["yaw=1.0", "pitch=2.0"]);
+        // Zero out the answer count.
+        msg[6] = 0;
+        msg[7] = 0;
+        assert!(parse_response_pose(&msg, "kitchen-cat").is_none());
+    }
+
+    #[test]
+    fn read_name_handles_simple_qname() {
+        // "kitchen-cat._stackchan._tcp.local."
+        let mut msg = alloc::vec::Vec::new();
+        for label in ["kitchen-cat", "_stackchan", "_tcp", "local"] {
+            #[allow(clippy::cast_possible_truncation, reason = "test labels are short")]
+            msg.push(label.len() as u8);
+            msg.extend_from_slice(label.as_bytes());
+        }
+        msg.push(0x00);
+        let (name, after) = read_name(&msg, 0).unwrap();
+        assert_eq!(name.as_str(), "kitchen-cat._stackchan._tcp.local");
+        assert_eq!(after, msg.len());
+    }
+
+    #[test]
+    fn read_name_follows_compression_pointer() {
+        // Build "_stackchan._tcp.local." at offset 0, then a
+        // separate name "kitchen-cat" + compression pointer back
+        // to offset 0.
+        let mut msg = alloc::vec::Vec::new();
+        // Offset 0: "_stackchan._tcp.local."
+        for label in ["_stackchan", "_tcp", "local"] {
+            #[allow(clippy::cast_possible_truncation, reason = "test labels are short")]
+            msg.push(label.len() as u8);
+            msg.extend_from_slice(label.as_bytes());
+        }
+        msg.push(0x00);
+        let second_start = msg.len();
+        // "kitchen-cat" + pointer to offset 0.
+        msg.push(11);
+        msg.extend_from_slice(b"kitchen-cat");
+        msg.push(0xC0);
+        msg.push(0x00);
+        let (name, after) = read_name(&msg, second_start).unwrap();
+        assert_eq!(name.as_str(), "kitchen-cat._stackchan._tcp.local");
+        // `after` is the offset just past the 2-byte pointer in
+        // the original stream — NOT past the followed labels.
+        assert_eq!(after, msg.len());
+    }
+
+    #[test]
+    fn read_name_rejects_pointer_loop() {
+        // A 2-byte pointer at offset 0 that points back to offset
+        // 0 — a one-cycle loop. Must terminate via the hop budget,
+        // not hang.
+        let msg = [0xC0_u8, 0x00];
+        assert!(read_name(&msg, 0).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Arc 3a. Closes the loop on the meganetaaan `mimic_main` protocol kai already half-implemented — the firmware was advertising live `yaw=` / `pitch=` on its own mDNS TXT record (the leader side); this PR adds the symmetric consumer (the follower side).

- **Opt-in via `behavior.follower_leader_hostname`.** Empty (the default) parks the follower task. Operator sets the leader's bare mDNS hostname (`"kitchen-cat"`, not `"kitchen-cat.local"`); both devices must share a multicast LAN segment.
- **Host-testable parser.** `stackchan-net::mdns_pose::parse_response_pose` walks an inbound DNS response, finds the TXT answer record matching `<leader>._stackchan._tcp.local`, extracts `yaw=<f32>` / `pitch=<f32>`, returns a `Pose` only when both keys are present. 11 new fixtures cover case-insensitive hostname matching, RFC 1035 § 4.1.4 compression-pointer following, pointer-loop bail-out via an 8-hop budget, partial-key short-circuit, QR-bit gating, and tolerant skipping of unrelated TXT keys (`txtvers`, `kai`, `version`, `path`, `mcp`).
- **No new socket.** The existing `serve_loop` in `net/mdns.rs` already inspects every inbound multicast packet to classify queries; the follower path piggybacks on the existing `classify_query == None` branch and signals `LEADER_POSE_SIGNAL` on a TXT hit.
- **Follower task → `RemoteCommand::LookAt` hold.** `firmware::net::mdns_follower::follower_task` drains `LEADER_POSE_SIGNAL` and fires a 1.5 s `LookAt` hold via `REMOTE_COMMAND_SIGNAL`. 1.5 × the leader's 1 s heartbeat is the sweet spot: short enough that operator-driven `POST /look-at` commands still feel snappy, long enough that a single dropped multicast packet doesn't bounce the head back to autonomy mid-stream.

## Wire compatibility

The TXT shape (`yaw=<deg>`, `pitch=<deg>`, one decimal, signed) matches meganetaaan's `mimic_main` mod, so a kai unit can lead an upstream stackchan follower or vice versa.

## Test plan

- [x] `cargo test -p stackchan-net mdns_pose` — 22 / 22 pass (11 existing + 11 new)
- [x] `just check` — fmt + workspace clippy + host tests
- [x] `cargo +esp clippy --release -p stackchan-firmware -- -D warnings` — strict clippy on the firmware target
- [x] `just ci` — adds `cargo deny` + rustdoc-warnings gate
- [ ] On-device: two units with matching SSID + `behavior.follower_leader_hostname` set on the follower to the leader's hostname. Verify head motion mirrors within ~100 ms (the leader's `mdns_pose::POSE_PUBLISH_MIN_INTERVAL_MS` cadence). Deferred to the next on-device session.