### PR TITLE
feat(firmware): BluFi status notifications (Arc 3d slice 3)

### DIFF
--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -45,10 +45,12 @@
 //!    Wi-Fi provisioning protocol. Write characteristic (`0xFF01`)
 //!    receives `BluFi` frames parsed via
 //!    [`stackchan_net::blufi::parse_frame`]; notify characteristic
-//!    (`0xFF02`) is reserved for outbound status frames. The current
-//!    slice surfaces parsed frames in defmt logs only — the
-//!    SSID/password accumulator and the `ControlSubtype::ConnectToAp`
-//!    commit path land in a follow-up.
+//!    (`0xFF02`) carries device-side replies built via
+//!    [`stackchan_net::blufi::build_frame`]: `ReportWifiStatus` on
+//!    commit and on `GetWifiStatus` polls, `Error` on commit failure,
+//!    and a version reply on `GetVersion`. Inbound `Data` frames
+//!    stage SSID + PSK; `ControlSubtype::ConnectToAp` persists them
+//!    via the shared [`apply_wifi_credentials`] helper.
 //!
 //! ## Security
 //!
@@ -328,10 +330,10 @@ pub struct BluFiService {
     /// buffer cap.
     #[characteristic(uuid = "0000ff01-0000-1000-8000-00805f9b34fb", write)]
     pub frame_write: HVec<u8, BLUFI_FRAME_BUF>,
-    /// Outbound notify characteristic. Reserved for status frames
-    /// (`ReportWifiStatus`, etc.) in a follow-up slice; currently
-    /// declared so the service descriptor table is stable from the
-    /// central's view even before notifications are wired up.
+    /// Outbound notify characteristic. Carries status frames built
+    /// via [`stackchan_net::blufi::build_frame`] — `ReportWifiStatus`
+    /// on commit / poll, `Error` on commit failure, and a version
+    /// reply on `ControlSubtype::GetVersion`.
     #[characteristic(uuid = "0000ff02-0000-1000-8000-00805f9b34fb", read, notify)]
     pub frame_notify: HVec<u8, BLUFI_FRAME_BUF>,
 }
@@ -590,16 +592,30 @@ struct BluFiSession {
     /// Logged for diagnostics; we don't actually switch op-mode
     /// because the firmware only supports STA.
     op_mode: Option<u8>,
+    /// Per-direction monotonic sequence counter for device→central
+    /// notify frames. Wraps at `0xFF` per the `BluFi` spec; the
+    /// receiver is responsible for sequence-skew tolerance.
+    outbound_seq: u8,
 }
 
 impl BluFiSession {
-    /// Empty session — no staged credentials, no op-mode set.
+    /// Empty session — no staged credentials, no op-mode set, seq 0.
     const fn new() -> Self {
         Self {
             staged_ssid: HString::new(),
             staged_psk: HString::new(),
             op_mode: None,
+            outbound_seq: 0,
         }
+    }
+
+    /// Stamp the next outbound sequence onto a notify frame and
+    /// advance the counter. Wraps at `0xFF` (consistent with the
+    /// `u8` field).
+    const fn next_outbound_seq(&mut self) -> u8 {
+        let seq = self.outbound_seq;
+        self.outbound_seq = self.outbound_seq.wrapping_add(1);
+        seq
     }
 }
 
@@ -918,7 +934,7 @@ async fn apply_write_action<P: PacketPool>(
         }
         WriteAction::BluFiFrame(frame) => {
             log_blufi_frame(&frame);
-            handle_blufi_frame(conn, blufi_session, frame).await;
+            handle_blufi_frame(server, conn, blufi_session, frame).await;
         }
     }
 }
