### PR TITLE
feat(esp-tflite-micro-sys): tensor I/O byte accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,13 @@ section summarises the milestone work in human terms.
   shim macro. A tiny `src/esp_timer.h` stub satisfies the ESP-NN
   kernel's unconditional `<esp_timer.h>` include (used for an
   unused per-op profiling counter) without dragging in ESP-IDF.
+- `esp-tflite-micro-sys` — tensor I/O. Added `Interpreter::inputs_len`,
+  `outputs_len`, `input_bytes_mut(idx) -> Option<&mut [u8]>`, and
+  `output_bytes(idx) -> Option<&[u8]>` for direct byte access to the
+  TFLM tensor arena. The borrow split (`&mut self` for input, `&self`
+  for output) matches TFLM's usage pattern — write inputs, invoke,
+  read outputs — and lets the borrow checker prevent `invoke` from
+  running while a caller holds a writable input reference.
 - New `stackchan-audio-features` crate — `no_std` + `alloc`
   streaming mel-spectrogram frontend (Hann window → 512-point
   real FFT → 40-channel mel filterbank 125–7 500 Hz → log →

--- a/crates/esp-tflite-micro-sys/README.md
+++ b/crates/esp-tflite-micro-sys/README.md
@@ -33,9 +33,12 @@ the caller-supplied arena; `Interpreter::invoke` runs one
 inference pass. Both return `Result<(), TfLiteStatus>` where the
 non-zero `TfLiteStatus` codes are surfaced verbatim.
 
-Tensor I/O accessors (`Interpreter::input(idx)`, `output(idx)`,
-typed `[u8]` / `[i8]` slice views) wire up alongside the first
-firmware-side consumer.
+`Interpreter::input_bytes_mut(idx)` and `output_bytes(idx)`
+return `Option<&mut [u8]>` / `Option<&[u8]>` for direct access to
+the tensor arena. The borrow split (mutable for input, shared for
+output) matches TFLM's usage pattern — write inputs, invoke, read
+outputs. Typed slice views (`as_i8`, `as_f32`) layer on top once
+a model-side consumer needs them.
 
 The C-ABI shim header (`src/shim.h`) is pure C — `bindgen` runs
 against it without touching the C++ template surface; the

--- a/crates/esp-tflite-micro-sys/src/lib.rs
+++ b/crates/esp-tflite-micro-sys/src/lib.rs
@@ -304,6 +304,86 @@ impl<'a> Interpreter<'a> {
             Err(TfLiteStatus(status))
         }
     }
+
+    /// Number of input tensors the loaded model declares.
+    ///
+    /// Stable across the interpreter's lifetime; valid even before
+    /// [`Interpreter::allocate_tensors`] (TFLM reads the count from
+    /// the flatbuffer header at construction time).
+    #[must_use]
+    pub fn inputs_len(&self) -> usize {
+        // SAFETY: `self.handle` is a valid interpreter pointer for
+        // the duration of `&self`. The accessor reads from the
+        // model's graph metadata and doesn't mutate.
+        unsafe { ffi::etms_interpreter_inputs_size(self.handle.as_ptr()) }
+    }
+
+    /// Number of output tensors the loaded model declares.
+    #[must_use]
+    pub fn outputs_len(&self) -> usize {
+        // SAFETY: as in `inputs_len`.
+        unsafe { ffi::etms_interpreter_outputs_size(self.handle.as_ptr()) }
+    }
+
+    /// Writable byte view of the `idx`-th input tensor.
+    ///
+    /// Returns `None` if `idx >= self.inputs_len()` or if the
+    /// underlying tensor doesn't have a backing buffer yet (call
+    /// [`Interpreter::allocate_tensors`] first). The returned
+    /// slice's contents persist across [`Interpreter::invoke`]
+    /// calls — TFLM reads inputs from the buffer the caller writes
+    /// here and writes outputs to a separate buffer obtained via
+    /// [`Interpreter::output_bytes`].
+    ///
+    /// The borrow shape (`&mut self`) is what's required to prevent
+    /// `invoke` from running while a caller holds a writable
+    /// reference to the input arena; this is sound but conservative —
+    /// reading other tensors through an immutable accessor while
+    /// holding an input borrow is also rejected, even though that
+    /// would be safe.
+    pub fn input_bytes_mut(&mut self, idx: usize) -> Option<&mut [u8]> {
+        // SAFETY: the FFI returns either null (out-of-range or no
+        // arena) or a pointer into the tensor arena. The arena
+        // lives for `'a` (longer than `self`), and `&mut self`
+        // guarantees no other reference exists into the interpreter
+        // for the slice's lifetime.
+        unsafe {
+            let data = ffi::etms_interpreter_input_data(self.handle.as_ptr(), idx);
+            let bytes = ffi::etms_interpreter_input_bytes(self.handle.as_ptr(), idx);
+            if data.is_null() || bytes == 0 {
+                None
+            } else {
+                Some(core::slice::from_raw_parts_mut(data, bytes))
+            }
+        }
+    }
+
+    /// Readable byte view of the `idx`-th output tensor.
+    ///
+    /// Returns `None` if `idx >= self.outputs_len()` or if the
+    /// underlying tensor doesn't have a backing buffer yet (call
+    /// [`Interpreter::allocate_tensors`] first). The returned
+    /// slice's contents reflect the result of the last
+    /// [`Interpreter::invoke`] call — calling this *before* the
+    /// first invocation returns a buffer of zero (or
+    /// implementation-defined) bytes.
+    #[must_use]
+    pub fn output_bytes(&self, idx: usize) -> Option<&[u8]> {
+        // SAFETY: the FFI returns either null (out-of-range or no
+        // arena) or a pointer into the tensor arena. The arena
+        // lives for `'a` (longer than `self`); `&self` is enough
+        // for read-only access because TFLM doesn't mutate output
+        // tensors except during `invoke`, which takes `&mut self`.
+        unsafe {
+            let data = ffi::etms_interpreter_output_data(self.handle.as_ptr(), idx);
+            let bytes = ffi::etms_interpreter_output_bytes(self.handle.as_ptr(), idx);
+            if data.is_null() || bytes == 0 {
+                None
+            } else {
+                Some(core::slice::from_raw_parts(data, bytes))
+            }
+        }
+    }
 }
 
 impl Drop for Interpreter<'_> {

