### PR TITLE
feat(firmware): persist cmd:name to /sd/DEVICE.NAM + soft-reset

### DIFF
--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -183,8 +183,14 @@ fn reply_status(boot: Instant) {
 /// with the reason and we skip the reset (no point cycling if the
 /// new name isn't actually on disk).
 async fn set_name(name: &str) {
-    defmt::info!("desktop_control: name → {=str}", name);
-    let outcome = crate::storage::with_storage(|s| s.write_device_name(name)).await;
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        defmt::warn!("desktop_control: name → empty; rejecting without reboot");
+        ack("name", false, 0, Some("empty name"));
+        return;
+    }
+    defmt::info!("desktop_control: name → {=str}", trimmed);
+    let outcome = crate::storage::with_storage(|s| s.write_device_name(trimmed)).await;
     match outcome {
         Some(Ok(())) => {
             ack("name", true, 0, None);

--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -202,6 +202,10 @@ async fn set_name(name: &str) {
             defmt::info!("desktop_control: rebooting to pick up new BLE name");
             esp_hal::system::software_reset();
         }
+        Some(Err(crate::storage::StorageError::TooLarge)) => {
+            defmt::warn!("desktop_control: name too long (> 22 bytes)");
+            ack("name", false, 0, Some("name too long"));
+        }
         Some(Err(e)) => {
             defmt::warn!(
                 "desktop_control: write_device_name failed ({})",

--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -10,9 +10,10 @@
 //! - **status** → builds a [`StatusData`] from the current
 //!   battery / uptime / heap / approval+deny counters and replies.
 //! - **owner** → logs + acks.
-//! - **name** → logs + acks. Persistence to `/sd/RUNTIME.RON`
-//!   joins a later slice; the in-RAM name visible over BLE doesn't
-//!   change until that lands.
+//! - **name** → writes `/sd/DEVICE.NAM` and soft-resets so the
+//!   new name takes effect on the next advertise cycle (the BLE
+//!   local name is captured into a `StaticCell` early in `main`).
+//!   The ack flushes before the reset.
 //! - **unpair** → wipes the SD-backed bonds via
 //!   [`crate::ble::bonds::save_all`] with an empty list, then acks.
 //! - **time** (`{"time":[epoch,tz]}`) → fans the epoch out to
@@ -84,11 +85,7 @@ async fn handle(message: Inbound, boot: Instant) {
             ack("owner", true, 0, None);
         }
         Inbound::Cmd(Cmd::SetName { name }) => {
-            defmt::info!(
-                "desktop_control: name → {=str} (persistence pending)",
-                name.as_str()
-            );
-            ack("name", true, 0, None);
+            set_name(&name).await;
         }
         Inbound::Cmd(Cmd::Unpair) => {
             unpair().await;
@@ -168,6 +165,49 @@ fn reply_status(boot: Instant) {
         stats: None, // counters land alongside operator-visible UX in a follow-up
     };
     DESKTOP_OUTBOUND.signal(Outbound::StatusAck(data));
+}
+
+/// Persist the desktop-supplied BLE name to `/sd/DEVICE.NAM` and
+/// soft-reset the device so the new name takes effect on the next
+/// advertise cycle.
+///
+/// The BLE local name is captured into a `StaticCell` early in
+/// `main`; there's no in-flight way to swap it. The reboot avoids
+/// the more invasive "hot-swap the advertise name" refactor that
+/// would otherwise be needed. Operators see the reboot as the
+/// device cycling once after they hit "Save" in the desktop's
+/// Hardware Buddy panel — a one-second blip, then the device
+/// reappears with the new name.
+///
+/// On SD-absent / write-failure paths the ack reports `ok: false`
+/// with the reason and we skip the reset (no point cycling if the
+/// new name isn't actually on disk).
+async fn set_name(name: &str) {
+    defmt::info!("desktop_control: name → {=str}", name);
+    let outcome = crate::storage::with_storage(|s| s.write_device_name(name)).await;
+    match outcome {
+        Some(Ok(())) => {
+            ack("name", true, 0, None);
+            // Best-effort: give the BLE notify path a tick to flush
+            // the ack onto the wire before we reboot, otherwise the
+            // desktop sees the disconnect first and may interpret
+            // the missing ack as failure.
+            embassy_time::Timer::after(Duration::from_millis(250)).await;
+            defmt::info!("desktop_control: rebooting to pick up new BLE name");
+            esp_hal::system::software_reset();
+        }
+        Some(Err(e)) => {
+            defmt::warn!(
+                "desktop_control: write_device_name failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            ack("name", false, 0, Some("sd write failed"));
+        }
+        None => {
+            defmt::warn!("desktop_control: no SD mounted; cannot persist name");
+            ack("name", false, 0, Some("no sd mounted"));
+        }
+    }
 }
 
 /// Wipe the bonds file and send the ack. Bond wipe takes effect

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1587,17 +1587,39 @@ async fn main(spawner: Spawner) -> ! {
     #[allow(clippy::items_after_statements)]
     static BLE_NAME: StaticCell<heapless::String<32>> = StaticCell::new();
     let ble_mac = esp_hal::efuse::Efuse::mac_address();
+    // First, try the operator-supplied name from
+    // `/sd/DEVICE.NAM` (set via the Hardware Buddy `cmd:name`
+    // message). Fall back to the MAC-suffixed default. The name
+    // must start with `Claude` so the Hardware Buddy picker filters
+    // us in; the default does, and a desktop-set override is
+    // assumed to as well — we don't enforce the prefix.
+    let persisted_name = stackchan_firmware::storage::with_storage(
+        stackchan_firmware::storage::FirmwareStorage::read_device_name,
+    )
+    .await
+    .and_then(|r| match r {
+        Ok(opt) => opt,
+        Err(e) => {
+            defmt::warn!(
+                "ble: device name read failed ({}); using MAC-suffixed default",
+                defmt::Debug2Format(&e)
+            );
+            None
+        }
+    });
     let ble_name: &'static str = {
         use core::fmt::Write as _;
         let mut s: heapless::String<32> = heapless::String::new();
-        // Must start with `Claude` so Claude Desktop's Hardware
-        // Desktop picker filters us in. `Claude stk-XXXXXX` is 17
-        // bytes — comfortably under the 22-byte BLE GAP-name cap
-        // and leaves headroom for an operator-supplied display
-        // name in a later slice. The mDNS hostname stays
-        // `stackchan-…` separately so LAN-side discovery isn't
-        // affected.
-        if let Err(e) = write!(
+        if let Some(name) = persisted_name.as_deref() {
+            // Cap at heapless::String<32>'s capacity. Operator
+            // names longer than the BLE GAP 22-byte limit will be
+            // rejected by the advertise layer; here we just keep
+            // the buffer write infallible.
+            let n = name.len().min(32);
+            if let Err(e) = s.push_str(&name[..n]) {
+                defmt::panic!("ble: name copy failed: {}", defmt::Debug2Format(&e));
+            }
+        } else if let Err(e) = write!(
             &mut s,
             "Claude stk-{:02x}{:02x}{:02x}",
             ble_mac[3], ble_mac[4], ble_mac[5]
@@ -1606,6 +1628,7 @@ async fn main(spawner: Spawner) -> ! {
         }
         BLE_NAME.init(s).as_str()
     };
+    defmt::info!("ble: advertising as {=str}", ble_name);
     let ble_connector = match esp_radio::ble::controller::BleConnector::new(
         radio,
         peripherals.BT,

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -184,9 +184,11 @@ const DEVICE_NAME_FILE: &str = "DEVICE.NAM";
 /// dance as the session UUID.
 const DEVICE_NAME_STAGING_FILE: &str = "DEVICE.NEW";
 
-/// Cap on the `DEVICE.NAM` file. BLE GAP local-name maxes at 22
-/// bytes; 32 absorbs a trailing newline and small margin.
-const MAX_DEVICE_NAME_BYTES: u32 = 32;
+/// Cap on the `DEVICE.NAM` file. Matches the BLE GAP local-name
+/// hard limit so a name that survives `write_device_name` will
+/// also survive the advertise layer — keeps the stored value and
+/// the advertised value in lockstep.
+const MAX_DEVICE_NAME_BYTES: u32 = 22;
 
 /// Filename for the operator-triggered camera capture. Single fixed
 /// name (no rotation) so each capture overwrites the previous —

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -174,6 +174,20 @@ const SESSION_UUID_STAGING_FILE: &str = "SESSION.NEW";
 /// unbounded SRAM allocation at boot.
 const MAX_SESSION_UUID_BYTES: u32 = 64;
 
+/// File holding the operator-supplied BLE local name, set via the
+/// Hardware Buddy `{"cmd":"name","name":"..."}` message. Empty /
+/// missing reverts to the MAC-suffixed default at boot. Persisted
+/// rather than RAM-only so a `cmd:name` survives reboots.
+const DEVICE_NAME_FILE: &str = "DEVICE.NAM";
+
+/// Atomic-write staging name for the device name. Same staged-copy
+/// dance as the session UUID.
+const DEVICE_NAME_STAGING_FILE: &str = "DEVICE.NEW";
+
+/// Cap on the `DEVICE.NAM` file. BLE GAP local-name maxes at 22
+/// bytes; 32 absorbs a trailing newline and small margin.
+const MAX_DEVICE_NAME_BYTES: u32 = 32;
+
 /// Filename for the operator-triggered camera capture. Single fixed
 /// name (no rotation) so each capture overwrites the previous —
 /// the workflow is "trigger, eject SD, view, repeat", not a
@@ -437,6 +451,62 @@ where
         }
         self.write_file(SESSION_UUID_STAGING_FILE, uuid.as_bytes())?;
         self.copy_then_delete(SESSION_UUID_STAGING_FILE, SESSION_UUID_FILE)?;
+        Ok(())
+    }
+
+    /// Read `/sd/DEVICE.NAM` — the operator-supplied BLE local name
+    /// set via the Hardware Buddy `cmd:name` message — as a trimmed
+    /// UTF-8 string. Returns `Ok(None)` if the file is absent (the
+    /// boot path falls back to the MAC-suffixed default).
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Read`] on a partial / failed read,
+    /// [`StorageError::TooLarge`] if the file exceeds
+    /// [`MAX_DEVICE_NAME_BYTES`], [`StorageError::NotUtf8`] if the
+    /// bytes don't decode as UTF-8.
+    pub fn read_device_name(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        let Ok(file) = root.open_file_in_dir(DEVICE_NAME_FILE, Mode::ReadOnly) else {
+            return Ok(None);
+        };
+        let len = file.length();
+        if len > MAX_DEVICE_NAME_BYTES {
+            return Err(StorageError::TooLarge);
+        }
+        let len = len as usize;
+        let mut buf = alloc::vec![0u8; len];
+        let n = file.read(&mut buf).map_err(|_| StorageError::Read)?;
+        buf.truncate(n);
+        let text = alloc::string::String::from_utf8(buf).map_err(|_| StorageError::NotUtf8)?;
+        let trimmed = text.trim().to_string();
+        if trimmed.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(trimmed))
+        }
+    }
+
+    /// Atomically replace `/sd/DEVICE.NAM` with `name`. The new name
+    /// takes effect on next boot — the BLE advertised name is
+    /// captured into a `StaticCell` early in `main` and not
+    /// re-readable from disk while the firmware runs.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Write`] on any underlying write failure,
+    /// [`StorageError::TooLarge`] if `name` exceeds
+    /// [`MAX_DEVICE_NAME_BYTES`].
+    pub fn write_device_name(&mut self, name: &str) -> Result<(), StorageError> {
+        if name.len() > MAX_DEVICE_NAME_BYTES as usize {
+            return Err(StorageError::TooLarge);
+        }
+        self.write_file(DEVICE_NAME_STAGING_FILE, name.as_bytes())?;
+        self.copy_then_delete(DEVICE_NAME_STAGING_FILE, DEVICE_NAME_FILE)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

\`desktop_control::set_name\` writes the operator-supplied BLE local name to \`/sd/DEVICE.NAM\` and triggers \`esp_hal::system::software_reset()\` after a 250 ms ack-flush delay. On the next boot, \`main\` reads the file first via the new \`FirmwareStorage::read_device_name\` (mirroring the \`read_session_uuid\` pattern), falling back to the MAC-suffixed \`Claude stk-XXXXXX\` default when the file is absent or empty.

## Why a reboot?

The BLE local name is captured into a \`StaticCell\` early in \`main\` and there's no in-flight way to swap it. The reboot avoids the more invasive "hot-swap the advertise name" refactor that would otherwise be needed. Operators see a one-second blip after hitting "Save" in the desktop's Hardware Buddy panel, then the device reappears with the new name. This matches the operator-visible cadence the desktop already expects.

## Edge cases

| State | Ack | Reset? |
|---|---|---|
| Write succeeds | \`ok:true, n:0\` | yes (after 250 ms ack flush) |
| Write fails | \`ok:false, error:"sd write failed"\` | no |
| No SD mounted | \`ok:false, error:"no sd mounted"\` | no |

## Adjacent fix

Fixed a comment in \`main.rs\` that the buddy→desktop rename (#380) had garbled across a line break ("Hardware\\nBuddy" became "Hardware\\nDesktop"). The sed-based rename's placeholder for "Hardware Buddy" only matched single-line; this one slipped.

## Test plan

- [x] \`cargo +esp clippy --release -- -D warnings\`
- [ ] On-device: pair to Claude Desktop in dev mode, set a new name via the Hardware Buddy panel, observe the reboot, confirm the device re-advertises with the new name
- [ ] On-device negative: remove SD card, set a name, confirm the desktop receives \`ok:false\` with \`"no sd mounted"\` and the device does NOT reboot