### PR TITLE
fix(firmware): unblock release-build link, close CI gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,16 @@ jobs:
         working-directory: crates/stackchan-firmware
         run: cargo clippy --all-features -- -D warnings
 
-      # `cargo check` is redundant with `cargo clippy` above — clippy
-      # runs a full type-check as part of its lint pass. Dropping it
-      # cuts ~45 s off the 2 m 22 s firmware job (the longest in CI).
+      # `cargo build --release` exercises the link step that clippy
+      # alone never reaches. Without this gate, a link regression in
+      # any vendored C/C++ archive (e.g. esp-tflite-micro-sys) would
+      # pass clippy but break "just fmr" on every developer's machine.
+      # Previously caught the hard way after the TFLM merges in
+      # PRs 331/334/335/336/337 left the firmware unflashable on
+      # main for a day.
+      - name: Build (firmware, release)
+        working-directory: crates/stackchan-firmware
+        run: cargo build --release
 
   msrv:
     name: MSRV (host crates)

--- a/crates/esp-tflite-micro-sys/build.rs
+++ b/crates/esp-tflite-micro-sys/build.rs
@@ -67,6 +67,15 @@ fn main() {
 fn s3_build() -> cc::Build {
     let mut b = cc::Build::new();
     b.compiler("xtensa-esp32s3-elf-gcc");
+    // `-mlongcalls` tells GAS to translate direct `call4`/`call8`
+    // into indirect `callx` whenever the target is out of the
+    // 1 MiB displacement window. Without it, a release build that
+    // grows past ~1 MiB lands `dangerous relocation: call8: call
+    // target out of range` errors on libgcc soft-float helpers
+    // (`__divdf3`, `__extendsfdf2`, …) and libc (`memcpy`, `memset`,
+    // `strcmp`). ESP-IDF sets `-mlongcalls` globally; the cc-rs
+    // default doesn't, so mirroring upstream here is the fix.
+    b.flag("-mlongcalls");
     b
 }
 
@@ -167,6 +176,17 @@ fn is_s3_relevant(path: &Path) -> bool {
 /// `kernels/esp_nn/*.cc` variants `#include <esp_nn.h>`.
 fn compile_tflm_and_shim(tflm: &Path, esp_nn: &Path, manifest: &Path) {
     let mut b = s3_build();
+    // Disable cc-rs's automatic `-lstdc++` link. Without it, the
+    // toolchain's `libstdc++.a` gets pulled in and brings the full
+    // C++ exception personality runtime
+    // (`__gxx_personality_v0` → `_Unwind_GetIP` / `_Unwind_SetIP` /
+    // …), plus thread-safe-statics machinery
+    // (`pthread_mutex_lock` / `pthread_getspecific`), neither of
+    // which can run under our build flags or runtime. `runtime_stubs.cpp`
+    // provides the only C++ stdlib symbol TFLM actually needs
+    // (`operator new` / `operator delete`); the link line below also
+    // adds `-lm` for `frexp`, which `quantization_util.cc` uses.
+    b.cpp_link_stdlib(None);
     b.cpp(true)
         // C++17 — TFLM uses constexpr, structured bindings, and
         // template type-trait helpers that aren't in C++14. Use
@@ -227,8 +247,20 @@ fn compile_tflm_and_shim(tflm: &Path, esp_nn: &Path, manifest: &Path) {
 
     // Our shim TU — bridges Rust over the templated TFLM classes.
     b.file(manifest.join("src/shim.cpp"));
+    // Runtime stubs — `abort()` plus the minimal C++ runtime
+    // (`operator new` / `operator delete`) that TFLM references
+    // when we cut libstdc++ out of the link line. See
+    // `runtime_stubs.cpp` for the full rationale.
+    b.file(manifest.join("src/runtime_stubs.cpp"));
 
     b.compile("esp_tflite_micro");
+
+    // `frexp` is the one libm function TFLM's `quantization_util.cc`
+    // pulls in. Re-add libm on the link line — we cut the default
+    // libstdc++ above, and the firmware crate's `-nodefaultlibs`
+    // skips libm too. `=` (no `static=` / `dylib=`) lets the
+    // toolchain pick whichever flavour it ships.
+    println!("cargo:rustc-link-lib=m");
 }
 
 /// Lift upstream's `lib_srcs` from `esp-tflite-micro/CMakeLists.txt`

--- a/crates/esp-tflite-micro-sys/src/lib.rs
+++ b/crates/esp-tflite-micro-sys/src/lib.rs
@@ -61,6 +61,74 @@
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 
+extern crate alloc;
+
+/// C++ runtime bridge — `runtime_stubs.cpp` calls these in lieu of
+/// linking libstdc++. Routing through the Rust global allocator
+/// keeps both sides on the same `esp-alloc` PSRAM heap so heap
+/// accounting is unified across the FFI boundary. A small
+/// `usize`-sized header prefix records the user-visible size so
+/// `free` can recover the original `Layout`.
+mod runtime {
+    use core::alloc::Layout;
+
+    use alloc::alloc::{alloc as rust_alloc, dealloc as rust_dealloc};
+
+    /// Width of the size-header prefix prepended to every allocation.
+    const HEADER_SIZE: usize = core::mem::size_of::<usize>();
+    /// 16-byte alignment is `max_align_t` on xtensa-esp32s3 (covers
+    /// `double` + pointer pair) — the strictest alignment any
+    /// C++-side `operator new` call could need.
+    const ALIGN: usize = 16;
+
+    /// SAFETY: the only caller is C++ `operator new` in
+    /// `runtime_stubs.cpp`. Returns null on alloc failure to match
+    /// the `nothrow` contract the C++ side relies on.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn etms_runtime_alloc(size: usize) -> *mut u8 {
+        let Some(total) = size.checked_add(HEADER_SIZE) else {
+            return core::ptr::null_mut();
+        };
+        let Ok(layout) = Layout::from_size_align(total, ALIGN) else {
+            return core::ptr::null_mut();
+        };
+        // SAFETY: layout is well-formed.
+        let raw = unsafe { rust_alloc(layout) };
+        if raw.is_null() {
+            return core::ptr::null_mut();
+        }
+        // SAFETY: `raw` has at least `HEADER_SIZE` bytes per the
+        // layout. `write_unaligned` sidesteps clippy's alignment
+        // lint without changing semantics — `raw` is always
+        // 16-byte aligned per `ALIGN`, so any usize write is
+        // naturally aligned in practice.
+        unsafe { core::ptr::write_unaligned(raw.cast::<usize>(), size) };
+        // SAFETY: `raw + HEADER_SIZE` is inside the allocation.
+        unsafe { raw.add(HEADER_SIZE) }
+    }
+
+    /// SAFETY: caller is C++ `operator delete` and only passes
+    /// pointers previously returned by `etms_runtime_alloc`. Null
+    /// is tolerated (matches `delete nullptr`).
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn etms_runtime_free(ptr: *mut u8) {
+        if ptr.is_null() {
+            return;
+        }
+        // SAFETY: `ptr` came from `etms_runtime_alloc`, so backing
+        // up by `HEADER_SIZE` lands on the size header.
+        let header = unsafe { ptr.sub(HEADER_SIZE) };
+        // SAFETY: header slot was written during alloc. Same
+        // alignment story as the matching `write_unaligned`.
+        let size = unsafe { core::ptr::read_unaligned(header.cast::<usize>()) };
+        let Ok(layout) = Layout::from_size_align(size + HEADER_SIZE, ALIGN) else {
+            return;
+        };
+        // SAFETY: `header` + `layout` matches the original allocation.
+        unsafe { rust_dealloc(header, layout) };
+    }
+}
+
 /// bindgen-generated `extern "C"` declarations for the C-ABI shim.
 mod ffi {
     // The shim header is pure C and uses only `<stdint.h>` and

--- a/crates/esp-tflite-micro-sys/src/lib.rs
+++ b/crates/esp-tflite-micro-sys/src/lib.rs
@@ -74,12 +74,18 @@ mod runtime {
 
     use alloc::alloc::{alloc as rust_alloc, dealloc as rust_dealloc};
 
-    /// Width of the size-header prefix prepended to every allocation.
-    const HEADER_SIZE: usize = core::mem::size_of::<usize>();
     /// 16-byte alignment is `max_align_t` on xtensa-esp32s3 (covers
     /// `double` + pointer pair) — the strictest alignment any
     /// C++-side `operator new` call could need.
     const ALIGN: usize = 16;
+    /// Width of the size-header slot prepended to every allocation,
+    /// padded to `ALIGN` so the user-visible pointer returned by
+    /// `etms_runtime_alloc` (`raw + HEADER_SIZE`) inherits the
+    /// raw allocation's 16-byte alignment. A bare
+    /// `size_of::<usize>()` (4 bytes on this target) would land
+    /// 8- and 16-byte C++ allocations on a 4-byte boundary and
+    /// trip `LoadStoreAlignmentCause` on `double` / SIMD loads.
+    const HEADER_SIZE: usize = ALIGN;
 
     /// SAFETY: the only caller is C++ `operator new` in
     /// `runtime_stubs.cpp`. Returns null on alloc failure to match
@@ -105,6 +111,21 @@ mod runtime {
         unsafe { core::ptr::write_unaligned(raw.cast::<usize>(), size) };
         // SAFETY: `raw + HEADER_SIZE` is inside the allocation.
         unsafe { raw.add(HEADER_SIZE) }
+    }
+
+    /// C++ `abort()` landing pad — TFLM's `TFLITE_DCHECK_*` macros
+    /// route here on assertion failure. Surface a `panic!` so the
+    /// firmware's panic handler emits a defmt trace over the
+    /// USB-Serial-JTAG before halting; without this the C++ side
+    /// spin-loops with no diagnostic and any TFLM programmer error
+    /// looks indistinguishable from a hang.
+    #[unsafe(no_mangle)]
+    #[allow(
+        clippy::panic,
+        reason = "deliberate panic — routes TFLM's abort() through the firmware's defmt panic handler"
+    )]
+    pub extern "C" fn etms_runtime_abort() -> ! {
+        panic!("esp-tflite-micro-sys: C++ abort() reached (likely TFLITE_DCHECK)");
     }
 
     /// SAFETY: caller is C++ `operator delete` and only passes

--- a/crates/esp-tflite-micro-sys/src/runtime_stubs.cpp
+++ b/crates/esp-tflite-micro-sys/src/runtime_stubs.cpp
@@ -1,0 +1,112 @@
+// Bare-metal runtime stubs for the few C / C++ symbols TFLM references
+// when we cut libstdc++ out of the link line and run on `-nodefaultlibs`.
+//
+// Compilation flags in `build.rs` set `-fno-exceptions` and
+// `-fno-rtti`; `cpp_link_stdlib(None)` keeps cc-rs from auto-linking
+// `libstdc++.a`. That leaves three classes of unresolved symbol:
+//
+// 1. `abort()` — `TFLITE_DCHECK_*` macros expand to it. Real
+//    triggering would be a programmer bug in TFLM; nothing on the
+//    detection-path can hit it under normal operation.
+// 2. `operator new` / `operator delete` — TFLM uses these for shim-
+//    side internal control structures (the interpreter's per-op
+//    state allocators). Routes through the firmware's `esp-alloc`-
+//    backed global allocator via Rust-side `extern "C"` helpers so
+//    everything lands in the same heap.
+// 3. C++ ABI guards for static-local init (`__cxa_guard_acquire` /
+//    `__cxa_guard_release`). TFLM has a few constexpr-shaped static
+//    locals that the compiler conservatively wraps in guards even
+//    though they're trivially constructible. Single-threaded sema
+//    suffices.
+
+#include <cstddef>
+#include <new>
+
+// The `std::nothrow` global tag object. With libstdc++ pulled out of
+// the link, the C++ ABI's well-known instance is unresolved; provide
+// it ourselves. `nothrow_t` is an empty struct so the storage is
+// zero-sized and the address is the only thing that matters.
+namespace std {
+const nothrow_t nothrow{};
+}  // namespace std
+
+extern "C" {
+
+// Rust-side allocator bridge — implemented in `lib.rs`. Lets the C++
+// `operator new` route through `esp-alloc` so PSRAM is the backing
+// store for both Rust `Vec` and C++ `new`. Without this, we'd need
+// to give TFLM its own arena, which would fragment heap usage.
+void* etms_runtime_alloc(std::size_t size);
+void etms_runtime_free(void* ptr);
+
+// Replace newlib's abort. `noreturn` keeps GCC from flagging code that
+// follows a call as unreachable-warning material; `noinline` keeps the
+// stub out of TFLM's hot paths if the optimiser ever decides to inline.
+[[noreturn]] __attribute__((noinline)) void abort() {
+  while (true) {
+    __asm__ volatile("nop");
+  }
+}
+
+// C++ ABI guards for thread-safe static-local initialization. We are
+// single-threaded with respect to TFLM construction (the wake-word
+// task constructs the interpreter once at boot before any other code
+// can race), so a no-op suffices. `__cxa_guard_acquire` returns
+// non-zero to indicate "uninitialized — please initialize"; we cache
+// the guard variable's first byte so subsequent acquisitions skip
+// initialization.
+int __cxa_guard_acquire(char* guard) {
+  if (*guard) {
+    return 0;
+  }
+  return 1;
+}
+
+void __cxa_guard_release(char* guard) { *guard = 1; }
+
+void __cxa_guard_abort(char* /*guard*/) {
+  // No-op: an abort path during static-local init can't happen
+  // without exceptions enabled.
+}
+
+// Pure-virtual call landing pad. The compiler emits references to
+// `__cxa_pure_virtual` in vtables for abstract classes; reaching one
+// at runtime would indicate a TFLM bug.
+[[noreturn]] void __cxa_pure_virtual() { abort(); }
+
+}  // extern "C"
+
+// Global C++ allocation operators. TFLM with `-fno-exceptions` never
+// throws `std::bad_alloc`, so the `nothrow` and throwing forms can
+// share an implementation. All four overloads route through the same
+// Rust-side bridge so heap accounting is unified.
+
+void* operator new(std::size_t size) { return etms_runtime_alloc(size); }
+void* operator new[](std::size_t size) { return etms_runtime_alloc(size); }
+void operator delete(void* ptr) noexcept { etms_runtime_free(ptr); }
+void operator delete[](void* ptr) noexcept { etms_runtime_free(ptr); }
+// Sized-delete overloads (C++14). The size hint is informational; we
+// ignore it because the underlying allocator already tracks block
+// sizes.
+void operator delete(void* ptr, std::size_t /*size*/) noexcept {
+  etms_runtime_free(ptr);
+}
+void operator delete[](void* ptr, std::size_t /*size*/) noexcept {
+  etms_runtime_free(ptr);
+}
+
+// `new (std::nothrow) T` overloads — what the shim's
+// `ResolverImpl` / `InterpreterImpl` constructors actually call.
+// Allocation failure returns nullptr, matching the nothrow contract.
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+  return etms_runtime_alloc(size);
+}
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+  return etms_runtime_alloc(size);
+}
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
+  etms_runtime_free(ptr);
+}
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
+  etms_runtime_free(ptr);
+}

