### PR TITLE
feat(firmware): sidecar bearer auth + per-device session id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,11 @@ Cargo.lock.bak
 /target/xtensa-esp32s3-none-elf/
 *.elf
 *.bin
+
+# Python tooling caches (Python lives under sidecar/)
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/

--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -56,6 +56,27 @@ pub static PTT_TRIGGER: Signal<CriticalSectionRawMutex, u32> = Signal::new();
 /// One frame is 20 ms at 16 kHz — see [`AUDIO_FRAME_SAMPLES`].
 const FRAME_MS: u64 = 20;
 
+/// Format 16 random bytes as a canonical RFC 4122 v4 UUID string
+/// (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`, lowercase hex).
+///
+/// Sets the version (4) nibble in byte 6 and the variant (10xx)
+/// nibble in byte 8 before serialising. The caller supplies the
+/// entropy — typically `esp_hal::rng::Rng` at boot — so this stays
+/// pure and host-testable.
+#[must_use]
+pub fn format_uuid_v4(mut bytes: [u8; 16]) -> String {
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    let mut out = String::with_capacity(36);
+    for (i, b) in bytes.iter().enumerate() {
+        let _ = write!(&mut out, "{b:02x}");
+        if matches!(i, 3 | 5 | 7 | 9) {
+            out.push('-');
+        }
+    }
+    out
+}
+
 /// TCP RX buffer for the sidecar socket. Headers + JSON response
 /// ride here; 2 KiB covers a typical OpenAI-Chat-Completions reply
 /// shape plus our `kai_emotion` extension with margin.
@@ -72,6 +93,13 @@ const TCP_TX_BYTES: usize = 4096;
 /// is malformed or hostile and we'd rather log + drop than blow
 /// stack or wait forever.
 const RESPONSE_MAX_BYTES: usize = 2048;
+
+/// Cap on the rendered request-header string. The baseline POST
+/// line plus `Host` / `Content-Type` / `Content-Length` /
+/// `Connection` fits well under 300 B; the headroom covers a long
+/// `Authorization: Bearer …` token (operator-supplied secret, up
+/// to ~256 chars) plus the fixed 36-char `X-Session-Id` value.
+const HEADER_CAPACITY: usize = 768;
 
 /// Cap on the captured PCM duration. Operator-driven windows beyond
 /// this are clamped — a 30 s upload at 16 kHz mono is ~960 KiB,
