### PR TITLE
feat(firmware): folder-push receiver writes /sd/desktop/<char>/<file>

### DIFF
--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -245,6 +245,19 @@ fn file_announce(push: &mut PushState, path: &str, size: u32) {
         ack("file", false, 0, Some("subdirectories not supported"));
         return;
     }
+    // FAT short/long-name table rejects these even though POSIX
+    // allows them; without this guard a bad name passes
+    // `is_safe_relative_path` and fails at `open_file_in_dir` with
+    // a generic `"sd write failed"` after we've already buffered
+    // all chunks.
+    if path.contains(['*', '?', ':', '<', '>', '|', '"']) {
+        defmt::warn!(
+            "desktop_control: file {=str} — illegal FAT filename character",
+            path
+        );
+        ack("file", false, 0, Some("illegal filename character"));
+        return;
+    }
     if size > MAX_DESKTOP_FILE_BYTES {
         defmt::warn!(
             "desktop_control: file {=str} too large ({=u32}B > {=u32}B cap)",
@@ -287,9 +300,13 @@ fn chunk(push: &mut PushState, data: &[u8]) {
             MAX_DESKTOP_FILE_BYTES
         );
         ack("chunk", false, 0, Some("file exceeds size cap"));
-        // Drop the half-written file so a subsequent `file_end`
-        // doesn't commit truncated bytes to disk.
+        // Drop the half-written file AND end the push so a
+        // pipelined `file_end` doesn't reach the "no file in
+        // progress" branch (which would surface a second
+        // `ok:false` with a confusingly different reason). The
+        // desktop must restart with a fresh `char_begin`.
         push.current_file = None;
+        push.active_char = None;
         return;
     }
     file.buffer.extend_from_slice(data);

--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -173,6 +173,24 @@ fn char_begin(push: &mut PushState, name: &str, total: u32) {
         ack("char_begin", false, 0, Some("unsafe char name"));
         return;
     }
+    // Char names map to a single FAT directory entry under
+    // `/sd/desktop/`; embedded-sdmmc can't traverse `/` inside a
+    // single `open_dir` call. Reject up front instead of failing
+    // every file commit in the push with a misleading "sd write
+    // failed".
+    if name.contains('/') {
+        defmt::warn!(
+            "desktop_control: char_begin {=str} — slash in char name not supported",
+            name
+        );
+        ack(
+            "char_begin",
+            false,
+            0,
+            Some("slash in char name not supported"),
+        );
+        return;
+    }
     // Reset any stragglers from a prior interrupted push.
     *push = PushState::default();
     push.active_char = Some(name.to_string());
@@ -323,19 +341,26 @@ async fn file_end(push: &mut PushState) {
     }
 }
 
-/// End the current folder push. Always succeeds — the per-file
-/// commits happened in `file_end`; `char_end` is just the
-/// teardown signal.
+/// End the current folder push. The per-file commits happened in
+/// `file_end`; `char_end` is the teardown signal. If a file is
+/// still open (desktop sent `char_end` before `file_end`) we
+/// refuse with `ok:false` rather than silently dropping the
+/// buffered bytes — the desktop is bug-reporting an incomplete
+/// push and should retry.
 fn char_end(push: &mut PushState) {
+    if push.current_file.is_some() {
+        defmt::warn!("desktop_control: char_end arrived with open file; dropping buffer");
+        push.current_file = None;
+        push.active_char = None;
+        ack("char_end", false, 0, Some("file still open"));
+        return;
+    }
     if let Some(name) = push.active_char.take() {
         defmt::info!("desktop_control: char_end {=str}", name.as_str());
         ack("char_end", true, 0, None);
     } else {
         ack("char_end", false, 0, Some("no char in progress"));
     }
-    // `current_file` should already be None after `file_end`; drop
-    // any stray buffer defensively.
-    push.current_file = None;
 }
 
 /// Build a [`StatusData`] from the firmware's current snapshot and

