### PR TITLE
feat(core): rounded-square eyes, smile-arc closed eye, gradient cheeks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ section summarises the milestone work in human terms.
 
 ### Avatar surface
 
+- Face primitives refresh. Open neutral eyes draw as filled rounded
+  squares instead of ellipses (corner radius scales with `eye_scale`
+  and clamps to half-height so mid-blink frames stay valid). Closed
+  eyes draw as a shallow upward "smile" arc instead of a flat line.
+  Cheeks paint as two concentric circles — an outer halo at 50% of
+  the requested blush plus an inner core at full blush — to fake a
+  soft radial gradient without alpha. Arc resolution lifts from a
+  17-point to a 25-point polyline so curved eyes / mouth read as
+  continuous. Default eye half-radius drops 25 → 20 px so the
+  rounded-square silhouette doesn't overpower the face; the matching
+  `FaceGeometry::Default` baseline moves with it.
 - On-screen battery indicator drawn in the top-left corner; opt-in
   via `behavior.battery_icon_enabled`. The percent reading is
   quantised into five buckets (Critical / Low / Medium / High /

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -8,9 +8,9 @@
 //! ## Palette
 //!
 //! - Background: `Rgb565::WHITE`.
-//! - Eyes: `Rgb565::BLACK`, either filled ellipses (when
-//!   [`Style::eye_curve`](crate::face::Style::eye_curve) is 0) or a
-//!   stroked polyline arc (otherwise).
+//! - Eyes: `palette.eye`. Filled rounded squares when open and
+//!   neutral ([`Style::eye_curve`](crate::face::Style::eye_curve) is 0);
+//!   stroked polyline arcs when curved (Happy / Sad) or closed (blink).
 //! - Mouth: from `palette.mouth`, either the v0.1.0 line/ellipse (when
 //!   [`Style::mouth_curve`](crate::face::Style::mouth_curve) is 0) or
 //!   a stroked polyline curve.
@@ -20,10 +20,10 @@
 //!
 //! ## Curves
 //!
-//! Arcs are drawn as a 17-point polyline sampled from a parabola
+//! Arcs are drawn as a 25-point polyline sampled from a parabola
 //! `y = cy + sag * (1 - u²)`, `u ∈ [-1, 1]`. Integer-only math keeps the
-//! code `no_std` without pulling in `libm`; at 320×240 the 17-segment
-//! polyline is visually indistinguishable from a continuous curve.
+//! code `no_std` without pulling in `libm`; at 320×240 the 24-segment
+//! polyline reads as a smooth continuous curve.
 
 use embedded_graphics::{
     Drawable,
@@ -33,7 +33,7 @@ use embedded_graphics::{
     pixelcolor::{Rgb565, RgbColor},
     primitives::{
         Circle, Ellipse, Line, Polyline, Primitive, PrimitiveStyle, PrimitiveStyleBuilder,
-        Rectangle,
+        Rectangle, RoundedRectangle,
     },
     text::{Alignment, Baseline, Text, TextStyleBuilder},
 };
@@ -79,13 +79,40 @@ const LINE_WIDTH: u32 = 3;
 /// so a ~50 px wide arc reads as strong as the filled-ellipse variant.
 const EYE_ARC_WIDTH: u32 = 5;
 
-/// Number of polyline segments used to approximate one parabolic arc.
-/// 16 segments (17 points) keeps the polyline well under embedded-graphics'
-/// scanline-iterator limits while reading as a smooth curve at 320×240.
-const ARC_SEGMENTS: i32 = 16;
+/// Divisor for the rounded-square eye corner radius: `corner = scaled_rx /
+/// EYE_CORNER_DIVISOR`. With the default 20 px half-width this gives a
+/// 10 px corner — half the half-side, which reads as a soft rounded square
+/// (clearly not a circle, clearly not a sharp rectangle).
+const EYE_CORNER_DIVISOR: u16 = 2;
 
-/// Cheek circle diameter, in pixels.
-const CHEEK_DIAMETER: u32 = 18;
+/// Sag divisor for the closed-eye smile arc: the arc lifts its midpoint
+/// `scaled_ry / CLOSED_EYE_SAG_DIVISOR` pixels above the eye centre.
+/// Picked so the closed eye reads clearly as a "smile-eye" arc but stays
+/// visibly shallower than the Happy expression's full `eye_curve` arc
+/// (whose sag is `~scaled_ry × eye_curve / 100`, peaking near `scaled_ry`
+/// at curve = 100).
+const CLOSED_EYE_SAG_DIVISOR: i32 = 2;
+
+/// Number of polyline segments used to approximate one parabolic arc.
+/// 24 segments (25 points) reads as a smooth continuous curve at 320×240
+/// while the 25-point stack buffer in `draw_parabolic_arc` stays a 200-byte
+/// blip on the embassy render task.
+const ARC_SEGMENTS: i32 = 24;
+
+/// Outer halo diameter for the cheek "blush", in pixels. The cheek is
+/// drawn as two concentric circles (outer halo + inner core) to fake a
+/// soft radial gradient without alpha or anti-aliasing.
+const CHEEK_OUTER_DIAMETER: u32 = 22;
+
+/// Inner core diameter for the cheek, in pixels. Drawn on top of the
+/// outer halo at full blush intensity, giving a darker centre that fades
+/// outward into the lighter halo.
+const CHEEK_INNER_DIAMETER: u32 = 12;
+
+/// Outer-halo intensity as a percentage of the requested `cheek_blush`.
+/// The halo paints at this fraction so it reads as a soft fade into white
+/// rather than a hard ring around the inner core.
+const CHEEK_HALO_INTENSITY_PCT: u32 = 50;
 
 /// Vertical gap between the bottom of an eye and the top of its cheek.
 const CHEEK_VERTICAL_GAP: i32 = 6;
@@ -616,9 +643,12 @@ where
 
 /// Draw one eye. Decision tree:
 ///
-/// 1. Closed phase, or `weight == 0`: horizontal closed-eye line (unchanged
-///    v0.1.0 behavior; curves don't apply when the lid is shut).
-/// 2. `curve == 0`: filled ellipse, with radii scaled by `eye_scale`.
+/// 1. Closed phase, or `weight == 0`: a shallow upward "smile" arc
+///    spanning the open eye's full width. Reads as a soft squinted /
+///    sleeping eye in the same family as the rounded-square open eye.
+/// 2. `curve == 0`: filled rounded square, with side lengths scaled by
+///    `eye_scale` and corner radius scaled proportionally so the look
+///    stays consistent across emotions.
 /// 3. Otherwise: a stroked parabolic arc. `curve > 0` (Happy) arches
 ///    upward, `curve < 0` (Sad) dips downward.
 #[allow(clippy::similar_names)] // `scaled_rx` / `scaled_ry` is the intended x/y pair.
@@ -637,11 +667,16 @@ where
     let height = scaled_height(scaled_ry, eye.weight);
 
     if matches!(eye.phase, EyePhase::Closed) || height == 0 {
-        return draw_horizontal_line(
+        // Shallow upward smile-arc. Negative sag lifts the midpoint
+        // above the baseline; endpoints stay at `eye.center.y` so the
+        // arc tucks into where the open eye's bottom edge used to be.
+        let sag = -i32::from(scaled_ry) / CLOSED_EYE_SAG_DIVISOR;
+        return draw_parabolic_arc(
             eye.center.x,
             eye.center.y,
             scaled_rx,
-            stroke(eye_color, LINE_WIDTH),
+            sag,
+            stroke(eye_color, EYE_ARC_WIDTH),
             target,
         );
     }
@@ -652,7 +687,14 @@ where
         let half_h = i32::from(height / 2);
         let top_left = EgPoint::new(eye.center.x - half_w, eye.center.y - half_h);
         let size = Size::new(u32::from(width), u32::from(height));
-        return Ellipse::new(top_left, size)
+        // Corner radius scales with the eye so the rounding ratio stays
+        // constant across `eye_scale` (Surprised stays as round-square as
+        // Neutral). The min-clamp against half-height keeps mid-blink
+        // frames valid: at low `weight` the rectangle is shorter than wide
+        // and a fixed corner would produce a degenerate shape.
+        let corner = u32::from(scaled_rx / EYE_CORNER_DIVISOR).min(u32::from(height / 2));
+        let corner_size = Size::new(corner, corner);
+        return RoundedRectangle::with_equal_corners(Rectangle::new(top_left, size), corner_size)
             .into_styled(fill(eye_color))
             .draw(target);
     }
@@ -763,11 +805,13 @@ fn audio_open_height(mouth_open: f32) -> u16 {
     rounded
 }
 
-/// Draw a cheek circle below `eye` with color blended between the
-/// palette background and the palette cheek colour by `blush`
-/// (0..=255). The blend lives in the palette's colour space rather
-/// than always-against-white so a `Dark` palette's cheek reads
-/// correctly against the black background.
+/// Draw a cheek below `eye` as two concentric circles: an outer halo
+/// painted at `CHEEK_HALO_INTENSITY_PCT` of the requested blush, then an
+/// inner core painted at full blush. The two-tone step approximates a
+/// soft radial gradient without needing alpha blending. Both rings
+/// blend in the palette's colour space (background → cheek) so a
+/// `Dark` palette reads correctly against its black background.
+#[allow(clippy::cast_possible_wrap)]
 fn draw_cheek<D>(
     eye: &Eye,
     blush: u8,
@@ -781,10 +825,26 @@ where
     let scaled_ry = scale_radius(eye.radius_y, eye_scale);
     let radius_signed = i32::from(scaled_ry);
     let cheek_top = eye.center.y + radius_signed + CHEEK_VERTICAL_GAP;
-    #[allow(clippy::cast_possible_wrap)]
-    let half = (CHEEK_DIAMETER / 2) as i32;
-    let top_left = EgPoint::new(eye.center.x - half, cheek_top);
-    Circle::new(top_left, CHEEK_DIAMETER)
+
+    let outer_half = (CHEEK_OUTER_DIAMETER / 2) as i32;
+    let outer_top_left = EgPoint::new(eye.center.x - outer_half, cheek_top);
+    let halo_blush =
+        u8::try_from(u32::from(blush) * CHEEK_HALO_INTENSITY_PCT / 100).unwrap_or(u8::MAX);
+    Circle::new(outer_top_left, CHEEK_OUTER_DIAMETER)
+        .into_styled(fill(blend_blush(
+            halo_blush,
+            palette.background,
+            palette.cheek,
+        )))
+        .draw(target)?;
+
+    // Inset the inner top-left so both circles share a centre. The inset
+    // is half the diameter difference; with 22 outer + 12 inner that's 5 px
+    // on each side.
+    let inner_half = (CHEEK_INNER_DIAMETER / 2) as i32;
+    let inset = ((CHEEK_OUTER_DIAMETER - CHEEK_INNER_DIAMETER) / 2) as i32;
+    let inner_top_left = EgPoint::new(eye.center.x - inner_half, cheek_top + inset);
+    Circle::new(inner_top_left, CHEEK_INNER_DIAMETER)
         .into_styled(fill(blend_blush(blush, palette.background, palette.cheek)))
         .draw(target)
 }
@@ -814,7 +874,7 @@ fn blend_blush(blush: u8, from: Rgb565, to: Rgb565) -> Rgb565 {
     )
 }
 
-/// Sample a parabolic arc into a stack-allocated 17-point polyline and
+/// Sample a parabolic arc into a stack-allocated 25-point polyline and
 /// draw it with `style`.
 ///
 /// `sag` is the vertical offset of the arc's midpoint relative to the

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -668,8 +668,8 @@ where
 
     if matches!(eye.phase, EyePhase::Closed) || height == 0 {
         // Shallow upward smile-arc. Negative sag lifts the midpoint
-        // above the baseline; endpoints stay at `eye.center.y` so the
-        // arc tucks into where the open eye's bottom edge used to be.
+        // above the baseline; endpoints stay at `eye.center.y` (the
+        // eye's vertical centre, same position as the old flat-line).
         let sag = -i32::from(scaled_ry) / CLOSED_EYE_SAG_DIVISOR;
         return draw_parabolic_arc(
             eye.center.x,

--- a/crates/stackchan-core/src/face.rs
+++ b/crates/stackchan-core/src/face.rs
@@ -264,13 +264,13 @@ impl FaceGeometry {
             Self::Default => (
                 EyeBaseline {
                     center: Point::new(100, 110),
-                    radius_x: 25,
-                    radius_y: 25,
+                    radius_x: 20,
+                    radius_y: 20,
                 },
                 EyeBaseline {
                     center: Point::new(220, 110),
-                    radius_x: 25,
-                    radius_y: 25,
+                    radius_x: 20,
+                    radius_y: 20,
                 },
                 MouthBaseline {
                     center: Point::new(160, 180),
@@ -468,16 +468,16 @@ impl Default for Face {
         Self {
             left_eye: Eye {
                 center: Point::new(100, 110),
-                radius_x: 25,
-                radius_y: 25,
+                radius_x: 20,
+                radius_y: 20,
                 phase: EyePhase::Open,
                 weight: 100,
                 open_weight: 100,
             },
             right_eye: Eye {
                 center: Point::new(220, 110),
-                radius_x: 25,
-                radius_y: 25,
+                radius_x: 20,
+                radius_y: 20,
                 phase: EyePhase::Open,
                 weight: 100,
                 open_weight: 100,

--- a/crates/stackchan-sim/tests/render_snapshot.rs
+++ b/crates/stackchan-sim/tests/render_snapshot.rs
@@ -15,7 +15,9 @@
 
 use embedded_graphics::pixelcolor::{Rgb565, RgbColor};
 use stackchan_core::modifiers::StyleFromEmotion;
-use stackchan_core::{BubbleState, Decorator, DecoratorState, Director, Emotion, Entity, Instant};
+use stackchan_core::{
+    BubbleState, Decorator, DecoratorState, Director, Emotion, Entity, EyePhase, Instant,
+};
 use stackchan_sim::Framebuffer;
 
 /// LCD canvas width the firmware targets.
@@ -32,7 +34,7 @@ fn default_avatar_renders_expected_pixels() {
         .expect("Framebuffer DrawTarget is Infallible");
 
     // Eye centers: default Entity places left eye at (100, 110), right at
-    // (220, 110), both filled black ellipses of radius 25.
+    // (220, 110), both filled black rounded squares of half-side 20.
     assert_eq!(fb.pixel(100, 110), Some(Rgb565::BLACK), "left eye center");
     assert_eq!(fb.pixel(220, 110), Some(Rgb565::BLACK), "right eye center");
 
@@ -290,6 +292,121 @@ fn bubble_overlay_handles_oversized_text() {
         .draw(&mut baseline)
         .expect("Framebuffer DrawTarget is Infallible");
     assert_ne!(fb.as_slice(), baseline.as_slice());
+}
+
+#[test]
+fn cheek_renders_two_tone_gradient_when_blush_set() {
+    // High blush so both rings paint clearly distinguishable colors:
+    // inner core at full intensity (≈ MOUTH_COLOR), outer halo at half
+    // intensity (a much lighter pink). Both must be non-white, and the
+    // two colors must differ.
+    let mut avatar = Entity::default();
+    avatar.face.style.cheek_blush = 200;
+
+    let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+    avatar
+        .face
+        .draw(&mut fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    // Cheek geometry under the LEFT eye at (100, 110) radius_y=20 with
+    // CHEEK_VERTICAL_GAP=6 → cheek_top = 136. Outer 22 px halo and inner
+    // 12 px core both centre on (100, 147).
+    let centre = fb.pixel(100, 147);
+    // (92, 147) is 8 px from the centre — well inside the 11 px halo and
+    // well outside the 6 px core.
+    let halo = fb.pixel(92, 147);
+
+    // (85, 147) is 15 px from the centre — outside the 11 px halo entirely,
+    // so it must be the white background.
+    assert_eq!(
+        fb.pixel(85, 147),
+        Some(Rgb565::WHITE),
+        "halo must not bleed past its 11 px radius"
+    );
+    assert_ne!(centre, Some(Rgb565::WHITE), "cheek core should be pink");
+    assert_ne!(halo, Some(Rgb565::WHITE), "cheek halo should be visible");
+    assert_ne!(
+        centre, halo,
+        "core and halo must paint distinguishable colors so the gradient reads as two-tone"
+    );
+}
+
+#[test]
+fn closed_eye_renders_as_upward_smile_arc() {
+    // Closed phase = an upward parabolic arc spanning the open eye's
+    // full width (40 px), apex lifted ~10 px above baseline. For the
+    // LEFT eye at (100, 110) radius 20 the curve runs from (80, 110)
+    // up through (100, 100) back to (120, 110), drawn with the same
+    // 5 px polyline stroke as the Happy/Sad eye_curve arcs. Polyline
+    // thick-stroke joins notch at the exact apex vertex, so the densest
+    // pixel sits one row below the geometric apex.
+    let mut avatar = Entity::default();
+    avatar.face.left_eye.phase = EyePhase::Closed;
+    avatar.face.right_eye.phase = EyePhase::Closed;
+
+    let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+    avatar
+        .face
+        .draw(&mut fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    assert_eq!(
+        fb.pixel(100, 101),
+        Some(Rgb565::BLACK),
+        "smile-arc apex stroke must be drawn one row below geometric apex"
+    );
+    assert_eq!(
+        fb.pixel(82, 110),
+        Some(Rgb565::BLACK),
+        "near-endpoint must sit on the baseline stroke"
+    );
+    assert_eq!(
+        fb.pixel(100, 110),
+        Some(Rgb565::WHITE),
+        "below the lifted arc must be background, not the old horizontal line"
+    );
+}
+
+#[test]
+fn open_eye_renders_as_rounded_square() {
+    // The open neutral eye is a 40×40 filled rounded rectangle with a
+    // 10 px corner radius. The bounding-box corner pixel (80, 90) sits
+    // outside the rounded corner's quarter-circle (distance from corner
+    // arc centre (90, 100) ≈ 14 px > 10 px radius), so it must be
+    // background. The corner-arc centre itself is firmly inside the
+    // shape and must be eye-black. This is what distinguishes a rounded
+    // square from a plain rectangle (where the corner pixel would be
+    // black) or an ellipse (where the bounding-box corner is also
+    // background but the centre arc shape differs).
+    let mut fb = Framebuffer::new(WIDTH, HEIGHT);
+    Entity::default()
+        .face
+        .draw(&mut fb)
+        .expect("Framebuffer DrawTarget is Infallible");
+
+    assert_eq!(
+        fb.pixel(80, 90),
+        Some(Rgb565::WHITE),
+        "bounding-box corner must be carved out by the 10 px rounded corner"
+    );
+    assert_eq!(
+        fb.pixel(90, 100),
+        Some(Rgb565::BLACK),
+        "rounded-corner arc centre must lie inside the shape"
+    );
+    // Side midpoints of the bounding box are flat edges of the rounded
+    // square — must be solidly inside.
+    assert_eq!(
+        fb.pixel(100, 90),
+        Some(Rgb565::BLACK),
+        "top edge midpoint must be inside the shape"
+    );
+    assert_eq!(
+        fb.pixel(80, 110),
+        Some(Rgb565::BLACK),
+        "left edge midpoint must be inside the shape"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Refresh the core face primitives. Open neutral eyes are now filled
  rounded squares (corner radius scales with `eye_scale`, clamps to
  half-height for mid-blink frames). Closed eyes are a shallow upward
  smile arc instead of a flat line. Cheeks fake a radial gradient
  with an outer halo at 50% blush plus an inner core at full blush.
- Lift arc resolution from a 17-point to a 25-point polyline so the
  curved eye / mouth arcs read as continuous at 320×240.
- Drop the default eye half-radius 25 → 20 px so the rounded-square
  silhouette doesn't overpower the face. `FaceGeometry::Default`'s
  baseline moves with it to keep the two sources of truth aligned.

Host-only: same draw target, same `Face::draw` signature, no
firmware-side touches. Visual change is global across all
`FaceGeometry` variants (they share `draw_eye` / `draw_cheek`).

## Test plan

- [x] `just check` — 466 host tests + clippy + fmt pass
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features`
- [x] New `render_snapshot` tests pin the new shapes: `open_eye_renders_as_rounded_square` checks the rounded-corner carve-out + flat-edge midpoints, `closed_eye_renders_as_upward_smile_arc` checks the apex stroke (one row below geometric apex — polyline thick-stroke join), `cheek_renders_two_tone_gradient_when_blush_set` checks core ≠ halo ≠ background
- [ ] On-device visual check