### PR TITLE
feat(sidecar): session memory + extra providers + Docker

### DIFF
--- a/sidecar/.dockerignore
+++ b/sidecar/.dockerignore
@@ -1,0 +1,16 @@
+.venv
+__pycache__
+*.pyc
+.mypy_cache
+.ruff_cache
+.pytest_cache
+tests/
+.env
+.env.example
+.git
+.gitignore
+dist/
+*.egg-info/
+Dockerfile
+docker-compose.yml
+systemd/

--- a/sidecar/.env.example
+++ b/sidecar/.env.example
@@ -1,2 +1,4 @@
 SIDECAR_BEARER_TOKEN=replace-me-with-a-long-random-token
 ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=
+DEEPGRAM_API_KEY=

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
+WORKDIR /app
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+COPY pyproject.toml uv.lock README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+
+FROM python:3.12-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libsndfile1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash --uid 10001 sidecar
+
+WORKDIR /app
+
+ENV PATH=/app/.venv/bin:$PATH \
+    PYTHONUNBUFFERED=1
+
+COPY --from=builder --chown=sidecar:sidecar /app/.venv /app/.venv
+COPY --chown=sidecar:sidecar src /app/src
+COPY --chown=sidecar:sidecar personas /app/personas
+
+USER sidecar
+
+EXPOSE 8080
+
+CMD ["python", "-m", "stackchan_sidecar"]

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -88,6 +88,58 @@ lines at the start of the file) — the sidecar strips it before sending the
 prompt to the model, so you can keep metadata next to the prompt without
 polluting it.
 
+## Provider selection
+
+Pick STT and LLM backends via `config.toml` (or env vars). Each provider has
+its own credential requirement.
+
+`stt_provider` — one of:
+
+- `faster_whisper` (default) — local CPU inference, no key required.
+- `openai` — OpenAI Whisper API. Requires `OPENAI_API_KEY`.
+- `deepgram` — Deepgram hosted STT. Requires `DEEPGRAM_API_KEY`.
+
+`llm_provider` — one of:
+
+- `anthropic` (default) — Claude via the Anthropic SDK. Requires `ANTHROPIC_API_KEY`.
+- `openai` — OpenAI chat completions with tool-use. Requires `OPENAI_API_KEY`.
+- `ollama` — local Ollama server. No key; uses `ollama_host` (default
+  `http://localhost:11434`). The model is instructed via system prompt to emit
+  a JSON object `{"short", "full", "emotion"}` rather than relying on tool-use,
+  which is still uneven across local models.
+
+`stt_model` and `llm_model` apply to whichever provider is selected.
+
+## Docker
+
+A multi-stage Dockerfile and a compose service for local dev:
+
+```bash
+docker compose up --build
+```
+
+`personas/` is bind-mounted read-only so you can edit prompts on the host
+without rebuilding. The HuggingFace model cache lives in a named volume
+(`hf-cache`) so faster-whisper weights survive container rebuilds.
+
+The runtime image installs `libsndfile1` for `faster-whisper`'s audio path,
+runs as a non-root `sidecar` user, and exposes `8080`.
+
+## systemd
+
+A user-service example lives at `systemd/stackchan-sidecar.service`. To
+install:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp systemd/stackchan-sidecar.service ~/.config/systemd/user/
+# edit paths inside the unit if your checkout is somewhere other than
+# ~/Git/stackchan-kai/sidecar
+systemctl --user daemon-reload
+systemctl --user enable --now stackchan-sidecar
+journalctl --user -u stackchan-sidecar -f
+```
+
 ## Quality gates
 
 ```bash

--- a/sidecar/config.example.toml
+++ b/sidecar/config.example.toml
@@ -5,3 +5,7 @@ llm_model = "claude-haiku-4-5"
 persona = "stack-chan"
 personas_dir = "./personas"
 log_level = "INFO"
+
+stt_provider = "faster_whisper"
+llm_provider = "anthropic"
+ollama_host = "http://localhost:11434"

--- a/sidecar/docker-compose.yml
+++ b/sidecar/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  sidecar:
+    build: .
+    ports:
+      - "8080:8080"
+    env_file: .env
+    volumes:
+      - ./personas:/app/personas:ro
+      - hf-cache:/root/.cache/huggingface
+    restart: unless-stopped
+
+volumes:
+  hf-cache: {}

--- a/sidecar/pyproject.toml
+++ b/sidecar/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "pydantic>=2.9",
     "pydantic-settings>=2.6",
     "anthropic>=0.39",
+    "openai>=1.50",
+    "httpx>=0.27",
     "faster-whisper>=1.0",
     "numpy>=1.26",
 ]

--- a/sidecar/src/stackchan_sidecar/__main__.py
+++ b/sidecar/src/stackchan_sidecar/__main__.py
@@ -1,19 +1,49 @@
 import uvicorn
 
 from .app import create_app
-from .config import load_settings
-from .llm.anthropic import AnthropicLLM
+from .config import Settings, load_settings
+from .llm import LLMProvider
 from .logging import setup_logging
-from .stt.faster_whisper import FasterWhisperSTT
+from .session_store import SessionStore
+from .stt import STTProvider
+
+
+def _build_stt(settings: Settings) -> STTProvider:
+    if settings.stt_provider == "openai":
+        from .stt.openai_whisper import OpenAIWhisperSTT
+
+        return OpenAIWhisperSTT(api_key=settings.openai_api_key, model=settings.stt_model)
+    if settings.stt_provider == "deepgram":
+        from .stt.deepgram import DeepgramSTT
+
+        return DeepgramSTT(api_key=settings.deepgram_api_key, model=settings.stt_model)
+    from .stt.faster_whisper import FasterWhisperSTT
+
+    return FasterWhisperSTT(model_name=settings.stt_model)
+
+
+def _build_llm(settings: Settings) -> LLMProvider:
+    if settings.llm_provider == "openai":
+        from .llm.openai import OpenAILLM
+
+        return OpenAILLM(api_key=settings.openai_api_key, model=settings.llm_model)
+    if settings.llm_provider == "ollama":
+        from .llm.ollama import OllamaLLM
+
+        return OllamaLLM(host=settings.ollama_host, model=settings.llm_model)
+    from .llm.anthropic import AnthropicLLM
+
+    return AnthropicLLM(api_key=settings.anthropic_api_key, model=settings.llm_model)
 
 
 def main() -> None:
     settings = load_settings()
     setup_logging(settings.log_level)
 
