### PR TITLE
feat(web): expose sidecar settings + fix behavior/esp_now PUT clobber

### DIFF
--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -11,6 +11,8 @@ export function Settings() {
   const [sntp, setSntp] = createSignal("");
   const [token, setToken] = createSignal("");
   const [tz, setTz] = createSignal("UTC");
+  const [sidecarUrl, setSidecarUrl] = createSignal("");
+  const [sidecarToken, setSidecarToken] = createSignal("");
 
   const load = async () => {
     try {
@@ -31,6 +33,8 @@ export function Settings() {
       setSntp(c.time.sntp_servers.join(", "));
       setToken(c.auth.token);
       setTz(c.time.tz);
+      setSidecarUrl(c.behavior.agent_sidecar_url);
+      setSidecarToken(c.behavior.agent_sidecar_token);
     } catch (e) {
       showToast(e instanceof Error ? e.message : String(e), true);
     }
@@ -55,6 +59,11 @@ export function Settings() {
       }
       const fresh = (await freshRes.json()) as SettingsType;
       const audio = snapshot()?.audio ?? fresh.audio;
+      // Spread `fresh.behavior` / `fresh.esp_now` / `fresh.tracker` so
+      // fields edited elsewhere (Calibration, hand-edited STACKCHAN.RON,
+      // operator-set wake_word/chime flags, ESP-NOW peer config) survive
+      // a save through this form. Only the keys this form binds get
+      // overwritten; everything else round-trips untouched.
       const body: SettingsType = {
         wifi: { ssid: ssid(), psk: psk(), country: country().toUpperCase() },
         mdns: { hostname: hostname() },
@@ -68,6 +77,12 @@ export function Settings() {
         auth: { token: token() },
         audio,
         tracker: fresh.tracker,
+        esp_now: fresh.esp_now,
+        behavior: {
+          ...fresh.behavior,
+          agent_sidecar_url: sidecarUrl(),
+          agent_sidecar_token: sidecarToken(),
+        },
       };
       const newToken = body.auth.token;
       const res = await authedFetch("/settings", {
@@ -186,6 +201,26 @@ export function Settings() {
             onInput={(e) => setToken(e.currentTarget.value)}
           />
         </label>
+        <label>
+          Sidecar URL
+          <input
+            type="text"
+            autocomplete="off"
+            placeholder="http://192.168.1.42:8080/v1/listen"
+            value={sidecarUrl()}
+            onInput={(e) => setSidecarUrl(e.currentTarget.value)}
+          />
+        </label>
+        <label>
+          Sidecar bearer token
+          <input
+            type="password"
+            autocomplete="off"
+            placeholder="(cleared = no Authorization header)"
+            value={sidecarToken()}
+            onInput={(e) => setSidecarToken(e.currentTarget.value)}
+          />
+        </label>
         <div class="btn-row">
           <button type="submit">Save</button>
           <button type="button" onClick={load}>
@@ -196,11 +231,12 @@ export function Settings() {
           </button>
         </div>
         <small>
-          PSK and token show as <code>***</code> in GET and pre-fill into the form.
-          Submit unchanged to keep the current value, clear the field to disable
-          (open AP / auth off), or type a new value to overwrite. Download backup
-          calls GET /settings/backup, which is the one auth-gated read — restore
-          by pasting the file contents back into the form fields.
+          PSK, auth token, and sidecar bearer token show as <code>***</code> in
+          GET and pre-fill into the form. Submit unchanged to keep the current
+          value, clear the field to disable (open AP / auth off / no Authorization
+          header), or type a new value to overwrite. Download backup calls
+          GET /settings/backup, which is the one auth-gated read — restore by
+          pasting the file contents back into the form fields.
         </small>
       </form>
     </section>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -63,6 +63,32 @@ export type Settings = {
   auth: { token: string };
   audio: AudioState;
   tracker: Tracker;
+  esp_now: EspNow;
+  behavior: Behavior;
+};
+
+export type EspNow = {
+  enabled: boolean;
+  pmk_hex: string;
+  peer_mac: string;
+  lmk_hex: string;
+  channel: number | null;
+  tx_rate_hz: number;
+};
+
+export type Behavior = {
+  soliloquy_enabled: boolean;
+  hourly_chime_enabled: boolean;
+  battery_icon_enabled: boolean;
+  toast_overlay_enabled: boolean;
+  auto_torque_release_ms: number;
+  audio_debug_udp_target: string;
+  agent_sidecar_url: string;
+  agent_sidecar_token: string;
+  follower_leader_hostname: string;
+  wake_word_enabled: boolean;
+  wake_word_threshold: number;
+  wake_word_arena_kib: number;
 };
 
 export type Imu = {


### PR DESCRIPTION
## Summary

- Add **Sidecar URL** + **Sidecar bearer token** fields to the Settings panel for the new \`behavior.agent_sidecar_url\` / \`behavior.agent_sidecar_token\` (landed in #359). The token gets the same redaction-sentinel UX as PSK and auth token — \`***\` in GET, pre-fill into a password input, submit unchanged to preserve.
- **Drive-by fix for a pre-existing data-loss bug**: the Settings form was omitting \`behavior\` and \`esp_now\` blocks from its PUT body. The firmware's parser fills missing blocks with \`unwrap_or_default\`, so every save through this form silently reset \`wake_word_enabled\`, \`hourly_chime_enabled\`, the battery / toast overlays, ESP-NOW peer config, and similar fields back to defaults. Now mirrors the existing \`tracker\` pattern — re-fetch \`/settings\`, spread \`fresh.behavior\` / \`fresh.esp_now\`, override only the keys this form actually binds.
- \`web/src/types.ts\` grows full \`Behavior\` and \`EspNow\` type shapes so the splat is type-safe.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — builds, gzips, no warnings
- [ ] Hands-on smoke once the firmware is reflashed: GET /settings shows redacted sidecar token, dashboard pre-fills it, save round-trips without wiping \`wake_word_enabled\` or other behavior flags (the bug this PR fixes).