### PR TITLE
feat(web): pose XY pad + telemetry sparklines

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { Settings } from "./components/Settings";
 import { Pair } from "./components/Pair";
 import { Speak } from "./components/Speak";
 import { TaskHealth } from "./components/TaskHealth";
+import { Telemetry } from "./components/Telemetry";
 import { Toast } from "./components/Toast";
 
 const EMOTION_KEYS: Record<string, string> = {
@@ -180,6 +181,7 @@ export function App() {
               <Match when={section() === "status"}>
                 <PageHead title="Status" tag="LIVE" />
                 <State />
+                <Telemetry />
               </Match>
               <Match when={section() === "behavior"}>
                 <PageHead title="Behavior" />

--- a/web/src/components/Audio.tsx
+++ b/web/src/components/Audio.tsx
@@ -1,7 +1,8 @@
 import { createEffect, createMemo, createSignal } from "solid-js";
 import { postJson } from "../auth";
 import { toggleMute } from "../actions";
-import { showToast, snapshot } from "../store";
+import { series, showToast, snapshot } from "../store";
+import { Sparkline } from "./Sparkline";
 
 const DEBOUNCE_MS = 250;
 
@@ -55,7 +56,14 @@ export function Audio() {
           }}
         />
       </label>
-      <div class="btn-row">
+      <div class="spark-card" style="margin-top:8px">
+        <div class="spark-head">
+          <span class="spark-label">VOLUME · LAST 2m</span>
+          <span class="spark-value">{volume()}%</span>
+        </div>
+        <Sparkline values={series("audio_volume_pct")} width={300} height={32} min={0} max={100} fill="var(--accent-soft)" />
+      </div>
+      <div class="btn-row" style="margin-top:8px">
         <button type="button" onClick={toggleMute} data-shortcut="mute">
           {muted() ? "Unmute" : "Mute"}
         </button>

--- a/web/src/components/LookAt.tsx
+++ b/web/src/components/LookAt.tsx
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import { postJson } from "../auth";
 import { showToast } from "../store";
+import { PosePad } from "./PosePad";
 
 const HOLD_MS = 30_000;
 
@@ -24,7 +25,8 @@ export function LookAt() {
   return (
     <section>
       <h2>Look-at</h2>
-      <div class="grid grid-2">
+      <PosePad />
+      <div class="grid grid-2" style="margin-top:12px">
         <label>
           Pan: <span>{pan()}°</span>
           <input
@@ -50,7 +52,10 @@ export function LookAt() {
           />
         </label>
       </div>
-      <small>Sliders POST /look-at on release. Holds for 30 s.</small>
+      <small>
+        Drag the pad for a quick aim; sliders POST on release for fine tweaks. Holds for 30 s. Dashed
+        outline shows the servo's actual position when available.
+      </small>
     </section>
   );
 }

--- a/web/src/components/PosePad.tsx
+++ b/web/src/components/PosePad.tsx
@@ -1,0 +1,148 @@
+import { Show, createMemo, createSignal } from "solid-js";
+import { postJson } from "../auth";
+import { showToast, snapshot } from "../store";
+
+const PAN_RANGE = 60;
+const TILT_RANGE = 30;
+const HOLD_MS = 30_000;
+
+const PAD_W = 320;
+const PAD_H = 200;
+
+type Pos = { pan: number; tilt: number };
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+function padToPose(x: number, y: number, rect: DOMRect): Pos {
+  const fx = clamp((x - rect.left) / rect.width, 0, 1);
+  const fy = clamp((y - rect.top) / rect.height, 0, 1);
+  return {
+    pan: Math.round((fx * 2 - 1) * PAN_RANGE),
+    tilt: Math.round((1 - fy * 2) * TILT_RANGE),
+  };
+}
+
+function poseToPad(p: Pos): { x: number; y: number } {
+  return {
+    x: ((p.pan / PAN_RANGE) * 0.5 + 0.5) * PAD_W,
+    y: (1 - ((p.tilt / TILT_RANGE) * 0.5 + 0.5)) * PAD_H,
+  };
+}
+
+export function PosePad() {
+  const [target, setTarget] = createSignal<Pos>({ pan: 0, tilt: 0 });
+  const [dragging, setDragging] = createSignal(false);
+  let svgEl: SVGSVGElement | undefined;
+
+  const commanded = createMemo<Pos>(() => {
+    if (dragging()) return target();
+    const s = snapshot();
+    if (!s) return target();
+    return { pan: Math.round(s.head_pose.pan_deg), tilt: Math.round(s.head_pose.tilt_deg) };
+  });
+
+  const actual = createMemo<Pos | null>(() => {
+    const a = snapshot()?.head_actual;
+    return a ? { pan: a.pan_deg, tilt: a.tilt_deg } : null;
+  });
+
+  const send = async (p: Pos) => {
+    try {
+      await postJson("/look-at", { pan_deg: p.pan, tilt_deg: p.tilt, hold_ms: HOLD_MS });
+      showToast(`look-at ${p.pan}°, ${p.tilt}°`);
+    } catch (e) {
+      showToast((e as Error).message, true);
+    }
+  };
+
+  const onPointerDown = (e: PointerEvent) => {
+    if (!svgEl) return;
+    svgEl.setPointerCapture(e.pointerId);
+    setDragging(true);
+    setTarget(padToPose(e.clientX, e.clientY, svgEl.getBoundingClientRect()));
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (!dragging() || !svgEl) return;
+    setTarget(padToPose(e.clientX, e.clientY, svgEl.getBoundingClientRect()));
+  };
+
+  const onPointerUp = () => {
+    if (!dragging()) return;
+    setDragging(false);
+    void send(target());
+  };
+
+  const center = () => {
+    setTarget({ pan: 0, tilt: 0 });
+    void send({ pan: 0, tilt: 0 });
+  };
+
+  const cmdXY = createMemo(() => poseToPad(commanded()));
+  const actXY = createMemo(() => {
+    const a = actual();
+    return a ? poseToPad(a) : null;
+  });
+
+  return (
+    <div class="pose-pad-wrap">
+      <svg
+        ref={svgEl}
+        viewBox={`0 0 ${PAD_W} ${PAD_H}`}
+        class="pose-pad"
+        preserveAspectRatio="xMidYMid meet"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        role="application"
+        aria-label="Head look-at pad"
+      >
+        <rect x={0} y={0} width={PAD_W} height={PAD_H} class="pad-bg" />
+
+        {Array.from({ length: 7 }, (_, i) => i - 3).map((i) => (
+          <line
+            x1={((i + 3) / 6) * PAD_W}
+            y1={0}
+            x2={((i + 3) / 6) * PAD_W}
+            y2={PAD_H}
+            class="pad-grid"
+          />
+        ))}
+        {Array.from({ length: 7 }, (_, i) => i - 3).map((i) => (
+          <line
+            x1={0}
+            y1={((i + 3) / 6) * PAD_H}
+            x2={PAD_W}
+            y2={((i + 3) / 6) * PAD_H}
+            class="pad-grid"
+          />
+        ))}
+
+        <line x1={PAD_W / 2} y1={0} x2={PAD_W / 2} y2={PAD_H} class="pad-axis" />
+        <line x1={0} y1={PAD_H / 2} x2={PAD_W} y2={PAD_H / 2} class="pad-axis" />
+
+        <Show when={actXY()}>
+          {(p) => (
+            <g>
+              <circle cx={p().x} cy={p().y} r={8} class="pad-actual" />
+              <line x1={cmdXY().x} y1={cmdXY().y} x2={p().x} y2={p().y} class="pad-link" />
+            </g>
+          )}
+        </Show>
+
+        <g class="pad-cmd">
+          <circle cx={cmdXY().x} cy={cmdXY().y} r={5} />
+          <circle cx={cmdXY().x} cy={cmdXY().y} r={11} class="pad-cmd-halo" />
+        </g>
+
+        <text x={8} y={16} class="pad-label">PAN</text>
+        <text x={PAD_W - 8} y={16} class="pad-label pad-label-r">
+          {commanded().pan}°
+        </text>
+        <text x={8} y={PAD_H - 8} class="pad-label">TILT {commanded().tilt}°</text>
+      </svg>
+      <button type="button" class="pad-center" onClick={center}>Center</button>
+    </div>
+  );
+}

--- a/web/src/components/Sparkline.tsx
+++ b/web/src/components/Sparkline.tsx
@@ -8,7 +8,6 @@ type Props = {
   max?: number;
   stroke?: string;
   fill?: string;
-  zeroLine?: boolean;
 };
 
 export function Sparkline(props: Props) {
@@ -17,14 +16,14 @@ export function Sparkline(props: Props) {
 
   const geom = createMemo(() => {
     const vs = props.values;
-    if (vs.length === 0) return null;
+    if (vs.length < 2) return null;
 
     const lo = props.min ?? Math.min(...vs);
     const hi = props.max ?? Math.max(...vs);
     const span = hi - lo || 1;
     const w = width();
     const h = height();
-    const stepX = vs.length > 1 ? w / (vs.length - 1) : 0;
+    const stepX = w / (vs.length - 1);
 
     let path = "";
     let area = `M 0 ${h} `;

--- a/web/src/components/Sparkline.tsx
+++ b/web/src/components/Sparkline.tsx
@@ -1,0 +1,67 @@
+import { Show, createMemo } from "solid-js";
+
+type Props = {
+  values: readonly number[];
+  width?: number;
+  height?: number;
+  min?: number;
+  max?: number;
+  stroke?: string;
+  fill?: string;
+  zeroLine?: boolean;
+};
+
+export function Sparkline(props: Props) {
+  const width = () => props.width ?? 120;
+  const height = () => props.height ?? 28;
+
+  const geom = createMemo(() => {
+    const vs = props.values;
+    if (vs.length === 0) return null;
+
+    const lo = props.min ?? Math.min(...vs);
+    const hi = props.max ?? Math.max(...vs);
+    const span = hi - lo || 1;
+    const w = width();
+    const h = height();
+    const stepX = vs.length > 1 ? w / (vs.length - 1) : 0;
+
+    let path = "";
+    let area = `M 0 ${h} `;
+    vs.forEach((v, i) => {
+      const x = i * stepX;
+      const y = h - ((v - lo) / span) * (h - 2) - 1;
+      const cmd = i === 0 ? "M" : "L";
+      path += `${cmd} ${x.toFixed(1)} ${y.toFixed(1)} `;
+      area += `L ${x.toFixed(1)} ${y.toFixed(1)} `;
+    });
+    area += `L ${w} ${h} Z`;
+    return { path, area, w, h, lo, hi };
+  });
+
+  return (
+    <Show
+      when={geom()}
+      fallback={
+        <svg width={width()} height={height()} class="sparkline sparkline-empty" aria-hidden="true">
+          <line x1={0} y1={height() / 2} x2={width()} y2={height() / 2} class="sparkline-axis" />
+        </svg>
+      }
+    >
+      {(g) => (
+        <svg
+          width={g().w}
+          height={g().h}
+          viewBox={`0 0 ${g().w} ${g().h}`}
+          class="sparkline"
+          aria-hidden="true"
+        >
+          <Show when={props.fill !== undefined}>
+            <path d={g().area} fill={props.fill} />
+          </Show>
+          <path d={g().path} fill="none" stroke={props.stroke ?? "var(--accent)"} stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      )}
+    </Show>
+  );
+}

--- a/web/src/components/Telemetry.tsx
+++ b/web/src/components/Telemetry.tsx
@@ -1,0 +1,77 @@
+import { Show, createMemo } from "solid-js";
+import { series, snapshot } from "../store";
+import { Sparkline } from "./Sparkline";
+
+function SparkCard(props: {
+  label: string;
+  values: number[];
+  value: string;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <div class="spark-card">
+      <div class="spark-head">
+        <span class="spark-label">{props.label}</span>
+        <span class="spark-value">{props.value}</span>
+      </div>
+      <Sparkline
+        values={props.values}
+        width={220}
+        height={36}
+        min={props.min}
+        max={props.max}
+        fill="var(--accent-soft)"
+      />
+    </div>
+  );
+}
+
+export function Telemetry() {
+  const battery = createMemo(() => snapshot()?.battery.percent);
+  const volume = createMemo(() => snapshot()?.audio.volume_pct);
+  const pan = createMemo(() => snapshot()?.head_pose.pan_deg);
+  const tilt = createMemo(() => snapshot()?.head_pose.tilt_deg);
+
+  return (
+    <section>
+      <h2>Telemetry</h2>
+      <Show
+        when={snapshot()}
+        fallback={<small>waiting for first SSE sample…</small>}
+      >
+        <div class="spark-grid">
+          <SparkCard
+            label="BATTERY · LAST 2m"
+            values={series("battery_pct")}
+            value={battery() != null ? `${battery()}%` : "—"}
+            min={0}
+            max={100}
+          />
+          <SparkCard
+            label="VOLUME · LAST 2m"
+            values={series("audio_volume_pct")}
+            value={`${volume() ?? 0}%`}
+            min={0}
+            max={100}
+          />
+          <SparkCard
+            label="PAN · LAST 2m"
+            values={series("pan_deg")}
+            value={`${(pan() ?? 0).toFixed(0)}°`}
+            min={-60}
+            max={60}
+          />
+          <SparkCard
+            label="TILT · LAST 2m"
+            values={series("tilt_deg")}
+            value={`${(tilt() ?? 0).toFixed(0)}°`}
+            min={-30}
+            max={30}
+          />
+        </div>
+      </Show>
+      <small>Client-side ring buffer of the last ~2 min of /state SSE samples; resets on reload.</small>
+    </section>
+  );
+}

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -20,6 +20,45 @@ export function showToast(msg: string, bad = false): void {
   toastTimer = setTimeout(() => setToastVal(null), 2500);
 }
 
+// Rolling window of SSE samples. ~2 min at the firmware's ~1 Hz cadence;
+// the sparkline components pick whichever slice they need.
+export type Sample = {
+  t: number;
+  battery_pct: number | null;
+  audio_volume_pct: number;
+  pan_deg: number;
+  tilt_deg: number;
+  pan_actual_deg: number | null;
+  tilt_actual_deg: number | null;
+};
+
+const MAX_SAMPLES = 120;
+let ring: Sample[] = [];
+export const [history, setHistory] = createSignal<readonly Sample[]>([]);
+
+function pushSample(s: AvatarSnapshot): void {
+  ring.push({
+    t: Date.now(),
+    battery_pct: s.battery.percent,
+    audio_volume_pct: s.audio.volume_pct,
+    pan_deg: s.head_pose.pan_deg,
+    tilt_deg: s.head_pose.tilt_deg,
+    pan_actual_deg: s.head_actual?.pan_deg ?? null,
+    tilt_actual_deg: s.head_actual?.tilt_deg ?? null,
+  });
+  if (ring.length > MAX_SAMPLES) ring = ring.slice(ring.length - MAX_SAMPLES);
+  setHistory(ring.slice());
+}
+
+export function series<K extends keyof Sample>(key: K): number[] {
+  const out: number[] = [];
+  for (const s of history()) {
+    const v = s[key];
+    if (typeof v === "number") out.push(v);
+  }
+  return out;
+}
+
 export function connectStream(): void {
   const open = () => {
     const es = new EventSource("/state/stream");
@@ -31,7 +70,9 @@ export function connectStream(): void {
     };
     es.onmessage = (ev) => {
       try {
-        setSnapshot(JSON.parse(ev.data) as AvatarSnapshot);
+        const snap = JSON.parse(ev.data) as AvatarSnapshot;
+        setSnapshot(snap);
+        pushSample(snap);
       } catch {
         // SSE payloads occasionally arrive partial during reconnect; drop.
       }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -602,6 +602,134 @@ small {
   letter-spacing: 0.3px;
 }
 
+/* ─── Sparkline ─────────────────────────────────────────────────── */
+
+.sparkline {
+  display: block;
+  overflow: visible;
+}
+
+.sparkline-axis {
+  stroke: var(--border-strong);
+  stroke-dasharray: 2 3;
+  stroke-width: 1;
+  opacity: 0.6;
+}
+
+.spark-card {
+  display: grid;
+  gap: 4px;
+  padding: 8px 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.spark-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.spark-label {
+  font: 10px/1 var(--mono);
+  letter-spacing: 1.2px;
+  color: var(--fg-faint);
+}
+
+.spark-value {
+  font: 600 13px/1 var(--mono);
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}
+
+.spark-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+/* ─── Pose pad ──────────────────────────────────────────────────── */
+
+.pose-pad-wrap {
+  display: grid;
+  gap: 8px;
+}
+
+.pose-pad {
+  width: 100%;
+  max-width: 420px;
+  height: auto;
+  aspect-ratio: 320 / 200;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  touch-action: none;
+  cursor: crosshair;
+}
+
+.pose-pad .pad-bg {
+  fill: var(--surface-2);
+}
+
+.pose-pad .pad-grid {
+  stroke: var(--border);
+  stroke-width: 1;
+  opacity: 0.6;
+}
+
+.pose-pad .pad-axis {
+  stroke: var(--border-strong);
+  stroke-width: 1;
+  opacity: 0.9;
+}
+
+.pose-pad .pad-cmd circle:first-child {
+  fill: var(--accent);
+  filter: drop-shadow(0 0 4px var(--accent-line));
+}
+
+.pose-pad .pad-cmd-halo {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1;
+  opacity: 0.5;
+}
+
+.pose-pad .pad-actual {
+  fill: none;
+  stroke: var(--fg-muted);
+  stroke-width: 2;
+  stroke-dasharray: 3 3;
+}
+
+.pose-pad .pad-link {
+  stroke: var(--fg-faint);
+  stroke-width: 1;
+  stroke-dasharray: 2 4;
+}
+
+.pose-pad .pad-label {
+  font: 10px var(--mono);
+  letter-spacing: 1px;
+  fill: var(--fg-faint);
+}
+
+.pose-pad .pad-label-r {
+  text-anchor: end;
+}
+
+.pad-center {
+  justify-self: start;
+}
+
+.status-bar-aux {
+  display: grid;
+  grid-template-columns: 90px 90px;
+  gap: 10px;
+  align-items: center;
+}
+
 /* ─── Toast ────────────────────────────────────────────────────── */
 
 .toast {


### PR DESCRIPTION
> Stacked on #387. Rebase / retarget if shell merges first.

## Summary
- **PosePad** — 320×200 SVG inside the Motion page. Drag-to-aim with grid + crosshair; commanded pose renders as a coral disc, reported actual servo position as a dashed outline so the operator can see tracking error at a glance. Sliders remain for fine tweaks.
- **Sparkline** + **Telemetry section** — generic inline-SVG sparkline component plus a Telemetry section on the Status page rendering 2-minute history for battery / volume / pan / tilt out of a 120-sample client-side ring buffer accumulated from the /state SSE. Audio also gets its own volume sparkline next to the slider.
- Ring buffer is in-memory only; resets on reload. No firmware-side history endpoint required.

**Bundle:** 20.5 KB → 23.3 KB gzipped.

## Test plan
- [ ] `cd web && npm run build` — bundle ~23.3 KB gzipped.
- [ ] `just build-firmware` — passes; `include_bytes!` finds the gzip.
- [ ] `cd web && npm run dev`, point at live `stackchan.local`:
  - [ ] Motion page: drag pad → coral disc follows pointer, release → POST /look-at fires, dashed outline appears once `head_actual` reports back.
  - [ ] Pan/tilt sliders still work for fine tuning.
  - [ ] Center button resets to 0/0.
  - [ ] Status page: Telemetry cards render battery + volume + pan + tilt sparklines, filling in over ~2 min.
  - [ ] Audio page: small volume sparkline shows recent trend.
  - [ ] Reload → ring buffer clears, fills in again.