-    stt = FasterWhisperSTT(model_name=settings.stt_model)
-    llm = AnthropicLLM(api_key=settings.anthropic_api_key, model=settings.llm_model)
-    app = create_app(settings, stt, llm)
+    stt = _build_stt(settings)
+    llm = _build_llm(settings)
+    session_store = SessionStore()
+    app = create_app(settings, stt, llm, session_store)
 
     uvicorn.run(app, host=settings.host, port=settings.port, log_config=None)
 

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -1,5 +1,7 @@
 import logging
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, HTTPException, Request, status
@@ -9,6 +11,7 @@ from .auth import make_verifier
 from .config import Settings
 from .llm import SHORT_MAX, Emotion, LLMProvider
 from .personas import load_persona
+from .session_store import SessionStore, Turn, session_store_lifespan
 from .stt import STTProvider
 
 _LOG = logging.getLogger("stackchan_sidecar")
@@ -19,8 +22,16 @@ def create_app(
     settings: Settings,
     stt: STTProvider,
     llm: LLMProvider,
+    session_store: SessionStore | None = None,
 ) -> FastAPI:
-    app = FastAPI(title="stackchan-sidecar", version="0.1.0")
+    store = session_store if session_store is not None else SessionStore()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        async with session_store_lifespan(app, store):
+            yield
+
+    app = FastAPI(title="stackchan-sidecar", version="0.1.0", lifespan=lifespan)
     verify_bearer = make_verifier(settings.bearer_token)
 
     @app.get("/healthz")
@@ -108,8 +119,9 @@ def create_app(
             transcript = await stt.transcribe(body, sample_rate=16000)
             stt_ms = int((time.perf_counter() - t_stt0) * 1000)
 
+            history = store.get_history(session_id)
             t_llm0 = time.perf_counter()
-            reply = await llm.reply(transcript, persona, session_id)
+            reply = await llm.reply(transcript, persona, session_id, history)
             llm_ms = int((time.perf_counter() - t_llm0) * 1000)
         except HTTPException:
             raise
@@ -130,6 +142,11 @@ def create_app(
         short = reply.short[:SHORT_MAX].replace('"', "'")
         emotion = reply.emotion if isinstance(reply.emotion, Emotion) else Emotion.NEUTRAL
         total_ms = int((time.perf_counter() - t0) * 1000)
+
+        store.record(
+            session_id,
+            Turn(user=transcript, assistant=reply.full, emotion=emotion),
+        )
 
         _LOG.info(
             "listen.ok",

--- a/sidecar/src/stackchan_sidecar/config.py
+++ b/sidecar/src/stackchan_sidecar/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -19,8 +20,14 @@ class Settings(BaseSettings):
     personas_dir: Path = Path("./personas")
     log_level: str = "INFO"
 
+    stt_provider: Literal["faster_whisper", "openai", "deepgram"] = "faster_whisper"
+    llm_provider: Literal["anthropic", "openai", "ollama"] = "anthropic"
+    ollama_host: str = "http://localhost:11434"
+
     bearer_token: str = Field(default="", alias="SIDECAR_BEARER_TOKEN")
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
+    openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
+    deepgram_api_key: str = Field(default="", alias="DEEPGRAM_API_KEY")
 
 
 def load_settings() -> Settings:
@@ -30,9 +37,24 @@ def load_settings() -> Settings:
             "SIDECAR_BEARER_TOKEN is not set. Refusing to start without a bearer "
             "token — set it in .env or the process environment."
         )
-    if not settings.anthropic_api_key:
+    if settings.stt_provider == "openai" and not settings.openai_api_key:
         raise RuntimeError(
-            "ANTHROPIC_API_KEY is not set. Refusing to start without an Anthropic "
-            "API key — set it in .env or the process environment."
+            "OPENAI_API_KEY is required when stt_provider=openai. "
+            "Set it in .env or the process environment."
+        )
+    if settings.stt_provider == "deepgram" and not settings.deepgram_api_key:
+        raise RuntimeError(
+            "DEEPGRAM_API_KEY is required when stt_provider=deepgram. "
+            "Set it in .env or the process environment."
+        )
+    if settings.llm_provider == "anthropic" and not settings.anthropic_api_key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY is required when llm_provider=anthropic. "
+            "Set it in .env or the process environment."
+        )
+    if settings.llm_provider == "openai" and not settings.openai_api_key:
+        raise RuntimeError(
+            "OPENAI_API_KEY is required when llm_provider=openai. "
+            "Set it in .env or the process environment."
         )
     return settings

--- a/sidecar/src/stackchan_sidecar/llm/__init__.py
+++ b/sidecar/src/stackchan_sidecar/llm/__init__.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..session_store import Turn
 
 SHORT_MAX = 32
 """Width of the firmware's toast band. The `Reply.short` field MUST fit."""
@@ -33,4 +36,17 @@ class Reply:
 
 @runtime_checkable
 class LLMProvider(Protocol):
-    async def reply(self, transcript: str, persona: str, session_id: str) -> Reply: ...
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: "list[Turn] | None" = None,
+    ) -> Reply: ...
+
+
+def sanitize_short(text: str) -> str:
+    cleaned = text.replace('"', "'")
+    if len(cleaned) <= SHORT_MAX:
+        return cleaned
+    return cleaned[:SHORT_MAX].rstrip()

--- a/sidecar/src/stackchan_sidecar/llm/anthropic.py
+++ b/sidecar/src/stackchan_sidecar/llm/anthropic.py
@@ -1,8 +1,11 @@
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import anthropic
 