--- a/crates/esp-tflite-micro-sys/src/lib.rs
+++ b/crates/esp-tflite-micro-sys/src/lib.rs
@@ -341,6 +341,7 @@ impl<'a> Interpreter<'a> {
     /// reading other tensors through an immutable accessor while
     /// holding an input borrow is also rejected, even though that
     /// would be safe.
+    #[must_use]
     pub fn input_bytes_mut(&mut self, idx: usize) -> Option<&mut [u8]> {
         // SAFETY: the FFI returns either null (out-of-range or no
         // arena) or a pointer into the tensor arena. The arena

--- a/crates/esp-tflite-micro-sys/src/shim.cpp
+++ b/crates/esp-tflite-micro-sys/src/shim.cpp
@@ -34,6 +34,22 @@ struct InterpreterImpl {
       : model(m), interpreter(m, r, arena, arena_size) {}
 };
 
+// Resolves an interpreter handle to the underlying `MicroInterpreter`
+// pointer. Returns nullptr if `interpreter` is null; callers must
+// handle that case. The cast back to a mutable pointer is safe even
+// when called from `const EtmsInterpreter*` shim wrappers — TFLM's
+// `input()` / `output()` / `inputs_size()` accessors are non-const
+// for historical reasons but don't mutate the interpreter for the
+// queries this shim makes.
+inline tflite::MicroInterpreter* as_interp(const EtmsInterpreter* interpreter) {
+  if (interpreter == nullptr) {
+    return nullptr;
+  }
+  return &const_cast<InterpreterImpl*>(
+              reinterpret_cast<const InterpreterImpl*>(interpreter))
+              ->interpreter;
+}
+
 }  // namespace
 
 extern "C" {
@@ -134,6 +150,52 @@ int etms_interpreter_invoke(EtmsInterpreter* interpreter) {
     return kTfLiteError;
   }
   return reinterpret_cast<InterpreterImpl*>(interpreter)->interpreter.Invoke();
+}
+
+size_t etms_interpreter_inputs_size(const EtmsInterpreter* interpreter) {
+  auto* impl = as_interp(interpreter);
+  return impl == nullptr ? 0 : impl->inputs_size();
+}
+
+size_t etms_interpreter_outputs_size(const EtmsInterpreter* interpreter) {
+  auto* impl = as_interp(interpreter);
+  return impl == nullptr ? 0 : impl->outputs_size();
+}
+
+uint8_t* etms_interpreter_input_data(EtmsInterpreter* interpreter, size_t idx) {
+  auto* impl = as_interp(interpreter);
+  if (impl == nullptr || idx >= impl->inputs_size()) {
+    return nullptr;
+  }
+  TfLiteTensor* t = impl->input(idx);
+  return t == nullptr ? nullptr : reinterpret_cast<uint8_t*>(t->data.data);
+}
+
+size_t etms_interpreter_input_bytes(const EtmsInterpreter* interpreter, size_t idx) {
+  auto* impl = as_interp(interpreter);
+  if (impl == nullptr || idx >= impl->inputs_size()) {
+    return 0;
+  }
+  const TfLiteTensor* t = impl->input(idx);
+  return t == nullptr ? 0 : t->bytes;
+}
+
+const uint8_t* etms_interpreter_output_data(const EtmsInterpreter* interpreter, size_t idx) {
+  auto* impl = as_interp(interpreter);
+  if (impl == nullptr || idx >= impl->outputs_size()) {
+    return nullptr;
+  }
+  const TfLiteTensor* t = impl->output(idx);
+  return t == nullptr ? nullptr : reinterpret_cast<const uint8_t*>(t->data.data);
+}
+
+size_t etms_interpreter_output_bytes(const EtmsInterpreter* interpreter, size_t idx) {
+  auto* impl = as_interp(interpreter);
+  if (impl == nullptr || idx >= impl->outputs_size()) {
+    return 0;
+  }
+  const TfLiteTensor* t = impl->output(idx);
+  return t == nullptr ? 0 : t->bytes;
 }
 
 }  // extern "C"