--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -196,9 +196,35 @@ fn file_announce(push: &mut PushState, path: &str, size: u32) {
         ack("file", false, 0, Some("no folder push in progress"));
         return;
     }
+    // A prior `file` without `file_end` is a desktop bug — refuse
+    // to silently drop the in-flight buffer (the desktop already
+    // received `ok:true` for that file's announce + chunks and
+    // would otherwise think the data landed).
+    if push.current_file.is_some() {
+        defmt::warn!(
+            "desktop_control: file {=str} arrived with prior file still open",
+            path
+        );
+        ack("file", false, 0, Some("prior file not ended"));
+        push.current_file = None;
+        return;
+    }
     if !is_safe_relative_path(path) {
         defmt::warn!("desktop_control: file {=str} — unsafe path", path);
         ack("file", false, 0, Some("unsafe file path"));
+        return;
+    }
+    // Folder push is documented as flat — no subdirectories. The
+    // `is_safe_relative_path` check accepts `subdir/icon.png` for
+    // other callers, but FAT doesn't traverse `/` inside a single
+    // `open_file_in_dir`, so accept here would commit a
+    // mid-transfer failure. Reject up front instead.
+    if path.contains('/') {
+        defmt::warn!(
+            "desktop_control: file {=str} — subdirectories not supported",
+            path
+        );
+        ack("file", false, 0, Some("subdirectories not supported"));
         return;
     }
     if size > MAX_DESKTOP_FILE_BYTES {

--- a/crates/stackchan-firmware/src/desktop_control.rs
+++ b/crates/stackchan-firmware/src/desktop_control.rs
@@ -22,22 +22,31 @@
 //! - **turn** events → push the assistant's first text block into
 //!   the toast band so the operator sees the recent reply.
 //! - **`char_begin` / `file` / `chunk` / `file_end` / `char_end`** →
-//!   acknowledged with `ok:false` so the desktop's drop target
-//!   surfaces a clear failure. The SD writer lands as a follow-up.
+//!   buffer each pushed file in PSRAM and commit on `file_end` via
+//!   [`crate::storage::FirmwareStorage::write_desktop_file`]. Files
+//!   land at `/sd/desktop/<char>/<path>`. Path components are
+//!   validated via
+//!   [`stackchan_desktop_protocol::is_safe_relative_path`] before
+//!   any disk touch; mismatched / out-of-sequence opcodes get an
+//!   `ok:false` ack so the desktop's drop target surfaces a clear
+//!   failure.
 
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use embassy_sync::pubsub::WaitResult;
 use embassy_time::{Duration, Instant};
 use heapless_09::Vec as HVec;
 use stackchan_core::Clock;
 use stackchan_desktop_protocol::{
     Ack, BatteryStatus, Cmd, ContentBlock, Inbound, Outbound, StatusData, SysStatus, Turn,
+    is_safe_relative_path,
 };
 
 use crate::ble::bonds;
 use crate::ble::desktop::{DESKTOP_INBOUND, DESKTOP_OUTBOUND};
 use crate::clock::HalClock;
 use crate::net::snapshot;
+use crate::storage::{self, FirmwareStorage};
 use crate::toast::{self, ToastLevel};
 
 /// Cap on how much of an assistant text block we push to the toast
@@ -45,6 +54,15 @@ use crate::toast::{self, ToastLevel};
 /// before push avoids re-walking long assistant essays on every
 /// turn event.
 const TOAST_PREVIEW_BYTES: usize = 64;
+
+/// Per-file byte cap for the folder-push buffer. Sized to absorb
+/// the largest character asset the operator is realistically going
+/// to drop — a long-tail GIF or a few seconds of mono PCM. The
+/// total-payload spec cap is `FOLDER_PUSH_MAX_BYTES` (~1.8 MB) but
+/// that's the sum across all files in a char; any one file
+/// larger than this gets rejected with `ok:false` to keep PSRAM
+/// pressure bounded.
+const MAX_DESKTOP_FILE_BYTES: u32 = 262_144;
 
 /// Command-surface task. Spawns once at boot, runs for the
 /// firmware lifetime.
@@ -59,7 +77,10 @@ pub async fn desktop_control_task() -> ! {
         }
     };
     let boot = Instant::now();