-from . import SHORT_MAX, Emotion, Reply
+from . import SHORT_MAX, Emotion, Reply, sanitize_short
+
+if TYPE_CHECKING:
+    from ..session_store import Turn
 
 _RESPOND_TOOL: dict[str, Any] = {
     "name": "respond",
@@ -48,15 +51,26 @@ class AnthropicLLM:
         self._model = model
         self._max_tokens = max_tokens
 
-    async def reply(self, transcript: str, persona: str, session_id: str) -> Reply:
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: "list[Turn] | None" = None,
+    ) -> Reply:
         _ = session_id
+        messages: list[dict[str, str]] = []
+        for turn in history or []:
+            messages.append({"role": "user", "content": turn.user})
+            messages.append({"role": "assistant", "content": turn.assistant})
+        messages.append({"role": "user", "content": transcript})
         response = await self._client.messages.create(
             model=self._model,
             system=persona,
             max_tokens=self._max_tokens,
             tools=[cast(Any, _RESPOND_TOOL)],
             tool_choice=cast(Any, {"type": "tool", "name": "respond"}),
-            messages=[{"role": "user", "content": transcript}],
+            messages=cast(Any, messages),
         )
         return _parse_response(response)
 
@@ -71,13 +85,6 @@ def _parse_response(response: Any) -> Reply:
         short_raw = str(raw.get("short", "")).strip()
         full_raw = str(raw.get("full", "")).strip() or short_raw
         emotion = Emotion.coerce(raw.get("emotion"))
-        short = _sanitize_short(short_raw)
+        short = sanitize_short(short_raw)
         return Reply(short=short, full=full_raw, emotion=emotion)
     raise ValueError("anthropic response did not include a respond tool_use block")
-
-
-def _sanitize_short(text: str) -> str:
-    cleaned = text.replace('"', "'")
-    if len(cleaned) <= SHORT_MAX:
-        return cleaned
-    return cleaned[:SHORT_MAX].rstrip()

--- a/sidecar/src/stackchan_sidecar/llm/ollama.py
+++ b/sidecar/src/stackchan_sidecar/llm/ollama.py
@@ -1,0 +1,64 @@
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import httpx
+
+from . import Emotion, Reply, sanitize_short
+
+if TYPE_CHECKING:
+    from ..session_store import Turn
+
+_LOG = logging.getLogger("stackchan_sidecar")
+
+
+class OllamaLLM:
+    def __init__(
+        self,
+        host: str = "http://localhost:11434",
+        model: str = "llama3.2:3b",
+        timeout_seconds: float = 60.0,
+    ) -> None:
+        self._host = host.rstrip("/")
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: "list[Turn] | None" = None,
+    ) -> Reply:
+        _ = session_id
+        messages: list[dict[str, str]] = [{"role": "system", "content": persona}]
+        for turn in history or []:
+            messages.append({"role": "user", "content": turn.user})
+            messages.append({"role": "assistant", "content": turn.assistant})
+        messages.append({"role": "user", "content": transcript})
+
+        async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+            response = await client.post(
+                f"{self._host}/api/chat",
+                json={
+                    "model": self._model,
+                    "messages": messages,
+                    "format": "json",
+                    "stream": False,
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        content = (payload.get("message") or {}).get("content", "") or ""
+        try:
+            raw = json.loads(content)
+        except json.JSONDecodeError:
+            _LOG.error("ollama.parse_failed", extra={"raw_content": content})
+            raise ValueError("ollama returned non-JSON content") from None
+
+        short_raw = str(raw.get("short", "")).strip()
+        full_raw = str(raw.get("full", "")).strip() or short_raw
+        emotion = Emotion.coerce(raw.get("emotion"))
+        short = sanitize_short(short_raw)
+        return Reply(short=short, full=full_raw, emotion=emotion)

--- a/sidecar/src/stackchan_sidecar/llm/openai.py
+++ b/sidecar/src/stackchan_sidecar/llm/openai.py
@@ -1,0 +1,100 @@
+import json
+from typing import TYPE_CHECKING, Any, cast
+
+import openai
+
+from . import SHORT_MAX, Emotion, Reply, sanitize_short
+
+if TYPE_CHECKING:
+    from ..session_store import Turn
+
+_RESPOND_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "respond",
+        "description": (
+            "Send your reply to the user. `short` is shown on the avatar's 32-char "
+            "toast band — it MUST be 32 characters or fewer. `full` is the longer "
+            "version logged server-side. `emotion` drives the avatar's face."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "short": {
+                    "type": "string",
+                    "maxLength": SHORT_MAX,
+                    "description": (
+                        "Reply for the avatar's 32-char toast band — must fit. "
+                        "No embedded double-quote characters."
+                    ),
+                },
+                "full": {
+                    "type": "string",
+                    "description": "Longer form of the reply, logged but not displayed.",
+                },
+                "emotion": {
+                    "type": "string",
+                    "enum": [e.value for e in Emotion],
+                    "description": "Face/voice emotion to render with the reply.",
+                },
+            },
+            "required": ["short", "full", "emotion"],
+        },
+    },
+}
+
+
+class OpenAILLM:
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gpt-4o-mini",
+        max_tokens: int = 400,
+    ) -> None:
+        self._client = openai.AsyncOpenAI(api_key=api_key)
+        self._model = model
+        self._max_tokens = max_tokens
+
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: "list[Turn] | None" = None,
+    ) -> Reply:
+        _ = session_id
+        messages: list[dict[str, str]] = [{"role": "system", "content": persona}]
+        for turn in history or []:
+            messages.append({"role": "user", "content": turn.user})
+            messages.append({"role": "assistant", "content": turn.assistant})
+        messages.append({"role": "user", "content": transcript})
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            messages=cast(Any, messages),
+            tools=cast(Any, [_RESPOND_TOOL]),
+            tool_choice=cast(Any, {"type": "function", "function": {"name": "respond"}}),
+        )
+        return _parse_response(response)
+
+
+def _parse_response(response: Any) -> Reply:
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        raise ValueError("openai response had no choices")
+    message = getattr(choices[0], "message", None)
+    tool_calls = getattr(message, "tool_calls", None) or []
+    if not tool_calls:
+        raise ValueError("openai response did not include a respond tool_call")
+    call = tool_calls[0]
+    fn = getattr(call, "function", None)
+    args_raw = getattr(fn, "arguments", None) or "{}"
+    try:
+        raw = json.loads(args_raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"openai tool_call arguments were not JSON: {e}") from e
+    short_raw = str(raw.get("short", "")).strip()
+    full_raw = str(raw.get("full", "")).strip() or short_raw
+    emotion = Emotion.coerce(raw.get("emotion"))
+    short = sanitize_short(short_raw)
+    return Reply(short=short, full=full_raw, emotion=emotion)

