### PR TITLE
feat(firmware): operator-tunable wake_word_arena_kib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,8 +169,10 @@ section summarises the milestone work in human terms.
   events. Detection threshold is operator-tunable via
   `behavior.wake_word_threshold` (signed int8, default `100`) so
   a `.tflite` with a different score distribution can be
-  re-calibrated without a firmware rebuild. Larger-than-default
-  arenas ride a follow-on PR.
+  re-calibrated without a firmware rebuild; tensor arena size is
+  operator-tunable via `behavior.wake_word_arena_kib` (default
+  `64`) so a model that fails `allocate_tensors` against the
+  default can be re-tried with more PSRAM at next boot.
 - New `stackchan-audio-features` crate — `no_std` + `alloc`
   streaming mel-spectrogram frontend (Hann window → 512-point
   real FFT → 40-channel mel filterbank 125–7 500 Hz → log →

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1480,9 +1480,18 @@ async fn main(spawner: Spawner) -> ! {
     // takes — sidecar PCM capture plus the cosmetic modifier graph
     // (`Attention::Listening`, ear decorator, ack chirp). Empty
     // model or `wake_word_enabled = false` parks the task.
+    // Saturating KiB→bytes: a pathological config (e.g.
+    // `wake_word_arena_kib: u32::MAX`) shouldn't wrap to a tiny
+    // allocation. `usize` is 32-bit on xtensa-esp32s3, so the upper
+    // bound `usize::MAX` clamps any value > ~4 GiB to 4 GiB — still
+    // way beyond what `esp-alloc` can satisfy, but the failure mode
+    // is a clean PSRAM-exhausted panic rather than a silent wrap.
+    let arena_bytes: usize =
+        (net_config.behavior.wake_word_arena_kib as usize).saturating_mul(1024);
     if let Err(e) = spawner.spawn(stackchan_firmware::wake_word::wake_word_task(
         net_config.behavior.wake_word_enabled,
         net_config.behavior.wake_word_threshold,
+        arena_bytes,
         wake_word_model,
     )) {
         defmt::panic!("spawn(wake_word_task) failed: {}", defmt::Debug2Format(&e));

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -712,7 +712,9 @@ async fn handle_get_settings_backup(socket: &mut TcpSocket<'_>) -> Result<(), Ht
 /// and tracker tuning take effect on the next boot — those tasks read
 /// their config once at start-up. Auth-token changes apply
 /// immediately to the next request via the lock-free read in the
-/// auth gate.
+/// auth gate. The `behavior.wake_word_*` fields are also boot-only:
+/// the detector reads them once at task spawn (enabled / threshold /
+/// arena size).
 fn requires_reboot(prev: &stackchan_net::Config, new: &stackchan_net::Config) -> bool {
     if prev.mdns.hostname != new.mdns.hostname {
         return true;
@@ -721,6 +723,12 @@ fn requires_reboot(prev: &stackchan_net::Config, new: &stackchan_net::Config) ->
         return true;
     }
     if prev.tracker != new.tracker {
+        return true;
+    }
+    if prev.behavior.wake_word_enabled != new.behavior.wake_word_enabled
+        || prev.behavior.wake_word_threshold != new.behavior.wake_word_threshold
+        || prev.behavior.wake_word_arena_kib != new.behavior.wake_word_arena_kib
+    {
         return true;
     }
     false

--- a/crates/stackchan-firmware/src/wake_word.rs
+++ b/crates/stackchan-firmware/src/wake_word.rs
@@ -49,12 +49,6 @@ use stackchan_core::RemoteCommand;
 use crate::audio::AUDIO_FRAME_PUBSUB;
 use crate::net::http::REMOTE_COMMAND_SIGNAL;
 
-/// Bytes of tensor arena handed to TFLM. microWakeWord v2 streaming
-/// models declare 17–26 KiB; 64 KiB leaves headroom for larger
-/// architectures and the runtime scratch space TFLM's planner adds
-/// on top of the model's nominal tensor footprint.
-const ARENA_BYTES: usize = 64 * 1024;
-
 /// Listen-window duration emitted on each wake fire. Matches the
 /// operator-initiated `POST /listen` default so the two paths
 /// converge on the same sidecar request shape and the same
@@ -99,9 +93,16 @@ const MAX_MEL_FRAMES_PER_AUDIO_FRAME: usize = 4;
 ///
 /// `threshold` mirrors `behavior.wake_word_threshold` — the int8
 /// score above which the model output is treated as a positive
-/// detection.
+/// detection. `arena_bytes` mirrors
+/// `behavior.wake_word_arena_kib * 1024` — the size of the TFLM
+/// tensor arena, allocated once from PSRAM at task start.
 #[embassy_executor::task]
-pub async fn wake_word_task(enabled: bool, threshold: i8, model_bytes: &'static [u8]) -> ! {
+pub async fn wake_word_task(
+    enabled: bool,
+    threshold: i8,
+    arena_bytes: usize,
+    model_bytes: &'static [u8],
+) -> ! {
     if !enabled || model_bytes.is_empty() {
         defmt::info!(
             "wake-word: disabled (enabled={=bool}, model={=usize} bytes); idle",
@@ -119,7 +120,7 @@ pub async fn wake_word_task(enabled: bool, threshold: i8, model_bytes: &'static 
     // PSRAM-backed tensor arena. Leaking the Vec yields a
     // `'static mut [u8]` that the interpreter can borrow for the
     // task's (i.e. program's) lifetime.
-    let arena: &'static mut [u8] = vec![0_u8; ARENA_BYTES].leak();
+    let arena: &'static mut [u8] = vec![0_u8; arena_bytes].leak();
 
     let Some(mut resolver) = Resolver::new() else {
         defmt::error!("wake-word: resolver alloc failed; idle");
@@ -150,7 +151,7 @@ pub async fn wake_word_task(enabled: bool, threshold: i8, model_bytes: &'static 
         "wake-word: interpreter ready ({=usize} inputs, {=usize} outputs, arena={=usize} B, threshold={=i8})",
         interp.inputs_len(),
         interp.outputs_len(),
-        ARENA_BYTES,
+        arena_bytes,
         threshold,
     );
 

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -165,6 +165,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        wake_word_threshold: {},",
         config.behavior.wake_word_threshold
     );
+    let _ = writeln!(
+        out,
+        "        wake_word_arena_kib: {},",
+        config.behavior.wake_word_arena_kib
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -531,6 +536,7 @@ impl<'a> Parser<'a> {
         let mut follower_leader_hostname: Option<String> = None;
         let mut wake_word_enabled: Option<bool> = None;
         let mut wake_word_threshold: Option<i8> = None;
+        let mut wake_word_arena_kib: Option<u32> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -553,6 +559,7 @@ impl<'a> Parser<'a> {
                 }
                 "wake_word_enabled" => wake_word_enabled = Some(self.parse_bool()?),
                 "wake_word_threshold" => wake_word_threshold = Some(self.parse_i8()?),
+                "wake_word_arena_kib" => wake_word_arena_kib = Some(self.parse_u32()?),
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -571,6 +578,7 @@ impl<'a> Parser<'a> {
             follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
+            wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -278,6 +278,11 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         ",\"wake_word_threshold\":{}",
         config.behavior.wake_word_threshold
     );
+    let _ = write!(
+        out,
+        ",\"wake_word_arena_kib\":{}",
+        config.behavior.wake_word_arena_kib
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -786,6 +791,7 @@ impl<'a> Parser<'a> {
         let mut follower_leader_hostname: Option<String> = None;
         let mut wake_word_enabled: Option<bool> = None;
         let mut wake_word_threshold: Option<i8> = None;
+        let mut wake_word_arena_kib: Option<u32> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -868,6 +874,12 @@ impl<'a> Parser<'a> {
                     }
                     wake_word_threshold = Some(self.parse_i8()?);
                 }
+                "wake_word_arena_kib" => {
+                    if wake_word_arena_kib.is_some() {
+                        return Err(bare_err("duplicate behavior field", "wake_word_arena_kib"));
+                    }
+                    wake_word_arena_kib = Some(self.parse_u32()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -886,6 +898,7 @@ impl<'a> Parser<'a> {
             follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
+            wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
         })
     }
 
@@ -1162,6 +1175,7 @@ mod tests {
                 follower_leader_hostname: "kitchen-cat".to_string(),
                 wake_word_enabled: true,
                 wake_word_threshold: 95,
+                wake_word_arena_kib: 96,
             },
         }
     }
@@ -1487,6 +1501,7 @@ mod tests {
                 follower_leader_hostname: "kitchen-cat".to_string(),
                 wake_word_enabled: true,
                 wake_word_threshold: -32,
+                wake_word_arena_kib: 128,
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();
@@ -1522,6 +1537,29 @@ mod tests {
         }"#;
         let parsed = parse_settings_json(input).unwrap();
         assert_eq!(parsed.behavior.wake_word_threshold, -32);
+    }
+
+    #[test]
+    fn wake_word_arena_kib_round_trips_custom_value() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "behavior":{"wake_word_arena_kib":96}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.behavior.wake_word_arena_kib, 96);
+    }
+
+    #[test]
+    fn wake_word_arena_kib_defaults_to_64_when_absent() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.behavior.wake_word_arena_kib, 64);
     }
 
     #[test]

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -279,11 +279,11 @@ impl Default for EspNowConfig {
 /// Behavioural toggles. Opt-in autonomous beats that aren't part of
 /// the always-on reactive surface.
 ///
-/// Default: every flag `false`, `wake_word_threshold: 100`. The
-/// boot config doesn't need a `behavior:` block at all —
-/// `serde(default)` on the parent populates it. Operators opt in
-/// by adding the block via `PUT /settings` or editing
-/// `STACKCHAN.RON` directly.
+/// Default: every flag `false`, `wake_word_threshold: 100`,
+/// `wake_word_arena_kib: 64`. The boot config doesn't need a
+/// `behavior:` block at all — `serde(default)` on the parent
+/// populates it. Operators opt in by adding the block via
+/// `PUT /settings` or editing `STACKCHAN.RON` directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
 #[allow(
@@ -382,6 +382,14 @@ pub struct BehaviorConfig {
     /// device per model: a different `.tflite` may want a
     /// different cut-point.
     pub wake_word_threshold: i8,
+    /// Size of the tensor arena handed to `TFLite` Micro at boot,
+    /// in KiB. The `microWakeWord` v2 streaming family declares
+    /// 17–26 KiB nominal; the default `64` leaves headroom for the
+    /// TFLM planner's scratch space and small architecture changes.
+    /// Bump when a custom `.tflite` model fails `allocate_tensors`
+    /// with the default. Allocated once at boot from PSRAM — config
+    /// changes via `PUT /settings` take effect on next reboot.
+    pub wake_word_arena_kib: u32,
 }
 
 impl Default for BehaviorConfig {
@@ -397,6 +405,7 @@ impl Default for BehaviorConfig {
             follower_leader_hostname: String::new(),
             wake_word_enabled: false,
             wake_word_threshold: 100,
+            wake_word_arena_kib: 64,
         }
     }
 }

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -389,6 +389,9 @@ pub struct BehaviorConfig {
     /// Bump when a custom `.tflite` model fails `allocate_tensors`
     /// with the default. Allocated once at boot from PSRAM — config
     /// changes via `PUT /settings` take effect on next reboot.
+    /// Must be `>= 1`; `0` is rejected by [`validate`] so the
+    /// operator gets feedback from the HTTP write rather than
+    /// discovering a parked task on next reboot.
     pub wake_word_arena_kib: u32,
 }
 
@@ -595,6 +598,9 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
         ));
     }
     validate_esp_now(&config.esp_now)?;
+    if config.behavior.wake_word_arena_kib == 0 {
+        return Err(ConfigError::InvalidWakeWordArenaKib);
+    }
     Ok(())
 }
 
@@ -779,6 +785,17 @@ mod tests {
         assert!(matches!(
             validate(&c),
             Err(ConfigError::InvalidVolumePct(101))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_zero_wake_word_arena_kib() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.behavior.wake_word_arena_kib = 0;
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidWakeWordArenaKib)
         ));
     }
 

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -120,4 +120,14 @@ pub enum ConfigError {
     /// Carries the offending value.
     #[error("esp_now.tx_rate_hz must be <= 20; got {0}")]
     InvalidEspNowTxRate(u8),
+
+    /// `behavior.wake_word_arena_kib` was `0`. The wake-word task
+    /// allocates the tensor arena once at boot; an empty arena
+    /// makes `Interpreter::new` return `None` and leaves the task
+    /// permanently parked with only a `defmt::error!` to show for
+    /// it. Reject at validation time so the operator gets feedback
+    /// from `PUT /settings` instead of needing to reboot to see
+    /// the failure.
+    #[error("behavior.wake_word_arena_kib must be >= 1; got 0")]
+    InvalidWakeWordArenaKib,
 }


### PR DESCRIPTION
## Summary

- `behavior.wake_word_arena_kib` (u32, default `64`) replaces the hard-coded 64 KiB `ARENA_BYTES` constant in `wake_word.rs`. Operators with a custom `/sd/WAKE_WORD.tflite` that exceeds the default arena can re-allocate without a firmware rebuild.
- Allocation is one-shot at boot; the field takes effect on next reboot, same as `wake_word_enabled` / `wake_word_threshold`.
- KiB → bytes conversion at the spawn site uses `saturating_mul` so a pathological `u32::MAX` config clamps to `usize::MAX` rather than wrapping to a tiny allocation.
- Closes the second half of the deferred follow-up captured in #337's CHANGELOG entry.

## Test plan

- [x] `just check` — workspace fmt + clippy + host tests (2 new JSON round-trip + default-when-absent tests)
- [x] `just clippy-firmware` — strict firmware clippy
- [ ] On-device: set `behavior.wake_word_arena_kib` via `PUT /settings`, reboot, confirm `wake-word: interpreter ready (… arena=<bytes> B …)` reflects the new value.