### PR TITLE
feat(firmware): operator-tunable wake_word_threshold via BehaviorConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,8 +166,11 @@ section summarises the milestone work in human terms.
   takes — sidecar PCM capture *and* the cosmetic modifier graph
   (`Attention::Listening` hold, ear decorator overlay, ack chirp)
   fire in lockstep so the avatar visibly reacts to local wake
-  events. Tunable on-device detection thresholds + larger-than-
-  default arenas ride a follow-on PR.
+  events. Detection threshold is operator-tunable via
+  `behavior.wake_word_threshold` (signed int8, default `100`) so
+  a `.tflite` with a different score distribution can be
+  re-calibrated without a firmware rebuild. Larger-than-default
+  arenas ride a follow-on PR.
 - New `stackchan-audio-features` crate — `no_std` + `alloc`
   streaming mel-spectrogram frontend (Hann window → 512-point
   real FFT → 40-channel mel filterbank 125–7 500 Hz → log →

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1482,6 +1482,7 @@ async fn main(spawner: Spawner) -> ! {
     // model or `wake_word_enabled = false` parks the task.
     if let Err(e) = spawner.spawn(stackchan_firmware::wake_word::wake_word_task(
         net_config.behavior.wake_word_enabled,
+        net_config.behavior.wake_word_threshold,
         wake_word_model,
     )) {
         defmt::panic!("spawn(wake_word_task) failed: {}", defmt::Debug2Format(&e));

--- a/crates/stackchan-firmware/src/wake_word.rs
+++ b/crates/stackchan-firmware/src/wake_word.rs
@@ -21,7 +21,8 @@
 //! `VarHandle` / `ReadVariable` / `AssignVariable` resource-variable
 //! ops, so the host side feeds one timestep at a time.
 //!
-//! When the output score crosses [`DETECTION_THRESHOLD`], the task
+//! When the output score crosses the operator-supplied threshold
+//! (`behavior.wake_word_threshold`, default `100`), the task
 //! signals [`crate::net::http::REMOTE_COMMAND_SIGNAL`] with
 //! [`RemoteCommand::StartListen`] for [`POST_WAKE_CAPTURE_MS`]. The
 //! render loop drains the signal and applies the same effects as
@@ -53,13 +54,6 @@ use crate::net::http::REMOTE_COMMAND_SIGNAL;
 /// architectures and the runtime scratch space TFLM's planner adds
 /// on top of the model's nominal tensor footprint.
 const ARENA_BYTES: usize = 64 * 1024;
-
-/// Int8 score (mapped from `u8` via `as i8`) above which we treat
-/// the model output as a positive detection. The microWakeWord
-/// reference threshold is ~0.95 of the float output, which lands
-/// near the high end of the int8 range — 100 is a safe starting
-/// point that's tunable once on-device tuning lands.
-const DETECTION_THRESHOLD: i8 = 100;
 
 /// Listen-window duration emitted on each wake fire. Matches the
 /// operator-initiated `POST /listen` default so the two paths
@@ -102,8 +96,12 @@ const MAX_MEL_FRAMES_PER_AUDIO_FRAME: usize = 4;
 /// missing-file path through `Storage::read_wake_word_model`
 /// returns `Vec::new()` rather than an error, so this is the
 /// expected default state for units without a model installed.
+///
+/// `threshold` mirrors `behavior.wake_word_threshold` — the int8
+/// score above which the model output is treated as a positive
+/// detection.
 #[embassy_executor::task]
-pub async fn wake_word_task(enabled: bool, model_bytes: &'static [u8]) -> ! {
+pub async fn wake_word_task(enabled: bool, threshold: i8, model_bytes: &'static [u8]) -> ! {
     if !enabled || model_bytes.is_empty() {
         defmt::info!(
             "wake-word: disabled (enabled={=bool}, model={=usize} bytes); idle",
@@ -149,10 +147,11 @@ pub async fn wake_word_task(enabled: bool, model_bytes: &'static [u8]) -> ! {
     }
 
     defmt::info!(
-        "wake-word: interpreter ready ({=usize} inputs, {=usize} outputs, arena={=usize} B)",
+        "wake-word: interpreter ready ({=usize} inputs, {=usize} outputs, arena={=usize} B, threshold={=i8})",
         interp.inputs_len(),
         interp.outputs_len(),
         ARENA_BYTES,
+        threshold,
     );
 
     let mut frontend = MelFrontend::new();
@@ -179,7 +178,7 @@ pub async fn wake_word_task(enabled: bool, model_bytes: &'static [u8]) -> ! {
                     }
                 });
                 for features in &mel_buf {
-                    run_inference(&mut interp, features, &mut next_fire_after);
+                    run_inference(&mut interp, features, threshold, &mut next_fire_after);
                 }
             }
             WaitResult::Lagged(n) => {
@@ -202,6 +201,7 @@ pub async fn wake_word_task(enabled: bool, model_bytes: &'static [u8]) -> ! {
 fn run_inference(
     interp: &mut Interpreter<'_>,
     features: &[i8; MEL_BIN_COUNT],
+    threshold: i8,
     next_fire_after: &mut Option<Instant>,
 ) {
     let Some(input) = interp.input_bytes_mut(0) else {
@@ -236,7 +236,7 @@ fn run_inference(
         return;
     };
     let score = score_u8.cast_signed();
-    if score < DETECTION_THRESHOLD {
+    if score < threshold {
         return;
     }
     let now = Instant::now();

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -631,7 +631,7 @@ impl<'a> Parser<'a> {
         let (digits, rest) = self.input.split_at(end);
         let magnitude: i16 = digits
             .parse()
-            .map_err(|_| bare_err("not an i8 literal", digits))?;
+            .map_err(|_| bare_err("i8 literal out of range", digits))?;
         let signed = if negative { -magnitude } else { magnitude };
         if !(i16::from(i8::MIN)..=i16::from(i8::MAX)).contains(&signed) {
             return Err(bare_err("i8 literal out of range", digits));

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -54,6 +54,7 @@ pub fn parse_ron_bare(input: &str) -> Result<Config, ConfigError> {
 ///
 /// Currently infallible — kept as `Result` for symmetry with the
 /// host renderer, which can fail under serde edge cases.
+#[allow(clippy::too_many_lines)]
 pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     let mut out = String::new();
     out.push_str("(\n");
@@ -158,6 +159,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         out,
         "        wake_word_enabled: {},",
         config.behavior.wake_word_enabled
+    );
+    let _ = writeln!(
+        out,
+        "        wake_word_threshold: {},",
+        config.behavior.wake_word_threshold
     );
     out.push_str("    ),\n");
 
@@ -524,6 +530,7 @@ impl<'a> Parser<'a> {
         let mut agent_sidecar_url: Option<String> = None;
         let mut follower_leader_hostname: Option<String> = None;
         let mut wake_word_enabled: Option<bool> = None;
+        let mut wake_word_threshold: Option<i8> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -545,6 +552,7 @@ impl<'a> Parser<'a> {
                     follower_leader_hostname = Some(self.parse_string()?);
                 }
                 "wake_word_enabled" => wake_word_enabled = Some(self.parse_bool()?),
+                "wake_word_threshold" => wake_word_threshold = Some(self.parse_i8()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -562,6 +570,7 @@ impl<'a> Parser<'a> {
             agent_sidecar_url: agent_sidecar_url.unwrap_or_default(),
             follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
+            wake_word_threshold: wake_word_threshold.unwrap_or(100),
         })
     }
 
@@ -603,6 +612,33 @@ impl<'a> Parser<'a> {
             .map_err(|_| bare_err("not a u32 literal", digits))?;
         self.input = rest;
         Ok(parsed)
+    }
+
+    /// Parse a signed decimal literal as an `i8`. Used for
+    /// `behavior.wake_word_threshold`. Accepts an optional leading
+    /// `-`; out-of-range values land on `BareParse` rather than
+    /// wrapping silently.
+    fn parse_i8(&mut self) -> Result<i8, ConfigError> {
+        let negative = self.try_consume_char('-');
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected signed integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let magnitude: i16 = digits
+            .parse()
+            .map_err(|_| bare_err("not an i8 literal", digits))?;
+        let signed = if negative { -magnitude } else { magnitude };
+        if !(i16::from(i8::MIN)..=i16::from(i8::MAX)).contains(&signed) {
+            return Err(bare_err("i8 literal out of range", digits));
+        }
+        self.input = rest;
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(signed as i8)
     }
 
     /// Parse a contiguous run of decimal digits as a `u8`. Used for

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -273,6 +273,11 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         ",\"wake_word_enabled\":{}",
         config.behavior.wake_word_enabled
     );
+    let _ = write!(
+        out,
+        ",\"wake_word_threshold\":{}",
+        config.behavior.wake_word_threshold
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -780,6 +785,7 @@ impl<'a> Parser<'a> {
         let mut agent_sidecar_url: Option<String> = None;
         let mut follower_leader_hostname: Option<String> = None;
         let mut wake_word_enabled: Option<bool> = None;
+        let mut wake_word_threshold: Option<i8> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -856,6 +862,12 @@ impl<'a> Parser<'a> {
                     }
                     wake_word_enabled = Some(self.parse_bool()?);
                 }
+                "wake_word_threshold" => {
+                    if wake_word_threshold.is_some() {
+                        return Err(bare_err("duplicate behavior field", "wake_word_threshold"));
+                    }
+                    wake_word_threshold = Some(self.parse_i8()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -873,6 +885,7 @@ impl<'a> Parser<'a> {
             agent_sidecar_url: agent_sidecar_url.unwrap_or_default(),
             follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
+            wake_word_threshold: wake_word_threshold.unwrap_or(100),
         })
     }
 
@@ -919,6 +932,32 @@ impl<'a> Parser<'a> {
         self.input = rest;
         #[allow(clippy::cast_possible_truncation)]
         Ok(parsed as u8)
+    }
+
+    /// Parse a signed decimal literal as an `i8`. Used for
+    /// `behavior.wake_word_threshold`. Accepts an optional leading
+    /// `-`; out-of-range values land on `BareParse`.
+    fn parse_i8(&mut self) -> Result<i8, ConfigError> {
+        let negative = self.try_consume_char('-');
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected signed integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let magnitude: i16 = digits
+            .parse()
+            .map_err(|_| bare_err("not an i8 literal", digits))?;
+        let signed = if negative { -magnitude } else { magnitude };
+        if !(i16::from(i8::MIN)..=i16::from(i8::MAX)).contains(&signed) {
+            return Err(bare_err("i8 literal out of range", digits));
+        }
+        self.input = rest;
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(signed as i8)
     }
 
     /// Parse a contiguous run of decimal digits as `u32`. Used for
@@ -1122,6 +1161,7 @@ mod tests {
                 agent_sidecar_url: "http://192.168.1.42:8080/v1/listen".to_string(),
                 follower_leader_hostname: "kitchen-cat".to_string(),
                 wake_word_enabled: true,
+                wake_word_threshold: 95,
             },
         }
     }
@@ -1446,6 +1486,7 @@ mod tests {
                 agent_sidecar_url: "http://192.168.1.42:8080/v1/listen".to_string(),
                 follower_leader_hostname: "kitchen-cat".to_string(),
                 wake_word_enabled: true,
+                wake_word_threshold: -32,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();
@@ -1464,6 +1505,46 @@ mod tests {
         let parsed = parse_settings_json(input).unwrap();
         assert_eq!(parsed.audio.volume_pct, 50);
         assert!(!parsed.audio.muted);
+    }
+
+    #[test]
+    fn wake_word_threshold_round_trips_negative() {
+        // Confirms `parse_i8` handles the optional leading `-` and
+        // that the render side emits a signed-i8 literal the parser
+        // accepts. The 1.42 fixture sets `wake_word_threshold: -32`
+        // (a sensitive cut-point for a calibrated model); round-trip
+        // through render+parse must preserve the sign.
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "behavior":{"wake_word_threshold":-32}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.behavior.wake_word_threshold, -32);
+    }
+
+    #[test]
+    fn wake_word_threshold_defaults_to_100_when_absent() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.behavior.wake_word_threshold, 100);
+    }
+
+    #[test]
+    fn wake_word_threshold_rejects_out_of_range() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "behavior":{"wake_word_threshold":200}
+        }"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -950,7 +950,7 @@ impl<'a> Parser<'a> {
         let (digits, rest) = self.input.split_at(end);
         let magnitude: i16 = digits
             .parse()
-            .map_err(|_| bare_err("not an i8 literal", digits))?;
+            .map_err(|_| bare_err("i8 literal out of range", digits))?;
         let signed = if negative { -magnitude } else { magnitude };
         if !(i16::from(i8::MIN)..=i16::from(i8::MAX)).contains(&signed) {
             return Err(bare_err("i8 literal out of range", digits));

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -283,7 +283,7 @@ impl Default for EspNowConfig {
 /// `behavior:` block at all — `serde(default)` on the parent populates
 /// it. Operators opt in by adding the block via `PUT /settings` or
 /// editing `STACKCHAN.RON` directly.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 #[allow(
     clippy::struct_excessive_bools,
@@ -370,6 +370,34 @@ pub struct BehaviorConfig {
     /// model fails to load, the task logs and parks — the rest
     /// of the firmware is unaffected.
     pub wake_word_enabled: bool,
+    /// Int8 score threshold above which the wake-word detector
+    /// treats a model output as a positive detection. The
+    /// microWakeWord int8 quantization maps the streaming
+    /// classifier's `[0.0, 1.0]` confidence onto `[-128, 127]`;
+    /// the bundled-model reference threshold ≈ 0.95 lands near
+    /// `100`, which is the firmware default. Lower values
+    /// (≈80) increase sensitivity (more wakes, more false
+    /// positives); higher values (≈115) tighten it. Tune on
+    /// device per model: a different `.tflite` may want a
+    /// different cut-point.
+    pub wake_word_threshold: i8,
+}
+
+impl Default for BehaviorConfig {
+    fn default() -> Self {
+        Self {
+            soliloquy_enabled: false,
+            hourly_chime_enabled: false,
+            battery_icon_enabled: false,
+            toast_overlay_enabled: false,
+            auto_torque_release_ms: 0,
+            audio_debug_udp_target: String::new(),
+            agent_sidecar_url: String::new(),
+            follower_leader_hostname: String::new(),
+            wake_word_enabled: false,
+            wake_word_threshold: 100,
+        }
+    }
 }
 
 /// Time / SNTP configuration.

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -279,10 +279,11 @@ impl Default for EspNowConfig {
 /// Behavioural toggles. Opt-in autonomous beats that aren't part of
 /// the always-on reactive surface.
 ///
-/// Default: every flag `false`. The boot config doesn't need a
-/// `behavior:` block at all — `serde(default)` on the parent populates
-/// it. Operators opt in by adding the block via `PUT /settings` or
-/// editing `STACKCHAN.RON` directly.
+/// Default: every flag `false`, `wake_word_threshold: 100`. The
+/// boot config doesn't need a `behavior:` block at all —
+/// `serde(default)` on the parent populates it. Operators opt in
+/// by adding the block via `PUT /settings` or editing
+/// `STACKCHAN.RON` directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 #[allow(

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -130,6 +130,8 @@ emotion for ~2.5 s.
 - Capture windows open from one of three triggers: `POST /listen`,
   the MCP `start_listen` tool, or the on-device microWakeWord
   detector (opt-in via `behavior.wake_word_enabled` plus a
-  `.tflite` model at `/sd/WAKE_WORD.tflite`). All three converge
-  on the same `RemoteCommand::StartListen` signal, so the sidecar
-  request shape is identical regardless of trigger.
+  `.tflite` model at `/sd/WAKE_WORD.tflite`; detection cut-point
+  is `behavior.wake_word_threshold`, signed int8, default `100`).
+  All three converge on the same `RemoteCommand::StartListen`
+  signal, so the sidecar request shape is identical regardless
+  of trigger.


### PR DESCRIPTION
## Summary

- `behavior.wake_word_threshold` (signed int8, default `100`) replaces the hard-coded `DETECTION_THRESHOLD` constant in `wake_word.rs`. Operators with a custom `/sd/WAKE_WORD.tflite` — or models where the upstream microWakeWord score distribution shifted — can re-calibrate the cut-point without a firmware rebuild.
- `parse_i8` helper added to both `bare.rs` and `bare_json.rs`, handles optional leading `-` and rejects out-of-range literals.
- Hand-rolled `Default for BehaviorConfig` keeps the missing-block path consistent with the in-block default (the derived impl would have yielded `0`, silently shipping a sensitivity-0 detector — caught by the new round-trip test).
- Boot log line now surfaces the active threshold for diagnostics.

Closes the deferred follow-up captured in the Arc 4b detector PR (#337).

## Test plan

- [x] `just check` — workspace fmt + clippy + host tests (322 stackchan-net tests pass; 3 new for `wake_word_threshold`)
- [x] `just clippy-firmware` — strict firmware clippy
- [ ] On-device: drop a `.tflite` at `/sd/WAKE_WORD.tflite`, vary `behavior.wake_word_threshold` via `PUT /settings`, confirm sensitivity changes match.