--- a/sidecar/src/stackchan_sidecar/session_store.py
+++ b/sidecar/src/stackchan_sidecar/session_store.py
@@ -1,0 +1,88 @@
+import asyncio
+import logging
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .llm import Emotion
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+_LOG = logging.getLogger("stackchan_sidecar")
+_SWEEP_INTERVAL_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class Turn:
+    user: str
+    assistant: str
+    emotion: Emotion
+
+
+@dataclass
+class SessionEntry:
+    last_seen: float
+    turns: list[Turn] = field(default_factory=list)
+
+
+class SessionStore:
+    def __init__(self, *, max_turns: int = 8, ttl_seconds: float = 600.0) -> None:
+        self._max_turns = max_turns
+        self._ttl_seconds = ttl_seconds
+        self._entries: dict[str, SessionEntry] = {}
+
+    def get_history(self, session_id: str) -> list[Turn]:
+        if not session_id:
+            return []
+        entry = self._entries.get(session_id)
+        if entry is None:
+            return []
+        entry.last_seen = time.monotonic()
+        return list(entry.turns)
+
+    def record(self, session_id: str, turn: Turn) -> None:
+        if not session_id:
+            return
+        entry = self._entries.get(session_id)
+        if entry is None:
+            entry = SessionEntry(last_seen=time.monotonic())
+            self._entries[session_id] = entry
+        entry.turns.append(turn)
+        while len(entry.turns) > self._max_turns:
+            entry.turns.pop(0)
+        entry.last_seen = time.monotonic()
+
+    def sweep(self) -> int:
+        now = time.monotonic()
+        expired = [sid for sid, e in self._entries.items() if now - e.last_seen > self._ttl_seconds]
+        for sid in expired:
+            del self._entries[sid]
+        return len(expired)
+
+
+async def _sweeper_loop(store: SessionStore) -> None:
+    while True:
+        try:
+            await asyncio.sleep(_SWEEP_INTERVAL_SECONDS)
+            removed = store.sweep()
+            if removed:
+                _LOG.info("session_store.sweep", extra={"removed": removed})
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _LOG.exception("session_store.sweep_failed")
+
+
+@asynccontextmanager
+async def session_store_lifespan(app: "FastAPI", store: SessionStore) -> AsyncIterator[None]:
+    _ = app
+    task = asyncio.create_task(_sweeper_loop(store))
+    try:
+        yield
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/sidecar/src/stackchan_sidecar/stt/deepgram.py
+++ b/sidecar/src/stackchan_sidecar/stt/deepgram.py
@@ -1,0 +1,43 @@
+import httpx
+
+_ENDPOINT = "https://api.deepgram.com/v1/listen"
+
+
+class DeepgramSTT:
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "nova-2",
+        language: str = "en",
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._language = language
+        self._timeout_seconds = timeout_seconds
+
+    async def transcribe(self, pcm: bytes, sample_rate: int = 16000) -> str:
+        if not pcm:
+            return ""
+        headers = {
+            "Authorization": f"Token {self._api_key}",
+            "Content-Type": f"audio/L16;rate={sample_rate};channels=1",
+        }
+        params = {"model": self._model, "language": self._language}
+        async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+            response = await client.post(
+                _ENDPOINT,
+                headers=headers,
+                params=params,
+                content=pcm,
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        channels = (payload.get("results") or {}).get("channels") or []
+        if not channels:
+            return ""
+        alternatives = channels[0].get("alternatives") or []
+        if not alternatives:
+            return ""
+        return str(alternatives[0].get("transcript", "")).strip()

--- a/sidecar/src/stackchan_sidecar/stt/openai_whisper.py
+++ b/sidecar/src/stackchan_sidecar/stt/openai_whisper.py
@@ -1,0 +1,31 @@
+import io
+import wave
+
+import openai
+
+
+def _pcm_to_wav(pcm: bytes, sample_rate: int) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(pcm)
+    return buf.getvalue()
+
+
+class OpenAIWhisperSTT:
+    def __init__(self, api_key: str, model: str = "whisper-1") -> None:
+        self._client = openai.AsyncOpenAI(api_key=api_key)
+        self._model = model
+
+    async def transcribe(self, pcm: bytes, sample_rate: int = 16000) -> str:
+        if not pcm:
+            return ""
+        wav_bytes = _pcm_to_wav(pcm, sample_rate)
+        response = await self._client.audio.transcriptions.create(
+            model=self._model,
+            file=("audio.wav", wav_bytes, "audio/wav"),
+            language="en",
+        )
+        return (getattr(response, "text", "") or "").strip()

--- a/sidecar/systemd/stackchan-sidecar.service
+++ b/sidecar/systemd/stackchan-sidecar.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=stackchan-kai voice agent sidecar
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Git/stackchan-kai/sidecar
+EnvironmentFile=%h/Git/stackchan-kai/sidecar/.env
+Environment=PATH=%h/Git/stackchan-kai/sidecar/.venv/bin
+ExecStart=%h/Git/stackchan-kai/sidecar/.venv/bin/python -m stackchan_sidecar
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/sidecar/tests/conftest.py
+++ b/sidecar/tests/conftest.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from stackchan_sidecar.app import create_app
 from stackchan_sidecar.config import Settings
 from stackchan_sidecar.llm import Emotion, Reply
+from stackchan_sidecar.session_store import Turn
 
 TEST_TOKEN = "test-token-do-not-use-in-prod"
 
@@ -28,10 +29,16 @@ class FakeLLM:
             full="Hi friend! Lovely to meet you.",
             emotion=Emotion.HAPPY,
         )
