### PR TITLE
feat(firmware): wake fires through REMOTE_COMMAND_SIGNAL so avatar reacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ section summarises the milestone work in human terms.
   running while a caller holds a writable input reference.
 - On-device wake-word detector — new firmware task wired between
   `AUDIO_FRAME_PUBSUB`, the mel-spectrogram frontend, and the
-  agent-sidecar `PTT_TRIGGER`. Opt-in via
+  HTTP control-plane `REMOTE_COMMAND_SIGNAL`. Opt-in via
   `behavior.wake_word_enabled` AND a model at
   `/sd/WAKE_WORD.tflite`; missing either parks the task with no
   audio subscriber slot, no tensor arena allocation, and no
@@ -161,10 +161,13 @@ section summarises the milestone work in human terms.
   `Resolver`, allocates a 64 KiB PSRAM-backed tensor arena, and
   for every mel frame (one or two per 20 ms audio frame) feeds the
   40 int8 features into `Interpreter::invoke`. A score above the
-  detection threshold fires `PTT_TRIGGER.signal(4 000 ms)`, routing
-  the post-wake utterance through the same sidecar HTTP pipeline as
-  operator-initiated `POST /listen`. Tunable on-device detection
-  thresholds + larger-than-default arenas ride a follow-on PR.
+  detection threshold signals `RemoteCommand::StartListen { 4 000 ms }`,
+  converging on the same path operator-initiated `POST /listen`
+  takes — sidecar PCM capture *and* the cosmetic modifier graph
+  (`Attention::Listening` hold, ear decorator overlay, ack chirp)
+  fire in lockstep so the avatar visibly reacts to local wake
+  events. Tunable on-device detection thresholds + larger-than-
+  default arenas ride a follow-on PR.
 - New `stackchan-audio-features` crate — `no_std` + `alloc`
   streaming mel-spectrogram frontend (Hann window → 512-point
   real FFT → 40-channel mel filterbank 125–7 500 Hz → log →

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1474,10 +1474,12 @@ async fn main(spawner: Spawner) -> ! {
     // `/sd/WAKE_WORD.tflite`. The detector subscribes to
     // `AUDIO_FRAME_PUBSUB`, feeds each 20 ms frame through the
     // mel-spectrogram frontend, and runs each mel frame through
-    // a TFLite Micro interpreter. A positive detection fires
-    // `PTT_TRIGGER`, routing the post-wake utterance through the
-    // same sidecar HTTP pipeline as operator-initiated capture.
-    // Empty model or `wake_word_enabled = false` parks the task.
+    // a TFLite Micro interpreter. A positive detection signals
+    // `REMOTE_COMMAND_SIGNAL` with `RemoteCommand::StartListen`,
+    // converging on the same path operator-initiated `POST /listen`
+    // takes — sidecar PCM capture plus the cosmetic modifier graph
+    // (`Attention::Listening`, ear decorator, ack chirp). Empty
+    // model or `wake_word_enabled = false` parks the task.
     if let Err(e) = spawner.spawn(stackchan_firmware::wake_word::wake_word_task(
         net_config.behavior.wake_word_enabled,
         wake_word_model,

--- a/crates/stackchan-firmware/src/wake_word.rs
+++ b/crates/stackchan-firmware/src/wake_word.rs
@@ -158,7 +158,7 @@ pub async fn wake_word_task(enabled: bool, model_bytes: &'static [u8]) -> ! {
     let mut frontend = MelFrontend::new();
     let mut mel_buf: heapless::Vec<[i8; MEL_BIN_COUNT], MAX_MEL_FRAMES_PER_AUDIO_FRAME> =
         heapless::Vec::new();
-    // Earliest wall-clock instant at which the next PTT fire is
+    // Earliest wall-clock instant at which the next wake fire is
     // allowed. `None` (the initial state) means "any score is
     // eligible to fire"; updated to `now + cooldown` on each fire.
     let mut next_fire_after: Option<Instant> = None;

--- a/crates/stackchan-firmware/src/wake_word.rs
+++ b/crates/stackchan-firmware/src/wake_word.rs
@@ -8,10 +8,9 @@
 //! ## Pipeline
 //!
 //! ```text
-//! AUDIO_FRAME_PUBSUB  ─►  MelFrontend  ─►  Interpreter  ─►  PTT_TRIGGER
-//!   (320 i16 samples       (480 / 160      (1 × 40 i8        (signal post-
-//!    every 20 ms)           window/hop)     per timestep)     wake capture
-//!                                                             window)
+//! AUDIO_FRAME_PUBSUB  ─►  MelFrontend  ─►  Interpreter  ─►  REMOTE_COMMAND_SIGNAL
+//!   (320 i16 samples       (480 / 160      (1 × 40 i8        (StartListen, drained
+//!    every 20 ms)           window/hop)     per timestep)     by the render loop)
 //! ```
 //!
 //! Each 20 ms `AudioFrame` (320 samples @ 16 kHz) yields one or two
@@ -23,10 +22,14 @@
 //! ops, so the host side feeds one timestep at a time.
 //!
 //! When the output score crosses [`DETECTION_THRESHOLD`], the task
-//! fires [`crate::agent_sidecar::PTT_TRIGGER`] with
-//! [`POST_WAKE_CAPTURE_MS`], which routes the post-wake utterance
-//! through the same sidecar HTTP pipeline that `POST /listen` uses
-//! for operator-initiated capture.
+//! signals [`crate::net::http::REMOTE_COMMAND_SIGNAL`] with
+//! [`RemoteCommand::StartListen`] for [`POST_WAKE_CAPTURE_MS`]. The
+//! render loop drains the signal and applies the same effects as
+//! an operator-initiated `POST /listen`: trigger the sidecar PCM
+//! capture *and* hand the variant to the modifier graph so the
+//! avatar visibly reacts — [`stackchan_core::Attention::Listening`] hold,
+//! ear decorator overlay, acknowledgement chirp. Both the local
+//! and operator paths converge on this one signal.
 
 // microWakeWord, ESPHome, TFLite Micro, MixConv, MicroInterpreter
 // appear throughout the prose; per-occurrence backticking buries
@@ -40,9 +43,10 @@ use embassy_sync::pubsub::WaitResult;
 use embassy_time::Instant;
 use esp_tflite_micro_sys::{Interpreter, Resolver, TfLiteStatus};
 use stackchan_audio_features::{MEL_BIN_COUNT, MelFrontend};
+use stackchan_core::RemoteCommand;
 
-use crate::agent_sidecar::PTT_TRIGGER;
 use crate::audio::AUDIO_FRAME_PUBSUB;
+use crate::net::http::REMOTE_COMMAND_SIGNAL;
 
 /// Bytes of tensor arena handed to TFLM. microWakeWord v2 streaming
 /// models declare 17–26 KiB; 64 KiB leaves headroom for larger
@@ -57,21 +61,24 @@ const ARENA_BYTES: usize = 64 * 1024;
 /// point that's tunable once on-device tuning lands.
 const DETECTION_THRESHOLD: i8 = 100;
 
-/// PCM capture window the agent-sidecar task uses after a wake
-/// fires. Matches the operator-initiated `POST /listen` default so
-/// the two paths converge on the same sidecar request shape.
+/// Listen-window duration emitted on each wake fire. Matches the
+/// operator-initiated `POST /listen` default so the two paths
+/// converge on the same sidecar request shape and the same
+/// `Attention::Listening` hold.
 const POST_WAKE_CAPTURE_MS: u32 = 4_000;
 
-/// Minimum gap between consecutive `PTT_TRIGGER.signal()` calls.
-/// Without this, a real wake utterance — which spans dozens of mel
-/// frames above threshold — would call `signal()` on every frame.
-/// Since `Signal` is one-shot consume-and-clear with last-write-wins
-/// payload, the sidecar would re-fire as soon as its first capture
-/// finished, cascading into a second / third capture from queued
-/// signals. The cooldown is set to `POST_WAKE_CAPTURE_MS + 1 000 ms`
-/// so a new fire is only possible after the sidecar has finished
-/// the previous capture *and* drained the trigger, ruling out the
-/// cascade pattern.
+/// Minimum gap between consecutive `REMOTE_COMMAND_SIGNAL.signal()`
+/// calls. Without this, a real wake utterance — which spans dozens
+/// of mel frames above threshold — would call `signal()` on every
+/// frame. Since `Signal` is one-shot consume-and-clear with
+/// last-write-wins payload, the downstream consumers (sidecar
+/// capture, `Attention::Listening` modifier) would re-fire as soon
+/// as the first listen window finished, cascading into a second /
+/// third capture from queued signals. The cooldown is set to
+/// `POST_WAKE_CAPTURE_MS + 1 000 ms` so a new fire is only possible
+/// after the previous window has fully elapsed, ruling out the
+/// cascade pattern regardless of which downstream is slower to
+/// drain.
 const POST_WAKE_COOLDOWN_MS: u64 = POST_WAKE_CAPTURE_MS as u64 + 1_000;
 
 /// Index of the wake-word score in the model output tensor. For
@@ -182,15 +189,16 @@ pub async fn wake_word_task(enabled: bool, model_bytes: &'static [u8]) -> ! {
     }
 }
 
-/// Feed one mel frame through the interpreter and fire
-/// [`PTT_TRIGGER`] on detection. Logs and continues on transient
-/// errors so a single bad invoke doesn't kill the task.
+/// Feed one mel frame through the interpreter and signal
+/// [`REMOTE_COMMAND_SIGNAL`] with [`RemoteCommand::StartListen`] on
+/// detection. Logs and continues on transient errors so a single
+/// bad invoke doesn't kill the task.
 ///
 /// `next_fire_after` carries the cooldown deadline across calls:
 /// a fresh fire is suppressed (no `signal()`) until the deadline
 /// has passed, which prevents a single utterance — spanning dozens
 /// of consecutive high-score mel frames — from queueing repeated
-/// captures behind the sidecar's first capture window.
+/// listen windows behind the first one.
 fn run_inference(
     interp: &mut Interpreter<'_>,
     features: &[i8; MEL_BIN_COUNT],
@@ -241,7 +249,9 @@ fn run_inference(
         return;
     }
     defmt::info!("wake-word: fired (score={=i8})", score);
-    PTT_TRIGGER.signal(POST_WAKE_CAPTURE_MS);
+    REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::StartListen {
+        duration_ms: POST_WAKE_CAPTURE_MS,
+    });
     *next_fire_after = Some(now + embassy_time::Duration::from_millis(POST_WAKE_COOLDOWN_MS));
 }
 

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -127,7 +127,9 @@ emotion for ~2.5 s.
   `stackchan-core`.
 - No conversation memory between requests. Each `POST /listen`
   uploads a fresh capture; the sidecar owns any cross-turn state.
-- No on-device wake-word yet (`microWakeWord` integration is a
-  separate arc). Today every capture window is operator-driven via
-  `POST /listen`, the MCP `start_listen` tool, or a future
-  body-touch trigger.
+- Capture windows open from one of three triggers: `POST /listen`,
+  the MCP `start_listen` tool, or the on-device microWakeWord
+  detector (opt-in via `behavior.wake_word_enabled` plus a
+  `.tflite` model at `/sd/WAKE_WORD.tflite`). All three converge
+  on the same `RemoteCommand::StartListen` signal, so the sidecar
+  request shape is identical regardless of trigger.


### PR DESCRIPTION
## Summary

- The on-device wake-word detector was signalling `agent_sidecar::PTT_TRIGGER` directly, which started the sidecar PCM capture but bypassed the modifier-graph path that `POST /listen` uses. Net effect: a local wake fire produced an upload but no visible avatar reaction — `Attention::Listening` hold, ear decorator overlay, and acknowledgement chirp all stayed dormant.
- Route the wake event through `REMOTE_COMMAND_SIGNAL` with `RemoteCommand::StartListen { duration_ms }` instead. The render loop in `main.rs` already drains that signal and applies both effects on the operator path (`PTT_TRIGGER.signal(...)` for capture *plus* `entity.input.remote_command = ...` for the modifier graph), so the local and operator paths now converge on one source of truth.
- The mel-frame-rate cooldown is unchanged in shape (5 s deadline carried in `next_fire_after`); the docstring is updated to describe the cascade in terms of the new downstreams (`Attention::Listening` modifier + sidecar capture) instead of just the sidecar.
- CHANGELOG entry for the wake-word detector reworded to describe the converged routing.
- `docs/sidecar.md`'s "No on-device wake-word yet" stub is replaced with a one-paragraph note that all three triggers (HTTP, MCP, local wake) emit the same `RemoteCommand::StartListen`, so the sidecar request shape is trigger-agnostic.

## Test plan

- [x] `just check` — host fmt + clippy + tests
- [x] `just clippy-firmware` — strict release-mode clippy on the firmware crate, `-D warnings`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features` — workspace doc-link gate (the firmware doc baseline is unchanged from main; pre-existing rustdoc errors in `watchdog.rs` / `reminders.rs` / etc. are not in CI scope)
- [ ] On-device validation (pending): operator drops a `/sd/WAKE_WORD.tflite` model, sets `behavior.wake_word_enabled = true`, reflashes, and confirms that speaking the wake word produces both `wake-word: fired` defmt and a visible `Attention::Listening` reaction on the avatar (ear decorator + ack chirp + listening pose hold), matching what operator-initiated `POST /listen` already does.