### PR TITLE
feat(firmware): buddy_render task + Claude-prefixed BLE name

### DIFF
--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -108,9 +108,11 @@ round-trips between the SD-card RON file and the HTTP `/settings`
 JSON.
 
 In parallel, the device advertises a BLE peripheral named
-`stackchan-XXXXXX` (last three MAC bytes) so a phone or laptop on the
-same physical radio can read state and drive the firmware without
-joining the LAN. Services exposed: Device Information (`0x180A` —
+`Claude stk-XXXXXX` (last three MAC bytes) so a phone or laptop on
+the same physical radio can read state and drive the firmware
+without joining the LAN. The `Claude ` prefix is required for
+Claude Desktop's Hardware Buddy picker to filter the device in; the
+mDNS hostname is configured separately and unaffected. Services exposed: Device Information (`0x180A` —
 manufacturer / model / firmware revision), Battery (`0x180F`), a
 Stack-chan custom service for emotion read+notify, a Wi-Fi
 provisioning service for SSID + PSK writes, an audio service

--- a/crates/stackchan-firmware/src/ble/mod.rs
+++ b/crates/stackchan-firmware/src/ble/mod.rs
@@ -4,9 +4,11 @@
 //! `ExternalController` (built from `esp_radio`'s `BleConnector`) and
 //! drives an advertise → accept-connection → serve-GATT loop for the
 //! firmware lifetime. The advertised local name is
-//! `stackchan-XXXXXX`, where `XXXXXX` is the last three bytes of the
-//! Wi-Fi MAC; clients see the same handle whether they discover us
-//! over BLE or mDNS.
+//! `Claude stk-XXXXXX`, where `XXXXXX` is the last three bytes of
+//! the Wi-Fi MAC. The `Claude ` prefix is required for Claude
+//! Desktop's Hardware Buddy picker to filter the device in. The
+//! mDNS hostname stays `stackchan-XXXXXX` separately so LAN-side
+//! discovery isn't affected.
 //!
 //! Services exposed (in declaration order):
 //!

--- a/crates/stackchan-firmware/src/buddy_render.rs
+++ b/crates/stackchan-firmware/src/buddy_render.rs
@@ -17,10 +17,11 @@
 //!
 //! Emotion holds are re-asserted on every snapshot the desktop
 //! sends. The reference protocol guarantees a keepalive every 10 s,
-//! so a 2 s hold safely covers two consecutive keepalive intervals
+//! so a 25 s hold safely covers two consecutive keepalive intervals
 //! without letting autonomy slip in between, and a dropped link
 //! falls back to autonomy within one hold window.
 
+use embassy_sync::pubsub::WaitResult;
 use stackchan_buddy_proto::{Cmd, Inbound, Snapshot};
 use stackchan_core::{Clock, Emotion, RemoteCommand};
 
@@ -55,7 +56,16 @@ pub async fn buddy_render_task() -> ! {
     let mut last_emotion: Option<Emotion> = None;
 
     loop {
-        let message = sub.next_message_pure().await;
+        let message = match sub.next_message().await {
+            WaitResult::Message(m) => m,
+            WaitResult::Lagged(n) => {
+                defmt::warn!(
+                    "buddy_render: subscriber lagged, dropped {=u64} message(s)",
+                    n
+                );
+                continue;
+            }
+        };
         match message {
             Inbound::Snapshot(snap) => apply_snapshot(&snap, &mut last_emotion),
             Inbound::Cmd(Cmd::Owner { name }) => {

--- a/crates/stackchan-firmware/src/buddy_render.rs
+++ b/crates/stackchan-firmware/src/buddy_render.rs
@@ -1,0 +1,134 @@
+//! Render snapshots from Claude Desktop onto the avatar's existing
+//! affect surfaces.
+//!
+//! Subscribes to [`crate::ble::buddy::BUDDY_INBOUND`] and translates
+//! each [`Inbound`] into something the firmware's existing channels
+//! already understand:
+//!
+//! - `Snapshot { waiting > 0, .. }` → curious emotion + toast band
+//!   carrying the desktop's one-line `msg`
+//! - `Snapshot { running > 0, .. }` → happy emotion (engaged, no
+//!   blocking prompt)
+//! - `Snapshot { total == 0 }` → release autonomy (`Reset`) so the
+//!   avatar idles
+//! - `Cmd::Owner { name }` → log only for now (persistence joins the
+//!   owner / status / unpair handlers in a later slice)
+//! - everything else → log only
+//!
+//! Emotion holds are re-asserted on every snapshot the desktop
+//! sends. The reference protocol guarantees a keepalive every 10 s,
+//! so a 2 s hold safely covers two consecutive keepalive intervals
+//! without letting autonomy slip in between, and a dropped link
+//! falls back to autonomy within one hold window.
+
+use stackchan_buddy_proto::{Cmd, Inbound, Snapshot};
+use stackchan_core::{Clock, Emotion, RemoteCommand};
+
+use crate::ble::buddy::BUDDY_INBOUND;
+use crate::clock::HalClock;
+use crate::net::http::REMOTE_COMMAND_SIGNAL;
+use crate::toast::{self, ToastLevel};
+
+/// Hold each derived emotion for two heartbeat keepalive intervals.
+/// The desktop guarantees a 10 s keepalive cadence; 25 s covers two
+/// missed keepalives before autonomy resumes — long enough to ride
+/// out one dropped notification but short enough to fall back if the
+/// link silently dies.
+const EMOTION_HOLD_MS: u32 = 25_000;
+
+/// Render task. Spawns once at boot, runs for the firmware lifetime.
+/// Parks until the first inbound, then loops one message at a time.
+/// Lost messages from a back-pressured subscriber slot surface as a
+/// warning — at ≤10 Hz the queue should never genuinely back up.
+#[embassy_executor::task]
+pub async fn buddy_render_task() -> ! {
+    let Ok(mut sub) = BUDDY_INBOUND.subscriber() else {
+        defmt::error!(
+            "buddy_render: BUDDY_INBOUND subscriber slot exhausted; task parking forever"
+        );
+        loop {
+            embassy_time::Timer::after(embassy_time::Duration::from_secs(3600)).await;
+        }
+    };
+    defmt::info!("buddy_render: subscribed to BUDDY_INBOUND");
+
+    let mut last_emotion: Option<Emotion> = None;
+
+    loop {
+        let message = sub.next_message_pure().await;
+        match message {
+            Inbound::Snapshot(snap) => apply_snapshot(&snap, &mut last_emotion),
+            Inbound::Cmd(Cmd::Owner { name }) => {
+                defmt::info!("buddy_render: owner = {=str}", name.as_str());
+            }
+            Inbound::Cmd(other) => {
+                defmt::trace!(
+                    "buddy_render: cmd received (handled by other task) {}",
+                    defmt::Debug2Format(&other),
+                );
+            }
+            Inbound::Turn(_) | Inbound::TimeSync { .. } => {
+                // Out of scope for the snapshot renderer; other
+                // subscribers (or a later slice) handle these.
+            }
+        }
+    }
+}
+
+/// Translate one heartbeat snapshot into emotion + toast updates.
+fn apply_snapshot(snap: &Snapshot, last_emotion: &mut Option<Emotion>) {
+    let derived = derive_emotion(snap);
+
+    match derived {
+        Some(emotion) => {
+            // Re-assert on every snapshot so the hold timer keeps
+            // refreshing while the desktop stays engaged. Only log
+            // on edge transitions to avoid spamming defmt at 10 Hz.
+            if *last_emotion != Some(emotion) {
+                defmt::info!("buddy_render: emotion → {=str}", emotion.wire_str(),);
+                *last_emotion = Some(emotion);
+            }
+            REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::SetEmotion {
+                emotion,
+                hold_ms: EMOTION_HOLD_MS,
+            });
+        }
+        None => {
+            if last_emotion.is_some() {
+                defmt::info!("buddy_render: idle (total=0); releasing autonomy");
+                REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::Reset);
+                *last_emotion = None;
+            }
+        }
+    }
+
+    if !snap.msg.is_empty() {
+        // `msg` may exceed the toast band's char cap; `toast::push`
+        // truncates by codepoints, so passing the full string is
+        // safe across multi-byte UTF-8. The toast tier stays at
+        // `Warn` for both prompts and progress — the desktop only
+        // sends `msg` when there's something operator-facing to
+        // show, and a band that flickers between Warn/Error
+        // colors per-tick would read as instability.
+        toast::push(ToastLevel::Warn, &snap.msg, HalClock.now());
+    }
+}
+
+/// Map heartbeat counts to an [`Emotion`].
+///
+/// - `waiting > 0` (a permission prompt is blocking a session) →
+///   `Curious` so the operator notices something needs attention
+/// - `running > 0` (work in flight, no prompt) → `Happy` so the
+///   avatar reads as engaged-but-busy
+/// - `total == 0` → no override (caller releases autonomy)
+const fn derive_emotion(snap: &Snapshot) -> Option<Emotion> {
+    if snap.waiting > 0 {
+        Some(Emotion::Curious)
+    } else if snap.running > 0 {
+        Some(Emotion::Happy)
+    } else if snap.total > 0 {
+        Some(Emotion::Neutral)
+    } else {
+        None
+    }
+}

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -24,6 +24,7 @@ pub mod audio_debug;
 pub mod ble;
 pub mod board;
 pub mod body_touch;
+pub mod buddy_render;
 pub mod button;
 pub mod camera;
 pub mod chime;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1577,10 +1577,16 @@ async fn main(spawner: Spawner) -> ! {
     let ble_name: &'static str = {
         use core::fmt::Write as _;
         let mut s: heapless::String<32> = heapless::String::new();
-        // 16 bytes total — well under the 22-byte BLE GAP-name cap.
+        // Must start with `Claude` so Claude Desktop's Hardware
+        // Buddy picker filters us in. `Claude stk-XXXXXX` is 17
+        // bytes — comfortably under the 22-byte BLE GAP-name cap
+        // and leaves headroom for an operator-supplied display
+        // name in a later slice. The mDNS hostname stays
+        // `stackchan-…` separately so LAN-side discovery isn't
+        // affected.
         if let Err(e) = write!(
             &mut s,
-            "stackchan-{:02x}{:02x}{:02x}",
+            "Claude stk-{:02x}{:02x}{:02x}",
             ble_mac[3], ble_mac[4], ble_mac[5]
         ) {
             defmt::panic!("ble: name format failed: {}", defmt::Debug2Format(&e));
@@ -1606,6 +1612,13 @@ async fn main(spawner: Spawner) -> ! {
         local_name: ble_name,
     })) {
         defmt::panic!("spawn(ble_task) failed: {}", defmt::Debug2Format(&e));
+    }
+
+    if let Err(e) = spawner.spawn(stackchan_firmware::buddy_render::buddy_render_task()) {
+        defmt::panic!(
+            "spawn(buddy_render_task) failed: {}",
+            defmt::Debug2Format(&e)
+        );
     }
 
     // Sample the chip's hardware RNG twice — once for IdleDrift


### PR DESCRIPTION
## Summary

`buddy_render::buddy_render_task` subscribes to `BUDDY_INBOUND` (from #368) and translates heartbeat snapshots into the firmware's existing affect surfaces — emotion, autonomy gate, toast band. The advertised BLE local name also flips from \`stackchan-XXXXXX\` to \`Claude stk-XXXXXX\` so Claude Desktop's Hardware Buddy picker filters the device in.

This is PR 3 of 5; stacks off #368.

## Mapping

| Snapshot state | Action |
|---|---|
| \`waiting > 0\` | \`SetEmotion(Curious)\` — operator needs to act on a pending prompt |
| \`running > 0\` | \`SetEmotion(Happy)\` — engaged, no blocking prompt |
| \`total > 0\` | \`SetEmotion(Neutral)\` — idle session |
| \`total == 0\` | \`Reset\` — release autonomy |
| non-empty \`msg\` | toast band |

Each emotion is re-asserted on every snapshot with a 25 s hold so two consecutive 10 s keepalives can land before autonomy reclaims the avatar. Edge-only logging avoids flooding defmt at the heartbeat cadence. \`Cmd::Owner\` is logged; persistence (and the rest of the command surface — \`status\` / \`unpair\` / \`name\` / folder push / time-sync / turn events) lands in a later slice.

## BLE name

Default is now \`Claude stk-XXXXXX\` (17 bytes; comfortably under the 22-byte GAP cap) with the last 3 MAC bytes for uniqueness. The mDNS hostname (\`stackchan-XXXXXX\` by default, operator-overridable in \`STACKCHAN.RON\`) is unaffected — LAN discovery and the BLE picker can keep their own naming conventions.

## Test plan

- [x] \`cargo +esp clippy --release -- -D warnings\`
- [x] \`cargo +esp build --release\`
- [x] \`cargo fmt --check\` + host gates green
- [ ] On-device: pair to Claude Desktop in dev mode, verify the device appears in the Hardware Buddy picker with the new name; observe emotion / toast transitions as the desktop sends real heartbeats