-        self.calls: list[tuple[str, str, str]] = []
+        self.calls: list[tuple[str, str, str, list[Turn]]] = []
 
-    async def reply(self, transcript: str, persona: str, session_id: str) -> Reply:
-        self.calls.append((transcript, persona, session_id))
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: list[Turn] | None = None,
+    ) -> Reply:
+        self.calls.append((transcript, persona, session_id, list(history or [])))
         return self.reply_value
 
 

--- a/sidecar/tests/llm/test_ollama.py
+++ b/sidecar/tests/llm/test_ollama.py
@@ -1,0 +1,83 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from stackchan_sidecar.llm import Emotion
+from stackchan_sidecar.llm.ollama import OllamaLLM
+from stackchan_sidecar.session_store import Turn
+
+
+def _ollama_response(payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json=payload,
+        request=httpx.Request("POST", "http://localhost:11434/api/chat"),
+    )
+
+
+async def test_reply_parses_json_content() -> None:
+    llm = OllamaLLM(host="http://localhost:11434", model="llama3.2:3b")
+    content = json.dumps({"short": "hi friend", "full": "Hi friend!", "emotion": "happy"})
+    mock = AsyncMock(return_value=_ollama_response({"message": {"content": content}}))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        reply = await llm.reply("hello", "be friendly", "sid")
+    assert reply.short == "hi friend"
+    assert reply.full == "Hi friend!"
+    assert reply.emotion is Emotion.HAPPY
+
+    mock.assert_awaited_once()
+    args, kwargs = mock.await_args.args, mock.await_args.kwargs  # type: ignore[union-attr]
+    url = args[0] if args else kwargs.get("url")
+    assert url == "http://localhost:11434/api/chat"
+    body = kwargs["json"]
+    assert body["model"] == "llama3.2:3b"
+    assert body["format"] == "json"
+    assert body["stream"] is False
+    assert body["messages"][0] == {"role": "system", "content": "be friendly"}
+    assert body["messages"][-1] == {"role": "user", "content": "hello"}
+
+
+async def test_reply_clamps_short() -> None:
+    llm = OllamaLLM()
+    long = "x" * 100
+    content = json.dumps({"short": long, "full": "full", "emotion": "neutral"})
+    mock = AsyncMock(return_value=_ollama_response({"message": {"content": content}}))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        reply = await llm.reply("hi", "p", "sid")
+    assert len(reply.short) == 32
+
+
+async def test_reply_unknown_emotion_falls_back_to_neutral() -> None:
+    llm = OllamaLLM()
+    content = json.dumps({"short": "ok", "full": "ok", "emotion": "ecstatic"})
+    mock = AsyncMock(return_value=_ollama_response({"message": {"content": content}}))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        reply = await llm.reply("hi", "p", "sid")
+    assert reply.emotion is Emotion.NEUTRAL
+
+
+async def test_reply_includes_history() -> None:
+    llm = OllamaLLM()
+    content = json.dumps({"short": "ok", "full": "ok", "emotion": "neutral"})
+    mock = AsyncMock(return_value=_ollama_response({"message": {"content": content}}))
+    history = [Turn(user="u1", assistant="a1", emotion=Emotion.NEUTRAL)]
+    with patch.object(httpx.AsyncClient, "post", mock):
+        await llm.reply("u2", "p", "sid", history=history)
+    body = mock.await_args.kwargs["json"]  # type: ignore[union-attr]
+    msgs = body["messages"]
+    assert msgs[1] == {"role": "user", "content": "u1"}
+    assert msgs[2] == {"role": "assistant", "content": "a1"}
+    assert msgs[3] == {"role": "user", "content": "u2"}
+
+
+async def test_reply_raises_on_non_json_content() -> None:
+    llm = OllamaLLM()
+    mock = AsyncMock(return_value=_ollama_response({"message": {"content": "not-json"}}))
+    with (
+        patch.object(httpx.AsyncClient, "post", mock),
+        pytest.raises(ValueError, match="non-JSON"),
+    ):
+        await llm.reply("hi", "p", "sid")