@@ -197,8 +225,21 @@ impl defmt::Format for PostError {
 ///
 /// `sidecar_url` is the operator-configured
 /// `behavior.agent_sidecar_url`. Empty / unparseable → park.
+///
+/// `bearer_token` is the operator-configured
+/// `behavior.agent_sidecar_token`. Empty disables the
+/// `Authorization: Bearer …` header (LAN-only mode).
+///
+/// `session_id` is the per-device identifier sent as `X-Session-Id`
+/// so the sidecar can scope conversation memory to this physical
+/// unit across requests. Hydrated at boot from `/sd/SESSION.UUID`.
 #[embassy_executor::task]
-pub async fn agent_sidecar_task(stack: Stack<'static>, sidecar_url: String) -> ! {
+pub async fn agent_sidecar_task(
+    stack: Stack<'static>,
+    sidecar_url: String,
+    bearer_token: String,
+    session_id: String,
+) -> ! {
     if sidecar_url.is_empty() {
         defmt::info!("agent-sidecar: url empty, idle");
         park_forever().await;
@@ -248,7 +289,15 @@ pub async fn agent_sidecar_task(stack: Stack<'static>, sidecar_url: String) -> !
 
         let outcome = embassy_time::with_timeout(
             Duration::from_millis(REQUEST_TIMEOUT_MS),
-            post_pcm(stack, &endpoint, &pcm, &mut rx_buf, &mut tx_buf),
+            post_pcm(
+                stack,
+                &endpoint,
+                &pcm,
+                &bearer_token,
+                &session_id,
+                &mut rx_buf,
+                &mut tx_buf,
+            ),
         )
         .await;
         apply_outcome(outcome);
@@ -369,6 +418,8 @@ async fn post_pcm(
     stack: Stack<'static>,
     endpoint: &SidecarEndpoint,
     pcm: &[i16],
+    bearer_token: &str,
+    session_id: &str,
     rx_buf: &mut [u8; TCP_RX_BYTES],
     tx_buf: &mut [u8; TCP_TX_BYTES],
 ) -> Result<(heapless::String<256>, Option<Emotion>), PostError> {
@@ -393,20 +444,30 @@ async fn post_pcm(
     })?;
 
     let body_len = pcm.len() * 2;
-    let mut header: heapless::String<512> = heapless::String::new();
+    let mut header: heapless::String<HEADER_CAPACITY> = heapless::String::new();
     write!(
         &mut header,
         "POST {} HTTP/1.1\r\n\
          Host: {}\r\n\
          Content-Type: audio/L16;rate=16000;channels=1\r\n\
          Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n",
+         Connection: close\r\n",
         endpoint.path.as_str(),
         endpoint.host_header.as_str(),
         body_len,
     )
     .map_err(|_| PostError::HeaderTooLong)?;
+    if !bearer_token.is_empty() {
+        write!(&mut header, "Authorization: Bearer {bearer_token}\r\n")
+            .map_err(|_| PostError::HeaderTooLong)?;
+    }
+    if !session_id.is_empty() {
+        write!(&mut header, "X-Session-Id: {session_id}\r\n")
+            .map_err(|_| PostError::HeaderTooLong)?;
+    }
+    header
+        .push_str("\r\n")
+        .map_err(|()| PostError::HeaderTooLong)?;
 
     socket
         .write_all(header.as_bytes())
@@ -650,5 +711,35 @@ mod tests {
             parse_http_response(raw),
             Err(PostError::BadStatus)
         ));
+    }
+
+    #[test]
+    fn format_uuid_v4_matches_canonical_layout() {
+        // Hyphen positions and the version/variant nibbles are
+        // load-bearing for downstream UUID parsers.
+        let bytes = [
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+            0xde, 0xf0,
+        ];
+        let uuid = format_uuid_v4(bytes);
+        assert_eq!(uuid.len(), 36);
+        assert_eq!(&uuid[14..15], "4", "version nibble must be 4");
+        let variant = uuid.as_bytes()[19];
+        assert!(
+            matches!(variant, b'8' | b'9' | b'a' | b'b'),
+            "variant nibble must be one of 8/9/a/b, got '{}'",
+            variant as char
+        );
+        for pos in [8, 13, 18, 23] {
+            assert_eq!(&uuid[pos..=pos], "-", "expected hyphen at position {pos}");
+        }
+    }
+
+    #[test]
+    fn format_uuid_v4_handles_zero_bytes() {
+        // All-zero entropy is the worst case: the formatter still
+        // has to inject the version + variant nibbles correctly.
+        let uuid = format_uuid_v4([0_u8; 16]);
+        assert_eq!(uuid, "00000000-0000-4000-8000-000000000000");
     }
 }

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1453,6 +1453,55 @@ async fn main(spawner: Spawner) -> ! {
         );
     }
 
+    // Per-device session identifier sent on every sidecar POST as
+    // `X-Session-Id`. Persisted as a canonical UUIDv4 in
+    // `/sd/SESSION.UUID` so the sidecar can scope conversation
+    // memory to this physical unit across reboots. First boot mints
+    // a fresh ID; SD-less boots get an ephemeral ID that rotates
+    // each cold start (degraded mode — the sidecar simply sees a
+    // new conversation each time).
+    let session_uuid: alloc::string::String = match storage::with_storage(
+        stackchan_firmware::storage::Storage::read_session_uuid,
+    )
+    .await
+    {
+        Some(Ok(Some(s))) if !s.is_empty() => {
+            defmt::info!("sidecar session: hydrated {=str}", s.as_str());
+            s
+        }
+        other => {
+            if let Some(Err(ref e)) = other {
+                defmt::warn!(
+                    "sidecar session: read /sd/SESSION.UUID failed ({}); minting fresh",
+                    e
+                );
+            }
+            let rng = Rng::new();
+            let mut bytes = [0_u8; 16];
+            for chunk in bytes.chunks_mut(4) {
+                chunk.copy_from_slice(&rng.random().to_le_bytes());
+            }
+            let minted = stackchan_firmware::agent_sidecar::format_uuid_v4(bytes);
+            match storage::with_storage(|s| s.write_session_uuid(&minted)).await {
+                Some(Ok(())) => {
+                    defmt::info!(
+                        "sidecar session: minted + persisted {=str}",
+                        minted.as_str()
+                    );
+                }
+                Some(Err(e)) => defmt::warn!(
+                    "sidecar session: persist failed ({}); ID will rotate next boot",
+                    e
+                ),
+                None => defmt::info!(
+                    "sidecar session: SD not mounted; ephemeral {=str}",
+                    minted.as_str()
+                ),
+            }
+            minted
+        }
+    };
+
     // Sidecar agent client — opt-in via
     // `behavior.agent_sidecar_url`. Empty URL parks the task; a
     // configured URL turns `POST /listen` into a PCM capture +
@@ -1462,6 +1511,8 @@ async fn main(spawner: Spawner) -> ! {
     if let Err(e) = spawner.spawn(stackchan_firmware::agent_sidecar::agent_sidecar_task(
         net_stack,
         net_config.behavior.agent_sidecar_url.clone(),
+        net_config.behavior.agent_sidecar_token.clone(),
+        session_uuid.clone(),
     )) {
         defmt::panic!(
             "spawn(agent_sidecar_task) failed: {}",

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -15,6 +15,7 @@
 //! [`Config`]: stackchan_net::Config
 //! [`Config::default`]: stackchan_net::Config::default
 
+use alloc::string::ToString as _;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
@@ -153,6 +154,25 @@ const WAKE_WORD_FILE: &str = "WAKE_WORD.tflite";
 /// newer architectures without inviting a 1 MiB binary on the SD
 /// card.
 const MAX_WAKE_WORD_BYTES: u32 = 256 * 1024;
+
+/// Filename for the persisted device session identifier. `UUIDv4`
+/// in the canonical 36-character hyphenated form, generated once on
+/// first boot and reused thereafter. Sent as the `X-Session-Id`
+/// header on every sidecar POST so the agent can scope conversation
+/// memory to this physical unit. Deleting the file rotates the
+/// session on next boot; copying it across SD cards preserves it.
+const SESSION_UUID_FILE: &str = "SESSION.UUID";
+
+/// Atomic-write staging name for the session UUID. Same staged-copy
+/// dance as the boot config — mid-write power loss leaves any prior
+/// `SESSION.UUID` intact.
+const SESSION_UUID_STAGING_FILE: &str = "SESSION.NEW";
+
+/// Cap on the `SESSION.UUID` file. Canonical `UUIDv4` is 36 bytes;
+/// the 64-byte ceiling absorbs an optional trailing newline plus a
+/// small margin for future identifier-format changes without
+/// unbounded SRAM allocation at boot.
+const MAX_SESSION_UUID_BYTES: u32 = 64;
 
 /// Filename for the operator-triggered camera capture. Single fixed
 /// name (no rotation) so each capture overwrites the previous —
@@ -367,6 +387,56 @@ where
     pub fn write_runtime(&mut self, rendered: &str) -> Result<(), StorageError> {
         self.write_file(RUNTIME_STAGING_FILE, rendered.as_bytes())?;
         self.copy_then_delete(RUNTIME_STAGING_FILE, RUNTIME_FILE)?;
+        Ok(())
+    }
+
+    /// Read `/sd/SESSION.UUID` as a trimmed UTF-8 string. Returns
+    /// `Ok(None)` if the file is absent — first-boot state, not an
+    /// error. Caller decides whether to generate + persist a fresh
+    /// identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Read`] on a partial / failed read,
+    /// [`StorageError::TooLarge`] if the file exceeds
+    /// [`MAX_SESSION_UUID_BYTES`], [`StorageError::NotUtf8`] if the
+    /// bytes don't decode as UTF-8.
+    pub fn read_session_uuid(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(file) = root.open_file_in_dir(SESSION_UUID_FILE, Mode::ReadOnly) else {
+            return Ok(None);
+        };
+        let len = file.length();
+        if len > MAX_SESSION_UUID_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = len as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+        let text = alloc::string::String::from_utf8(buf).map_err(|_| StorageError::NotUtf8)?;
+        Ok(Some(text.trim().to_string()))
+    }
+
+    /// Atomically replace `/sd/SESSION.UUID` with `uuid`. Same staging
+    /// dance as [`Self::write_config`] so a mid-write power loss
+    /// preserves any prior identifier.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying write failure,
+    /// [`StorageError::TooLarge`] if `uuid` exceeds
+    /// [`MAX_SESSION_UUID_BYTES`].
+    pub fn write_session_uuid(&mut self, uuid: &str) -> Result<(), StorageError> {
+        if uuid.len() > MAX_SESSION_UUID_BYTES as usize {
+            return Err(StorageError::TooLarge);
+        }
+        self.write_file(SESSION_UUID_STAGING_FILE, uuid.as_bytes())?;
+        self.copy_then_delete(SESSION_UUID_STAGING_FILE, SESSION_UUID_FILE)?;
         Ok(())
     }
 

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -152,6 +152,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     );
     push_field(
         &mut out,
+        "        agent_sidecar_token",
+        &config.behavior.agent_sidecar_token,
+    );
+    push_field(
+        &mut out,
         "        follower_leader_hostname",
         &config.behavior.follower_leader_hostname,
     );
@@ -533,6 +538,7 @@ impl<'a> Parser<'a> {
         let mut auto_torque_release_ms: Option<u32> = None;
         let mut audio_debug_udp_target: Option<String> = None;
         let mut agent_sidecar_url: Option<String> = None;
+        let mut agent_sidecar_token: Option<String> = None;
         let mut follower_leader_hostname: Option<String> = None;
         let mut wake_word_enabled: Option<bool> = None;
         let mut wake_word_threshold: Option<i8> = None;
@@ -554,6 +560,7 @@ impl<'a> Parser<'a> {
                 "auto_torque_release_ms" => auto_torque_release_ms = Some(self.parse_u32()?),
                 "audio_debug_udp_target" => audio_debug_udp_target = Some(self.parse_string()?),
                 "agent_sidecar_url" => agent_sidecar_url = Some(self.parse_string()?),
+                "agent_sidecar_token" => agent_sidecar_token = Some(self.parse_string()?),
                 "follower_leader_hostname" => {
                     follower_leader_hostname = Some(self.parse_string()?);
                 }
@@ -575,6 +582,7 @@ impl<'a> Parser<'a> {
             auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
             audio_debug_udp_target: audio_debug_udp_target.unwrap_or_default(),
             agent_sidecar_url: agent_sidecar_url.unwrap_or_default(),
+            agent_sidecar_token: agent_sidecar_token.unwrap_or_default(),
             follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
@@ -1025,6 +1033,23 @@ mod tests {
         let reparsed = parse_ron_bare(&rendered).unwrap();
         assert_eq!(cfg, reparsed);
         assert_eq!(reparsed.auth.token, "abc-123");
+    }
+
+    #[test]
+    fn round_trips_with_agent_sidecar_token() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                behavior: ( agent_sidecar_token: "sk-sidecar-1234" ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        let rendered = render_ron_bare(&cfg).unwrap();
+        let reparsed = parse_ron_bare(&rendered).unwrap();
+        assert_eq!(cfg, reparsed);
+        assert_eq!(reparsed.behavior.agent_sidecar_token, "sk-sidecar-1234");
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -40,6 +40,13 @@ pub const PSK_REDACTED: &str = "***";
 /// [`PSK_REDACTED`] — see [`merge_settings_with_current`].
 pub const TOKEN_REDACTED: &str = "***";
 
+/// Sentinel emitted in place of a non-empty `behavior.agent_sidecar_token` on render.
+///
+/// Same redaction + preserve-on-echo discipline as [`PSK_REDACTED`]
+/// and [`TOKEN_REDACTED`] — the sidecar bearer secret is just as
+/// sensitive as the AP PSK or the device auth token.
+pub const SIDECAR_TOKEN_REDACTED: &str = "***";
+
 /// Sentinel emitted in place of a non-empty `esp_now.pmk_hex` /
 /// `esp_now.lmk_hex` on render.
 ///
@@ -132,7 +139,14 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
             channel: new.esp_now.channel,
             tx_rate_hz: new.esp_now.tx_rate_hz,
         },
-        behavior: new.behavior,
+        behavior: BehaviorConfig {
+            agent_sidecar_token: if new.behavior.agent_sidecar_token == SIDECAR_TOKEN_REDACTED {
+                current.behavior.agent_sidecar_token.clone()
+            } else {
+                new.behavior.agent_sidecar_token
+            },
+            ..new.behavior
+        },
     }
 }
 
@@ -261,6 +275,16 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         &mut out,
         "agent_sidecar_url",
         &config.behavior.agent_sidecar_url,
+    );
+    out.push(',');
+    push_string_field(
+        &mut out,
+        "agent_sidecar_token",
+        if redact_secrets && !config.behavior.agent_sidecar_token.is_empty() {
+            SIDECAR_TOKEN_REDACTED
+        } else {
+            &config.behavior.agent_sidecar_token
+        },
     );
     out.push(',');
     push_string_field(
@@ -788,6 +812,7 @@ impl<'a> Parser<'a> {
         let mut auto_torque_release_ms: Option<u32> = None;
         let mut audio_debug_udp_target: Option<String> = None;
         let mut agent_sidecar_url: Option<String> = None;
+        let mut agent_sidecar_token: Option<String> = None;
         let mut follower_leader_hostname: Option<String> = None;
         let mut wake_word_enabled: Option<bool> = None;
         let mut wake_word_threshold: Option<i8> = None;
@@ -853,6 +878,12 @@ impl<'a> Parser<'a> {
                     }
                     agent_sidecar_url = Some(self.parse_string()?);
                 }
+                "agent_sidecar_token" => {
+                    if agent_sidecar_token.is_some() {
+                        return Err(bare_err("duplicate behavior field", "agent_sidecar_token"));
+                    }
+                    agent_sidecar_token = Some(self.parse_string()?);
+                }
                 "follower_leader_hostname" => {
                     if follower_leader_hostname.is_some() {
                         return Err(bare_err(
@@ -895,6 +926,7 @@ impl<'a> Parser<'a> {
             auto_torque_release_ms: auto_torque_release_ms.unwrap_or(0),
             audio_debug_udp_target: audio_debug_udp_target.unwrap_or_default(),
             agent_sidecar_url: agent_sidecar_url.unwrap_or_default(),
+            agent_sidecar_token: agent_sidecar_token.unwrap_or_default(),
             follower_leader_hostname: follower_leader_hostname.unwrap_or_default(),
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
@@ -1172,6 +1204,7 @@ mod tests {
                 auto_torque_release_ms: 30_000,
                 audio_debug_udp_target: "192.168.1.42:5005".to_string(),
                 agent_sidecar_url: "http://192.168.1.42:8080/v1/listen".to_string(),
+                agent_sidecar_token: "sk-sidecar-secret-1234".to_string(),
                 follower_leader_hostname: "kitchen-cat".to_string(),
                 wake_word_enabled: true,
                 wake_word_threshold: 95,
@@ -1363,6 +1396,48 @@ mod tests {
     }
 
     #[test]
+    fn render_redacts_agent_sidecar_token_when_requested() {
+        let original = full_config();
+        let rendered = render_settings_json(&original, true).unwrap();
+        assert!(
+            rendered.contains("\"agent_sidecar_token\":\"***\""),
+            "expected redacted agent_sidecar_token in: {rendered}"
+        );
+        assert!(
+            !rendered.contains("sk-sidecar-secret-1234"),
+            "agent_sidecar_token leaked through redaction: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_does_not_redact_empty_agent_sidecar_token() {
+        let mut cfg = full_config();
+        cfg.behavior.agent_sidecar_token = String::new();
+        let redacted = render_settings_json(&cfg, true).unwrap();
+        assert!(
+            redacted.contains("\"agent_sidecar_token\":\"\""),
+            "empty agent_sidecar_token should render as empty string: {redacted}"
+        );
+    }
+
+    #[test]
+    fn merge_substitutes_redacted_agent_sidecar_token_with_current() {
+        let current = full_config();
+        let new = Config {
+            behavior: BehaviorConfig {
+                agent_sidecar_token: SIDECAR_TOKEN_REDACTED.to_string(),
+                ..current.behavior.clone()
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert_eq!(
+            merged.behavior.agent_sidecar_token,
+            "sk-sidecar-secret-1234"
+        );
+    }
+
+    #[test]
     fn merge_overwrites_explicit_value() {
         let current = full_config();
         let new = Config {
@@ -1498,6 +1573,7 @@ mod tests {
                 auto_torque_release_ms: 30_000,
                 audio_debug_udp_target: "192.168.1.42:5005".to_string(),
                 agent_sidecar_url: "http://192.168.1.42:8080/v1/listen".to_string(),
+                agent_sidecar_token: "y".repeat(96),
                 follower_leader_hostname: "kitchen-cat".to_string(),
                 wake_word_enabled: true,
                 wake_word_threshold: -32,

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -348,6 +348,14 @@ pub struct BehaviorConfig {
     /// `docs/sidecar.md`. Hostname-only URLs are not resolved —
     /// use a raw IPv4 literal (mirrors `audio_debug_udp_target`).
     pub agent_sidecar_url: String,
+    /// Shared-secret bearer token presented to the agent sidecar
+    /// as `Authorization: Bearer <token>` on every POST. Empty
+    /// disables the header — pick that only when the sidecar is on
+    /// a trusted LAN with no other reachable callers. Wire-redacted
+    /// in `GET /settings` exactly like `wifi.psk` and `auth.token`:
+    /// the `"***"` sentinel echoed back on `PUT /settings` preserves
+    /// the persisted value.
+    pub agent_sidecar_token: String,
     /// mDNS hostname of another Stack-chan to mimic, as the bare
     /// first label (`"kitchen-cat"`, not the fully-qualified
     /// `"kitchen-cat.local"`). Empty disables follower mode.
@@ -405,6 +413,7 @@ impl Default for BehaviorConfig {
             auto_torque_release_ms: 0,
             audio_debug_udp_target: String::new(),
             agent_sidecar_url: String::new(),
+            agent_sidecar_token: String::new(),
             follower_leader_hostname: String::new(),
             wake_word_enabled: false,
             wake_word_threshold: 100,

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -610,6 +610,38 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
     if config.behavior.wake_word_arena_kib == 0 {
         return Err(ConfigError::InvalidWakeWordArenaKib);
     }
+    validate_agent_sidecar_token(&config.behavior.agent_sidecar_token)?;
+    Ok(())
+}
+
+/// Cap on the bearer-token byte length the firmware will accept.
+///
+/// The firmware sizes its per-request header buffer to absorb the
+/// baseline POST line + `Host` + `Content-Type` + `Content-Length` +
+/// `Connection: close` + the fixed-size `X-Session-Id` line, leaving
+/// ~256 bytes for the bearer token. Reject anything above that at
+/// config time so the operator gets immediate feedback instead of
+/// silent per-POST `HeaderTooLong` failures after a `PUT /settings`.
+const AGENT_SIDECAR_TOKEN_MAX_BYTES: usize = 256;
+
+/// Reject sidecar tokens that would corrupt or oversize the HTTP
+/// request.
+///
+/// Empty + the redaction sentinel (`"***"`) short-circuit — those
+/// are the documented "no auth" and "preserve current" wire
+/// markers. Otherwise the token must be ASCII-control-free (so it
+/// can't inject extra headers via embedded `\r\n`) and fit within
+/// [`AGENT_SIDECAR_TOKEN_MAX_BYTES`].
+fn validate_agent_sidecar_token(token: &str) -> Result<(), ConfigError> {
+    if token.is_empty() || token == "***" {
+        return Ok(());
+    }
+    if token.len() > AGENT_SIDECAR_TOKEN_MAX_BYTES {
+        return Err(ConfigError::AgentSidecarTokenTooLong(token.len()));
+    }
+    if token.chars().any(|c| c.is_ascii_control()) {
+        return Err(ConfigError::AgentSidecarTokenInvalidChars);
+    }
     Ok(())
 }
 
@@ -806,6 +838,38 @@ mod tests {
             validate(&c),
             Err(ConfigError::InvalidWakeWordArenaKib)
         ));
+    }
+
+    #[test]
+    fn validate_rejects_agent_sidecar_token_too_long() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.behavior.agent_sidecar_token = "x".repeat(AGENT_SIDECAR_TOKEN_MAX_BYTES + 1);
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::AgentSidecarTokenTooLong(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_agent_sidecar_token_with_crlf() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.behavior.agent_sidecar_token = "good-token\r\nX-Pwned: 1".to_string();
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::AgentSidecarTokenInvalidChars)
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_empty_or_redaction_sentinel_agent_sidecar_token() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.behavior.agent_sidecar_token = String::new();
+        assert!(validate(&c).is_ok());
+        c.behavior.agent_sidecar_token = "***".to_string();
+        assert!(validate(&c).is_ok());
     }
 
     #[test]

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -130,4 +130,23 @@ pub enum ConfigError {
     /// the failure.
     #[error("behavior.wake_word_arena_kib must be >= 1; got 0")]
     InvalidWakeWordArenaKib,
+
+    /// `behavior.agent_sidecar_token` exceeded the per-request HTTP
+    /// header budget. The firmware's request-header buffer is sized
+    /// to absorb a long bearer secret plus the fixed `X-Session-Id`
+    /// line; tokens above this cap would silently fail every POST
+    /// with `HeaderTooLong`. Reject at validation time so the
+    /// operator sees the failure on `PUT /settings` instead of
+    /// after the next push-to-talk.
+    #[error("behavior.agent_sidecar_token must be <= 256 bytes; got {0}")]
+    AgentSidecarTokenTooLong(usize),
+
+    /// `behavior.agent_sidecar_token` contained an ASCII control
+    /// character (CR, LF, tab, NUL, …). Embedding `\r\n` in the
+    /// token would split the HTTP request header section and inject
+    /// an arbitrary header line into the upstream sidecar POST —
+    /// reject at validation time so the corrupt value never reaches
+    /// the wire.
+    #[error("behavior.agent_sidecar_token contains an ASCII control character")]
+    AgentSidecarTokenInvalidChars,
 }

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -63,12 +63,14 @@ The firmware clamps capture at 30 s to keep PSRAM allocation
 bounded.
 
 `Authorization` is only sent when `agent_sidecar_token` is set.
-`X-Session-Id` is always sent — it carries a canonical UUIDv4 the
-firmware mints on first boot and persists to `/sd/SESSION.UUID`.
-Sidecars that care about multi-turn context key memory off this
-value; sidecars that don't can ignore it. Deleting the file
-rotates the identifier; copying it across SD cards preserves it.
-SD-less boots get a fresh ephemeral ID per cold start.
+`X-Session-Id` is sent on every healthy boot — it carries a
+canonical UUIDv4 the firmware mints on first boot and persists to
+`/sd/SESSION.UUID`. The send-side guard skips the header if the
+hydrated value is empty (it never is in practice). Sidecars that
+care about multi-turn context key memory off this value; sidecars
+that don't can ignore it. Deleting the file rotates the identifier;
+copying it across SD cards preserves it. SD-less boots get a fresh
+ephemeral ID per cold start.
 
 ### Response (sidecar → firmware)
 

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -13,11 +13,13 @@ URL.
 
 ## Enabling the agent
 
-Set `behavior.agent_sidecar_url` in `STACKCHAN.RON`:
+Set `behavior.agent_sidecar_url` (and optionally `behavior.agent_sidecar_token`)
+in `STACKCHAN.RON`:
 
 ```ron
 behavior: (
     agent_sidecar_url: "http://192.168.1.42:8080/v1/listen",
+    agent_sidecar_token: "sk-sidecar-shared-secret",
     // ...other behavior flags...
 )
 ```
@@ -30,6 +32,14 @@ without a sidecar configured.
 Hostnames are not resolved. Use a raw IPv4 literal — same shape as
 `audio_debug_udp_target`. DNS support is a future extension.
 
+`agent_sidecar_token` is the shared-secret bearer token presented
+to the sidecar as `Authorization: Bearer <token>` on every POST.
+Empty disables the header — only safe on a fully trusted LAN where
+no other host can reach the sidecar. The token is wire-redacted on
+`GET /settings` (echoed as `"***"`) and round-trips losslessly
+through `PUT /settings` when the operator submits the same
+sentinel.
+
 ## Wire protocol
 
 ### Request (firmware → sidecar)
@@ -40,6 +50,8 @@ Host: 192.168.1.42:8080
 Content-Type: audio/L16;rate=16000;channels=1
 Content-Length: <n>
 Connection: close
+Authorization: Bearer sk-sidecar-shared-secret
+X-Session-Id: 7f3c2a1d-9b40-4e8a-93f1-2bc6d4e1a7f0
 
 <n bytes of raw little-endian s16 PCM @ 16 kHz mono>
 ```
@@ -49,6 +61,14 @@ The capture window length is set by the `duration_ms` field of the
 Default is the same 3 000 ms the cosmetic listen modifier uses.
 The firmware clamps capture at 30 s to keep PSRAM allocation
 bounded.
+
+`Authorization` is only sent when `agent_sidecar_token` is set.
+`X-Session-Id` is always sent — it carries a canonical UUIDv4 the
+firmware mints on first boot and persists to `/sd/SESSION.UUID`.
+Sidecars that care about multi-turn context key memory off this
+value; sidecars that don't can ignore it. Deleting the file
+rotates the identifier; copying it across SD cards preserves it.
+SD-less boots get a fresh ephemeral ID per cold start.
 
 ### Response (sidecar → firmware)
 


### PR DESCRIPTION
## Summary

- Every sidecar POST now carries `Authorization: Bearer <token>` (when `behavior.agent_sidecar_token` is set) and `X-Session-Id: <uuid>` so the operator's agent can authenticate the firmware *and* scope conversation memory to this physical unit across reboots.
- `agent_sidecar_token` lands in `BehaviorConfig` with the same `"***"` round-trip redaction as `wifi.psk` and `auth.token`; the JSON parser, RON parser, renderer, and `merge_settings_with_current` all handle the sentinel.
- Session identifier is a canonical UUIDv4 persisted to `/sd/SESSION.UUID`. First boot mints it (via the chip RNG), reboots reuse it, SD-less boots fall back to an ephemeral ID per cold start. Deleting the file rotates the session; copying it across SD cards preserves it.
- Header buffer bumped from 512 → 768 bytes to absorb a long bearer token plus the 36-char UUID without tripping `HeaderTooLong`.
- `docs/sidecar.md` documents both new headers, the token-redaction behavior, and the SD-less degraded mode.

This unblocks the v0 sidecar work (multi-turn memory keyed off `X-Session-Id`, auth gating on the operator-supplied bearer token).

## Test plan

- [x] `cargo test -p stackchan-net` — added redaction tests for `agent_sidecar_token` and a RON round-trip for the new field
- [x] `cargo clippy --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features` (intra-doc links resolve)
- [x] `cargo +esp clippy --release -- -D warnings` (firmware default features)
- [x] `cargo +esp clippy --all-features --release -- -D warnings` (firmware all features)
- [x] `cargo +esp build --release` (link gate — clippy doesn't catch link-time issues)
- [ ] On-device boot smoke after merge: confirm `sidecar session: minted + persisted <uuid>` on first boot, `sidecar session: hydrated <uuid>` on subsequent boots, and a POST with both headers reaches a `nc -l` listener