### PR TITLE
fix(firmware): buddy unpair ack honors bond-wipe result + control cleanups

### DIFF
--- a/crates/stackchan-firmware/src/ble/bonds.rs
+++ b/crates/stackchan-firmware/src/ble/bonds.rs
@@ -68,13 +68,38 @@ pub async fn load_all() -> HVec<BondInformation, MAX_BONDS> {
 
 /// Persist the entire bond list atomically. Called on each
 /// `PairingComplete` event with the latest snapshot from
-/// `Stack::get_bond_information`.
-pub async fn save_all(bonds: &[BondInformation]) {
+/// `Stack::get_bond_information`, and on `unpair` with an empty
+/// list to wipe stored bonds.
+///
+/// Callers that only care about best-effort persistence
+/// (`PairingComplete`) can discard the `Result` with `let _ =`.
+/// Callers that ack back to a peer (the buddy `unpair` handler)
+/// need the result to report honestly.
+///
+/// # Errors
+///
+/// Returns `Err` with a short fixed reason when the SD card is
+/// absent (`"no sd mounted"`) or the FAT write fails
+/// (`"sd write failed"`). The underlying [`StorageError`] is logged
+/// at `warn` level inside this function and the wire-friendly
+/// reason is returned to the caller.
+///
+/// [`StorageError`]: crate::storage::StorageError
+pub async fn save_all(bonds: &[BondInformation]) -> Result<(), &'static str> {
     let encoded = encode(bonds);
     match with_storage(|s| s.write_bonds(&encoded)).await {
-        Some(Ok(())) => defmt::info!("ble: bonds: persisted {=usize} bond(s)", bonds.len()),
-        Some(Err(e)) => defmt::warn!("ble: bonds: write failed ({})", e),
-        None => defmt::warn!("ble: bonds: no SD mounted; cannot persist"),
+        Some(Ok(())) => {
+            defmt::info!("ble: bonds: persisted {=usize} bond(s)", bonds.len());
+            Ok(())
+        }
+        Some(Err(e)) => {
+            defmt::warn!("ble: bonds: write failed ({})", e);
+            Err("sd write failed")
+        }
+        None => {
+            defmt::warn!("ble: bonds: no SD mounted; cannot persist");
+            Err("no sd mounted")
+        }
     }
 }
 

--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -837,7 +837,9 @@ async fn gatt_events_task<P: PacketPool>(
                 );
                 if bond.is_some() {
                     let snapshot = stack.get_bond_information();
-                    super::bonds::save_all(&snapshot).await;
+                    // Best-effort persistence on pairing-complete;
+                    // `save_all` already logs the failure reason.
+                    let _ = super::bonds::save_all(&snapshot).await;
                 }
             }
             GattConnectionEvent::PairingFailed(e) => {

--- a/crates/stackchan-firmware/src/buddy_control.rs
+++ b/crates/stackchan-firmware/src/buddy_control.rs
@@ -45,8 +45,8 @@ use crate::toast::{self, ToastLevel};
 /// turn event.
 const TOAST_PREVIEW_BYTES: usize = 64;
 
-/// Render task. Spawns once at boot, runs for the firmware
-/// lifetime.
+/// Command-surface task. Spawns once at boot, runs for the
+/// firmware lifetime.
 #[embassy_executor::task]
 pub async fn buddy_control_task() -> ! {
     let Ok(mut sub) = BUDDY_INBOUND.subscriber() else {
@@ -142,7 +142,6 @@ async fn handle(message: Inbound, boot: Instant) {
 /// signal it as an ack reply.
 fn reply_status(boot: Instant) {
     let snap = snapshot::read();
-    let sensors = snapshot::read_sensors();
 
     let battery = snap.battery.percent.map(|pct| BatteryStatus {
         pct,
@@ -150,9 +149,6 @@ fn reply_status(boot: Instant) {
         ma: 0,      // current draw isn't surfaced in the snapshot
         usb: false, // usb-attach state isn't surfaced today
     });
-    // Suppress the unused-binding warning when no battery field
-    // is set yet — the snapshot is empty pre-AXP2101 init.
-    let _ = sensors;
 
     let uptime_secs =
         u32::try_from(Instant::now().duration_since(boot).as_secs()).unwrap_or(u32::MAX);
@@ -175,11 +171,19 @@ fn reply_status(boot: Instant) {
 /// immediately on disk; the current pairing remains live until the
 /// central disconnects (the desktop typically does so after a
 /// `Forget`).
+///
+/// The ack reports the wipe's actual outcome: if the SD card is
+/// absent or the write fails, `ok: false` goes back to the desktop
+/// (otherwise on next boot the unchanged bonds would silently
+/// re-pair). Reasons are short fixed strings so defmt + the wire
+/// stay terse.
 async fn unpair() {
     defmt::info!("buddy_control: unpair — wiping bonds");
     let empty: HVec<trouble_host::prelude::BondInformation, 8> = HVec::new();
-    bonds::save_all(&empty).await;
-    ack("unpair", true, 0, None);
+    match bonds::save_all(&empty).await {
+        Ok(()) => ack("unpair", true, 0, None),
+        Err(reason) => ack("unpair", false, 0, Some(reason)),
+    }
 }
 
 /// Push the first text content block from a completed turn onto
@@ -210,15 +214,15 @@ fn text_preview(block: &ContentBlock) -> Option<alloc::string::String> {
         return None;
     }
     // Walk char boundaries so a multi-byte UTF-8 codepoint never
-    // gets cut mid-sequence.
-    let mut taken = 0;
+    // gets cut mid-sequence. `char_indices` yields byte offsets;
+    // the next-char check is `i + ch.len_utf8() > cap` so the
+    // longest prefix that fits remains in `end`.
     let mut end = 0;
     for (i, ch) in text.char_indices() {
-        if taken + ch.len_utf8() > TOAST_PREVIEW_BYTES {
+        if i + ch.len_utf8() > TOAST_PREVIEW_BYTES {
             break;
         }
         end = i + ch.len_utf8();
-        taken += ch.len_utf8();
     }
     Some(text[..end].to_string())
 }


### PR DESCRIPTION
## Summary

Four greptile follow-ups on #374 that landed after the PR had auto-merged.

**P1 — unpair always acked success.** \`bonds::save_all\` previously absorbed both \`Err(StorageError)\` and "no SD mounted" internally and returned \`()\`, so \`buddy_control::unpair\` could only build \`ok:true\`. The desktop received a successful ack even when the bond file was never cleared, and on next boot the device would load the unchanged bonds and re-pair silently with the supposedly-forgotten peer. Switched \`save_all\` to return \`Result<(), &'static str>\` with two short fixed reasons (\`"no sd mounted"\` / \`"sd write failed"\`); the unpair handler maps errors into \`ok:false\` with the reason in the ack's \`error\` field. The pairing-complete caller in \`gatt_events_task\` explicitly discards with \`let _ =\` — best-effort persistence there is the historical behaviour and not what changed.

**P2 — stale "Render task" doc** on \`buddy_control_task\` (copy-paste from \`buddy_render_task\`).

**P2 — dead \`read_sensors()\` call** in \`reply_status\`. The result was immediately discarded with \`let _ = sensors\`; nothing from \`SensorsSnapshot\` ends up in the status ack.

**P2 — redundant \`taken\` variable** in \`text_preview\`. \`char_indices\` already yields the byte offset of each char; the running \`taken\` counter was a duplicate of the next-position math.

## Test plan

- [x] \`cargo +esp clippy --release -- -D warnings\`
- [x] \`cargo +esp build --release\`
- [x] Host gates green
- [ ] On-device: pair to Claude Desktop, click Forget in the desktop UI, verify the next pair requires a fresh passkey (i.e. bonds were actually wiped); on a unit booted without an SD card, click Forget and verify the desktop surfaces the \`no sd mounted\` error