--- a/sidecar/tests/llm/test_openai.py
+++ b/sidecar/tests/llm/test_openai.py
@@ -1,0 +1,121 @@
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from stackchan_sidecar.llm import Emotion
+from stackchan_sidecar.llm.openai import OpenAILLM
+from stackchan_sidecar.session_store import Turn
+
+
+@dataclass
+class _Function:
+    arguments: str
+
+
+@dataclass
+class _ToolCall:
+    function: _Function
+
+
+@dataclass
+class _Message:
+    tool_calls: list[_ToolCall]
+
+
+@dataclass
+class _Choice:
+    message: _Message
+
+
+@dataclass
+class _Response:
+    choices: list[_Choice]
+
+
+def _make_response(short: str, full: str, emotion: str) -> _Response:
+    payload = json.dumps({"short": short, "full": full, "emotion": emotion})
+    return _Response(
+        choices=[_Choice(message=_Message(tool_calls=[_ToolCall(function=_Function(payload))]))]
+    )
+
+
+async def test_reply_parses_tool_call() -> None:
+    llm = OpenAILLM(api_key="sk-test", model="gpt-4o-mini")
+    mock = AsyncMock(return_value=_make_response("hi there", "Hi there friend!", "happy"))
+    with patch.object(llm._client.chat.completions, "create", mock):
+        reply = await llm.reply("hello", "you are a robot", "session-abc")
+    assert reply.short == "hi there"
+    assert reply.full == "Hi there friend!"
+    assert reply.emotion is Emotion.HAPPY
+    mock.assert_awaited_once()
+    kwargs = mock.await_args.kwargs  # type: ignore[union-attr]
+    assert kwargs["model"] == "gpt-4o-mini"
+    assert kwargs["tool_choice"] == {"type": "function", "function": {"name": "respond"}}
+    assert kwargs["messages"][0] == {"role": "system", "content": "you are a robot"}
+    assert kwargs["messages"][-1] == {"role": "user", "content": "hello"}
+
+
+async def test_reply_clamps_short_to_32() -> None:
+    llm = OpenAILLM(api_key="sk-test")
+    long = "a" * 100
+    mock = AsyncMock(return_value=_make_response(long, "full body", "neutral"))
+    with patch.object(llm._client.chat.completions, "create", mock):
+        reply = await llm.reply("hi", "persona", "sid")
+    assert len(reply.short) == 32
+
+
+async def test_reply_unknown_emotion_falls_back_to_neutral() -> None:
+    llm = OpenAILLM(api_key="sk-test")
+    mock = AsyncMock(return_value=_make_response("ok", "ok", "ecstatic"))
+    with patch.object(llm._client.chat.completions, "create", mock):
+        reply = await llm.reply("hi", "persona", "sid")
+    assert reply.emotion is Emotion.NEUTRAL
+
+
+async def test_reply_strips_embedded_quotes() -> None:
+    llm = OpenAILLM(api_key="sk-test")
+    mock = AsyncMock(return_value=_make_response('hi "there"', "full body", "happy"))
+    with patch.object(llm._client.chat.completions, "create", mock):
+        reply = await llm.reply("hi", "persona", "sid")
+    assert '"' not in reply.short
+
+
+async def test_reply_includes_history_in_messages() -> None:
+    llm = OpenAILLM(api_key="sk-test")
+    mock = AsyncMock(return_value=_make_response("ok", "ok", "neutral"))
+    history = [Turn(user="first user", assistant="first assistant", emotion=Emotion.NEUTRAL)]
+    with patch.object(llm._client.chat.completions, "create", mock):
+        await llm.reply("second user", "persona", "sid", history=history)
+    kwargs = mock.await_args.kwargs  # type: ignore[union-attr]
+    msgs = kwargs["messages"]
+    assert msgs[0]["role"] == "system"
+    assert msgs[1] == {"role": "user", "content": "first user"}
+    assert msgs[2] == {"role": "assistant", "content": "first assistant"}
+    assert msgs[3] == {"role": "user", "content": "second user"}
+
+
+async def test_reply_missing_tool_calls_raises() -> None:
+    llm = OpenAILLM(api_key="sk-test")
+    empty = _Response(choices=[_Choice(message=_Message(tool_calls=[]))])
+    mock = AsyncMock(return_value=empty)
+    with (
+        patch.object(llm._client.chat.completions, "create", mock),
+        pytest.raises(ValueError, match="tool_call"),
+    ):
+        await llm.reply("hi", "persona", "sid")
+
+
+async def test_reply_bad_json_arguments_raises() -> None:
+    llm = OpenAILLM(api_key="sk-test")
+    bad: Any = _Response(
+        choices=[_Choice(message=_Message(tool_calls=[_ToolCall(function=_Function("not-json"))]))]
+    )
+    mock = AsyncMock(return_value=bad)
+    with (
+        patch.object(llm._client.chat.completions, "create", mock),
+        pytest.raises(ValueError, match="JSON"),
+    ):
+        await llm.reply("hi", "persona", "sid")

--- a/sidecar/tests/stt/test_deepgram.py
+++ b/sidecar/tests/stt/test_deepgram.py
@@ -1,0 +1,72 @@
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from stackchan_sidecar.stt.deepgram import DeepgramSTT
+
+
+def _dg_response(payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json=payload,
+        request=httpx.Request("POST", "https://api.deepgram.com/v1/listen"),
+    )
+
+
+async def test_transcribe_extracts_transcript() -> None:
+    stt = DeepgramSTT(api_key="dg-key")
+    payload = {
+        "results": {
+            "channels": [
+                {"alternatives": [{"transcript": "hello stack chan"}]},
+            ]
+        }
+    }
+    mock = AsyncMock(return_value=_dg_response(payload))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        result = await stt.transcribe(b"\x00\x00" * 1600, sample_rate=16000)
+    assert result == "hello stack chan"
+
+
+async def test_transcribe_empty_input_short_circuits() -> None:
+    stt = DeepgramSTT(api_key="dg-key")
+    mock = AsyncMock()
+    with patch.object(httpx.AsyncClient, "post", mock):
+        assert await stt.transcribe(b"", sample_rate=16000) == ""
+    mock.assert_not_awaited()
+
+
+async def test_transcribe_request_shape() -> None:
+    stt = DeepgramSTT(api_key="dg-key", model="nova-2", language="en")
+    payload = {"results": {"channels": [{"alternatives": [{"transcript": "x"}]}]}}
+    pcm = b"\x01\x02" * 800
+    mock = AsyncMock(return_value=_dg_response(payload))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        await stt.transcribe(pcm, sample_rate=16000)
+
+    mock.assert_awaited_once()
+    args = mock.await_args.args  # type: ignore[union-attr]
+    kwargs = mock.await_args.kwargs  # type: ignore[union-attr]
+    url = args[0] if args else kwargs.get("url")
+    assert url == "https://api.deepgram.com/v1/listen"
+    headers = kwargs["headers"]
+    assert headers["Authorization"] == "Token dg-key"
+    assert headers["Content-Type"] == "audio/L16;rate=16000;channels=1"
+    assert kwargs["params"] == {"model": "nova-2", "language": "en"}
+    assert kwargs["content"] == pcm
+
+
+async def test_transcribe_missing_channels_returns_empty() -> None:
+    stt = DeepgramSTT(api_key="dg-key")
+    mock = AsyncMock(return_value=_dg_response({"results": {"channels": []}}))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        assert await stt.transcribe(b"\x00\x00" * 800, sample_rate=16000) == ""
+
+
+async def test_transcribe_missing_alternatives_returns_empty() -> None:
+    stt = DeepgramSTT(api_key="dg-key")
+    payload: dict[str, Any] = {"results": {"channels": [{"alternatives": []}]}}
+    mock = AsyncMock(return_value=_dg_response(payload))
+    with patch.object(httpx.AsyncClient, "post", mock):
+        assert await stt.transcribe(b"\x00\x00" * 800, sample_rate=16000) == ""