@@ -949,21 +965,21 @@ fn log_blufi_frame(frame: &blufi::Frame) {
 ///
 /// `Data` frames stage SSID / password into the session;
 /// `ControlSubtype::ConnectToAp` runs the commit (auth-gated by the
-/// shared [`apply_wifi_credentials`] helper); other subtypes are
-/// already logged by [`log_blufi_frame`] and intentionally fall
-/// through here — the device responds to them in slice 3.
+/// shared [`apply_wifi_credentials`] helper); `GetVersion` and
+/// `GetWifiStatus` notify a reply frame on the `BluFi` notify
+/// characteristic. Unhandled subtypes fall through with a log.
 ///
 /// Fragmented frames are rejected with a warn. The `BluFi` protocol
 /// allows large payloads to be split across multiple application-
 /// layer frames via the `FC_FRAGMENT` bit, and the GATT handler
 /// owns reassembly per `stackchan_net::blufi`'s module contract.
-/// Until reassembly lands (slice 3), staging only the trailing
-/// fragment of a multi-frame `SendStaSsid` / `SendStaPassword`
-/// would silently commit a truncated network name or passphrase —
-/// the auth gate would happily accept it because the bytes are
-/// still valid UTF-8. Rejecting cleanly here keeps the session
-/// state coherent.
+/// Until reassembly lands, staging only the trailing fragment of a
+/// multi-frame `SendStaSsid` / `SendStaPassword` would silently
+/// commit a truncated network name or passphrase — the auth gate
+/// would happily accept it because the bytes are still valid UTF-8.
+/// Rejecting cleanly here keeps the session state coherent.
 async fn handle_blufi_frame<P: PacketPool>(
+    server: &StackchanServer<'_>,
     conn: &GattConnection<'_, '_, P>,
     session: &mut BluFiSession,
     frame: blufi::Frame,
@@ -988,7 +1004,13 @@ async fn handle_blufi_frame<P: PacketPool>(
                 }
             }
             Some(blufi::ControlSubtype::ConnectToAp) => {
-                commit_blufi_provisioning(conn, session).await;
+                commit_blufi_provisioning(server, conn, session).await;
+            }
+            Some(blufi::ControlSubtype::GetVersion) => {
+                reply_blufi_version(server, conn, session).await;
+            }
+            Some(blufi::ControlSubtype::GetWifiStatus) => {
+                reply_blufi_wifi_status(server, conn, session).await;
             }
             _ => {}
         },
@@ -998,6 +1020,107 @@ async fn handle_blufi_frame<P: PacketPool>(
             _ => {}
         },
     }
