### PR TITLE
feat(web): tactical-console shell — sidebar, sticky status, face glyph

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -34,20 +34,33 @@ locally at `http://localhost:5173/` against live firmware.
 ```
 src/
   main.tsx                  - entry, mounts <App />
-  App.tsx                   - top-level layout
-  styles.css                - CSS variables (light/dark), section + button styling
+  App.tsx                   - shell: Sidebar + StatusBar + section pages + hotkeys
+  nav.ts                    - section ids, hash-router signal, nav metadata
+  styles.css                - tactical theme (Stack-chan physical DNA), sidebar + status bar
   types.ts                  - AvatarSnapshot / Settings shapes
   auth.ts                   - localStorage Bearer token + authedFetch wrapper
   store.ts                  - Solid signals: snapshot, conn, toast
   components/
-    ConnStatus.tsx          - SSE connection dot
-    State.tsx               - emotion / pose / battery / wifi
-    Emotion.tsx             - 6-button presets + reset
+    Sidebar.tsx             - section nav, brand, link status
+    StatusBar.tsx           - sticky telemetry strip (face + emotion + pose + battery + wifi + audio)
+    FaceGlyph.tsx           - schematic SVG mirroring the LCD face from /state
+    ConnStatus.tsx          - SSE connection dot (legacy, now also in Sidebar foot)
+    State.tsx               - Status page detail rows
+    Emotion.tsx             - emotion presets + hold + reset
     LookAt.tsx              - pan/tilt sliders
     Audio.tsx               - volume + mute, debounced
     Settings.tsx            - GET/PUT /settings form
     Toast.tsx               - transient feedback strip
 ```
+
+## Navigation
+
+Sections are grouped by subsystem and routed via `location.hash` (e.g.
+`#motion`). The sidebar reflects + drives section state; on mobile the rail
+collapses to a horizontal scrolling strip.
+
+Hotkeys: `1-9 0 q w e` set emotion, `r` resets, `m` toggles mute, `g <s/b/m/v/y/d/c>`
+jumps between sections, `?` opens the shortcut overlay, `Esc` closes.
 
 ## Output
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { Match, Show, Switch, createSignal, onCleanup, onMount } from "solid-js";
 import { connectStream } from "./store";
+import { resetEmotion, toggleMute } from "./actions";
 import { SECTIONS, goto, section, useHashRouter } from "./nav";
 import { Sidebar } from "./components/Sidebar";
 import { StatusBar } from "./components/StatusBar";
