### PR TITLE
fix(firmware): BluFi reject fragmented frames + clarify commit-side comment

### DIFF
--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -952,11 +952,31 @@ fn log_blufi_frame(frame: &blufi::Frame) {
 /// shared [`apply_wifi_credentials`] helper); other subtypes are
 /// already logged by [`log_blufi_frame`] and intentionally fall
 /// through here — the device responds to them in slice 3.
+///
+/// Fragmented frames are rejected with a warn. The `BluFi` protocol
+/// allows large payloads to be split across multiple application-
+/// layer frames via the `FC_FRAGMENT` bit, and the GATT handler
+/// owns reassembly per `stackchan_net::blufi`'s module contract.
+/// Until reassembly lands (slice 3), staging only the trailing
+/// fragment of a multi-frame `SendStaSsid` / `SendStaPassword`
+/// would silently commit a truncated network name or passphrase —
+/// the auth gate would happily accept it because the bytes are
+/// still valid UTF-8. Rejecting cleanly here keeps the session
+/// state coherent.
 async fn handle_blufi_frame<P: PacketPool>(
     conn: &GattConnection<'_, '_, P>,
     session: &mut BluFiSession,
     frame: blufi::Frame,
 ) {
+    if frame.fragmented {
+        defmt::warn!(
+            "ble: blufi fragmented frame (subtype={=u8:02x} seq={=u8}); \
+             reassembly not implemented — dropping",
+            frame.subtype,
+            frame.sequence,
+        );
+        return;
+    }
     match frame.frame_type {
         blufi::Type::Control => match frame.control_subtype() {
             Some(blufi::ControlSubtype::SetWifiOpMode) => {
@@ -1319,17 +1339,18 @@ async fn commit_provisioning<P: PacketPool>(
         }
     };
 
-    let committed =
-        apply_wifi_credentials(conn, "prov", staged_ssid.as_str(), new_psk.as_str()).await;
+    // Return value intentionally dropped: the GATT-table PSK clear
+    // below runs unconditionally, regardless of whether the commit
+    // succeeded. The bool is only meaningful for the BluFi callsite,
+    // which uses it to decide whether to scrub the in-memory session
+    // copy. `apply_wifi_credentials` itself logs each outcome.
+    let _ = apply_wifi_credentials(conn, "prov", staged_ssid.as_str(), new_psk.as_str()).await;
 
     // Clear the PSK from the GATT table unconditionally. Even on a
     // rejected commit the central just wrote the secret bytes into
     // the table; leaving them there for a subsequent retry or a
     // future maintenance change to the macro attributes (e.g.
-    // accidentally enabling `read`) would let them leak. The
-    // `committed` flag is consulted only to decide whether to log
-    // the clear as routine vs. defensive.
-    let _ = committed;
+    // accidentally enabling `read`) would let them leak.
     let empty: HString<PROV_PSK_CAP> = HString::new();
     if let Err(e) = server.set(&server.provisioning.psk, &empty) {
         defmt::warn!(


### PR DESCRIPTION
## Summary

Two greptile findings on the just-merged Arc 3d slice 2 (#344) that posted after the automerge fired. Both addressed here.

### P1 — silent SSID/PSK truncation on fragmented frames

The BluFi protocol allows large payloads to be split across multiple application-layer frames via the `FC_FRAGMENT` bit. Per the [`stackchan-net::blufi`](crates/stackchan-net/src/blufi.rs) module contract, the GATT handler owns reassembly. `handle_blufi_frame` never consulted `frame.fragmented`, so a `SendStaSsid` / `SendStaPassword` split across multiple frames would have each fragment overwrite `session.staged_ssid` / `staged_psk` with only that fragment's bytes. A subsequent `ConnectToAp` would silently commit a truncated credential — the auth gate has no way to detect this because the truncated bytes are still valid UTF-8.

**Fix**: reject fragmented frames at the top of `handle_blufi_frame` with a defmt warn. Actual reassembly remains slice 3's responsibility; until then, dropping cleanly is the right shape.

### P2 — stale comment in `commit_provisioning`

After the slice 2 refactor that extracted `apply_wifi_credentials`, the existing service's call to it bound the bool return into `committed` with a comment claiming the flag was *"consulted only to decide whether to log the clear as routine vs. defensive"* — but the next line was `let _ = committed;` with no conditional logging anywhere. The return is meaningful only for the BluFi callsite (which uses it to scrub the in-memory session copy on success). Dropped the binding and the misleading comment; the new inline comment describes the actual reason for dropping the return.

## Process note

The slice 2 automerge watcher gated only on the firmware cross-check, not on the Greptile Review check also completing. The cross-check finished first and the merge fired before greptile's findings posted. For future PRs with substantive code (vs docs-only), the watcher should gate on both. Captured in memory for the next session.

## Test plan

- [x] `just check` — host fmt + clippy + tests
- [x] `just clippy-firmware` — strict release-mode firmware clippy with `-D warnings`
- [ ] On-device validation (next: slice 3 also gates on this): does the official ESP BLE Provisioning app actually fragment SSID writes? Most real-world SSIDs (≤32 bytes) fit in one frame, so the fragmented path may not be exercised in practice — but rejecting cleanly is the right default until reassembly lands.