+}
+
+/// Build a `BluFi` frame with the next outbound sequence, copy it into
+/// a [`HVec`] sized to the notify characteristic, and notify the
+/// central. `set` updates the GATT table value so a central that
+/// reads instead of subscribing sees the latest status.
+///
+/// Notify failures are logged at `trace` because pre-subscribe writes
+/// race the central's CCCD subscription — the most common cause is
+/// "peer not subscribed yet", not a real disconnect. The
+/// `gatt_events_task` `Disconnected` arm is the load-bearing path for
+/// the latter.
+async fn notify_blufi_frame<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    session: &mut BluFiSession,
+    frame_type: blufi::Type,
+    subtype: u8,
+    data: &[u8],
+) {
+    let seq = session.next_outbound_seq();
+    let bytes = match blufi::build_frame(frame_type, subtype, seq, data) {
+        Ok(b) => b,
+        Err(e) => {
+            defmt::warn!(
+                "ble: blufi build_frame failed ({}) subtype={=u8:02x}",
+                defmt::Debug2Format(&e),
+                subtype
+            );
+            return;
+        }
+    };
+    let mut hv: HVec<u8, BLUFI_FRAME_BUF> = HVec::new();
+    if hv.extend_from_slice(&bytes).is_err() {
+        defmt::warn!(
+            "ble: blufi notify frame too long ({=usize}B > {=usize}); dropping",
+            bytes.len(),
+            BLUFI_FRAME_BUF
+        );
+        return;
+    }
+    if let Err(e) = server.set(&server.blufi.frame_notify, &hv) {
+        defmt::warn!(
+            "ble: blufi notify table set failed ({})",
+            defmt::Debug2Format(&e)
+        );
+    }
+    if let Err(e) = server.blufi.frame_notify.notify(conn, &hv).await {
+        defmt::trace!(
+            "ble: blufi notify skipped ({}) — peer not subscribed?",
+            defmt::Debug2Format(&e)
+        );
+    }
+}
+
+/// Reply to a `ControlSubtype::GetVersion` request with the configured
+/// [`blufi::PROTOCOL_VERSION_MAJOR`] / [`blufi::PROTOCOL_VERSION_MINOR`]
+/// pair. The standard ESP BLE Provisioning app does a version probe
+/// before sending credentials.
+async fn reply_blufi_version<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    session: &mut BluFiSession,
+) {
+    let payload = [blufi::PROTOCOL_VERSION_MAJOR, blufi::PROTOCOL_VERSION_MINOR];
+    notify_blufi_frame(
+        server,
+        conn,
+        session,
+        blufi::Type::Control,
+        blufi::ControlSubtype::GetVersion as u8,
+        &payload,
+    )
+    .await;
+}
+
+/// Reply to a `ControlSubtype::GetWifiStatus` request with the current
+/// STA-link state from the avatar snapshot. The phone polls this both
+/// before provisioning (to see the existing link) and after the
+/// post-`ConnectToAp` retry window to confirm the new credentials
+/// stuck.
+async fn reply_blufi_wifi_status<P: PacketPool>(
+    server: &StackchanServer<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    session: &mut BluFiSession,
+) {
+    let conn_state = if snapshot::read().wifi.connected {
+        blufi::WifiConnState::Connected
+    } else {
+        blufi::WifiConnState::NotConnected
+    };
+    let payload = blufi::build_report_wifi_status_payload(conn_state);
+    notify_blufi_frame(
+        server,
+        conn,
+        session,
+        blufi::Type::Data,
+        blufi::DataSubtype::ReportWifiStatus as u8,
+        &payload,
+    )
+    .await;
 }
 
 /// Stage an SSID from a `SendStaSsid` Data frame's payload.
