### PR TITLE
feat(sidecar): per-stage timeouts, bounded retries, structured error envelope

### DIFF
--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -27,6 +27,23 @@ Response is JSON:
 defensively. `emotion` is one of `neutral`, `happy`, `sleepy`, `surprised`,
 `sad`, `angry`. Unknown values fall back to `neutral`.
 
+On a graceful failure (provider timeout, transient error exhausted retries,
+LLM tool-use parse failure) the sidecar still returns 200 with the same
+envelope plus an `error` member, so the firmware lands a meaningful toast:
+
+```json
+{
+  "text": "thinking too hard, try again",
+  "emotion": "sad",
+  "error": {"code": "llm_timeout", "stage": "llm"}
+}
+```
+
+Operator-side validation failures (bad `Content-Type`, wrong sample rate,
+too-small or oversize body) still return 4xx with the same envelope shape;
+the firmware drops non-2xx replies, so those are for logs and curl smoke
+tests. See `errors.py` for the full `code` / `stage` catalog.
+
 The firmware-side schema and request layout live in `docs/sidecar.md` in the
 stackchan-kai firmware repo.
 
@@ -109,6 +126,29 @@ its own credential requirement.
   which is still uneven across local models.
 
 `stt_model` and `llm_model` apply to whichever provider is selected.
+
+## Resilience
+
+Each upstream call (STT, LLM) runs under a per-stage `asyncio.wait_for`
+timeout, with up to N total attempts. Transient classes are retried
+(Anthropic 529, OpenAI 5xx, Deepgram 5xx, generic httpx network errors,
+in-flight timeouts); permanent classes are not (4xx, parse errors, plain
+`ValueError`). A shared `total_timeout_seconds` deadline caps the whole
+listen call so a slow STT can't starve the LLM.
+
+Tunables in `config.toml` (defaults shown):
+
+```toml
+stt_timeout_seconds = 10.0
+llm_timeout_seconds = 20.0
+total_timeout_seconds = 30.0
+stt_max_attempts = 2
+llm_max_attempts = 2
+retry_initial_backoff_seconds = 0.5
+```
+
+`*_max_attempts = 1` disables retries for that stage; the per-stage timeout
+still applies.
 
 ## Docker
 

--- a/sidecar/config.example.toml
+++ b/sidecar/config.example.toml
@@ -9,3 +9,14 @@ log_level = "INFO"
 stt_provider = "faster_whisper"
 llm_provider = "anthropic"
 ollama_host = "http://localhost:11434"
+
+# Resilience. Per-stage timeouts wrap each provider call; bounded retries
+# cover transient upstream classes (Anthropic 529, OpenAI 5xx, Deepgram 5xx,
+# httpx network errors). The total deadline is shared across STT + LLM so a
+# slow STT can't starve the LLM call.
+stt_timeout_seconds = 10.0
+llm_timeout_seconds = 20.0
+total_timeout_seconds = 30.0
+stt_max_attempts = 2
+llm_max_attempts = 2
+retry_initial_backoff_seconds = 0.5

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -1,21 +1,78 @@
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from uuid import uuid4
 
-from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from .auth import make_verifier
 from .config import Settings
-from .llm import SHORT_MAX, Emotion, LLMProvider
+from .errors import (
+    ErrorCode,
+    audio_validation_status,
+    build_envelope,
+    failure_kind,
+)
+from .llm import Emotion, LLMProvider, sanitize_short
 from .personas import load_persona
+from .retry import StageDeadlineError, retry_with_timeout
 from .session_store import SessionStore, Turn, session_store_lifespan
 from .stt import STTProvider
 
 _LOG = logging.getLogger("stackchan_sidecar")
 _MAX_BODY_BYTES = 30 * 16000 * 2 + 1024