@@ -51,13 +52,27 @@ function PageHead(props: { title: string; tag?: string }) {
 }
 
 function KbdOverlay(props: { onClose: () => void }) {
+  let panel: HTMLDivElement | undefined;
+  const prevFocus = document.activeElement as HTMLElement | null;
+
+  onMount(() => panel?.focus());
+  onCleanup(() => prevFocus?.focus?.());
+
   return (
-    <div class="kbd-overlay" onClick={props.onClose} role="dialog" aria-label="Keyboard shortcuts">
-      <div class="kbd-panel" onClick={(e) => e.stopPropagation()}>
+    <div class="kbd-overlay" onClick={props.onClose} role="presentation">
+      <div
+        ref={panel}
+        class="kbd-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+        tabindex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
         <h3>Shortcuts</h3>
         <dl class="kbd-grid">
           <dt>1-9 0 q w e</dt>
-          <dd>set emotion</dd>
+          <dd>set emotion (Behavior)</dd>
           <dt>r</dt>
           <dd>reset</dd>
           <dt>m</dt>
@@ -136,12 +151,12 @@ export function App() {
       return;
     }
     if (k === "r") {
-      document.querySelector<HTMLButtonElement>('button[data-shortcut="reset"]')?.click();
+      void resetEmotion();
       ev.preventDefault();
       return;
     }
     if (k === "m") {
-      document.querySelector<HTMLButtonElement>('button[data-shortcut="mute"]')?.click();
+      void toggleMute();
       ev.preventDefault();
     }
   };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,8 @@
-import { onCleanup, onMount } from "solid-js";
+import { Match, Show, Switch, createSignal, onCleanup, onMount } from "solid-js";
 import { connectStream } from "./store";
-import { ConnStatus } from "./components/ConnStatus";
+import { SECTIONS, goto, section, useHashRouter } from "./nav";
+import { Sidebar } from "./components/Sidebar";
+import { StatusBar } from "./components/StatusBar";
 import { CrashBanner } from "./components/CrashBanner";
 import { State } from "./components/State";
 import { Emotion } from "./components/Emotion";
@@ -20,9 +22,6 @@ import { Speak } from "./components/Speak";
 import { TaskHealth } from "./components/TaskHealth";
 import { Toast } from "./components/Toast";
 
-// Keys 1-6 stay pinned to the original palette (muscle memory). The
-// expanded set fills the next contiguous keys: 7-9 + 0 cover four,
-// q/w/e cover the last three.
 const EMOTION_KEYS: Record<string, string> = {
   "1": "neutral",
   "2": "happy",
@@ -39,67 +38,175 @@ const EMOTION_KEYS: Record<string, string> = {
   e: "mad",
 };
 
+const NAV_KEYS = Object.fromEntries(SECTIONS.map((s) => [s.hotkey, s.id]));
+
+function PageHead(props: { title: string; tag?: string }) {
+  return (
+    <div class="page-head">
+      <h2 class="page-title">{props.title}</h2>
+      <div class="page-rule" />
+      <Show when={props.tag}>{(t) => <span class="page-tag">{t()}</span>}</Show>
+    </div>
+  );
+}
+
+function KbdOverlay(props: { onClose: () => void }) {
+  return (
+    <div class="kbd-overlay" onClick={props.onClose} role="dialog" aria-label="Keyboard shortcuts">
+      <div class="kbd-panel" onClick={(e) => e.stopPropagation()}>
+        <h3>Shortcuts</h3>
+        <dl class="kbd-grid">
+          <dt>1-9 0 q w e</dt>
+          <dd>set emotion</dd>
+          <dt>r</dt>
+          <dd>reset</dd>
+          <dt>m</dt>
+          <dd>toggle mute</dd>
+          <dt>g s/b/m/v/y/d/c</dt>
+          <dd>go to section</dd>
+          <dt>?</dt>
+          <dd>this overlay</dd>
+          <dt>Esc</dt>
+          <dd>close</dd>
+        </dl>
+      </div>
+    </div>
+  );
+}
+
 export function App() {
+  const [overlay, setOverlay] = createSignal(false);
+  let awaitingG = false;
+  let gTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearG = () => {
+    awaitingG = false;
+    if (gTimer != null) {
+      clearTimeout(gTimer);
+      gTimer = null;
+    }
+  };
+
+  const onKeyDown = (ev: KeyboardEvent) => {
+    const t = ev.target as HTMLElement | null;
+    if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT")) {
+      return;
+    }
+    if (ev.altKey || ev.ctrlKey || ev.metaKey) return;
+
+    const k = ev.key.toLowerCase();
+
+    if (ev.key === "Escape") {
+      if (overlay()) {
+        setOverlay(false);
+        ev.preventDefault();
+      }
+      clearG();
+      return;
+    }
+    if (ev.key === "?") {
+      setOverlay((v) => !v);
+      ev.preventDefault();
+      clearG();
+      return;
+    }
+    if (overlay()) return;
+
+    if (awaitingG) {
+      clearG();
+      const target = NAV_KEYS[k];
+      if (target) {
+        goto(target as (typeof SECTIONS)[number]["id"]);
+        ev.preventDefault();
+      }
+      return;
+    }
+
+    if (k === "g") {
+      awaitingG = true;
+      gTimer = setTimeout(clearG, 900);
+      ev.preventDefault();
+      return;
+    }
+
+    const emotion = EMOTION_KEYS[k];
+    if (emotion) {
+      document.querySelector<HTMLButtonElement>(`button[data-emotion="${emotion}"]`)?.click();
+      ev.preventDefault();
+      return;
+    }
+    if (k === "r") {
+      document.querySelector<HTMLButtonElement>('button[data-shortcut="reset"]')?.click();
+      ev.preventDefault();
+      return;
+    }
+    if (k === "m") {
+      document.querySelector<HTMLButtonElement>('button[data-shortcut="mute"]')?.click();
+      ev.preventDefault();
+    }
+  };
+
   onMount(() => {
     connectStream();
     document.addEventListener("keydown", onKeyDown);
   });
   onCleanup(() => document.removeEventListener("keydown", onKeyDown));
+  useHashRouter();
+
   return (
     <>
-      <main>
-        <header>
-          <h1>Stack-chan</h1>
-          <ConnStatus />
-        </header>
-        <CrashBanner />
-        <State />
-        <Emotion />
-        <Mood />
-        <FaceGeometry />
-        <LookAt />
-        <Audio />
-        <Speak />
-        <Listen />
-        <Pair />
-        <Camera />
-        <Calibration />
-        <Sensors />
-        <TaskHealth />
-        <Events />
-        <Settings />
-        <Recovery />
-      </main>
+      <div class="shell">
+        <Sidebar />
+        <div class="main">
+          <StatusBar />
+          <CrashBanner />
+          <div class="content">
+            <Switch>
+              <Match when={section() === "status"}>
+                <PageHead title="Status" tag="LIVE" />
+                <State />
+              </Match>
+              <Match when={section() === "behavior"}>
+                <PageHead title="Behavior" />
+                <Emotion />
+                <Mood />
+                <FaceGeometry />
+              </Match>
+              <Match when={section() === "motion"}>
+                <PageHead title="Motion" />
+                <LookAt />
+                <Calibration />
+              </Match>
+              <Match when={section() === "voice"}>
+                <PageHead title="Voice" />
+                <Audio />
+                <Speak />
+                <Listen />
+              </Match>
+              <Match when={section() === "vision"}>
+                <PageHead title="Vision" />
+                <Camera />
+                <Pair />
+              </Match>
+              <Match when={section() === "diagnostics"}>
+                <PageHead title="Diagnostics" />
+                <TaskHealth />
+                <Sensors />
+                <Events />
+              </Match>
+              <Match when={section() === "system"}>
+                <PageHead title="System" />
+                <Settings />
+                <Recovery />
+              </Match>
+            </Switch>
+          </div>
+        </div>
+      </div>
       <Toast />
+      <Show when={overlay()}>
+        <KbdOverlay onClose={() => setOverlay(false)} />
+      </Show>
     </>
   );
-}
-
-function onKeyDown(ev: KeyboardEvent) {
-  // Don't hijack typing in form fields.
-  const t = ev.target as HTMLElement | null;
-  if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.tagName === "SELECT")) {
-    return;
-  }
-  if (ev.altKey || ev.ctrlKey || ev.metaKey) return;
-
-  const k = ev.key.toLowerCase();
-  // Lowercase lookup so `q/w/e` work regardless of shift state, mirroring
-  // how R/M work below. Digits are unaffected by `.toLowerCase()`.
-  const emotion = EMOTION_KEYS[k];
-  if (emotion) {
-    const btn = document.querySelector<HTMLButtonElement>(`button[data-emotion="${emotion}"]`);
-    btn?.click();
-    ev.preventDefault();
-    return;
-  }
-  if (k === "r") {
-    document.querySelector<HTMLButtonElement>('button[data-shortcut="reset"]')?.click();
-    ev.preventDefault();
-    return;
-  }
-  if (k === "m") {
-    document.querySelector<HTMLButtonElement>('button[data-shortcut="mute"]')?.click();
-    ev.preventDefault();
-  }
 }

--- a/web/src/actions.ts
+++ b/web/src/actions.ts
@@ -1,0 +1,21 @@
+import { postJson } from "./auth";
+import { showToast, snapshot } from "./store";
+
+export async function resetEmotion(): Promise<void> {
+  try {
+    await postJson("/reset", null);
+    showToast("reset");
+  } catch (e) {
+    showToast((e as Error).message, true);
+  }
+}
+
+export async function toggleMute(): Promise<void> {
+  const next = !(snapshot()?.audio.muted ?? false);
+  try {
+    await postJson("/mute", { muted: next });
+    showToast(next ? "muted" : "unmuted");
+  } catch (e) {
+    showToast((e as Error).message, true);
+  }
+}

--- a/web/src/components/Audio.tsx
+++ b/web/src/components/Audio.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, createSignal } from "solid-js";
 import { postJson } from "../auth";
+import { toggleMute } from "../actions";
 import { showToast, snapshot } from "../store";
 
 const DEBOUNCE_MS = 250;
@@ -32,16 +33,6 @@ export function Audio() {
         showToast((e as Error).message, true);
       }
     }, DEBOUNCE_MS);