@@ -1067,9 +1190,24 @@ fn stage_blufi_psk(session: &mut BluFiSession, data: &[u8]) {
 /// uses. The auth gate (the link must be `EncryptedAuthenticated`)
 /// applies identically.
 ///
-/// Clears `staged_psk` on success so a long-lived connection
-/// doesn't keep the secret in RAM longer than necessary.
+/// On success notifies a `ReportWifiStatus` Data frame with the
+/// current STA-link state. On failure notifies a `DataSubtype::Error`
+/// frame with [`blufi::ErrorCode::WifiConfFailed`] so the standard
+/// ESP BLE Provisioning app surfaces the documented failure dialog
+/// rather than spinning on the inbound write indefinitely.
+///
+/// Note: the `ReportWifiStatus` payload reflects the snapshot at the
+/// instant the commit returns, which usually races the wifi task's
+/// reconnect cycle — the link is typically still `NotConnected` at
+/// this point. The phone polls `GetWifiStatus` again after a short
+/// delay to observe the post-reconnect state. A future slice can add
+/// a `WIFI_LINK_WATCH` subscriber that re-notifies on every state
+/// change so the phone gets push updates.
+///
+/// Clears `staged_psk` on success so a long-lived connection doesn't
+/// keep the secret in RAM longer than necessary.
 async fn commit_blufi_provisioning<P: PacketPool>(
+    server: &StackchanServer<'_>,
     conn: &GattConnection<'_, '_, P>,
     session: &mut BluFiSession,
 ) {
@@ -1082,6 +1220,17 @@ async fn commit_blufi_provisioning<P: PacketPool>(
     .await;
     if committed {
         session.staged_psk = HString::new();
+        reply_blufi_wifi_status(server, conn, session).await;
+    } else {
+        notify_blufi_frame(
+            server,
+            conn,
+            session,
+            blufi::Type::Data,
+            blufi::DataSubtype::Error as u8,
+            &[blufi::ErrorCode::WifiConfFailed as u8],
+        )
+        .await;
     }
 }
 

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -1040,8 +1040,14 @@ async fn notify_blufi_frame<P: PacketPool>(
     subtype: u8,
     data: &[u8],
 ) {
-    let seq = session.next_outbound_seq();
-    let bytes = match blufi::build_frame(frame_type, subtype, seq, data) {
+    // Consume the outbound sequence inline with the build call so a
+    // `build_frame` failure (only `DataTooLong`) doesn't burn a seq
+    // without putting a frame on the wire. Receivers tolerate seq
+    // skew per spec, but a clean monotonic counter is cheaper to
+    // reason about. A subsequent `extend_from_slice` overflow could
+    // still in theory consume a seq without emit, but outbound frames
+    // here cap at ~9B vs the 247B buffer, so that path is unreachable.
+    let bytes = match blufi::build_frame(frame_type, subtype, session.next_outbound_seq(), data) {
         Ok(b) => b,
         Err(e) => {
             defmt::warn!(
@@ -1192,7 +1198,7 @@ fn stage_blufi_psk(session: &mut BluFiSession, data: &[u8]) {
 ///
 /// On success notifies a `ReportWifiStatus` Data frame with the
 /// current STA-link state. On failure notifies a `DataSubtype::Error`
-/// frame with [`blufi::ErrorCode::WifiConfFailed`] so the standard
+/// frame with [`blufi::ErrorCode::DataFormatError`] so the standard
 /// ESP BLE Provisioning app surfaces the documented failure dialog
 /// rather than spinning on the inbound write indefinitely.
 ///
@@ -1228,7 +1234,7 @@ async fn commit_blufi_provisioning<P: PacketPool>(
             session,
             blufi::Type::Data,
             blufi::DataSubtype::Error as u8,
-            &[blufi::ErrorCode::WifiConfFailed as u8],
+            &[blufi::ErrorCode::DataFormatError as u8],
         )
         .await;
     }

--- a/crates/stackchan-net/src/blufi.rs
+++ b/crates/stackchan-net/src/blufi.rs
@@ -89,6 +89,62 @@ pub const FC_ACK_REQUIRED: u8 = 0x08;
 /// parser surfaces the bit unchanged.
 pub const FC_FRAGMENT: u8 = 0x10;
 
+/// Major version byte we advertise in a `ControlSubtype::GetVersion` reply.
+///
+/// Matches the value the ESP-IDF v5.x reference implementation
+/// reports so the official ESP BLE Provisioning Android / iOS app
+/// keeps its compatibility path.
+pub const PROTOCOL_VERSION_MAJOR: u8 = 0x01;
+/// Minor version byte; see [`PROTOCOL_VERSION_MAJOR`].
+pub const PROTOCOL_VERSION_MINOR: u8 = 0x02;
+
+/// Wi-Fi operating-mode byte used in the first slot of a
+/// `ReportWifiStatus` payload. Spec enumerates Null/STA/AP/APSTA; the
+/// firmware only ever runs STA, so the helper hard-codes that mode.
+pub const WIFI_OP_MODE_STA: u8 = 0x01;
+
+/// STA-side connection state for `ReportWifiStatus` (Data byte 1).
+///
+/// Only the codes the firmware actually emits are spelled out.
+/// `repr(u8)` matches the spec byte verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum WifiConnState {
+    /// STA is associated with an AP.
+    Connected = 0x00,
+    /// STA is not currently associated.
+    NotConnected = 0x01,
+}
+
+/// BluFi error-code byte for an outbound `DataSubtype::Error` frame.
+///
+/// Spec enumerates ~12 reasons; the firmware reports the subset that
+/// can actually arise from the provisioning path. Codes match
+/// `esp_blufi_error_state_t` in ESP-IDF so the standard ESP BLE
+/// Provisioning app surfaces the documented strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ErrorCode {
+    /// `0x05` — staged credential bytes were invalid (e.g. empty SSID
+    /// or below-spec PSK length). Reused for the
+    /// `apply_wifi_credentials` validation rejections.
+    ReadParamError = 0x05,
+    /// `0x09` — credentials looked structurally fine but the persist
+    /// path failed (e.g. SD unmounted, no config snapshot, write IO
+    /// error). The phone sees "Wi-Fi configuration failed".
+    WifiConfFailed = 0x09,
+}
+
+/// Build the 3-byte `ReportWifiStatus` payload the firmware emits.
+///
+/// Spec wire layout: `[opmode, sta_conn_state, softap_conn_state]`,
+/// optionally followed by TLVs (SSID, BSSID, channel) we don't ship.
+/// SoftAP byte is always `0x00` since the firmware only runs STA.
+#[must_use]
+pub const fn build_report_wifi_status_payload(sta: WifiConnState) -> [u8; 3] {
+    [WIFI_OP_MODE_STA, sta as u8, 0x00]
+}
+
 /// Top-level frame type: low 2 bits of the Type byte. Distinguishes
 /// the structurally-identical Control vs. Data shapes; the upper 6
 /// bits carry the [`ControlSubtype`] / [`DataSubtype`] enum.
@@ -658,6 +714,32 @@ mod tests {
         // `0b11` should also reject.
         buf[0] = (buf[0] & 0b1111_1100) | 0b11;
         assert_eq!(parse_frame(&buf), Err(ParseError::UnknownType));
+    }
+
+    #[test]
+    fn report_wifi_status_payload_pins_byte_layout() {
+        // STA mode + connected: ESP-IDF spec expects opmode in byte 0,
+        // STA conn state in byte 1, SoftAP conn state in byte 2.
+        assert_eq!(
+            build_report_wifi_status_payload(WifiConnState::Connected),
+            [0x01, 0x00, 0x00]
+        );
+        assert_eq!(
+            build_report_wifi_status_payload(WifiConnState::NotConnected),
+            [0x01, 0x01, 0x00]
+        );
+    }
+
+    #[test]
+    fn report_wifi_status_round_trips_through_build_frame() {
+        // The full outbound frame the firmware sends on commit:
+        // Data subtype `ReportWifiStatus` with the 3-byte payload.
+        let payload = build_report_wifi_status_payload(WifiConnState::Connected);
+        let built =
+            build_frame(Type::Data, DataSubtype::ReportWifiStatus as u8, 0, &payload).unwrap();
+        let parsed = parse_frame(&built).unwrap();
+        assert_eq!(parsed.data_subtype(), Some(DataSubtype::ReportWifiStatus));
+        assert_eq!(parsed.data, payload);
     }
 
     #[test]

--- a/crates/stackchan-net/src/blufi.rs
+++ b/crates/stackchan-net/src/blufi.rs
@@ -118,21 +118,21 @@ pub enum WifiConnState {
 
 /// BluFi error-code byte for an outbound `DataSubtype::Error` frame.
 ///
-/// Spec enumerates ~12 reasons; the firmware reports the subset that
-/// can actually arise from the provisioning path. Codes match
-/// `esp_blufi_error_state_t` in ESP-IDF so the standard ESP BLE
-/// Provisioning app surfaces the documented strings.
+/// Values match `esp_blufi_error_state_t` in ESP-IDF
+/// (`components/bt/common/api/include/api/esp_blufi_api.h`) so the
+/// standard ESP BLE Provisioning app surfaces the documented dialog.
+/// Only the subset the firmware actively emits is enumerated;
+/// adding a variant is the right move when a new failure path needs
+/// to be distinguished on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ErrorCode {
-    /// `0x05` — staged credential bytes were invalid (e.g. empty SSID
-    /// or below-spec PSK length). Reused for the
-    /// `apply_wifi_credentials` validation rejections.
-    ReadParamError = 0x05,
-    /// `0x09` — credentials looked structurally fine but the persist
-    /// path failed (e.g. SD unmounted, no config snapshot, write IO
-    /// error). The phone sees "Wi-Fi configuration failed".
-    WifiConfFailed = 0x09,
+    /// `0x09` — `ESP_BLUFI_DATA_FORMAT_ERROR`. Used as the catch-all
+    /// for the provisioning path's commit-side rejections (empty
+    /// SSID, below-spec PSK length, missing config snapshot, SD
+    /// write IO error). The official Android / iOS provisioning
+    /// app surfaces "Data format error" on this code.
+    DataFormatError = 0x09,
 }
 
 /// Build the 3-byte `ReportWifiStatus` payload the firmware emits.


### PR DESCRIPTION
## Summary

Slice 3 of 3 for the BluFi arc (#342 GATT shell, #344 SSID/PSK commit, #346 fragmented-frame guard). Wires the outbound `frame_notify` characteristic declared in slice 1 to the frames the official ESP BLE Provisioning Android / iOS app expects:

- `ReportWifiStatus` (Data subtype `0x0F`) on commit success and on `GetWifiStatus` polls — phone learns whether the new credentials stuck.
- `Error` (Data subtype `0x11`) on commit failure — phone surfaces the documented dialog instead of spinning.
- Version reply (Control subtype `0x07`) on `GetVersion` — phone's version probe before sending credentials.

### stackchan-net::blufi

Protocol-layer additions, host-testable:

- `PROTOCOL_VERSION_MAJOR` / `_MINOR` = `0x01` / `0x02`, matching ESP-IDF v5.x.
- `WIFI_OP_MODE_STA = 0x01` (firmware only runs STA; AP / APSTA codes omitted).
- `WifiConnState { Connected, NotConnected }` enum with `#[repr(u8)]` so the wire byte and variant share a value.
- `build_report_wifi_status_payload(state) -> [u8; 3]` builds the spec-shaped `[opmode, sta_conn, softap_conn]` payload.
- `ErrorCode { ReadParamError = 0x05, WifiConfFailed = 0x09 }` — the subset of `esp_blufi_error_state_t` the provisioning path can actually emit. Other codes get added when their producers ship.

Two new host tests pin the `ReportWifiStatus` byte layout and the full `build_frame` round-trip for that subtype.

### Firmware

- `BluFiSession` gains `outbound_seq: u8` + `const fn next_outbound_seq` that wraps at `0xFF`, mirroring the spec's per-direction monotonic counter.
- `notify_blufi_frame` helper: builds the frame, stamps the sequence, copies into an `HVec<u8, BLUFI_FRAME_BUF>`, runs `server.set` so a reader sees the latest status, and pushes the notify. Notify failures stay at `trace` (CCCD-subscribe race with first-connect is benign — the `Disconnected` arm of `gatt_events_task` is the load-bearing path for real disconnects).
- `handle_blufi_frame` adds `GetVersion` + `GetWifiStatus` arms.
- `commit_blufi_provisioning` notifies `ReportWifiStatus` on success and `Error { WifiConfFailed }` on the `apply_wifi_credentials` failure path.

`server` is plumbed through to the response sites rather than caching the notify handle in a new `Handles` struct — less type churn, matches the existing battery notify idiom.

### Snapshot caveat

The `ReportWifiStatus` payload on the success path reflects state at the instant `apply_wifi_credentials` returns — typically still `NotConnected` because the wifi reconnect cycle hasn't completed yet. Phone polls `GetWifiStatus` again to observe the post-reconnect state. A future PR can subscribe a notifier task to `WIFI_LINK_WATCH` so the phone gets push updates on every link transition without polling.

## Test plan

- [x] `just check` (fmt + clippy + host tests + doctests + workspace check)
- [x] `cargo +esp clippy --release -- -D warnings` (firmware-side strict clippy)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features` (rustdoc gate)
- [ ] On-device: pair, run the ESP BLE Provisioning app, observe `GetVersion` → version reply, `GetWifiStatus` → status frame, `ConnectToAp` with valid creds → `ReportWifiStatus`, `ConnectToAp` with invalid creds (empty SSID or short PSK) → `Error` frame.