+_MIN_BODY_BYTES = 640  # 20 ms @ 16 kHz mono s16; anything smaller is operator error
+_EXPECTED_SAMPLE_RATE = 16000
+_RATE_RE = re.compile(r"rate=(\d+)", re.IGNORECASE)
+
+
+def _failure(
+    code: ErrorCode,
+    *,
+    request_id: str,
+    session_id: str,
+    status: int,
+    extra: dict[str, object] | None = None,
+) -> JSONResponse:
+    kind = failure_kind(code)
+    log_extra: dict[str, object] = {
+        "request_id": request_id,
+        "session_id": session_id,
+        "code": kind.code.value,
+        "stage": kind.stage.value,
+        "status": status,
+    }
+    if extra:
+        log_extra.update(extra)
+    _LOG.warning("listen.fail", extra=log_extra)
+    return JSONResponse(build_envelope(kind), status_code=status)
+
+
+def _audio_failure(code: ErrorCode, *, request_id: str, session_id: str) -> JSONResponse:
+    return _failure(
+        code,
+        request_id=request_id,
+        session_id=session_id,
+        status=audio_validation_status(code),
+    )
+
+
+def _validate_content_type(content_type: str) -> ErrorCode | None:
+    if not content_type.lower().startswith("audio/l16"):
+        return ErrorCode.BAD_CONTENT_TYPE
+    match = _RATE_RE.search(content_type)
+    if match is None:
+        return None
+    try:
+        rate = int(match.group(1))
+    except ValueError:
+        return ErrorCode.AUDIO_RATE_UNSUPPORTED
+    if rate != _EXPECTED_SAMPLE_RATE:
+        return ErrorCode.AUDIO_RATE_UNSUPPORTED
+    return None
 
 
 def create_app(
@@ -47,59 +104,47 @@ def create_app(
         session_id = request.headers.get("x-session-id", "")
         content_type = request.headers.get("content-type", "")
 
-        if not content_type.lower().startswith("audio/l16"):
-            _LOG.warning(
-                "rejecting non-audio content-type",
-                extra={
-                    "request_id": request_id,
-                    "session_id": session_id,
-                    "content_type": content_type,
-                    "status": 415,
-                },
-            )
-            raise HTTPException(
-                status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-                detail="expected Content-Type: audio/L16;rate=16000;channels=1",
-            )
+        ct_err = _validate_content_type(content_type)
+        if ct_err is not None:
+            return _audio_failure(ct_err, request_id=request_id, session_id=session_id)
 
         declared_length = request.headers.get("content-length")
         if declared_length is not None:
             try:
-                if int(declared_length) > _MAX_BODY_BYTES:
-                    raise HTTPException(
-                        status_code=status.HTTP_413_CONTENT_TOO_LARGE,
-                        detail=f"audio payload exceeds {_MAX_BODY_BYTES} bytes",
-                    )
-            except ValueError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="invalid Content-Length header",
-                ) from e
+                declared = int(declared_length)
+            except ValueError:
+                return _audio_failure(
+                    ErrorCode.BAD_CONTENT_LENGTH,
+                    request_id=request_id,
+                    session_id=session_id,
+                )
+            if declared > _MAX_BODY_BYTES:
+                return _audio_failure(
+                    ErrorCode.AUDIO_TOO_LARGE,
+                    request_id=request_id,
+                    session_id=session_id,
+                )
 
         body = await request.body()
         if not body:
-            _LOG.warning(
-                "rejecting empty body",
-                extra={
-                    "request_id": request_id,
-                    "session_id": session_id,
-                    "status": 400,
-                },
-            )
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="request body is empty",
+            return _audio_failure(
+                ErrorCode.AUDIO_EMPTY, request_id=request_id, session_id=session_id
             )
         if len(body) > _MAX_BODY_BYTES:
-            raise HTTPException(
-                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
-                detail=f"audio payload exceeds {_MAX_BODY_BYTES} bytes",
+            return _audio_failure(
+                ErrorCode.AUDIO_TOO_LARGE, request_id=request_id, session_id=session_id
+            )
+        if len(body) < _MIN_BODY_BYTES:
+            return _audio_failure(
+                ErrorCode.AUDIO_TOO_SMALL, request_id=request_id, session_id=session_id
             )
 
         t0 = time.perf_counter()
+        deadline = time.monotonic() + settings.total_timeout_seconds
+
         try:
             persona = load_persona(settings.persona, settings.personas_dir)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             _LOG.exception(
                 "persona load failed",
                 extra={
@@ -109,37 +154,87 @@ def create_app(
                     "status": 500,
                 },
             )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"persona unavailable: {e}",
-            ) from e
+            return _failure(
+                ErrorCode.PERSONA_MISSING,
+                request_id=request_id,
+                session_id=session_id,
+                status=500,
+                extra={"persona": settings.persona},
+            )
 
+        t_stt0 = time.perf_counter()
         try:
-            t_stt0 = time.perf_counter()
-            transcript = await stt.transcribe(body, sample_rate=16000)
-            stt_ms = int((time.perf_counter() - t_stt0) * 1000)
-
-            history = store.get_history(session_id)
-            t_llm0 = time.perf_counter()
-            reply = await llm.reply(transcript, persona, session_id, history)
-            llm_ms = int((time.perf_counter() - t_llm0) * 1000)
-        except HTTPException:
-            raise
+            transcript = await retry_with_timeout(
+                lambda: stt.transcribe(body, sample_rate=_EXPECTED_SAMPLE_RATE),
+                max_attempts=settings.stt_max_attempts,
+                per_attempt_timeout=settings.stt_timeout_seconds,
+                deadline=deadline,
+                initial_backoff=settings.retry_initial_backoff_seconds,
+                label="stt",
+            )
+        except (TimeoutError, StageDeadlineError):
+            return _failure(
+                ErrorCode.STT_TIMEOUT,
+                request_id=request_id,
+                session_id=session_id,
+                status=200,
+            )
         except Exception:
             _LOG.exception(
-                "pipeline failure",
-                extra={
-                    "request_id": request_id,
-                    "session_id": session_id,
-                    "status": 500,
-                },
+                "stt failed",
+                extra={"request_id": request_id, "session_id": session_id, "stage": "stt"},
             )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="internal error",
-            ) from None
+            return _failure(
+                ErrorCode.STT_FAILED,
+                request_id=request_id,
+                session_id=session_id,
+                status=200,
+            )
+        stt_ms = int((time.perf_counter() - t_stt0) * 1000)
 
-        short = reply.short[:SHORT_MAX].replace('"', "'")
+        history = store.get_history(session_id)
+        t_llm0 = time.perf_counter()
+        try:
+            reply = await retry_with_timeout(
+                lambda: llm.reply(transcript, persona, session_id, history),
+                max_attempts=settings.llm_max_attempts,
+                per_attempt_timeout=settings.llm_timeout_seconds,
+                deadline=deadline,
+                initial_backoff=settings.retry_initial_backoff_seconds,
+                label="llm",
+            )
+        except (TimeoutError, StageDeadlineError):
+            return _failure(
+                ErrorCode.LLM_TIMEOUT,
+                request_id=request_id,
+                session_id=session_id,
+                status=200,
+            )
+        except ValueError:
+            _LOG.exception(
+                "llm parse failed",
+                extra={"request_id": request_id, "session_id": session_id, "stage": "llm"},
+            )
+            return _failure(
+                ErrorCode.LLM_PARSE_FAILED,
+                request_id=request_id,
+                session_id=session_id,
+                status=200,
+            )
+        except Exception:
+            _LOG.exception(
+                "llm failed",
+                extra={"request_id": request_id, "session_id": session_id, "stage": "llm"},
+            )
+            return _failure(
+                ErrorCode.LLM_FAILED,
+                request_id=request_id,
+                session_id=session_id,
+                status=200,
+            )
+        llm_ms = int((time.perf_counter() - t_llm0) * 1000)
+
+        short = sanitize_short(reply.short)
         emotion = reply.emotion if isinstance(reply.emotion, Emotion) else Emotion.NEUTRAL
         total_ms = int((time.perf_counter() - t0) * 1000)
 

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -66,11 +66,7 @@ def _validate_content_type(content_type: str) -> ErrorCode | None:
     match = _RATE_RE.search(content_type)
     if match is None:
         return None
-    try:
-        rate = int(match.group(1))
-    except ValueError:
-        return ErrorCode.AUDIO_RATE_UNSUPPORTED
-    if rate != _EXPECTED_SAMPLE_RATE:
+    if int(match.group(1)) != _EXPECTED_SAMPLE_RATE:
         return ErrorCode.AUDIO_RATE_UNSUPPORTED
     return None
 

--- a/sidecar/src/stackchan_sidecar/config.py
+++ b/sidecar/src/stackchan_sidecar/config.py
@@ -24,6 +24,13 @@ class Settings(BaseSettings):
     llm_provider: Literal["anthropic", "openai", "ollama"] = "anthropic"
     ollama_host: str = "http://localhost:11434"
 
+    stt_timeout_seconds: float = Field(default=10.0, gt=0.0)
+    llm_timeout_seconds: float = Field(default=20.0, gt=0.0)
+    total_timeout_seconds: float = Field(default=30.0, gt=0.0)
+    stt_max_attempts: int = Field(default=2, ge=1)
+    llm_max_attempts: int = Field(default=2, ge=1)
+    retry_initial_backoff_seconds: float = Field(default=0.5, ge=0.0)
+
     bearer_token: str = Field(default="", alias="SIDECAR_BEARER_TOKEN")
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
     openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")

--- a/sidecar/src/stackchan_sidecar/errors.py
+++ b/sidecar/src/stackchan_sidecar/errors.py
@@ -1,0 +1,128 @@
+"""Wire-level error envelope returned to the kai firmware.
+
+Successful replies are `{"text", "emotion"}` and the firmware ignores
+unknown keys, so failure replies use the same envelope plus an
+`error: {code, stage}` member. The firmware drops non-2xx responses
+on the floor (see `crates/stackchan-firmware/src/agent_sidecar.rs`),
+so graceful failures (provider timeout, parse error) return 200 with
+this envelope to land a meaningful toast on the avatar. Validation
+failures stay as 4xx — kai never sees the body, the envelope is for
+operator logs and curl smoke tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .llm import SHORT_MAX, Emotion, sanitize_short
+
+
+class Stage(StrEnum):
+    AUDIO = "audio"
+    STT = "stt"
+    LLM = "llm"
+    SYSTEM = "system"
+
+
+class ErrorCode(StrEnum):
+    BAD_CONTENT_TYPE = "bad_content_type"
+    BAD_CONTENT_LENGTH = "bad_content_length"
+    AUDIO_RATE_UNSUPPORTED = "audio_rate_unsupported"
+    AUDIO_EMPTY = "audio_empty"
+    AUDIO_TOO_SMALL = "audio_too_small"
+    AUDIO_TOO_LARGE = "audio_too_large"
+    STT_TIMEOUT = "stt_timeout"
+    STT_FAILED = "stt_failed"
+    LLM_TIMEOUT = "llm_timeout"
+    LLM_FAILED = "llm_failed"
+    LLM_PARSE_FAILED = "llm_parse_failed"
+    PERSONA_MISSING = "persona_missing"
+    INTERNAL = "internal"
+
+
+@dataclass(frozen=True)
+class FailureKind:
+    code: ErrorCode
+    stage: Stage
+    fallback_text: str
+    emotion: Emotion = Emotion.SAD
+
+
+_FAILURES: dict[ErrorCode, FailureKind] = {
+    ErrorCode.BAD_CONTENT_TYPE: FailureKind(
+        ErrorCode.BAD_CONTENT_TYPE, Stage.AUDIO, "wrong audio format", Emotion.NEUTRAL
+    ),
+    ErrorCode.BAD_CONTENT_LENGTH: FailureKind(
+        ErrorCode.BAD_CONTENT_LENGTH, Stage.AUDIO, "bad content-length", Emotion.NEUTRAL
+    ),
+    ErrorCode.AUDIO_RATE_UNSUPPORTED: FailureKind(
+        ErrorCode.AUDIO_RATE_UNSUPPORTED, Stage.AUDIO, "need 16kHz audio", Emotion.NEUTRAL
+    ),
+    ErrorCode.AUDIO_EMPTY: FailureKind(
+        ErrorCode.AUDIO_EMPTY, Stage.AUDIO, "no audio received", Emotion.NEUTRAL
+    ),
+    ErrorCode.AUDIO_TOO_SMALL: FailureKind(
+        ErrorCode.AUDIO_TOO_SMALL, Stage.AUDIO, "audio too short", Emotion.NEUTRAL
+    ),
+    ErrorCode.AUDIO_TOO_LARGE: FailureKind(
+        ErrorCode.AUDIO_TOO_LARGE, Stage.AUDIO, "audio too long", Emotion.NEUTRAL
+    ),
+    ErrorCode.STT_TIMEOUT: FailureKind(
+        ErrorCode.STT_TIMEOUT, Stage.STT, "didn't catch that, try again"
+    ),
+    ErrorCode.STT_FAILED: FailureKind(
+        ErrorCode.STT_FAILED, Stage.STT, "hearing's wonky, try again"
+    ),
+    ErrorCode.LLM_TIMEOUT: FailureKind(
+        ErrorCode.LLM_TIMEOUT, Stage.LLM, "thinking too hard, try again"
+    ),
+    ErrorCode.LLM_FAILED: FailureKind(ErrorCode.LLM_FAILED, Stage.LLM, "brain hiccup, try again"),
+    ErrorCode.LLM_PARSE_FAILED: FailureKind(
+        ErrorCode.LLM_PARSE_FAILED, Stage.LLM, "got confused, try again"
+    ),
+    ErrorCode.PERSONA_MISSING: FailureKind(
+        ErrorCode.PERSONA_MISSING, Stage.SYSTEM, "persona missing", Emotion.NEUTRAL
+    ),
+    ErrorCode.INTERNAL: FailureKind(
+        ErrorCode.INTERNAL, Stage.SYSTEM, "internal error", Emotion.NEUTRAL
+    ),
+}
+
+
+def failure_kind(code: ErrorCode) -> FailureKind:
+    return _FAILURES[code]
+
+
+def build_envelope(kind: FailureKind) -> dict[str, object]:
+    text = sanitize_short(kind.fallback_text)
+    return {
+        "text": text,
+        "emotion": kind.emotion.value,
+        "error": {"code": kind.code.value, "stage": kind.stage.value},
+    }
+
+
+_HTTP_STATUS_BY_CODE: dict[ErrorCode, int] = {
+    ErrorCode.BAD_CONTENT_TYPE: 415,
+    ErrorCode.BAD_CONTENT_LENGTH: 400,
+    ErrorCode.AUDIO_RATE_UNSUPPORTED: 415,
+    ErrorCode.AUDIO_EMPTY: 400,
+    ErrorCode.AUDIO_TOO_SMALL: 400,
+    ErrorCode.AUDIO_TOO_LARGE: 413,
+}
+
+
+def audio_validation_status(code: ErrorCode) -> int:
+    return _HTTP_STATUS_BY_CODE[code]
+
+
+__all__ = [
+    "SHORT_MAX",
+    "ErrorCode",
+    "FailureKind",
+    "Stage",
+    "audio_validation_status",
+    "build_envelope",
+    "failure_kind",
+]

--- a/sidecar/src/stackchan_sidecar/errors.py
+++ b/sidecar/src/stackchan_sidecar/errors.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from .llm import SHORT_MAX, Emotion, sanitize_short
+from .llm import Emotion, sanitize_short
 
 
 class Stage(StrEnum):
@@ -118,7 +118,6 @@ def audio_validation_status(code: ErrorCode) -> int:
 
 
 __all__ = [
-    "SHORT_MAX",
     "ErrorCode",
     "FailureKind",
     "Stage",

--- a/sidecar/src/stackchan_sidecar/retry.py
+++ b/sidecar/src/stackchan_sidecar/retry.py
@@ -1,0 +1,99 @@
+"""Retry + per-attempt timeout helper for upstream provider calls.
+
+The pipeline runs one STT call followed by one LLM call. Each upstream
+can fail in transient ways the user wants masked: Anthropic 529,
+OpenAI 5xx, Deepgram 5xx, an Ollama connection blip, a faster-whisper
+subprocess hiccup. This helper wraps a single async callable with a
+per-attempt `asyncio.wait_for` and re-tries up to `max_attempts` total,
+respecting an overall `deadline` (monotonic seconds) shared across
+both stages so a slow STT can't starve the LLM call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+import anthropic
+import httpx
+import openai
+
+_LOG = logging.getLogger("stackchan_sidecar")
+
+_RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504, 529})
+
+
+class StageDeadlineError(Exception):
+    """No attempt could fit inside the remaining shared deadline."""
+
+
+def is_transient(exc: BaseException) -> bool:
+    if isinstance(exc, TimeoutError):
+        return True
+    if isinstance(exc, httpx.TimeoutException):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _RETRYABLE_STATUS
+    if isinstance(exc, httpx.HTTPError):
+        return True
+    if isinstance(exc, anthropic.APIConnectionError | anthropic.APITimeoutError):
+        return True
+    if isinstance(exc, anthropic.APIStatusError):
+        return exc.status_code in _RETRYABLE_STATUS
+    if isinstance(exc, openai.APIConnectionError | openai.APITimeoutError):
+        return True
+    if isinstance(exc, openai.APIStatusError):
+        return exc.status_code in _RETRYABLE_STATUS
+    return False
+
+
+async def retry_with_timeout[T](
+    call: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int,
+    per_attempt_timeout: float,
+    deadline: float,
+    initial_backoff: float,
+    label: str,
+    is_transient_fn: Callable[[BaseException], bool] = is_transient,
+) -> T:
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+
+    backoff = initial_backoff
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise StageDeadlineError(label) from last_exc
+        attempt_timeout = min(per_attempt_timeout, remaining)
+        try:
+            return await asyncio.wait_for(call(), timeout=attempt_timeout)
+        except Exception as exc:
+            if not is_transient_fn(exc):
+                raise
+            last_exc = exc
+            if attempt == max_attempts:
+                raise
+            sleep_for = min(backoff, max(0.0, deadline - time.monotonic()))
+            _LOG.info(
+                "%s.retry",
+                label,
+                extra={
+                    "label": label,
+                    "attempt": attempt,
+                    "max_attempts": max_attempts,
+                    "exc": type(exc).__name__,
+                    "sleep": sleep_for,
+                },
+            )
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
+            backoff *= 2
+
+    raise RuntimeError("retry_with_timeout exited loop without return")
+
+
+__all__ = ["StageDeadlineError", "is_transient", "retry_with_timeout"]

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -126,14 +126,17 @@ def test_listen_persona_missing_returns_500(
         persona="missing",
     )
     app = create_app(settings, fake_stt, fake_llm)