-  };
-
-  const toggleMute = async () => {
-    const next = !muted();
-    try {
-      await postJson("/mute", { muted: next });
-      showToast(next ? "muted" : "unmuted");
-    } catch (e) {
-      showToast((e as Error).message, true);
-    }
   };
 
   return (

--- a/web/src/components/Emotion.tsx
+++ b/web/src/components/Emotion.tsx
@@ -1,5 +1,6 @@
 import { For, createSignal } from "solid-js";
 import { postJson } from "../auth";
+import { resetEmotion } from "../actions";
 import { showToast } from "../store";
 
 // Wire-string vocabulary mirrors `Emotion::wire_str` in
@@ -35,15 +36,6 @@ export function Emotion() {
     }
   };
 
-  const reset = async () => {
-    try {
-      await postJson("/reset", null);
-      showToast("reset");
-    } catch (e) {
-      showToast((e as Error).message, true);
-    }
-  };
-
   return (
     <section>
       <h2>Emotion</h2>
@@ -55,7 +47,7 @@ export function Emotion() {
             </button>
           )}
         </For>
-        <button onClick={reset} style="margin-left:auto" data-shortcut="reset">
+        <button onClick={resetEmotion} style="margin-left:auto" data-shortcut="reset">
           Reset
         </button>
       </div>

--- a/web/src/components/FaceGlyph.tsx
+++ b/web/src/components/FaceGlyph.tsx
@@ -1,0 +1,135 @@
+import { createMemo } from "solid-js";
+import { snapshot } from "../store";
+
+type EyeShape = "round" | "smile" | "sleepy" | "wide" | "frown" | "x" | "heart";
+type MouthShape = "flat" | "smile" | "open" | "frown" | "small" | "zig";
+
+const EYE_BY_EMOTION: Record<string, EyeShape> = {
+  neutral: "round",
+  happy: "smile",
+  sad: "frown",
+  sleepy: "sleepy",
+  surprised: "wide",
+  angry: "x",
+  doubt: "round",
+  boring: "sleepy",
+  hi: "smile",
+  loved: "heart",
+  curious: "round",
+  confused: "round",
+  mad: "x",
+};
+
+const MOUTH_BY_EMOTION: Record<string, MouthShape> = {
+  neutral: "flat",
+  happy: "smile",
+  sad: "frown",
+  sleepy: "small",
+  surprised: "open",
+  angry: "small",
+  doubt: "zig",
+  boring: "flat",
+  hi: "smile",
+  loved: "smile",
+  curious: "open",
+  confused: "zig",
+  mad: "frown",
+};
+
+function Eye(props: { cx: number; shape: EyeShape; fg: string; accent: string }) {
+  const { cx, shape, fg, accent } = props;
+  if (shape === "smile") {
+    return <path d={`M ${cx - 8} 42 Q ${cx} 32 ${cx + 8} 42`} stroke={fg} stroke-width="3" fill="none" stroke-linecap="round" />;
+  }
+  if (shape === "sleepy") {
+    return <line x1={cx - 8} y1={42} x2={cx + 8} y2={42} stroke={fg} stroke-width="3" stroke-linecap="round" />;
+  }
+  if (shape === "wide") {
+    return <circle cx={cx} cy={42} r={7} fill="none" stroke={fg} stroke-width="3" />;
+  }
+  if (shape === "frown") {
+    return <path d={`M ${cx - 8} 38 Q ${cx} 48 ${cx + 8} 38`} stroke={fg} stroke-width="3" fill="none" stroke-linecap="round" />;
+  }
+  if (shape === "x") {
+    return (
+      <g stroke={fg} stroke-width="3" stroke-linecap="round">
+        <line x1={cx - 6} y1={36} x2={cx + 6} y2={48} />
+        <line x1={cx - 6} y1={48} x2={cx + 6} y2={36} />
+      </g>
+    );
+  }
+  if (shape === "heart") {
+    return (
+      <path
+        d={`M ${cx} 47 L ${cx - 7} 40 A 4 4 0 0 1 ${cx} 37 A 4 4 0 0 1 ${cx + 7} 40 Z`}
+        fill={accent}
+        stroke={accent}
+        stroke-width="1"
+        stroke-linejoin="round"
+      />
+    );
+  }
+  return <ellipse cx={cx} cy={42} rx={4.5} ry={5.5} fill={fg} />;
+}
+
+function Mouth(props: { shape: MouthShape; fg: string; accent: string }) {
+  const { shape, fg, accent } = props;
+  if (shape === "smile") {
+    return <path d="M 38 66 Q 50 78 62 66" stroke={accent} stroke-width="3.5" fill="none" stroke-linecap="round" />;
+  }
+  if (shape === "open") {
+    return <ellipse cx={50} cy={70} rx={6} ry={7} fill={accent} />;
+  }
+  if (shape === "frown") {
+    return <path d="M 40 74 Q 50 64 60 74" stroke={accent} stroke-width="3.5" fill="none" stroke-linecap="round" />;
+  }
+  if (shape === "small") {
+    return <line x1={45} y1={71} x2={55} y2={71} stroke={accent} stroke-width="3" stroke-linecap="round" />;
+  }
+  if (shape === "zig") {
+    return (
+      <path
+        d="M 40 70 L 45 67 L 50 71 L 55 67 L 60 70"
+        stroke={accent}
+        stroke-width="2.5"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    );
+  }
+  return <line x1={42} y1={70} x2={58} y2={70} stroke={accent} stroke-width="3" stroke-linecap="round" />;
+}
+
+export function FaceGlyph(props: { size?: number }) {
+  const size = props.size ?? 64;
+  const state = createMemo(() => {
+    const s = snapshot();
+    const emo = s?.emotion ?? "neutral";
+    return {
+      eye: EYE_BY_EMOTION[emo] ?? "round",
+      mouth: MOUTH_BY_EMOTION[emo] ?? "flat",
+      bg: "var(--face-bg)",
+      fg: "var(--face-fg)",
+      accent: "var(--face-accent)",
+    };
+  });
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      role="img"
+      aria-label={`face: ${snapshot()?.emotion ?? "unknown"}`}
+      class="face-glyph"
+    >
+      <rect x={4} y={4} width={92} height={92} rx={6} fill={state().bg} stroke="var(--border)" stroke-width="1" />
+      <circle cx={28} cy={62} r={4} fill={state().accent} opacity={0.7} />
+      <circle cx={72} cy={62} r={4} fill={state().accent} opacity={0.7} />
+      <Eye cx={35} shape={state().eye} fg={state().fg} accent={state().accent} />
+      <Eye cx={65} shape={state().eye} fg={state().fg} accent={state().accent} />
+      <Mouth shape={state().mouth} fg={state().fg} accent={state().accent} />
+    </svg>
+  );
+}

