### PR TITLE
fix(sidecar): _RATE_RE word-boundary so bitrate= doesn't mask missing rate=

### DIFF
--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -26,7 +26,7 @@ _LOG = logging.getLogger("stackchan_sidecar")
 _MAX_BODY_BYTES = 30 * 16000 * 2 + 1024
 _MIN_BODY_BYTES = 640  # 20 ms @ 16 kHz mono s16; anything smaller is operator error
 _EXPECTED_SAMPLE_RATE = 16000
-_RATE_RE = re.compile(r"rate=(\d+)", re.IGNORECASE)
+_RATE_RE = re.compile(r"\brate=(\d+)", re.IGNORECASE)
 
 
 def _failure(

--- a/sidecar/tests/test_app_resilience.py
+++ b/sidecar/tests/test_app_resilience.py
@@ -207,6 +207,19 @@ def test_audio_rate_omitted_accepted(
     assert r.status_code == 200
 
 
+def test_audio_bitrate_does_not_mask_missing_rate(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": "audio/L16;bitrate=128000"},
+    )
+    assert r.status_code == 200
+
+
 def test_audio_body_too_small(
     client: TestClient,
     auth_headers: dict[str, str],


### PR DESCRIPTION
## Summary

Follow-up to #365 addressing the round-2 Greptile P3.

`_RATE_RE = r"rate=(\d+)"` had no token-boundary anchor, so
`audio/L16;bitrate=128000` would match `bitrate=` and extract `128000`,
falsely rejecting as `audio_rate_unsupported`. Kai never sends bitrate
so the bug was unreachable in practice, but the fix is one character
and the regression test pins the bitrate-shadow case.

## Test plan

- [x] `uv run pytest` — 88 passed (one new regression test for the
  bitrate-shadow case)
- [x] `uv run ruff check .` clean
- [x] `uv run mypy .` clean