-    with TestClient(app, raise_server_exceptions=False) as c:
+    with TestClient(app) as c:
         r = c.post(
             "/v1/listen",
             content=pcm_payload,
             headers={**auth_headers, "Content-Type": _AUDIO_CT},
         )
     assert r.status_code == 500
-    assert "persona unavailable" in r.json()["detail"]
+    body = r.json()
+    assert body["error"]["code"] == "persona_missing"
+    assert body["error"]["stage"] == "system"
+    assert body["text"] == "persona missing"
 
 
 def test_listen_records_session_history(

--- a/sidecar/tests/test_app_resilience.py
+++ b/sidecar/tests/test_app_resilience.py
@@ -1,0 +1,257 @@
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from stackchan_sidecar.app import create_app
+from stackchan_sidecar.config import Settings
+from stackchan_sidecar.llm import Emotion, Reply
+from stackchan_sidecar.session_store import Turn
+
+from .conftest import TEST_TOKEN, FakeLLM, FakeSTT
+
+_AUDIO_CT = "audio/L16;rate=16000;channels=1"
+
+
+@pytest.fixture
+def fast_settings(personas_dir: Path) -> Settings:
+    return Settings(
+        SIDECAR_BEARER_TOKEN=TEST_TOKEN,
+        ANTHROPIC_API_KEY="sk-ant-test",
+        personas_dir=personas_dir,
+        stt_timeout_seconds=0.1,
+        llm_timeout_seconds=0.1,
+        total_timeout_seconds=0.5,
+        stt_max_attempts=2,
+        llm_max_attempts=2,
+        retry_initial_backoff_seconds=0.0,
+    )
+
+
+class SlowSTT:
+    async def transcribe(self, pcm: bytes, sample_rate: int = 16000) -> str:
+        await asyncio.sleep(10)
+        return "never"
+
+
+class SlowLLM:
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: list[Turn] | None = None,
+    ) -> Reply:
+        await asyncio.sleep(10)
+        return Reply(short="never", full="never", emotion=Emotion.NEUTRAL)
+
+
+class FlakySTT:
+    def __init__(self, fail_count: int, exc_factory: Callable[[], BaseException]) -> None:
+        self.fail_count = fail_count
+        self.exc_factory = exc_factory
+        self.calls = 0
+
+    async def transcribe(self, pcm: bytes, sample_rate: int = 16000) -> str:
+        self.calls += 1
+        if self.calls <= self.fail_count:
+            raise self.exc_factory()
+        return "hello recovered"
+
+
+class CrashSTT:
+    async def transcribe(self, pcm: bytes, sample_rate: int = 16000) -> str:
+        raise RuntimeError("subprocess crashed")
+
+
+class ParseFailLLM:
+    async def reply(
+        self,
+        transcript: str,
+        persona: str,
+        session_id: str,
+        history: list[Turn] | None = None,
+    ) -> Reply:
+        raise ValueError("did not include respond tool_use block")
+
+
+def _conn_error() -> httpx.ConnectError:
+    return httpx.ConnectError("upstream unavailable")
+
+
+def test_stt_timeout_returns_envelope(
+    fast_settings: Settings,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    app = create_app(fast_settings, SlowSTT(), fake_llm)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["error"]["code"] == "stt_timeout"
+    assert body["error"]["stage"] == "stt"
+    assert body["emotion"] == "sad"
+    assert body["text"]
+
+
+def test_llm_timeout_returns_envelope(
+    fast_settings: Settings,
+    fake_stt: FakeSTT,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    app = create_app(fast_settings, fake_stt, SlowLLM())
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["error"]["code"] == "llm_timeout"
+    assert body["error"]["stage"] == "llm"
+
+
+def test_stt_transient_then_success(
+    fast_settings: Settings,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    flaky = FlakySTT(fail_count=1, exc_factory=_conn_error)
+    app = create_app(fast_settings, flaky, fake_llm)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert "error" not in body
+    assert flaky.calls == 2
+
+
+def test_stt_permanent_failure(
+    fast_settings: Settings,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    app = create_app(fast_settings, CrashSTT(), fake_llm)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["error"]["code"] == "stt_failed"
+
+
+def test_llm_parse_failure(
+    fast_settings: Settings,
+    fake_stt: FakeSTT,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    app = create_app(fast_settings, fake_stt, ParseFailLLM())
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["error"]["code"] == "llm_parse_failed"
+
+
+def test_audio_rate_unsupported(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": "audio/L16;rate=8000;channels=1"},
+    )
+    assert r.status_code == 415
+    body = r.json()
+    assert body["error"]["code"] == "audio_rate_unsupported"
+    assert body["error"]["stage"] == "audio"
+
+
+def test_audio_rate_omitted_accepted(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": "audio/L16"},
+    )
+    assert r.status_code == 200
+
+
+def test_audio_body_too_small(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    too_small = b"\x00" * 100
+    r = client.post(
+        "/v1/listen",
+        content=too_small,
+        headers={**auth_headers, "Content-Type": _AUDIO_CT},
+    )
+    assert r.status_code == 400
+    body = r.json()
+    assert body["error"]["code"] == "audio_too_small"
+
+
+def test_envelope_shape_on_validation_error(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": "application/octet-stream"},
+    )
+    assert r.status_code == 415
+    body = r.json()
+    assert set(body.keys()) == {"text", "emotion", "error"}
+    assert set(body["error"].keys()) == {"code", "stage"}
+    assert body["error"]["code"] == "bad_content_type"
+
+
+def test_envelope_shape_on_provider_failure(
+    fast_settings: Settings,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    app = create_app(fast_settings, CrashSTT(), fake_llm)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    body = r.json()
+    assert set(body.keys()) == {"text", "emotion", "error"}
+    assert set(body["error"].keys()) == {"code", "stage"}

--- a/sidecar/tests/test_retry.py
+++ b/sidecar/tests/test_retry.py
@@ -1,0 +1,185 @@
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from stackchan_sidecar.retry import StageDeadlineError, is_transient, retry_with_timeout
+
+
+def _deadline(seconds: float) -> float:
+    return time.monotonic() + seconds
+
+
+async def _ok() -> str:
+    return "ok"
+
+
+async def test_succeeds_first_attempt() -> None:
+    result = await retry_with_timeout(
+        _ok,
+        max_attempts=3,
+        per_attempt_timeout=1.0,
+        deadline=_deadline(5.0),
+        initial_backoff=0.0,
+        label="t",
+    )
+    assert result == "ok"
+
+
+async def test_retries_until_success() -> None:
+    calls = {"n": 0}
+
+    async def call() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ConnectError("boom")
+        return "ok"
+
+    result = await retry_with_timeout(
+        call,
+        max_attempts=3,
+        per_attempt_timeout=1.0,
+        deadline=_deadline(5.0),
+        initial_backoff=0.0,
+        label="t",
+    )
+    assert result == "ok"
+    assert calls["n"] == 3
+
+
+async def test_does_not_retry_non_transient() -> None:
+    calls = {"n": 0}
+
+    async def call() -> str:
+        calls["n"] += 1
+        raise ValueError("permanent")
+
+    with pytest.raises(ValueError):
+        await retry_with_timeout(
+            call,
+            max_attempts=3,
+            per_attempt_timeout=1.0,
+            deadline=_deadline(5.0),
+            initial_backoff=0.0,
+            label="t",
+        )
+    assert calls["n"] == 1
+
+
+async def test_exhausts_and_raises_last_transient() -> None:
+    calls = {"n": 0}
+
+    async def call() -> str:
+        calls["n"] += 1
+        raise httpx.ConnectError("always")
+
+    with pytest.raises(httpx.ConnectError):
+        await retry_with_timeout(
+            call,
+            max_attempts=2,
+            per_attempt_timeout=1.0,
+            deadline=_deadline(5.0),
+            initial_backoff=0.0,
+            label="t",
+        )
+    assert calls["n"] == 2
+
+
+async def test_per_attempt_timeout_fires() -> None:
+    async def call() -> str:
+        await asyncio.sleep(10)
+        return "never"
+
+    with pytest.raises(TimeoutError):
+        await retry_with_timeout(
+            call,
+            max_attempts=1,
+            per_attempt_timeout=0.05,
+            deadline=_deadline(5.0),
+            initial_backoff=0.0,
+            label="t",
+        )
+
+
+async def test_global_deadline_caps_attempts() -> None:
+    calls = {"n": 0}
+
+    async def call() -> str:
+        calls["n"] += 1
+        raise httpx.ConnectError("boom")
+
+    with pytest.raises((httpx.ConnectError, StageDeadlineError)):
+        await retry_with_timeout(
+            call,
+            max_attempts=10,
+            per_attempt_timeout=0.01,
+            deadline=_deadline(0.05),
+            initial_backoff=0.1,
+            label="t",
+        )
+    assert calls["n"] < 10
+
+
+async def test_stage_deadline_when_past_deadline() -> None:
+    with pytest.raises(StageDeadlineError):
+        await retry_with_timeout(
+            _ok,
+            max_attempts=3,
+            per_attempt_timeout=1.0,
+            deadline=time.monotonic() - 1.0,
+            initial_backoff=0.0,
+            label="t",
+        )
+
+
+async def test_max_attempts_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        await retry_with_timeout(
+            _ok,
+            max_attempts=0,
+            per_attempt_timeout=1.0,
+            deadline=_deadline(5.0),
+            initial_backoff=0.0,
+            label="t",
+        )
+
+
+def test_is_transient_httpx_5xx() -> None:
+    req = httpx.Request("POST", "http://x")
+    resp = httpx.Response(503, request=req)
+    err = httpx.HTTPStatusError("boom", request=req, response=resp)
+    assert is_transient(err) is True
+
+
+def test_is_transient_httpx_4xx_false() -> None:
+    req = httpx.Request("POST", "http://x")
+    resp = httpx.Response(400, request=req)
+    err = httpx.HTTPStatusError("boom", request=req, response=resp)
+    assert is_transient(err) is False
+
+
+def test_is_transient_anthropic_overloaded() -> None:
+    import anthropic
+
+    req = httpx.Request("POST", "http://x")
+    resp = httpx.Response(529, request=req)
+    err = anthropic.APIStatusError("overloaded", response=resp, body=None)
+    assert is_transient(err) is True
+
+
+def test_is_transient_openai_5xx() -> None:
+    import openai
+
+    req = httpx.Request("POST", "http://x")
+    resp = httpx.Response(503, request=req)
+    err = openai.APIStatusError("server", response=resp, body=None)
+    assert is_transient(err) is True
+
+
+def test_is_transient_value_error_false() -> None:
+    assert is_transient(ValueError("nope")) is False
+
+
+def test_is_transient_timeout_error_true() -> None:
+    assert is_transient(TimeoutError("slow")) is True


### PR DESCRIPTION
## Summary

Polishes the resilience surface of the Python sidecar. Three slices in one
PR (held tight per the v0.2 cadence):

- **Per-stage timeouts + bounded retries.** Each upstream provider call
  (STT, LLM) runs under an `asyncio.wait_for` per-attempt timeout and up
  to N total attempts. Transient classes are retried — Anthropic 529,
  OpenAI 5xx, Deepgram 5xx, generic httpx network errors, in-flight
  timeouts. Permanent classes (4xx, parse errors, plain `ValueError`)
  fall through immediately. A shared `total_timeout_seconds` deadline
  caps the whole listen call so a slow STT can't starve the LLM.

- **Structured error envelope to kai.** Failure replies share the
  success shape plus an `error: {code, stage}` member. Graceful failures
  (retries exhausted, parse error) return 200 so the firmware lands a
  meaningful toast — kai's parser drops non-2xx on the floor
  (`agent_sidecar.rs:548-551`). Operator-visible validation failures
  (bad Content-Type, wrong sample rate, too-small body) stay as 4xx with
  the same envelope shape — the firmware never reads the body, but curl
  smoke tests and logs benefit from one consistent JSON contract.

- **Tighter audio validation at the FastAPI boundary.** Parses `rate=`
  from `Content-Type: audio/L16` and rejects non-16000 with
  `audio_rate_unsupported`. Rejects bodies shorter than 20 ms of 16 kHz
  mono s16 (640 bytes) with `audio_too_small`. Existing empty/oversize/
  Content-Length guards preserved.

New `config.toml` tunables (defaults shown):

```toml
stt_timeout_seconds = 10.0
llm_timeout_seconds = 20.0
total_timeout_seconds = 30.0
stt_max_attempts = 2
llm_max_attempts = 2
retry_initial_backoff_seconds = 0.5
```

Failure envelope (returned at 200 on graceful failure, at 4xx on
validation failure):

```json
{
  "text": "thinking too hard, try again",
  "emotion": "sad",
  "error": {"code": "llm_timeout", "stage": "llm"}
}
```

Non-breaking on the firmware side: kai's `extract_string` reads `text`
and `emotion` and ignores unknown keys.

## Test plan

- [x] `uv run ruff format --check .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy .` clean (strict)
- [x] `uv run pytest` — 87 passed, including 24 new (10 resilience
  integration + 14 retry unit). Each provider failure path has a
  dedicated test, plus envelope-shape assertions for both 200 and 4xx
  paths.
- [ ] Smoke test against a running sidecar with a slow STT (e.g.
  Deepgram disconnected) — verify the firmware shows the toast
  `didn't catch that, try again` and emotion `sad`.
- [ ] Smoke test the wrong-sample-rate path with curl
  (`Content-Type: audio/L16;rate=8000`) — verify 415 + envelope.