--- a/crates/esp-tflite-micro-sys/src/shim.h
+++ b/crates/esp-tflite-micro-sys/src/shim.h
@@ -104,6 +104,35 @@ int etms_interpreter_allocate_tensors(EtmsInterpreter* interpreter);
 // last call. Returns 0 (`kTfLiteOk`) on success.
 int etms_interpreter_invoke(EtmsInterpreter* interpreter);
 
+// --- Tensor I/O ------------------------------------------------------------
+//
+// Direct byte access to TFLM's input and output tensor buffers. The
+// pointers are aliases into the tensor arena passed to
+// `etms_interpreter_create`; their lifetimes match the interpreter's,
+// and the contents survive across `etms_interpreter_invoke` calls.
+//
+// The shim treats tensor data as raw bytes — the typed-view layer
+// (int8 mel features, float32 logits, …) is the caller's
+// responsibility. For microWakeWord the inputs and outputs are both
+// int8 and a byte-level reinterpretation is sufficient.
+
+// Number of input or output tensors the model declares. Returns 0
+// for a null handle.
+size_t etms_interpreter_inputs_size(const EtmsInterpreter* interpreter);
+size_t etms_interpreter_outputs_size(const EtmsInterpreter* interpreter);
+
+// Pointer to the writable byte buffer backing the `idx`-th input
+// tensor. Returns NULL if `interpreter` is null or `idx` is out of
+// range. The buffer length is `etms_interpreter_input_bytes(idx)`.
+uint8_t* etms_interpreter_input_data(EtmsInterpreter* interpreter, size_t idx);
+size_t etms_interpreter_input_bytes(const EtmsInterpreter* interpreter, size_t idx);
+
+// Pointer to the readable byte buffer backing the `idx`-th output
+// tensor. Returns NULL if `interpreter` is null or `idx` is out of
+// range. The buffer length is `etms_interpreter_output_bytes(idx)`.
+const uint8_t* etms_interpreter_output_data(const EtmsInterpreter* interpreter, size_t idx);
+size_t etms_interpreter_output_bytes(const EtmsInterpreter* interpreter, size_t idx);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

Builds on #335. Four new `Interpreter` methods for byte-level access to the TFLM tensor arena.

- `inputs_len()` / `outputs_len()` — tensor counts from the model graph
- `input_bytes_mut(idx: usize) -> Option<&mut [u8]>` — writable slice of the `idx`-th input
- `output_bytes(idx: usize) -> Option<&[u8]>` — readable slice of the `idx`-th output

The borrow split — `&mut self` for input, `&self` for output — matches TFLM's usage pattern: write inputs, invoke, read outputs. The borrow checker prevents `invoke()` from running while a caller holds a writable input reference, and prevents reading the output while inputs are being mutated.

## Shim

Six new `extern "C"` functions hidden behind a single `as_interp` helper in the existing anonymous namespace. The shim treats tensor data as raw bytes; typed views (int8, float32) are the caller's responsibility. For microWakeWord both inputs and outputs are int8 and a byte slice is sufficient.

One sharp edge worth flagging — TFLM's `MicroInterpreter::input()` / `output()` are non-const member functions for historical reasons; the `as_interp` helper `const_cast`s the underlying `InterpreterImpl*` to make const shim wrappers compile. The cast is sound because the operations called through it don't mutate the interpreter.

## Out of scope

- **Typed slice views**. `input_i8_mut`, `output_f32`, etc. layer on top once a model-side consumer needs them.
- **Tensor metadata**. `dtype()`, `dims()`, `quantization_params()`. Future PR if introspection becomes load-bearing.
- **Firmware-side wake-word task**. Subscribes to `AUDIO_FRAME_PUBSUB`, runs frames through the audio-features mel frontend, feeds the resulting feature tensor via `input_bytes_mut`, calls `invoke`, reads the score via `output_bytes`, fires `PTT_TRIGGER.signal()` on detection.

## Test plan

- [x] `cargo +esp build -p esp-tflite-micro-sys --release` — clean
- [x] `cargo +esp clippy --release -- -D warnings` — clean
- [x] `just check` — passes
- [x] `just ci` (cargo-deny + rustdoc-warnings) — passes
- [x] `just clippy-firmware` — passes (firmware unaffected)
- [ ] On-device end-to-end — gated on the wake-word task PR