-    defmt::info!("desktop_control: armed (status / owner / name / unpair / turn / push)");
+    let mut push = PushState::default();
+    defmt::info!(
+        "desktop_control: armed (status / owner / name / unpair / turn / push → /sd/desktop/)"
+    );
 
     loop {
         let message = match sub.next_message().await {
@@ -72,12 +93,36 @@ pub async fn desktop_control_task() -> ! {
                 continue;
             }
         };
-        handle(message, boot).await;
+        handle(message, boot, &mut push).await;
     }
 }
 
+/// Folder-push pipeline state. Drops back to default on any
+/// failure / completion / out-of-sequence opcode so the receiver
+/// can't get wedged between drag attempts.
+#[derive(Debug, Default)]
+struct PushState {
+    /// `<char_name>` from the most recent successful `char_begin`.
+    /// Path-validated; `None` means "no folder push in flight."
+    active_char: Option<String>,
+    /// File metadata + buffer for the file currently streaming. The
+    /// `Vec` collects chunk bytes until `file_end` flushes them to
+    /// SD via [`FirmwareStorage::write_desktop_file`].
+    current_file: Option<CurrentFile>,
+}
+
+/// One in-flight file inside a folder push.
+#[derive(Debug)]
+struct CurrentFile {
+    /// `<file_name>` from the `file` opcode. Path-validated.
+    name: String,
+    /// Bytes accumulated from `chunk` opcodes; flushed + reset on
+    /// `file_end`.
+    buffer: Vec<u8>,
+}
+
 /// React to one inbound message.