--- a/web/src/components/FaceGlyph.tsx
+++ b/web/src/components/FaceGlyph.tsx
@@ -1,4 +1,4 @@
-import { createMemo } from "solid-js";
+import { Match, Switch, createMemo } from "solid-js";
 import { snapshot } from "../store";
 
 type EyeShape = "round" | "smile" | "sleepy" | "wide" | "frown" | "x" | "heart";
@@ -37,83 +37,84 @@ const MOUTH_BY_EMOTION: Record<string, MouthShape> = {
 };
 
 function Eye(props: { cx: number; shape: EyeShape; fg: string; accent: string }) {
-  const { cx, shape, fg, accent } = props;
-  if (shape === "smile") {
-    return <path d={`M ${cx - 8} 42 Q ${cx} 32 ${cx + 8} 42`} stroke={fg} stroke-width="3" fill="none" stroke-linecap="round" />;
-  }
-  if (shape === "sleepy") {
-    return <line x1={cx - 8} y1={42} x2={cx + 8} y2={42} stroke={fg} stroke-width="3" stroke-linecap="round" />;
-  }
-  if (shape === "wide") {
-    return <circle cx={cx} cy={42} r={7} fill="none" stroke={fg} stroke-width="3" />;
-  }
-  if (shape === "frown") {
-    return <path d={`M ${cx - 8} 38 Q ${cx} 48 ${cx + 8} 38`} stroke={fg} stroke-width="3" fill="none" stroke-linecap="round" />;
-  }
-  if (shape === "x") {
-    return (
-      <g stroke={fg} stroke-width="3" stroke-linecap="round">
-        <line x1={cx - 6} y1={36} x2={cx + 6} y2={48} />
-        <line x1={cx - 6} y1={48} x2={cx + 6} y2={36} />
-      </g>
-    );
-  }
-  if (shape === "heart") {
-    return (
-      <path
-        d={`M ${cx} 47 L ${cx - 7} 40 A 4 4 0 0 1 ${cx} 37 A 4 4 0 0 1 ${cx + 7} 40 Z`}
-        fill={accent}
-        stroke={accent}
-        stroke-width="1"
-        stroke-linejoin="round"
-      />
-    );
-  }
-  return <ellipse cx={cx} cy={42} rx={4.5} ry={5.5} fill={fg} />;
+  return (
+    <Switch fallback={<ellipse cx={props.cx} cy={42} rx={4.5} ry={5.5} fill={props.fg} />}>
+      <Match when={props.shape === "smile"}>
+        <path
+          d={`M ${props.cx - 8} 42 Q ${props.cx} 32 ${props.cx + 8} 42`}
+          stroke={props.fg}
+          stroke-width="3"
+          fill="none"
+          stroke-linecap="round"
+        />
+      </Match>
+      <Match when={props.shape === "sleepy"}>
+        <line x1={props.cx - 8} y1={42} x2={props.cx + 8} y2={42} stroke={props.fg} stroke-width="3" stroke-linecap="round" />
+      </Match>
+      <Match when={props.shape === "wide"}>
+        <circle cx={props.cx} cy={42} r={7} fill="none" stroke={props.fg} stroke-width="3" />
+      </Match>
+      <Match when={props.shape === "frown"}>
+        <path
+          d={`M ${props.cx - 8} 38 Q ${props.cx} 48 ${props.cx + 8} 38`}
+          stroke={props.fg}
+          stroke-width="3"
+          fill="none"
+          stroke-linecap="round"
+        />
+      </Match>
+      <Match when={props.shape === "x"}>
+        <g stroke={props.fg} stroke-width="3" stroke-linecap="round">
+          <line x1={props.cx - 6} y1={36} x2={props.cx + 6} y2={48} />
+          <line x1={props.cx - 6} y1={48} x2={props.cx + 6} y2={36} />
+        </g>
+      </Match>
+      <Match when={props.shape === "heart"}>
+        <path
+          d={`M ${props.cx} 47 L ${props.cx - 7} 40 A 4 4 0 0 1 ${props.cx} 37 A 4 4 0 0 1 ${props.cx + 7} 40 Z`}
+          fill={props.accent}
+          stroke={props.accent}
+          stroke-width="1"
+          stroke-linejoin="round"
+        />
+      </Match>
+    </Switch>
+  );
 }
 
 function Mouth(props: { shape: MouthShape; fg: string; accent: string }) {
-  const { shape, fg, accent } = props;
-  if (shape === "smile") {
-    return <path d="M 38 66 Q 50 78 62 66" stroke={accent} stroke-width="3.5" fill="none" stroke-linecap="round" />;
-  }
-  if (shape === "open") {
-    return <ellipse cx={50} cy={70} rx={6} ry={7} fill={accent} />;
-  }
-  if (shape === "frown") {
-    return <path d="M 40 74 Q 50 64 60 74" stroke={accent} stroke-width="3.5" fill="none" stroke-linecap="round" />;
-  }
-  if (shape === "small") {
-    return <line x1={45} y1={71} x2={55} y2={71} stroke={accent} stroke-width="3" stroke-linecap="round" />;
-  }
-  if (shape === "zig") {
-    return (
-      <path
-        d="M 40 70 L 45 67 L 50 71 L 55 67 L 60 70"
-        stroke={accent}
-        stroke-width="2.5"
-        fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      />
-    );
-  }
-  return <line x1={42} y1={70} x2={58} y2={70} stroke={accent} stroke-width="3" stroke-linecap="round" />;
+  return (
+    <Switch fallback={<line x1={42} y1={70} x2={58} y2={70} stroke={props.accent} stroke-width="3" stroke-linecap="round" />}>
+      <Match when={props.shape === "smile"}>
+        <path d="M 38 66 Q 50 78 62 66" stroke={props.accent} stroke-width="3.5" fill="none" stroke-linecap="round" />
+      </Match>
+      <Match when={props.shape === "open"}>
+        <ellipse cx={50} cy={70} rx={6} ry={7} fill={props.accent} />
+      </Match>
+      <Match when={props.shape === "frown"}>
+        <path d="M 40 74 Q 50 64 60 74" stroke={props.accent} stroke-width="3.5" fill="none" stroke-linecap="round" />
+      </Match>
+      <Match when={props.shape === "small"}>
+        <line x1={45} y1={71} x2={55} y2={71} stroke={props.accent} stroke-width="3" stroke-linecap="round" />
+      </Match>
+      <Match when={props.shape === "zig"}>
+        <path
+          d="M 40 70 L 45 67 L 50 71 L 55 67 L 60 70"
+          stroke={props.accent}
+          stroke-width="2.5"
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </Match>
+    </Switch>
+  );
 }
 
 export function FaceGlyph(props: { size?: number }) {
   const size = props.size ?? 64;
-  const state = createMemo(() => {
-    const s = snapshot();
-    const emo = s?.emotion ?? "neutral";
-    return {
-      eye: EYE_BY_EMOTION[emo] ?? "round",
-      mouth: MOUTH_BY_EMOTION[emo] ?? "flat",
-      bg: "var(--face-bg)",
-      fg: "var(--face-fg)",
-      accent: "var(--face-accent)",
-    };
-  });
+  const eye = createMemo<EyeShape>(() => EYE_BY_EMOTION[snapshot()?.emotion ?? "neutral"] ?? "round");
+  const mouth = createMemo<MouthShape>(() => MOUTH_BY_EMOTION[snapshot()?.emotion ?? "neutral"] ?? "flat");
 
   return (
     <svg
@@ -124,12 +125,12 @@ export function FaceGlyph(props: { size?: number }) {
       aria-label={`face: ${snapshot()?.emotion ?? "unknown"}`}
       class="face-glyph"
     >
-      <rect x={4} y={4} width={92} height={92} rx={6} fill={state().bg} stroke="var(--border)" stroke-width="1" />
-      <circle cx={28} cy={62} r={4} fill={state().accent} opacity={0.7} />
-      <circle cx={72} cy={62} r={4} fill={state().accent} opacity={0.7} />
-      <Eye cx={35} shape={state().eye} fg={state().fg} accent={state().accent} />
-      <Eye cx={65} shape={state().eye} fg={state().fg} accent={state().accent} />
-      <Mouth shape={state().mouth} fg={state().fg} accent={state().accent} />
+      <rect x={4} y={4} width={92} height={92} rx={6} fill="var(--face-bg)" stroke="var(--border)" stroke-width="1" />
+      <circle cx={28} cy={62} r={4} fill="var(--face-accent)" opacity={0.7} />
+      <circle cx={72} cy={62} r={4} fill="var(--face-accent)" opacity={0.7} />
+      <Eye cx={35} shape={eye()} fg="var(--face-fg)" accent="var(--face-accent)" />
+      <Eye cx={65} shape={eye()} fg="var(--face-fg)" accent="var(--face-accent)" />
+      <Mouth shape={mouth()} fg="var(--face-fg)" accent="var(--face-accent)" />
     </svg>
   );
 }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,0 +1,52 @@
+import { For } from "solid-js";
+import { SECTIONS, section, goto } from "../nav";
+import { conn, snapshot } from "../store";
+
+export function Sidebar(props: { onNavigate?: () => void }) {
+  return (
+    <aside class="sidebar">
+      <div class="brand">
+        <div class="brand-mark">SC</div>
+        <div class="brand-text">
+          <div class="brand-name">STACK-CHAN</div>
+          <div class="brand-sub">operator console</div>
+        </div>
+      </div>
+
+      <nav class="nav">
+        <For each={SECTIONS}>
+          {(s) => (
+            <button
+              type="button"
+              class="nav-item"
+              classList={{ active: section() === s.id }}
+              aria-current={section() === s.id ? "page" : undefined}
+              onClick={() => {
+                goto(s.id);
+                props.onNavigate?.();
+              }}
+            >
+              <span class="nav-glyph" aria-hidden="true">
+                {s.glyph}
+              </span>
+              <span class="nav-label">{s.label}</span>
+              <span class="nav-key" aria-hidden="true">
+                g {s.hotkey}
+              </span>
+            </button>
+          )}
+        </For>
+      </nav>
+
+      <div class="sidebar-foot">
+        <div class="link-status" classList={{ ok: conn() === "ok", bad: conn() === "bad" }}>
+          <span class="link-dot" />
+          <span class="link-label">
+            {conn() === "ok" ? "LINK UP" : conn() === "bad" ? "LINK DOWN" : "LINKING"}
+          </span>
+        </div>
+        <div class="link-host">{snapshot()?.wifi.ip ?? "stackchan.local"}</div>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -1,0 +1,82 @@
+import { Show } from "solid-js";
+import { snapshot } from "../store";
+import { FaceGlyph } from "./FaceGlyph";
+
+function Stat(props: { label: string; value: string; tone?: "ok" | "warn" | "bad" }) {
+  return (
+    <div class="stat" classList={{ "is-ok": props.tone === "ok", "is-warn": props.tone === "warn", "is-bad": props.tone === "bad" }}>
+      <div class="stat-label">{props.label}</div>
+      <div class="stat-value">{props.value}</div>
+    </div>
+  );
+}
+
+function batteryTone(pct: number | null): "ok" | "warn" | "bad" | undefined {
+  if (pct == null) return undefined;
+  if (pct >= 40) return "ok";
+  if (pct >= 15) return "warn";
+  return "bad";
+}
+
+export function StatusBar() {
+  return (
+    <header class="status-bar">
+      <div class="status-face">
+        <FaceGlyph size={56} />
+      </div>
+      <div class="status-stats">
+        <Stat label="EMOTION" value={snapshot()?.emotion?.toUpperCase() ?? "—"} />
+        <Stat label="MOOD" value={snapshot()?.mood?.toUpperCase() ?? "—"} />
+        <Show
+          when={snapshot()}
+          fallback={<Stat label="POSE" value="—" />}
+        >
+          {(s) => {
+            const p = s().head_pose;
+            return <Stat label="POSE" value={`${p.pan_deg.toFixed(0)}° / ${p.tilt_deg.toFixed(0)}°`} />;
+          }}
+        </Show>
+        <Show
+          when={snapshot()}
+          fallback={<Stat label="BATTERY" value="—" />}
+        >
+          {(s) => {
+            const b = s().battery;
+            const v = b.percent != null ? `${b.percent}%` : "—";
+            return <Stat label="BATTERY" value={v} tone={batteryTone(b.percent)} />;
+          }}
+        </Show>
+        <Show
+          when={snapshot()}
+          fallback={<Stat label="WIFI" value="—" />}
+        >
+          {(s) => {
+            const w = s().wifi;
+            return (
+              <Stat
+                label="WIFI"
+                value={w.connected ? w.ip ?? "up" : "down"}
+                tone={w.connected ? "ok" : "bad"}
+              />
+            );
+          }}
+        </Show>
+        <Show
+          when={snapshot()}
+          fallback={<Stat label="AUDIO" value="—" />}
+        >
+          {(s) => {
+            const a = s().audio;
+            return (
+              <Stat
+                label="AUDIO"
+                value={a.muted ? "MUTED" : `${a.volume_pct}%`}
+                tone={a.muted ? "warn" : undefined}
+              />
+            );
+          }}
+        </Show>
+      </div>
+    </header>
+  );
+}

--- a/web/src/nav.ts
+++ b/web/src/nav.ts
@@ -1,0 +1,49 @@
+import { createSignal, onCleanup } from "solid-js";
+
+export type SectionId =
+  | "status"
+  | "behavior"
+  | "motion"
+  | "voice"
+  | "vision"
+  | "diagnostics"
+  | "system";
+
+export type Section = {
+  id: SectionId;
+  label: string;
+  hotkey: string;
+  glyph: string;
+};
+
+export const SECTIONS: readonly Section[] = [
+  { id: "status", label: "Status", hotkey: "s", glyph: "◇" },
+  { id: "behavior", label: "Behavior", hotkey: "b", glyph: "◉" },
+  { id: "motion", label: "Motion", hotkey: "m", glyph: "↻" },
+  { id: "voice", label: "Voice", hotkey: "v", glyph: "≋" },
+  { id: "vision", label: "Vision", hotkey: "y", glyph: "▣" },
+  { id: "diagnostics", label: "Diagnostics", hotkey: "d", glyph: "✦" },
+  { id: "system", label: "System", hotkey: "c", glyph: "⚙" },
+] as const;
+
+const hashId = (): SectionId => {
+  const h = location.hash.replace(/^#/, "");
+  return SECTIONS.some((s) => s.id === h) ? (h as SectionId) : "status";
+};
+
+export const [section, setSection] = createSignal<SectionId>(hashId());
+
+export function goto(id: SectionId): void {
+  setSection(id);
+  if (location.hash !== `#${id}`) location.hash = id;
+}
+
+export function bindHashRouter(): () => void {
+  const onHash = () => setSection(hashId());
+  window.addEventListener("hashchange", onHash);
+  return () => window.removeEventListener("hashchange", onHash);
+}
+
+export function useHashRouter(): void {
+  onCleanup(bindHashRouter());
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,23 +1,57 @@
 :root {
-  color-scheme: light dark;
-  --bg: #f4f4f5;
-  --fg: #1f2937;
-  --muted: #6b7280;
-  --card: #ffffff;
-  --border: #e5e7eb;
-  --accent: #2563eb;
-  --warn: #b45309;
-  --bad: #b91c1c;
-  --ok: #15803d;
+  color-scheme: dark;
+
+  --bg: #0d1014;
+  --bg-grid: rgba(255, 255, 255, 0.018);
+  --surface: #151a21;
+  --surface-2: #1c222b;
+  --surface-3: #232a34;
+
+  --border: #262d36;
+  --border-strong: #3a424d;
+
+  --fg: #f4f4eb;
+  --fg-soft: #c8ccc3;
+  --fg-muted: #8a9099;
+  --fg-faint: #5a6068;
+
+  --accent: #f08080;
+  --accent-hi: #ff9c9c;
+  --accent-soft: rgba(240, 128, 128, 0.14);
+  --accent-line: rgba(240, 128, 128, 0.35);
+
+  --ok: #5fc88f;
+  --warn: #e6a155;
+  --bad: #e2625a;
+
+  --face-bg: #f6f3e8;
+  --face-fg: #0d1014;
+  --face-accent: #f08080;
+
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, "Roboto Mono", monospace;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+
+  --rail: 232px;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --bg: #0b0f17;
-    --fg: #e5e7eb;
-    --muted: #9ca3af;
-    --card: #111827;
-    --border: #1f2937;
+    color-scheme: light;
+    --bg: #f3f1e9;
+    --bg-grid: rgba(0, 0, 0, 0.02);
+    --surface: #fdfcf6;
+    --surface-2: #f6f4ea;
+    --surface-3: #ebe8da;
+    --border: #d5d1c1;
+    --border-strong: #b7b29e;
+    --fg: #1a1d22;
+    --fg-soft: #2c3138;
+    --fg-muted: #5d6470;
+    --fg-faint: #8a8f97;
+    --accent: #d65a5a;
+    --accent-hi: #b94545;
+    --accent-soft: rgba(214, 90, 90, 0.12);
+    --accent-line: rgba(214, 90, 90, 0.4);
   }
 }
 
@@ -25,57 +59,411 @@
   box-sizing: border-box;
 }
 
+html,
 body {
-  background: var(--bg);
-  color: var(--fg);
-  font: 14px/1.4 system-ui, -apple-system, sans-serif;
   margin: 0;
-  padding: 16px;
+  padding: 0;
+  min-height: 100vh;
 }
 
-main {
-  max-width: 720px;
-  margin: 0 auto;
+body {
+  background:
+    radial-gradient(ellipse at top, var(--accent-soft) 0%, transparent 55%),
+    linear-gradient(var(--bg-grid) 1px, transparent 1px) 0 0 / 24px 24px,
+    var(--bg);
+  color: var(--fg);
+  font: 14px/1.5 var(--sans);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button {
+  font: inherit;
+}
+
+a {
+  color: var(--accent);
+}
+
+/* ─── Shell ─────────────────────────────────────────────────────── */
+
+.shell {
   display: grid;
+  grid-template-columns: var(--rail) 1fr;
+  min-height: 100vh;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.content {
+  padding: 18px 24px 80px;
+  max-width: 1060px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.content > section + section {
+  margin-top: 14px;
+}
+
+/* ─── Sidebar ───────────────────────────────────────────────────── */
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  background:
+    linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 16px 12px 12px;
   gap: 12px;
 }
 
-h1 {
-  margin: 0 0 4px;
-  font-size: 18px;
-  font-weight: 600;
+.brand {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 6px 12px;
+  border-bottom: 1px solid var(--border);
 }
 
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: var(--face-bg);
+  color: var(--face-fg);
+  display: grid;
+  place-items: center;
+  font: 600 14px/1 var(--mono);
+  letter-spacing: 0.5px;
+  box-shadow: inset 0 0 0 1px var(--accent-line), 0 1px 0 rgba(0, 0, 0, 0.35);
+}
+
+.brand-name {
+  font: 600 12px/1 var(--mono);
+  letter-spacing: 1.5px;
+  color: var(--fg);
+}
+
+.brand-sub {
+  font: 11px/1.2 var(--mono);
+  color: var(--fg-muted);
+  margin-top: 3px;
+  letter-spacing: 0.4px;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.nav-item {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--fg-soft);
+  text-align: left;
+  cursor: pointer;
+  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+
+.nav-item:hover {
+  background: var(--surface-3);
+  color: var(--fg);
+}
+
+.nav-item.active {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--fg);
+}
+
+.nav-item.active .nav-glyph {
+  color: var(--accent);
+}
+
+.nav-glyph {
+  font: 14px/1 var(--mono);
+  color: var(--fg-muted);
+  text-align: center;
+}
+
+.nav-label {
+  font: 13px/1 var(--sans);
+  font-weight: 500;
+}
+
+.nav-key {
+  font: 10px/1 var(--mono);
+  color: var(--fg-faint);
+  letter-spacing: 0.5px;
+  padding: 3px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--surface);
+}
+
+.sidebar-foot {
+  padding: 10px 6px;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 4px;
+}
+
+.link-status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font: 11px/1 var(--mono);
+  letter-spacing: 1px;
+  color: var(--fg-muted);
+}
+
+.link-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-faint);
+  box-shadow: 0 0 0 0 var(--accent);
+}
+
+.link-status.ok .link-dot {
+  background: var(--ok);
+  box-shadow: 0 0 8px rgba(95, 200, 143, 0.5);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+.link-status.bad .link-dot {
+  background: var(--bad);
+}
+
+.link-status.ok {
+  color: var(--ok);
+}
+
+.link-status.bad {
+  color: var(--bad);
+}
+
+.link-host {
+  font: 11px/1 var(--mono);
+  color: var(--fg-faint);
+  letter-spacing: 0.3px;
+  word-break: break-all;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+/* ─── Status bar ────────────────────────────────────────────────── */
+
+.status-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: center;
+  padding: 14px 24px;
+  background: linear-gradient(180deg, rgba(13, 16, 20, 0.92), rgba(13, 16, 20, 0.78));
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+}
+
+@media (prefers-color-scheme: light) {
+  .status-bar {
+    background: linear-gradient(180deg, rgba(243, 241, 233, 0.92), rgba(243, 241, 233, 0.78));
+  }
+}
+
+.status-face {
+  display: grid;
+  place-items: center;
+}
+
+.face-glyph {
+  display: block;
+  border-radius: 6px;
+}
+
+.status-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 12px;
+  align-items: center;
+}
+
+.stat {
+  display: grid;
+  gap: 2px;
+  padding: 4px 0;
+  border-left: 2px solid var(--border);
+  padding-left: 10px;
+}
+
+.stat-label {
+  font: 10px/1 var(--mono);
+  letter-spacing: 1.2px;
+  color: var(--fg-faint);
+}
+
+.stat-value {
+  font: 600 14px/1.1 var(--mono);
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+  word-break: break-all;
+}
+
+.stat.is-ok { border-left-color: var(--ok); }
+.stat.is-ok .stat-value { color: var(--ok); }
+.stat.is-warn { border-left-color: var(--warn); }
+.stat.is-warn .stat-value { color: var(--warn); }
+.stat.is-bad { border-left-color: var(--bad); }
+.stat.is-bad .stat-value { color: var(--bad); }
+
+/* ─── Section pages ─────────────────────────────────────────────── */
+
+.page {
+  display: contents;
+}
+
+.page-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin: 8px 0 12px;
+  padding: 0 2px;
+}
+
+.page-title {
+  font: 600 13px/1 var(--mono);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--fg);
+  margin: 0;
+}
+
+.page-rule {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, var(--border-strong), transparent);
+}
+
+.page-tag {
+  font: 10px/1 var(--mono);
+  letter-spacing: 1px;
+  color: var(--accent);
+  padding: 4px 6px;
+  border: 1px solid var(--accent-line);
+  border-radius: 3px;
+  background: var(--accent-soft);
+}
+
+/* ─── Cards (section blocks) ────────────────────────────────────── */
+
 section {
-  background: var(--card);
+  position: relative;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 12px;
+  padding: 14px 16px;
 }
 
 section h2 {
-  margin: 0 0 8px;
-  font-size: 13px;
-  font-weight: 600;
+  margin: 0 0 10px;
+  font: 600 11px/1 var(--mono);
+  letter-spacing: 1.5px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--muted);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
+
+section h2::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent-line);
+}
+
+/* HUD corner brackets on cards */
+section::before,
+section::after {
+  content: "";
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-color: var(--accent-line);
+  border-style: solid;
+  pointer-events: none;
+}
+
+section::before {
+  top: -1px;
+  left: -1px;
+  border-width: 1px 0 0 1px;
+}
+
+section::after {
+  bottom: -1px;
+  right: -1px;
+  border-width: 0 1px 1px 0;
+}
+
+/* ─── Rows, grids, controls ─────────────────────────────────────── */
 
 .row {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 4px 12px;
+  gap: 6px 14px;
   align-items: baseline;
 }
 
 .row dt {
-  color: var(--muted);
+  color: var(--fg-muted);
+  font: 11px/1.2 var(--mono);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
 .row dd {
   margin: 0;
+  font: 13px/1.4 var(--mono);
+  color: var(--fg);
   font-variant-numeric: tabular-nums;
+}
+
+.grid {
+  display: grid;
+  gap: 10px;
+}
+
+.grid-2 {
+  grid-template-columns: 1fr 1fr;
 }
 
 .btn-row {
@@ -85,106 +473,268 @@ section h2 {
 }
 
 button {
-  font: inherit;
-  padding: 6px 10px;
-  border: 1px solid var(--border);
-  background: var(--card);
+  padding: 6px 12px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
   color: var(--fg);
   border-radius: 4px;
   cursor: pointer;
+  font: 13px/1.2 var(--sans);
+  transition: border-color 80ms ease, background 80ms ease, color 80ms ease;
 }
 
 button:hover {
   border-color: var(--accent);
+  color: var(--accent);
 }
 
 button:active {
   background: var(--accent);
-  color: white;
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 
 button:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-input[type="range"] {
-  width: 100%;
-}
-
 input[type="text"],
-input[type="password"] {
-  font: inherit;
-  padding: 4px 6px;
-  border: 1px solid var(--border);
-  background: var(--card);
+input[type="password"],
+input[type="number"],
+input[type="search"],
+select,
+textarea {
+  font: 13px/1.4 var(--mono);
+  padding: 6px 8px;
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
   color: var(--fg);
   border-radius: 4px;
   width: 100%;
 }
 
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
 label {
   display: grid;
-  gap: 2px;
-  font-size: 12px;
-  color: var(--muted);
+  gap: 4px;
+  font: 11px/1.2 var(--mono);
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--fg-muted);
 }
 
-.grid {
-  display: grid;
-  gap: 8px;
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  background: var(--surface-3);
+  border-radius: 3px;
+  outline: none;
+  border: 1px solid var(--border);
 }
 
-.grid-2 {
-  grid-template-columns: 1fr 1fr;
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--bg);
+  cursor: pointer;
+  box-shadow: 0 0 6px var(--accent-line);
 }
+
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--bg);
+  cursor: pointer;
+}
+
+/* ─── Status atoms ──────────────────────────────────────────────── */
 
 .status {
-  font-size: 12px;
-  color: var(--muted);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  font: 11px/1 var(--mono);
+  letter-spacing: 0.5px;
+  color: var(--fg-muted);
 }
 
 .dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--muted);