--- a/sidecar/tests/stt/test_openai_whisper.py
+++ b/sidecar/tests/stt/test_openai_whisper.py
@@ -1,0 +1,68 @@
+import io
+import wave
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from stackchan_sidecar.stt.openai_whisper import OpenAIWhisperSTT
+
+
+@dataclass
+class _TranscriptionResponse:
+    text: str
+
+
+async def test_transcribe_returns_text_and_strips_whitespace() -> None:
+    stt = OpenAIWhisperSTT(api_key="sk-test", model="whisper-1")
+    mock = AsyncMock(return_value=_TranscriptionResponse(text="  hello there  "))
+    pcm = b"\x00\x00" * 1600
+    with patch.object(stt._client.audio.transcriptions, "create", mock):
+        result = await stt.transcribe(pcm, sample_rate=16000)
+    assert result == "hello there"
+    mock.assert_awaited_once()
+
+
+async def test_transcribe_empty_input_returns_empty_string() -> None:
+    stt = OpenAIWhisperSTT(api_key="sk-test")
+    mock = AsyncMock(return_value=_TranscriptionResponse(text="should not be returned"))
+    with patch.object(stt._client.audio.transcriptions, "create", mock):
+        assert await stt.transcribe(b"", sample_rate=16000) == ""
+    mock.assert_not_awaited()
+
+
+async def test_transcribe_wraps_pcm_in_valid_wav() -> None:
+    stt = OpenAIWhisperSTT(api_key="sk-test")
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> _TranscriptionResponse:
+        captured.update(kwargs)
+        return _TranscriptionResponse(text="ok")
+
+    pcm = b"\x10\x20" * 800
+    with patch.object(stt._client.audio.transcriptions, "create", side_effect=fake_create):
+        await stt.transcribe(pcm, sample_rate=16000)
+
+    file_tuple = captured["file"]
+    assert file_tuple[0] == "audio.wav"
+    wav_bytes = file_tuple[1]
+    assert file_tuple[2] == "audio/wav"
+
+    with wave.open(io.BytesIO(wav_bytes), "rb") as w:
+        assert w.getnchannels() == 1
+        assert w.getsampwidth() == 2
+        assert w.getframerate() == 16000
+        assert w.readframes(w.getnframes()) == pcm
+
+
+async def test_transcribe_passes_model() -> None:
+    stt = OpenAIWhisperSTT(api_key="sk-test", model="whisper-2")
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> _TranscriptionResponse:
+        captured.update(kwargs)
+        return _TranscriptionResponse(text="ok")
+
+    with patch.object(stt._client.audio.transcriptions, "create", side_effect=fake_create):
+        await stt.transcribe(b"\x00\x00" * 800, sample_rate=16000)
+
+    assert captured["model"] == "whisper-2"

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -44,8 +44,9 @@ def test_listen_happy_path(
     assert len(fake_stt.calls) == 1
     assert fake_stt.calls[0][1] == 16000
     assert len(fake_llm.calls) == 1
-    _, _, session_id = fake_llm.calls[0]
+    _, _, session_id, history = fake_llm.calls[0]
     assert session_id == "11111111-1111-4111-8111-111111111111"
+    assert history == []
 
 
 def test_listen_wrong_content_type(
@@ -133,6 +134,43 @@ def test_listen_persona_missing_returns_500(
         )
     assert r.status_code == 500
     assert "persona unavailable" in r.json()["detail"]
+
+
+def test_listen_records_session_history(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_llm: FakeLLM,
+) -> None:
+    sid = "33333333-3333-4333-8333-333333333333"
+    headers = {**auth_headers, "Content-Type": _AUDIO_CT, "X-Session-Id": sid}
+    r1 = client.post("/v1/listen", content=pcm_payload, headers=headers)
+    assert r1.status_code == 200
+    r2 = client.post("/v1/listen", content=pcm_payload, headers=headers)
+    assert r2.status_code == 200
+
+    assert len(fake_llm.calls) == 2
+    _, _, _, history_first = fake_llm.calls[0]
+    _, _, _, history_second = fake_llm.calls[1]
+    assert history_first == []
+    assert len(history_second) == 1
+    assert history_second[0].user == "hello stack chan"
+    assert history_second[0].assistant == "Hi friend! Lovely to meet you."
+    assert history_second[0].emotion is Emotion.HAPPY
+
+
+def test_listen_no_session_history_for_empty_session_id(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_llm: FakeLLM,
+) -> None:
+    headers = {**auth_headers, "Content-Type": _AUDIO_CT}
+    client.post("/v1/listen", content=pcm_payload, headers=headers)
+    client.post("/v1/listen", content=pcm_payload, headers=headers)
+    assert len(fake_llm.calls) == 2
+    assert fake_llm.calls[0][3] == []
+    assert fake_llm.calls[1][3] == []
 
 
 def test_listen_logs_session_id(

--- a/sidecar/tests/test_config.py
+++ b/sidecar/tests/test_config.py
@@ -10,7 +10,9 @@ def test_load_settings_requires_bearer_token(monkeypatch: pytest.MonkeyPatch) ->
         load_settings()
 
 
-def test_load_settings_requires_anthropic_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_settings_requires_anthropic_key_when_anthropic_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SIDECAR_BEARER_TOKEN", "tok")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
@@ -25,3 +27,45 @@ def test_load_settings_returns_settings_when_both_set(
     settings = load_settings()
     assert settings.bearer_token == "tok"
     assert settings.anthropic_api_key == "sk-ant-test"
+
+
+def test_load_settings_no_anthropic_key_when_ollama_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SIDECAR_BEARER_TOKEN", "tok")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    settings = load_settings()
+    assert settings.llm_provider == "ollama"
+
+
+def test_load_settings_requires_openai_key_when_openai_llm_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SIDECAR_BEARER_TOKEN", "tok")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        load_settings()
+
+
+def test_load_settings_requires_openai_key_when_openai_stt_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SIDECAR_BEARER_TOKEN", "tok")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("STT_PROVIDER", "openai")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        load_settings()
+
+
+def test_load_settings_requires_deepgram_key_when_deepgram_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SIDECAR_BEARER_TOKEN", "tok")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("STT_PROVIDER", "deepgram")
+    monkeypatch.delenv("DEEPGRAM_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="DEEPGRAM_API_KEY"):
+        load_settings()

--- a/sidecar/tests/test_session_store.py
+++ b/sidecar/tests/test_session_store.py
@@ -1,0 +1,97 @@
+import time
+
+import pytest
+
+from stackchan_sidecar.llm import Emotion
+from stackchan_sidecar.session_store import SessionStore, Turn
+
+
+def _turn(user: str = "hi", assistant: str = "hello") -> Turn:
+    return Turn(user=user, assistant=assistant, emotion=Emotion.HAPPY)
+
+
+def test_get_history_empty_when_unknown() -> None:
+    store = SessionStore()
+    assert store.get_history("sid-a") == []
+
+
+def test_record_then_get_history() -> None:
+    store = SessionStore()
+    store.record("sid-a", _turn("u1", "a1"))
+    store.record("sid-a", _turn("u2", "a2"))
+    history = store.get_history("sid-a")
+    assert len(history) == 2
+    assert history[0].user == "u1"
+    assert history[1].user == "u2"
+
+
+def test_get_history_is_isolated_per_session() -> None:
+    store = SessionStore()
+    store.record("sid-a", _turn("a-only", "a-resp"))
+    store.record("sid-b", _turn("b-only", "b-resp"))
+    history_a = store.get_history("sid-a")
+    history_b = store.get_history("sid-b")
+    assert len(history_a) == 1 and history_a[0].user == "a-only"
+    assert len(history_b) == 1 and history_b[0].user == "b-only"
+
+
+def test_get_history_returns_copy() -> None:
+    store = SessionStore()
+    store.record("sid", _turn("u1", "a1"))
+    history = store.get_history("sid")
+    history.append(_turn("forged", "forged"))
+    assert len(store.get_history("sid")) == 1
+
+
+def test_max_turns_eviction() -> None:
+    store = SessionStore(max_turns=3)
+    for i in range(5):
+        store.record("sid", _turn(f"u{i}", f"a{i}"))
+    history = store.get_history("sid")
+    assert len(history) == 3
+    assert history[0].user == "u2"
+    assert history[-1].user == "u4"
+
+
+def test_sweep_evicts_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [1000.0]
+
+    def fake_monotonic() -> float:
+        return now[0]
+
+    monkeypatch.setattr(time, "monotonic", fake_monotonic)
+    store = SessionStore(ttl_seconds=60.0)
+    store.record("sid-old", _turn())
+    now[0] += 120.0
+    store.record("sid-new", _turn())
+    removed = store.sweep()
+    assert removed == 1
+    assert store.get_history("sid-old") == []
+    assert len(store.get_history("sid-new")) == 1
+
+
+def test_sweep_returns_zero_when_nothing_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [1000.0]
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+    store = SessionStore(ttl_seconds=60.0)
+    store.record("sid", _turn())
+    now[0] += 30.0
+    assert store.sweep() == 0
+
+
+def test_get_history_touches_last_seen(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [1000.0]
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+    store = SessionStore(ttl_seconds=60.0)
+    store.record("sid", _turn())
+    now[0] += 50.0
+    store.get_history("sid")
+    now[0] += 30.0
+    assert store.sweep() == 0
+    assert len(store.get_history("sid")) == 1
+
+
+def test_empty_session_id_is_noop() -> None:
+    store = SessionStore()
+    store.record("", _turn())
+    assert store.get_history("") == []

--- a/sidecar/uv.lock
+++ b/sidecar/uv.lock
@@ -692,6 +692,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/50/5901f01ef14e6c27788beb91e54fef5d6204fb5fb9e97402fc8a14de2e32/openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9", size = 754706, upload-time = "2026-05-15T22:30:35.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/4c/bce61680d0699a78a405fd9a67989b175ba020590428831aab2ab1d2be7c/openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107", size = 1303238, upload-time = "2026-05-15T22:30:32.767Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1003,7 +1022,9 @@ dependencies = [
     { name = "anthropic" },
     { name = "fastapi" },
     { name = "faster-whisper" },
+    { name = "httpx" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1023,7 +1044,9 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.39" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "faster-whisper", specifier = ">=1.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "openai", specifier = ">=1.50" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },


### PR DESCRIPTION
Stacked on #360. **Don't merge before #360.**

## Summary

- **Session memory**: `SessionStore` keyed off `X-Session-Id` (8-turn FIFO, 10-min sliding TTL). Asyncio sweeper runs in the FastAPI lifespan. Empty session id is a no-op. `LLMProvider.reply` signature extended with `history`; all three LLM adapters thread it into their messages array.
- **STT providers**: OpenAI Whisper (wraps raw PCM in a stdlib `wave` WAV blob), Deepgram (raw `audio/L16` POST). Selected via `stt_provider` config.
- **LLM providers**: OpenAI with `tool_choice` on a `respond` function; Ollama via `/api/chat` `format=json` (no cross-model tool-use yet — persona prompt drives the JSON contract).
- **Provider gates**: `load_settings` requires only the keys for the chosen providers (e.g. picking Ollama means no Anthropic key needed).
- **Lazy imports** in `__main__.py` so unused SDKs stay out of the import path.
- **Docker**: multi-stage uv → slim, non-root, `libsndfile1` for faster-whisper. `.dockerignore` keeps caches + .env out. `docker-compose.yml` for one-command dev. Example systemd user unit under `systemd/`.
- README gains Provider selection / Docker / systemd sections.

## Test plan

- [x] `uv sync` (lockfile committed)
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .` (strict, 31 source files clean)
- [x] `uv run pytest` — **63/63** (was 27 in #360): SessionStore (9), OpenAI/Ollama LLM (12), OpenAI/Deepgram STT (9), per-provider gates (4 new), session-history flow + empty-sid no-op (2 new in `test_app.py`)
- [ ] `docker build -t stackchan-sidecar:dev .` (not run locally; structure looks sound on inspection)
- [ ] End-to-end smoke after this + #359 + #360 merge: real PTT from device produces a toast, second PTT in the same session sees the first turn in `X-Session-Id`-bound history.