### PR TITLE
feat(esp-tflite-micro-sys): 20-op resolver + ESP-NN op kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,9 +126,23 @@ section summarises the milestone work in human terms.
   the template size is fixed at 20 to match microWakeWord's
   operator count. Safe Rust wrapper exposes `Resolver` +
   `Interpreter<'a>` with `allocate_tensors` + `invoke` returning
-  `Result<(), TfLiteStatus>`. Op-kernel registration
-  (`Resolver::add_*`) and tensor I/O accessors are wired in a
-  subsequent slice.
+  `Result<(), TfLiteStatus>`.
+- `esp-tflite-micro-sys` — op-kernel registration. Activated the
+  117-kernel TFLM op tree in `cc::Build`, with the seven ops
+  that have ESP-NN-accelerated variants (`add`, `conv`,
+  `depthwise_conv`, `fully_connected`, `mul`, `pooling`,
+  `softmax`) replaced by their `kernels/esp_nn/*.cc`
+  counterparts. Expanded the esp-nn compile pass to walk every
+  S3-relevant kernel source (`*_esp32s3.{c,S}`, `*_ansi.c`,
+  `*_opt.c`) under `esp-nn/src/`, dropping ESP32-P4 variants.
+  Added 20 `Resolver::add_*` methods (Add, AssignVariable,
+  AveragePool2D, CallOnce, Concatenation, Conv2D,
+  DepthwiseConv2D, FullyConnected, Logistic, MaxPool2D, Mean,
+  Mul, Pack, Pad, Quantize, ReadVariable, Reshape, SplitV,
+  StridedSlice, VarHandle) backed by an `ETMS_RESOLVER_ADD_OP`
+  shim macro. A tiny `src/esp_timer.h` stub satisfies the ESP-NN
+  kernel's unconditional `<esp_timer.h>` include (used for an
+  unused per-op profiling counter) without dragging in ESP-IDF.
 - New `stackchan-audio-features` crate — `no_std` + `alloc`
   streaming mel-spectrogram frontend (Hann window → 512-point
   real FFT → 40-channel mel filterbank 125–7 500 Hz → log →

--- a/crates/esp-tflite-micro-sys/README.md
+++ b/crates/esp-tflite-micro-sys/README.md
@@ -13,9 +13,16 @@ Two owned Rust types front the templated TFLM classes:
 - `Resolver` wraps `tflite::MicroMutableOpResolver<20>`. The
   template parameter is fixed in the C-ABI shim at the operator
   count microWakeWord uses, so the same resolver size carries
-  through to the production wake-word task. Op-kernel registration
-  (`Resolver::add_conv2d`, …) wires up alongside its underlying
-  vendored kernels.
+  through to the production wake-word task. Twenty `add_*`
+  methods register the microWakeWord operator set
+  (`add_conv_2d`, `add_depthwise_conv_2d`, `add_fully_connected`,
+  `add_var_handle`, `add_read_variable`, `add_assign_variable`,
+  `add_strided_slice`, `add_concatenation`, `add_pack`,
+  `add_split_v`, `add_call_once`, `add_reshape`,
+  `add_average_pool_2d`, `add_max_pool_2d`, `add_logistic`,
+  `add_quantize`, `add_pad`, `add_mean`, `add_add`, `add_mul`);
+  the seven ops with ESP-NN-accelerated variants dispatch into
+  esp-nn's hand-tuned LX7 SIMD kernels at registration time.
 - `Interpreter<'a>` wraps `tflite::MicroInterpreter`. It borrows
   the model bytes, the resolver, and the tensor arena for its
   lifetime — the underlying C++ object holds raw pointers into

--- a/crates/esp-tflite-micro-sys/build.rs
+++ b/crates/esp-tflite-micro-sys/build.rs
@@ -115,6 +115,12 @@ fn add_esp_nn_sources(b: &mut cc::Build, src_root: &Path) {
     ];
     for category in categories {
         let dir = src_root.join(category);
+        // Tell cargo to rerun this build script when the directory
+        // listing changes. Without this, adding or removing an
+        // upstream kernel file would silently produce a stale archive
+        // (cargo only rebuilds when the explicitly-named files cc-rs
+        // adds via `b.file()` change, not when new ones appear).
+        println!("cargo:rerun-if-changed={}", dir.display());
         let entries =
             fs::read_dir(&dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
         for entry in entries {
@@ -139,7 +145,11 @@ fn is_s3_relevant(path: &Path) -> bool {
     let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
         return false;
     };
-    if !matches!(ext, "c" | "S" | "h") {
+    // Source-compilation units only. Header files in the same tree
+    // (e.g. a hypothetical `esp_nn_conv_esp32s3.h`) would match the
+    // `_esp32s3.` suffix below; passing one to `cc::Build::file` makes
+    // GCC invoke `-c` on a header, which is implementation-defined.
+    if !matches!(ext, "c" | "S") {
         return false;
     }
     // Suffix patterns rather than pure extensions: `_ansi.c` covers
@@ -337,6 +347,12 @@ fn add_tflm_library_sources(b: &mut cc::Build, tflm: &Path) {
 /// hand drifts immediately when upstream re-shuffles internals.
 fn add_tflm_op_kernels(b: &mut cc::Build, tflm: &Path) {
     let kernels = tflm.join("tensorflow/lite/micro/kernels");
+
+    // Tell cargo to rerun this build script when the directory
+    // listing changes. Without this, adding or removing a kernel
+    // file under `tensorflow/lite/micro/kernels/` would silently
+    // produce a stale archive.
+    println!("cargo:rerun-if-changed={}", kernels.display());
 
     // The seven ops whose reference `.cc` we skip — the ESP-NN
     // variant below provides `Register_*` symbols with the same

--- a/crates/esp-tflite-micro-sys/build.rs
+++ b/crates/esp-tflite-micro-sys/build.rs
@@ -18,10 +18,13 @@
 //!    The `xtensa-esp32s3-elf-gcc` pin is required because the generic
 //!    `xtensa-esp-elf-gcc` doesn't recognise the S3's DSP / PIE
 //!    extension instructions.
-//! 2. TFLM library — the subset of `esp-tflite-micro` that's needed
-//!    to construct a `MicroInterpreter`. Op kernels are not included
-//!    in this slice; the resolver template is instantiated at size 20
-//!    but `MicroMutableOpResolver::Add*` calls are wired separately.
+//! 2. TFLM library + 20 op kernels — the subset of `esp-tflite-micro`
+//!    that constructs and runs a `MicroInterpreter` for microWakeWord
+//!    inference. For the seven ops that have ESP-NN-accelerated
+//!    variants (`add`, `conv`, `depthwise_conv`, `fully_connected`,
+//!    `mul`, `pooling`, `softmax`), the upstream reference kernel is
+//!    replaced by the `tensorflow/lite/micro/kernels/esp_nn/*.cc`
+//!    variant; the remaining 13 ops use the upstream references.
 //! 3. Shim — our C-ABI `extern "C"` wrapper. Hides the
 //!    `MicroMutableOpResolver<N>` template behind opaque handles so
 //!    bindgen can route Rust through a flat C-style interface.
@@ -30,6 +33,7 @@
 //!    surface) and writes Rust FFI declarations to `OUT_DIR/bindings.rs`.
 
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 fn main() {
@@ -43,12 +47,12 @@ fn main() {
     // in call order; GNU ld is single-pass and only pulls an
     // archive member if a reference has already been seen, so
     // the consumer archive must precede the provider. The shim
-    // is the consumer of esp-nn's kernels (transitively, once op
-    // kernels are wired); esp-nn provides.
+    // and the TFLM op-kernel `esp_nn/*.cc` variants are the
+    // consumers of esp-nn's kernels; esp-nn provides.
     //
     // Two separate `cc::Build`s because the include paths and
     // language standards differ — esp-nn is C/asm, TFLM is C++.
-    compile_tflm_and_shim(&tflm, &manifest);
+    compile_tflm_and_shim(&tflm, &esp_nn, &manifest);
     compile_esp_nn(&esp_nn);
 
     generate_bindings(&manifest);
@@ -66,10 +70,14 @@ fn s3_build() -> cc::Build {
     b
 }
 
-/// Compile the esp-nn kernels we care about for the streaming
-/// MixConv operator set. The `*_ansi.c` files are the reference
-/// fallbacks; the `*_esp32s3.c` and `*.S` files are the
-/// PIE-accelerated specializations that give the ~7× speedup.
+/// Compile every esp-nn source relevant to ESP32-S3 — the `*_ansi.c`
+/// reference kernels, every `*_esp32s3.{c,S}` PIE-accelerated
+/// specialization, and the `*_opt.c` portable optimizations. Skip the
+/// `*_esp32p4.*` variants (different SoC; instructions don't assemble
+/// under the S3 toolchain). `-ffunction-sections` + `--gc-sections`
+/// (already enabled in the workspace release profile) drop unreferenced
+/// objects from the final binary, so over-including here costs build
+/// time and archive size, not flash.
 fn compile_esp_nn(esp_nn: &Path) {
     let mut b = s3_build();
     b.include(esp_nn.join("include"))
@@ -84,29 +92,70 @@ fn compile_esp_nn(esp_nn: &Path) {
         // standalone surfaces parameters that are only used by
         // alternate code paths we don't pull in.
         .flag("-Wno-unused-parameter")
-        .flag("-Wno-unused-function")
-        // Convolution kernels — ANSI depthwise + ANSI conv
-        // references, plus the S3-SIMD 1x1 pointwise. The 1x1
-        // file is the one that exercises the PIE assembly route
-        // (cf. the 59 `ee.*` opcode sanity check in the README);
-        // the ANSI files are reference fallbacks that work on
-        // every Xtensa core.
-        .file(esp_nn.join("src/convolution/esp_nn_depthwise_conv_ansi.c"))
-        .file(esp_nn.join("src/convolution/esp_nn_conv_ansi.c"))
-        .file(esp_nn.join("src/convolution/esp_nn_conv_s8_1x1_esp32s3.c"))
-        // Dense layer (final classifier head).
-        .file(esp_nn.join("src/fully_connected/esp_nn_fully_connected_ansi.c"))
-        // S3 assembly common helpers — referenced by the S3 C
-        // kernels above.
-        .file(esp_nn.join("src/common/esp_nn_dot_s8_esp32s3.S"))
-        .file(esp_nn.join("src/common/esp_nn_multiply_by_quantized_mult_esp32s3.S"));
+        .flag("-Wno-unused-function");
+
+    add_esp_nn_sources(&mut b, &esp_nn.join("src"));
     b.compile("esp_nn");
+}
+
+/// Walk every category under `esp-nn/src/` and add the S3-relevant
+/// kernel files to the build. The category list is the directory
+/// layout esp-nn ships with (activation_functions, basic_math, common,
+/// convolution, fully_connected, logistic, pooling, softmax).
+fn add_esp_nn_sources(b: &mut cc::Build, src_root: &Path) {
+    let categories = [
+        "activation_functions",
+        "basic_math",
+        "common",
+        "convolution",
+        "fully_connected",
+        "logistic",
+        "pooling",
+        "softmax",
+    ];
+    for category in categories {
+        let dir = src_root.join(category);
+        let entries =
+            fs::read_dir(&dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+        for entry in entries {
+            let path = entry.unwrap().path();
+            if is_s3_relevant(&path) {
+                b.file(&path);
+            }
+        }
+    }
+}
+
+/// Returns true for esp-nn source files that target ESP32-S3 or are
+/// portable across Xtensa cores. The `*_esp32p4.*` files target a
+/// different SoC and would fail at assembly time.
+fn is_s3_relevant(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if name.contains("esp32p4") {
+        return false;
+    }
+    let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+        return false;
+    };
+    if !matches!(ext, "c" | "S" | "h") {
+        return false;
+    }
+    // Suffix patterns rather than pure extensions: `_ansi.c` covers
+    // the portable reference kernels, `_opt.c` covers the portable
+    // optimized variants, and `_esp32s3.` (no leading underscore —
+    // also catches `_s8_esp32s3.S`) covers the S3-specialized
+    // assembly / C kernels.
+    name.contains("_esp32s3.") || name.ends_with("_ansi.c") || name.ends_with("_opt.c")
 }
 
 /// Compile the TFLM library subset + the C-ABI shim. One `cc::Build`
 /// — the shim's interpreter constructor needs every TFLM TU it
 /// touches available in the same archive for the single-pass linker.
-fn compile_tflm_and_shim(tflm: &Path, manifest: &Path) {
+/// `esp_nn` is passed in for the include path; the seven
+/// `kernels/esp_nn/*.cc` variants `#include <esp_nn.h>`.
+fn compile_tflm_and_shim(tflm: &Path, esp_nn: &Path, manifest: &Path) {
     let mut b = s3_build();
     b.cpp(true)
         // C++17 — TFLM uses constexpr, structured bindings, and
@@ -142,8 +191,16 @@ fn compile_tflm_and_shim(tflm: &Path, manifest: &Path) {
         .include(tflm.join("third_party/flatbuffers/include"))
         .include(tflm.join("third_party/gemmlowp"))
         .include(tflm.join("third_party/ruy"))
-        // Local shim header sits next to its .cpp in `src/`.
+        // Local shim header sits next to its .cpp in `src/`. The
+        // same directory holds our `<esp_timer.h>` stub — the
+        // seven `kernels/esp_nn/*.cc` variants `#include`d that
+        // ESP-IDF header for benchmarking, which we satisfy with
+        // a header that returns 0.
         .include(manifest.join("src"))
+        // esp-nn's public header — pulled in by the seven
+        // `kernels/esp_nn/*.cc` variants for the
+        // `esp_nn_{add,conv,...}_*` declarations they dispatch to.
+        .include(esp_nn.join("include"))
         // `TF_LITE_STATIC_MEMORY` disables runtime allocator paths
         // we don't use; `TF_LITE_DISABLE_X86_NEON` is harmless on
         // xtensa but matches upstream; `TF_LITE_STRIP_ERROR_STRINGS`
@@ -156,6 +213,7 @@ fn compile_tflm_and_shim(tflm: &Path, manifest: &Path) {
         .define("ESP_NN", None);
 
     add_tflm_library_sources(&mut b, tflm);
+    add_tflm_op_kernels(&mut b, tflm);
 
     // Our shim TU — bridges Rust over the templated TFLM classes.
     b.file(manifest.join("src/shim.cpp"));
@@ -265,6 +323,61 @@ fn add_tflm_library_sources(b: &mut cc::Build, tflm: &Path) {
     let mlir = tflm.join("tensorflow/compiler/mlir/lite");
     b.file(mlir.join("core/api/error_reporter.cc"))
         .file(mlir.join("schema/schema_utils.cc"));
+}
+
+/// TFLM op-kernel `.cc` files. Mirrors upstream's
+/// `file(GLOB srcs_kernels)` minus the seven ops that have ESP-NN
+/// accelerated variants (`add`, `conv`, `depthwise_conv`,
+/// `fully_connected`, `mul`, `pooling`, `softmax`) — those are
+/// substituted with their `kernels/esp_nn/<op>.cc` counterparts.
+/// Over-inclusion is intentional: `-ffunction-sections` +
+/// `--gc-sections` drop unreferenced kernels from the final binary,
+/// and tracking the per-microWakeWord-op transitive shared-code
+/// surface (`*_common.cc`, dispatch tables, helper utilities) by
+/// hand drifts immediately when upstream re-shuffles internals.
+fn add_tflm_op_kernels(b: &mut cc::Build, tflm: &Path) {
+    let kernels = tflm.join("tensorflow/lite/micro/kernels");
+
+    // The seven ops whose reference `.cc` we skip — the ESP-NN
+    // variant below provides `Register_*` symbols with the same
+    // names and linking both would be a multiple-definition error.
+    let esp_nn_replacements: &[&str] = &[
+        "add.cc",
+        "conv.cc",
+        "depthwise_conv.cc",
+        "fully_connected.cc",
+        "mul.cc",
+        "pooling.cc",
+        "softmax.cc",
+    ];
+
+    let kernel_entries =
+        fs::read_dir(&kernels).unwrap_or_else(|e| panic!("read_dir {}: {e}", kernels.display()));
+    for entry in kernel_entries {
+        let path = entry.unwrap().path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        if !matches!(ext, "cc" | "c") {
+            continue;
+        }
+        if esp_nn_replacements.contains(&name) {
+            continue;
+        }
+        b.file(&path);
+    }
+
+    // ESP-NN-accelerated variants — replace the seven skipped above.
+    let esp_nn = kernels.join("esp_nn");
+    for f in esp_nn_replacements {
+        b.file(esp_nn.join(f));
+    }
 }
 
 /// Run bindgen over the C-ABI shim header so Rust callers can use

--- a/crates/esp-tflite-micro-sys/src/esp_timer.h
+++ b/crates/esp-tflite-micro-sys/src/esp_timer.h
@@ -1,0 +1,32 @@
+// Minimal `<esp_timer.h>` shim — the seven `kernels/esp_nn/*.cc` op
+// implementations unconditionally `#include <esp_timer.h>` and call
+// `esp_timer_get_time()` to accumulate a per-op profiling counter
+// (`add_total_time`, `conv_total_time`, …) inside the kernels. The
+// counters aren't read anywhere in TFLM library code — they exist so
+// downstream ESP-IDF apps can poll them for inference-time benchmarks.
+//
+// We don't link against ESP-IDF (the firmware is bare-metal embassy
+// + esp-hal), so we provide our own header that satisfies the
+// declaration and an inline body that returns 0. The kernels then
+// compile cleanly; the unused counter increments become dead writes
+// the optimiser drops.
+//
+// If a future task needs real timing, swap the inline body for a
+// weak symbol the firmware can override with `embassy_time::Instant`.
+
+#ifndef ESP_TFLITE_MICRO_SYS_ESP_TIMER_H_
+#define ESP_TFLITE_MICRO_SYS_ESP_TIMER_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int64_t esp_timer_get_time(void) { return 0; }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ESP_TFLITE_MICRO_SYS_ESP_TIMER_H_

--- a/crates/esp-tflite-micro-sys/src/lib.rs
+++ b/crates/esp-tflite-micro-sys/src/lib.rs
@@ -126,6 +126,82 @@ impl Resolver {
     }
 }
 
+/// Shared body for every `Resolver::add_*` method. Each invocation
+/// expands to a thin `Result`-returning wrapper around the
+/// corresponding `etms_resolver_add_*` FFI call. The macro keeps the
+/// 20-op surface declarative — the resolver's capacity is 20, the
+/// op set is fixed by microWakeWord, and there's no per-op logic
+/// beyond status passthrough.
+macro_rules! resolver_add_methods {
+    ($($(#[$attr:meta])* $rust_name:ident => $ffi_name:ident),* $(,)?) => {
+        impl Resolver {
+            $(
+                $(#[$attr])*
+                ///
+                /// # Errors
+                ///
+                /// Returns the resolver's `TfLiteStatus` — non-zero
+                /// when the resolver's capacity (20 ops) is exceeded
+                /// or when the same op is registered twice.
+                pub fn $rust_name(&mut self) -> Result<(), TfLiteStatus> {
+                    // SAFETY: `self.handle` is a valid resolver
+                    // pointer (held in `NonNull`); the FFI call only
+                    // dereferences it for the duration of the call.
+                    let status = unsafe { ffi::$ffi_name(self.handle.as_ptr()) };
+                    if status == 0 {
+                        Ok(())
+                    } else {
+                        Err(TfLiteStatus(status))
+                    }
+                }
+            )*
+        }
+    };
+}
+
+resolver_add_methods! {
+    /// Registers `BuiltinOperator_ADD` (elementwise add, ESP-NN-accelerated).
+    add_add => etms_resolver_add_add,
+    /// Registers `BuiltinOperator_ASSIGN_VARIABLE` (resource-variable write).
+    add_assign_variable => etms_resolver_add_assign_variable,
+    /// Registers `BuiltinOperator_AVERAGE_POOL_2D` (ESP-NN-accelerated).
+    add_average_pool_2d => etms_resolver_add_average_pool_2d,
+    /// Registers `BuiltinOperator_CALL_ONCE` (fires at first invocation).
+    add_call_once => etms_resolver_add_call_once,
+    /// Registers `BuiltinOperator_CONCATENATION`.
+    add_concatenation => etms_resolver_add_concatenation,
+    /// Registers `BuiltinOperator_CONV_2D` (ESP-NN-accelerated).
+    add_conv_2d => etms_resolver_add_conv_2d,
+    /// Registers `BuiltinOperator_DEPTHWISE_CONV_2D` (ESP-NN-accelerated).
+    add_depthwise_conv_2d => etms_resolver_add_depthwise_conv_2d,
+    /// Registers `BuiltinOperator_FULLY_CONNECTED` (ESP-NN-accelerated).
+    add_fully_connected => etms_resolver_add_fully_connected,
+    /// Registers `BuiltinOperator_LOGISTIC` (sigmoid; reference kernel).
+    add_logistic => etms_resolver_add_logistic,
+    /// Registers `BuiltinOperator_MAX_POOL_2D` (ESP-NN-accelerated).
+    add_max_pool_2d => etms_resolver_add_max_pool_2d,
+    /// Registers `BuiltinOperator_MEAN` (reference reduction kernel).
+    add_mean => etms_resolver_add_mean,
+    /// Registers `BuiltinOperator_MUL` (elementwise multiply, ESP-NN-accelerated).
+    add_mul => etms_resolver_add_mul,
+    /// Registers `BuiltinOperator_PACK`.
+    add_pack => etms_resolver_add_pack,
+    /// Registers `BuiltinOperator_PAD` (zero-pad along tensor dims).
+    add_pad => etms_resolver_add_pad,
+    /// Registers `BuiltinOperator_QUANTIZE`.
+    add_quantize => etms_resolver_add_quantize,
+    /// Registers `BuiltinOperator_READ_VARIABLE` (resource-variable read).
+    add_read_variable => etms_resolver_add_read_variable,
+    /// Registers `BuiltinOperator_RESHAPE`.
+    add_reshape => etms_resolver_add_reshape,
+    /// Registers `BuiltinOperator_SPLIT_V` (variable-size split).
+    add_split_v => etms_resolver_add_split_v,
+    /// Registers `BuiltinOperator_STRIDED_SLICE`.
+    add_strided_slice => etms_resolver_add_strided_slice,
+    /// Registers `BuiltinOperator_VAR_HANDLE` (resource-variable allocation).
+    add_var_handle => etms_resolver_add_var_handle,
+}
+
 impl Drop for Resolver {
     fn drop(&mut self) {
         // SAFETY: `self.handle` was obtained from a successful

--- a/crates/esp-tflite-micro-sys/src/shim.cpp
+++ b/crates/esp-tflite-micro-sys/src/shim.cpp
@@ -51,6 +51,44 @@ void etms_resolver_destroy(EtmsResolver* resolver) {
   delete reinterpret_cast<ResolverImpl*>(resolver);
 }
 
+// One-liner wrapper per op-registration call. The expansion is
+// uniform: cast the opaque handle back to `ResolverImpl*` and call
+// the matching `Add*` method, surfacing the `TfLiteStatus` as int.
+//
+// Naming convention: snake_case in the C ABI to match the rest of
+// the shim; CamelCase on the C++ side to match TFLM's `Add*`
+// methods.
+#define ETMS_RESOLVER_ADD_OP(snake_name, MethodName)                       \
+  int etms_resolver_add_##snake_name(EtmsResolver* resolver) {             \
+    if (resolver == nullptr) {                                             \
+      return kTfLiteError;                                                 \
+    }                                                                      \
+    return reinterpret_cast<ResolverImpl*>(resolver)->MethodName();        \
+  }
+
+ETMS_RESOLVER_ADD_OP(add, AddAdd)
+ETMS_RESOLVER_ADD_OP(assign_variable, AddAssignVariable)
+ETMS_RESOLVER_ADD_OP(average_pool_2d, AddAveragePool2D)
+ETMS_RESOLVER_ADD_OP(call_once, AddCallOnce)
+ETMS_RESOLVER_ADD_OP(concatenation, AddConcatenation)
+ETMS_RESOLVER_ADD_OP(conv_2d, AddConv2D)
+ETMS_RESOLVER_ADD_OP(depthwise_conv_2d, AddDepthwiseConv2D)
+ETMS_RESOLVER_ADD_OP(fully_connected, AddFullyConnected)
+ETMS_RESOLVER_ADD_OP(logistic, AddLogistic)
+ETMS_RESOLVER_ADD_OP(max_pool_2d, AddMaxPool2D)
+ETMS_RESOLVER_ADD_OP(mean, AddMean)
+ETMS_RESOLVER_ADD_OP(mul, AddMul)
+ETMS_RESOLVER_ADD_OP(pack, AddPack)
+ETMS_RESOLVER_ADD_OP(pad, AddPad)
+ETMS_RESOLVER_ADD_OP(quantize, AddQuantize)
+ETMS_RESOLVER_ADD_OP(read_variable, AddReadVariable)
+ETMS_RESOLVER_ADD_OP(reshape, AddReshape)
+ETMS_RESOLVER_ADD_OP(split_v, AddSplitV)
+ETMS_RESOLVER_ADD_OP(strided_slice, AddStridedSlice)
+ETMS_RESOLVER_ADD_OP(var_handle, AddVarHandle)
+
+#undef ETMS_RESOLVER_ADD_OP
+
 EtmsInterpreter* etms_interpreter_create(const uint8_t* model_bytes,
                                          size_t model_len,
                                          const EtmsResolver* resolver,

--- a/crates/esp-tflite-micro-sys/src/shim.h
+++ b/crates/esp-tflite-micro-sys/src/shim.h
@@ -47,6 +47,36 @@ EtmsResolver* etms_resolver_create(void);
 // `NULL` is a no-op.
 void etms_resolver_destroy(EtmsResolver* resolver);
 
+// --- Resolver op registration ----------------------------------------------
+//
+// One C-ABI shim per op the resolver knows how to register. Each
+// function returns the underlying `TfLiteStatus` as an int (0 = ok,
+// non-zero = error) — the resolver fails registration when its
+// capacity is exceeded or the same op is registered twice. The set
+// here is microWakeWord's 20-op signature; the resolver template is
+// instantiated at `<20>` to match.
+
+int etms_resolver_add_add(EtmsResolver* resolver);
+int etms_resolver_add_assign_variable(EtmsResolver* resolver);
+int etms_resolver_add_average_pool_2d(EtmsResolver* resolver);
+int etms_resolver_add_call_once(EtmsResolver* resolver);
+int etms_resolver_add_concatenation(EtmsResolver* resolver);
+int etms_resolver_add_conv_2d(EtmsResolver* resolver);
+int etms_resolver_add_depthwise_conv_2d(EtmsResolver* resolver);
+int etms_resolver_add_fully_connected(EtmsResolver* resolver);
+int etms_resolver_add_logistic(EtmsResolver* resolver);
+int etms_resolver_add_max_pool_2d(EtmsResolver* resolver);
+int etms_resolver_add_mean(EtmsResolver* resolver);
+int etms_resolver_add_mul(EtmsResolver* resolver);
+int etms_resolver_add_pack(EtmsResolver* resolver);
+int etms_resolver_add_pad(EtmsResolver* resolver);
+int etms_resolver_add_quantize(EtmsResolver* resolver);
+int etms_resolver_add_read_variable(EtmsResolver* resolver);
+int etms_resolver_add_reshape(EtmsResolver* resolver);
+int etms_resolver_add_split_v(EtmsResolver* resolver);
+int etms_resolver_add_strided_slice(EtmsResolver* resolver);
+int etms_resolver_add_var_handle(EtmsResolver* resolver);
+
 // --- Interpreter lifecycle -------------------------------------------------
 
 // Constructs a `MicroInterpreter` over the given model. The caller


### PR DESCRIPTION
## Summary

Builds on #334's interpreter wrapper. Activates the TFLM op-kernel tree in `cc::Build`, expands the esp-nn compile pass to every S3-relevant kernel source, and adds 20 `Resolver::add_*` methods for the microWakeWord operator set.

- `add_tflm_op_kernels` globs all TFLM kernel sources minus the seven with ESP-NN-accelerated variants (`add`, `conv`, `depthwise_conv`, `fully_connected`, `mul`, `pooling`, `softmax`) and substitutes `kernels/esp_nn/<op>.cc` for them. Matches upstream's `list(REMOVE_ITEM srcs_kernels …)` pattern.
- `add_esp_nn_sources` walks every category under `esp-nn/src/` and adds `*_esp32s3.{c,S}`, `*_ansi.c`, `*_opt.c` files. ESP32-P4 variants are filtered out.
- Shim: an `ETMS_RESOLVER_ADD_OP` macro emits 20 uniform `extern \"C\"` wrappers around `MicroMutableOpResolver<20>::Add*` methods.
- Rust: a `resolver_add_methods!` `macro_rules!` block emits 20 `pub fn add_<op>(&mut self) -> Result<(), TfLiteStatus>` methods.

## ESP-IDF stub

The seven `kernels/esp_nn/*.cc` op implementations unconditionally `#include <esp_timer.h>` and call `esp_timer_get_time()` to accumulate a per-op profiling counter (`add_total_time`, `conv_total_time`, …). The counters aren't read anywhere in TFLM library code — they exist so downstream ESP-IDF apps can poll them. We don't link against ESP-IDF, so `src/esp_timer.h` provides an inline body returning 0; the kernels compile cleanly and the unused counter increments become dead writes the optimiser drops.

## What this verifies end-to-end

- **TFLM op tree compiles bare-metal.** ~110 op kernels cross-compiled for `xtensa-esp32s3-none-elf` with no ESP-IDF deps. The seven ESP-NN-accelerated variants dispatch into esp-nn's hand-tuned LX7 SIMD kernels.
- **ESP-NN coverage matches upstream.** \`add_esp_nn_sources\` produces the same kernel set upstream's `CMakeLists.txt` `file(GLOB)` does for S3.
- **Resolver capacity matches microWakeWord.** The `<20>` template parameter aligns with the 20 ops in ESPHome's `streaming_model.cpp` resolver — registering all 20 fills the capacity exactly.

## Out of scope (subsequent slice)

- **Tensor I/O accessors**. `Interpreter::input(idx)`, `output(idx)`, typed slice views (`as_i8()`, `as_u8()`).
- **Firmware-side wake-word task**. Subscribes to `AUDIO_FRAME_PUBSUB`, runs frames through the audio-features mel frontend, feeds the resulting feature tensor into `Interpreter::invoke`, fires `PTT_TRIGGER.signal()` on detection.

## Test plan

- [x] `cargo +esp build -p esp-tflite-micro-sys --release` — clean
- [x] `cargo +esp clippy --release -- -D warnings` — clean
- [x] `just check` — passes
- [x] `just ci` (cargo-deny + rustdoc-warnings) — passes
- [x] `just clippy-firmware` — passes (firmware unaffected)
- [ ] On-device end-to-end — gated on the wake-word task PR