-async fn handle(message: Inbound, boot: Instant) {
+async fn handle(message: Inbound, boot: Instant, push: &mut PushState) {
     match message {
         Inbound::Cmd(Cmd::Status) => reply_status(boot),
         Inbound::Cmd(Cmd::Owner { name }) => {
@@ -91,35 +136,16 @@ async fn handle(message: Inbound, boot: Instant) {
             unpair().await;
         }
         Inbound::Cmd(Cmd::CharBegin { name, total }) => {
-            defmt::info!(
-                "desktop_control: char_begin {=str} ({=u32}B) — rejecting (no SD writer yet)",
-                name.as_str(),
-                total
-            );
-            ack(
-                "char_begin",
-                false,
-                0,
-                Some("folder push not yet supported"),
-            );
+            char_begin(push, &name, total);
         }
         Inbound::Cmd(Cmd::File { path, size }) => {
-            defmt::warn!(
-                "desktop_control: stray file {=str} ({=u32}B) outside a char window",
-                path.as_str(),
-                size
-            );
-            ack("file", false, 0, Some("no folder push in progress"));
+            file_announce(push, &path, size);
         }
         Inbound::Cmd(Cmd::Chunk { data }) => {
-            defmt::warn!(
-                "desktop_control: stray chunk ({=usize}B) outside a file window",
-                data.len()
-            );
-            ack("chunk", false, 0, Some("no file in progress"));
+            chunk(push, &data);
         }
-        Inbound::Cmd(Cmd::FileEnd) => ack("file_end", false, 0, Some("no file in progress")),
-        Inbound::Cmd(Cmd::CharEnd) => ack("char_end", false, 0, Some("no char in progress")),
+        Inbound::Cmd(Cmd::FileEnd) => file_end(push).await,
+        Inbound::Cmd(Cmd::CharEnd) => char_end(push),
         Inbound::TimeSync {
             epoch_secs,
             tz_offset_secs,
@@ -136,6 +162,154 @@ async fn handle(message: Inbound, boot: Instant) {
         Inbound::Turn(turn) => render_turn(&turn),
         Inbound::Snapshot(_) => {}
     }
+}
+
+/// Start a new folder push. Reject path-unsafe `<name>`; drop any
+/// stale state from a previously-interrupted push so the device
+/// can't get wedged in a half-state across drag attempts.
+fn char_begin(push: &mut PushState, name: &str, total: u32) {
+    if !is_safe_relative_path(name) {
+        defmt::warn!("desktop_control: char_begin {=str} — unsafe path", name);
+        ack("char_begin", false, 0, Some("unsafe char name"));
+        return;
+    }
+    // Reset any stragglers from a prior interrupted push.
+    *push = PushState::default();
+    push.active_char = Some(name.to_string());
+    defmt::info!(
+        "desktop_control: char_begin {=str} ({=u32}B total)",
+        name,
+        total
+    );
+    ack("char_begin", true, 0, None);
+}
+
+/// Announce a single file inside the current char. Caps the
+/// per-file size and validates the path before allocating the
+/// chunk buffer.
+fn file_announce(push: &mut PushState, path: &str, size: u32) {
+    if push.active_char.is_none() {
+        defmt::warn!(
+            "desktop_control: stray file {=str} outside a char window",
+            path
+        );
+        ack("file", false, 0, Some("no folder push in progress"));
+        return;
+    }
+    if !is_safe_relative_path(path) {
+        defmt::warn!("desktop_control: file {=str} — unsafe path", path);
+        ack("file", false, 0, Some("unsafe file path"));
+        return;
+    }
+    if size > MAX_DESKTOP_FILE_BYTES {
+        defmt::warn!(
+            "desktop_control: file {=str} too large ({=u32}B > {=u32}B cap)",
+            path,
+            size,
+            MAX_DESKTOP_FILE_BYTES
+        );
+        ack("file", false, 0, Some("file exceeds size cap"));
+        return;
+    }
+    push.current_file = Some(CurrentFile {
+        name: path.to_string(),
+        buffer: Vec::with_capacity(size as usize),
+    });
+    ack("file", true, 0, None);
+}
+
+/// Append one chunk's bytes to the in-flight file buffer. The `n`
+/// counter in the ack reports total bytes accumulated for this
+/// file so far — the desktop uses it as a sanity check against
+/// its own send progress.
+fn chunk(push: &mut PushState, data: &[u8]) {
+    let Some(file) = push.current_file.as_mut() else {
+        defmt::warn!(
+            "desktop_control: stray chunk ({=usize}B) outside a file window",
+            data.len()
+        );
+        ack("chunk", false, 0, Some("no file in progress"));
+        return;
+    };
+    // Defensive: per-file cap is enforced at `file` announce, but
+    // a misbehaving desktop could send more bytes than the
+    // announced `size`. Reject the overflow rather than growing
+    // the Vec unbounded.
+    if file.buffer.len().saturating_add(data.len()) > MAX_DESKTOP_FILE_BYTES as usize {
+        defmt::warn!(
+            "desktop_control: chunk would exceed cap ({=usize}+{=usize}B > {=u32}B)",
+            file.buffer.len(),
+            data.len(),
+            MAX_DESKTOP_FILE_BYTES
+        );
+        ack("chunk", false, 0, Some("file exceeds size cap"));
+        // Drop the half-written file so a subsequent `file_end`
+        // doesn't commit truncated bytes to disk.
+        push.current_file = None;
+        return;
+    }
+    file.buffer.extend_from_slice(data);
+    let n = u32::try_from(file.buffer.len()).unwrap_or(u32::MAX);
+    ack("chunk", true, n, None);
+}
+
+/// Flush the in-flight file to SD via
+/// [`FirmwareStorage::write_desktop_file`]. On any SD error the
+/// ack reports `ok:false`; the buffer is dropped either way so a
+/// subsequent `file` opcode starts clean.
+async fn file_end(push: &mut PushState) {
+    let Some(file) = push.current_file.take() else {
+        ack("file_end", false, 0, Some("no file in progress"));
+        return;
+    };
+    let Some(char_name) = push.active_char.clone() else {
+        // Shouldn't happen — file_announce guards on active_char —
+        // but be defensive.
+        ack("file_end", false, 0, Some("no folder push in progress"));
+        return;
+    };
+    let final_size = u32::try_from(file.buffer.len()).unwrap_or(u32::MAX);
+    let outcome = storage::with_storage(|s: &mut FirmwareStorage| {
+        s.write_desktop_file(&char_name, &file.name, &file.buffer)
+    })
+    .await;
+    match outcome {
+        Some(Ok(())) => {
+            defmt::info!(
+                "desktop_control: wrote /sd/desktop/{=str}/{=str} ({=u32}B)",
+                char_name.as_str(),
+                file.name.as_str(),
+                final_size,
+            );
+            ack("file_end", true, final_size, None);
+        }
+        Some(Err(e)) => {
+            defmt::warn!(
+                "desktop_control: write_desktop_file failed ({})",
+                defmt::Debug2Format(&e)
+            );
+            ack("file_end", false, 0, Some("sd write failed"));
+        }
+        None => {
+            defmt::warn!("desktop_control: no SD mounted; dropping file");
+            ack("file_end", false, 0, Some("no sd mounted"));
+        }
+    }
+}
+
+/// End the current folder push. Always succeeds — the per-file
+/// commits happened in `file_end`; `char_end` is just the
+/// teardown signal.
+fn char_end(push: &mut PushState) {
+    if let Some(name) = push.active_char.take() {
+        defmt::info!("desktop_control: char_end {=str}", name.as_str());
+        ack("char_end", true, 0, None);
+    } else {
+        ack("char_end", false, 0, Some("no char in progress"));
+    }
+    // `current_file` should already be None after `file_end`; drop
+    // any stray buffer defensively.
+    push.current_file = None;
 }
 
 /// Build a [`StatusData`] from the firmware's current snapshot and

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -190,6 +190,11 @@ const DEVICE_NAME_STAGING_FILE: &str = "DEVICE.NEW";
 /// the advertised value in lockstep.
 const MAX_DEVICE_NAME_BYTES: u32 = 22;
 
+/// Top-level directory for assets pushed via the Hardware Buddy
+/// folder-push protocol. Each char-begin creates a `<name>/`
+/// subdir under this root and files land flat inside.
+const DESKTOP_ASSETS_DIR: &str = "desktop";
+
 /// Filename for the operator-triggered camera capture. Single fixed
 /// name (no rotation) so each capture overwrites the previous —
 /// the workflow is "trigger, eject SD, view, repeat", not a
@@ -756,6 +761,63 @@ where
         }
         self.write_file(BONDS_STAGING_FILE, data)?;
         self.copy_then_delete(BONDS_STAGING_FILE, BONDS_FILE)?;
+        Ok(())
+    }
+
+    /// Truncate-write `data` into `/sd/desktop/<char_name>/<file_name>`.
+    /// Used by the Hardware Buddy folder-push receiver in
+    /// [`crate::desktop_control`].
+    ///
+    /// `<char_name>` is created under `/sd/desktop/` if missing;
+    /// existing dirs are reused. Both directory components are
+    /// expected to already be validated via
+    /// [`stackchan_desktop_protocol::is_safe_relative_path`] by the
+    /// caller — this method does no path validation of its own.
+    /// Each call writes one file in full; the [`crate::desktop_control`]
+    /// folder-push state machine buffers the bytes in PSRAM across
+    /// chunk messages and commits via this method on `file_end`.
+    ///
+    /// # Errors
+    ///
+    /// [`StorageError::Volume`] on FAT-mount failure,
+    /// [`StorageError::Write`] on any underlying write failure.
+    pub fn write_desktop_file(
+        &self,
+        char_name: &str,
+        file_name: &str,
+        data: &[u8],
+    ) -> Result<(), StorageError> {
+        let volume = self
+            .mgr
+            .open_volume(VolumeIdx(0))
+            .map_err(|_| StorageError::Volume)?;
+        let root = volume.open_root_dir().map_err(|_| StorageError::Volume)?;
+        // Top-level `/sd/desktop/` — created once per session,
+        // ignored if already present.
+        let desktop_dir = if let Ok(d) = root.open_dir(DESKTOP_ASSETS_DIR) {
+            d
+        } else {
+            root.make_dir_in_dir(DESKTOP_ASSETS_DIR)
+                .map_err(|_| StorageError::Write)?;
+            root.open_dir(DESKTOP_ASSETS_DIR)
+                .map_err(|_| StorageError::Write)?
+        };
+        // Per-char subdir — same open-or-create pattern.
+        let char_dir = if let Ok(d) = desktop_dir.open_dir(char_name) {
+            d
+        } else {
+            desktop_dir
+                .make_dir_in_dir(char_name)
+                .map_err(|_| StorageError::Write)?;
+            desktop_dir
+                .open_dir(char_name)
+                .map_err(|_| StorageError::Write)?
+        };
+        let file = char_dir
+            .open_file_in_dir(file_name, Mode::ReadWriteCreateOrTruncate)
+            .map_err(|_| StorageError::Write)?;
+        file.write(data).map_err(|_| StorageError::Write)?;
+        file.flush().map_err(|_| StorageError::Write)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Wires the Hardware Buddy folder-push protocol's \`char_begin\` / \`file\` / \`chunk\` / \`file_end\` / \`char_end\` opcodes to a stateful SD writer. Each pushed file is buffered in PSRAM and committed on \`file_end\` via the new \`FirmwareStorage::write_desktop_file\`, which creates \`/sd/desktop/\` and \`/sd/desktop/<char>/\` on first use (embedded-sdmmc's \`make_dir_in_dir\`).

## State machine

| Opcode | In-progress state | Action |
|---|---|---|
| \`char_begin\` | n/a | Validate name; drop any prior state; ack |
| \`file\` | char active | Validate path; ack; accumulate buffer |
| \`chunk\` | file open | Append to buffer; ack with running count |
| \`file_end\` | file open | Write \`/sd/desktop/<char>/<path>\`; ack with final size |
| \`char_end\` | char active | Clear state; ack |

Out-of-sequence opcodes get \`ok:false\` with an explanatory \`error\` so the desktop's drop target surfaces a clear failure rather than appearing to hang.

## Path safety

All path components are validated via \`stackchan_desktop_protocol::is_safe_relative_path\` before any disk touch. Rejects \`..\` segments, absolute paths, leading \`~\`, backslash separators, NUL bytes, and Windows drive prefixes. Same predicate \`Cmd::File\` documents.

## Size caps

| Limit | Value | Rationale |
|---|---|---|
| Per-file | 256 KiB | Absorbs realistic character assets (long GIF, few-second audio clip) without unbounded PSRAM allocation |
| Per char-push | 1.8 MB | Spec-defined; desktop self-throttles, we don't re-enforce |

\`file\` announces over the per-file cap get rejected immediately so the desktop doesn't waste bandwidth pushing chunks we'd discard. A defensive overflow check on \`chunk\` covers the misbehaving-desktop case where actual bytes exceed the announced \`size\`.

## Test plan

- [x] \`cargo +esp clippy --release -- -D warnings\`
- [ ] On-device: drag a folder containing a few PNG/GIF files onto the Hardware Buddy panel; \`ls /sd/desktop/<name>/\` over USB and confirm the files are intact
- [ ] On-device negative: drop a folder containing a file named \`../escape\`; confirm the desktop sees \`ok:false\` with \`"unsafe file path"\` and nothing escapes \`/sd/desktop/<char>/\`