--- a/crates/esp-tflite-micro-sys/src/runtime_stubs.cpp
+++ b/crates/esp-tflite-micro-sys/src/runtime_stubs.cpp
@@ -32,17 +32,22 @@ const nothrow_t nothrow{};
 
 extern "C" {
 
-// Rust-side allocator bridge — implemented in `lib.rs`. Lets the C++
-// `operator new` route through `esp-alloc` so PSRAM is the backing
-// store for both Rust `Vec` and C++ `new`. Without this, we'd need
-// to give TFLM its own arena, which would fragment heap usage.
+// Rust-side bridge — implemented in `lib.rs`. The alloc/free pair
+// routes C++ `operator new` through `esp-alloc` so PSRAM is the
+// backing store for both Rust `Vec` and C++ `new`; `abort` surfaces
+// a `panic!` so the firmware's defmt panic handler emits a trace.
 void* etms_runtime_alloc(std::size_t size);
 void etms_runtime_free(void* ptr);
+[[noreturn]] void etms_runtime_abort();
 
-// Replace newlib's abort. `noreturn` keeps GCC from flagging code that
-// follows a call as unreachable-warning material; `noinline` keeps the
-// stub out of TFLM's hot paths if the optimiser ever decides to inline.
+// Replace newlib's abort with a Rust-panic trampoline. Reaching this
+// path indicates a TFLM `TFLITE_DCHECK_*` failure (corrupt model,
+// schema mismatch, out-of-bounds tensor index, …); the Rust panic
+// makes it diagnosable over USB-Serial-JTAG instead of an undiagnosed
+// hang. The trailing infinite loop is unreachable but keeps the
+// `[[noreturn]]` analysis happy.
 [[noreturn]] __attribute__((noinline)) void abort() {
+  etms_runtime_abort();
   while (true) {
     __asm__ volatile("nop");
   }


### PR DESCRIPTION
## Summary

The TFLM merges (#331/#334/#335/#336/#337) left main with a firmware that passed clippy but never successfully linked. CI's `Firmware cross-check` runs only `cargo clippy`, not `cargo build --release`, so the regression slipped past every PR until `just fmr` exposed it. This restores a flashable release build and adds the CI step that would have caught it.

Three concurrent root causes:

- **`call8: call target out of range`** for libgcc / libc symbols. Xtensa direct calls reach ±1 MiB; the TFLM C++ archive now spans past that to libgcc soft-float (`__divdf3`, `__extendsfdf2`, `__muldf3`) and libc (`memcpy`, `memset`, `strcmp`). ESP-IDF builds set `-mlongcalls` so GAS rewrites direct calls to indirect when out of range; `cc::Build` defaults don't. Add it in `build.rs`.
- **`_Unwind_*` / `pthread_*` / `__gxx_personality_v0` / `frexp` / `abort`** undefined. cc-rs auto-links `-lstdc++` on `b.cpp(true)`. With `-fno-exceptions -fno-rtti`, the C++ stdlib brings in machinery that can't run. Cut it with `cpp_link_stdlib(None)` and provide the minimum TFLM actually needs: `operator new` / `operator delete` overloads routed through `esp-alloc` via a Rust-side FFI bridge, plus `abort` and `__cxa_*` static-init guards. Add `-lm` for `frexp`.
- **CI never linked.** Add `cargo build --release` as a step in `Firmware cross-check (xtensa-esp32s3-none-elf)`.

## Test plan

- [x] `just check` — host gates clean
- [x] `just clippy-firmware` — strict firmware clippy
- [x] `cargo +esp build --release` — clean rebuild, 22.9 MB ELF
- [x] On-device: `just PORT=/dev/ttyACM2 fmr` reaches `boot complete — idle heartbeat` at 1.8 s. Wake-word task correctly idles (no SD model). Expected known-noise warnings only (BMI270 init retry, audio DMA pop, head MalformedResponse without servos powered).

Note: the diff includes `runtime_stubs.cpp` plus a `runtime` module in `esp-tflite-micro-sys/src/lib.rs` that bridges C++ `operator new`/`delete` through the Rust global allocator. This keeps TFLM's heap on the same `esp-alloc`-backed PSRAM heap as Rust `Vec`s rather than fragmenting heap usage with a separate arena.