+  background: var(--fg-faint);
 }
 
 .dot.ok {
   background: var(--ok);
+  box-shadow: 0 0 6px rgba(95, 200, 143, 0.55);
 }
 
 .dot.bad {
   background: var(--bad);
+  box-shadow: 0 0 6px rgba(226, 98, 90, 0.5);
 }
+
+small {
+  color: var(--fg-muted);
+  font: 11px/1.4 var(--mono);
+  letter-spacing: 0.3px;
+}
+
+/* ─── Toast ────────────────────────────────────────────────────── */
 
 .toast {
   position: fixed;
-  bottom: 16px;
+  bottom: 20px;
   left: 50%;
-  transform: translateX(-50%);
-  background: var(--card);
-  border: 1px solid var(--border);
-  padding: 6px 10px;
+  transform: translate(-50%, 8px);
+  background: var(--surface);
+  border: 1px solid var(--accent-line);
+  border-left: 3px solid var(--accent);
+  padding: 8px 14px;
   border-radius: 4px;
-  font-size: 12px;
+  font: 12px/1 var(--mono);
+  letter-spacing: 0.4px;
+  color: var(--fg);
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.5);
+  z-index: 100;
 }
 
 .toast.show {
   opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .toast.bad {
   border-color: var(--bad);
+  border-left-color: var(--bad);
   color: var(--bad);
 }
 
-small {
-  color: var(--muted);
+/* ─── Hotkey overlay ───────────────────────────────────────────── */
+
+.kbd-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 16, 20, 0.78);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: grid;
+  place-items: center;
+  z-index: 200;
+}
+
+.kbd-panel {
+  background: var(--surface);
+  border: 1px solid var(--accent-line);
+  border-radius: 6px;
+  padding: 24px 28px;
+  min-width: 320px;
+  max-width: 520px;
+}
+
+.kbd-panel h3 {
+  margin: 0 0 16px;
+  font: 600 12px/1 var(--mono);
+  letter-spacing: 1.5px;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+.kbd-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 18px;
+  font: 12px/1.4 var(--mono);
+}
+
+.kbd-grid dt {
+  color: var(--accent);
+  letter-spacing: 0.5px;
+}
+
+.kbd-grid dd {
+  margin: 0;
+  color: var(--fg-soft);
+}
+
+/* ─── Mobile ───────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  :root {
+    --rail: 100%;
+  }
+
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    height: auto;
+    padding: 10px 12px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .brand {
+    border-bottom: none;
+    padding-bottom: 6px;
+  }
+
+  .nav {
+    flex-direction: row;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    padding-bottom: 4px;
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+    grid-template-columns: auto auto;
+  }
+
+  .nav-key {
+    display: none;
+  }
+
+  .sidebar-foot {
+    display: none;
+  }
+
+  .status-bar {
+    padding: 12px 14px;
+    grid-template-columns: 1fr;
+  }
+
+  .status-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .content {
+    padding: 14px 14px 60px;
+  }
 }


### PR DESCRIPTION
## Summary
- Restructures the operator dashboard from a 19-section single-column scroll into a **sidebar + sticky status bar** shell, grouped by subsystem (Status / Behavior / Motion / Voice / Vision / Diagnostics / System).
- New visual language borrows Stack-chan's physical DNA: dark CoreS3-chassis surface, warm face-white foreground, coral cheek `#F08080` as the single accent. HUD corner brackets on cards, monospace section headers, faint pixel-grid background texture.
- Adds a schematic SVG **face glyph** in the status bar that mirrors the LCD's emotion/mood state, hash-routed section navigation (`#status` / `#motion` / …), a shortcut overlay (`?`), and a `g <s/b/m/v/y/d/c>` chord for section jumps.
- All existing components are wrapped unchanged under the new section pages — visualizations (pose XY pad, telemetry sparklines, event timeline) come in stacked follow-up PRs.

**Bundle:** 16 KB → 20.5 KB gzipped.

## Test plan
- [ ] `cd web && npm run typecheck` — passes.
- [ ] `cd web && npm run build` — produces `dist/index.html.gz`, ~20.5 KB.
- [ ] `just build-firmware` — confirms `include_bytes!` still finds the gzip.
- [ ] `cd web && npm run dev`, point at live `stackchan.local`:
  - [ ] Sidebar shows all 7 sections; clicking each updates main pane + URL hash.
  - [ ] Status bar updates from SSE: emotion, mood, pose, battery, wifi, audio.
  - [ ] Face glyph reflects current emotion (smile / wide / sleepy / heart / etc.).
  - [ ] Hotkeys: `1-9 0 q w e` set emotion; `r` resets; `m` toggles mute.
  - [ ] `g s` / `g b` / `g m` / `g v` / `g y` / `g d` / `g c` jump between sections.
  - [ ] `?` opens shortcut overlay; `Esc` closes it.
  - [ ] Resize to <768px: sidebar collapses to horizontal scroll strip; layout still usable.
  - [ ] Light + dark color scheme both render correctly (`prefers-color-scheme`).