### PR TITLE
feat(web): vertical event timeline

### DIFF
--- a/web/src/components/Events.tsx
+++ b/web/src/components/Events.tsx
@@ -1,5 +1,5 @@
 import { For, Show, createSignal, onCleanup, onMount } from "solid-js";
-import type { EventsResponse } from "../types";
+import type { EventEntry, EventsResponse } from "../types";
 import { showToast } from "../store";
 
 const POLL_MS = 3000;
@@ -12,6 +12,10 @@ function fmtTimestamp(ms: number): string {
   if (h > 0) return `${h}h${m.toString().padStart(2, "0")}m${s.toString().padStart(2, "0")}s`;
   if (m > 0) return `${m}m${s.toString().padStart(2, "0")}s`;
   return `${s}s`;
+}
+
+function kindClass(k: EventEntry["kind"]): string {
+  return `tl-row tl-${k}`;
 }
 
 export function Events() {
@@ -42,22 +46,32 @@ export function Events() {
       <Show when={data()} fallback={<small>waiting for first poll…</small>}>
         {(s) => (
           <>
-            <small>{s().total} since boot</small>
-            <div class="grid" style="margin-top:8px;font-family:ui-monospace,monospace;font-size:12px">
-              <For each={s().events.slice().reverse()}>
-                {(e) => (
-                  <div style="display:grid;grid-template-columns:max-content max-content 1fr;gap:8px;align-items:baseline">
-                    <span style="color:var(--muted);font-variant-numeric:tabular-nums">
-                      {fmtTimestamp(e.at_ms)}
-                    </span>
-                    <span style={`color:${e.kind === "warn" ? "var(--bad)" : e.kind === "control" ? "var(--accent)" : "var(--muted)"}`}>
-                      {e.kind}
-                    </span>
-                    <span>{e.message}</span>
-                  </div>
-                )}
-              </For>
+            <div class="tl-head">
+              <span class="tl-count">{s().total}</span>
+              <span class="tl-count-label">since boot</span>
+              <span class="tl-legend">
+                <span class="tl-legend-item tl-lifecycle">lifecycle</span>
+                <span class="tl-legend-item tl-control">control</span>
+                <span class="tl-legend-item tl-warn">warn</span>
+              </span>
             </div>
+            <Show
+              when={s().events.length > 0}
+              fallback={<small>no events buffered</small>}
+            >
+              <ol class="timeline">
+                <For each={s().events.slice().reverse()}>
+                  {(e) => (
+                    <li class={kindClass(e.kind)}>
+                      <span class="tl-time">{fmtTimestamp(e.at_ms)}</span>
+                      <span class="tl-dot" aria-hidden="true" />
+                      <span class="tl-kind">{e.kind}</span>
+                      <span class="tl-msg">{e.message}</span>
+                    </li>
+                  )}
+                </For>
+              </ol>
+            </Show>
           </>
         )}
       </Show>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -792,7 +792,7 @@ small {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 88px;
+  left: 97px;
   width: 1px;
   background: var(--border);
 }
@@ -824,7 +824,7 @@ small {
   border-radius: 50%;
   background: var(--fg-faint);
   margin-left: 3px;
-  margin-top: 4px;
+  align-self: center;
   outline: 2px solid var(--surface);
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -730,6 +730,124 @@ small {
   align-items: center;
 }
 
+/* ─── Event timeline ────────────────────────────────────────────── */
+
+.tl-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.tl-count {
+  font: 700 22px/1 var(--mono);
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.tl-count-label {
+  font: 10px/1 var(--mono);
+  letter-spacing: 1.2px;
+  color: var(--fg-faint);
+}
+
+.tl-legend {
+  margin-left: auto;
+  display: flex;
+  gap: 10px;
+  font: 10px/1 var(--mono);
+  letter-spacing: 0.5px;
+}
+
+.tl-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--fg-muted);
+}
+
+.tl-legend-item::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.tl-legend-item.tl-lifecycle { color: var(--fg-muted); }
+.tl-legend-item.tl-control { color: var(--accent); }
+.tl-legend-item.tl-warn { color: var(--bad); }
+
+.timeline {
+  position: relative;
+  margin: 0;
+  padding: 4px 0 4px 0;
+  list-style: none;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 88px;
+  width: 1px;
+  background: var(--border);
+}
+
+.tl-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 78px 16px max-content 1fr;
+  gap: 8px;
+  align-items: baseline;
+  padding: 6px 4px;
+  border-radius: 3px;
+}
+
+.tl-row:hover {
+  background: var(--surface-2);
+}
+
+.tl-time {
+  font: 11px/1.3 var(--mono);
+  color: var(--fg-faint);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.tl-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--fg-faint);
+  margin-left: 3px;
+  margin-top: 4px;
+  outline: 2px solid var(--surface);
+}
+
+.tl-row.tl-lifecycle .tl-dot { background: var(--fg-muted); }
+.tl-row.tl-control .tl-dot { background: var(--accent); box-shadow: 0 0 4px var(--accent-line); }
+.tl-row.tl-warn .tl-dot { background: var(--bad); box-shadow: 0 0 6px rgba(226, 98, 90, 0.55); }
+
+.tl-kind {
+  font: 10px/1.3 var(--mono);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.tl-row.tl-control .tl-kind { color: var(--accent); }
+.tl-row.tl-warn .tl-kind { color: var(--bad); }
+
+.tl-msg {
+  font: 12px/1.5 var(--mono);
+  color: var(--fg);
+  word-break: break-word;
+}
+
 /* ─── Toast ────────────────────────────────────────────────────── */
 
 .toast {


### PR DESCRIPTION
> Stacked on #388 (which is stacked on #387). Retarget if upstream merges first.

## Summary
- Replaces the dense same-line `/events` list with a vertical timeline: left-rail axis, kind-tinted dot per entry (lifecycle = neutral, control = coral, warn = red), uptime stamp + kind badge + message.
- Adds a prominent coral total-event-count and a legend at the top of the section.
- Bounded to 360 px of scroll so the section doesn't dominate the Diagnostics page.

**Bundle:** 23.3 KB → 23.7 KB gzipped (+0.4 KB, mostly CSS).

## Test plan
- [ ] `cd web && npm run build` — bundle ~23.7 KB gzipped.
- [ ] Diagnostics page on live firmware:
  - [ ] Event count renders as a large coral number.
  - [ ] Legend dots match row colors.
  - [ ] Events appear newest-first; uptime stamps tabular.
  - [ ] Hovering a row tints it.
  - [ ] Long rows wrap; no horizontal scroll.