### PR TITLE
feat(sidecar): 3D companion app — three.js mirror of live device state

### DIFF
--- a/justfile
+++ b/justfile
@@ -90,6 +90,16 @@ web-build:
 web-typecheck:
     cd web && npm install --no-audit --no-fund && npm run typecheck
 
+# Build the sidecar 3D companion bundle. Vite + three.js → `sidecar/web/dist/`.
+# The sidecar's `register_companion` mounts this directory under `/companion/`
+# when it exists. Independent of `web-build`; not chained into the firmware
+# recipes because the companion is served by the host sidecar, not the device.
+sidecar-companion-build:
+    cd sidecar/web && npm install --no-audit --no-fund && npm run build
+
+sidecar-companion-typecheck:
+    cd sidecar/web && npm install --no-audit --no-fund && npm run typecheck
+
 # ----- Firmware (requires `source ~/export-esp.sh` first) ------------------
 
 # Firmware-side compile check. Runs from inside the firmware crate so the

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -9,6 +9,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from .auth import make_verifier
+from .companion import register_companion
 from .config import Settings
 from .errors import (
     ErrorCode,
@@ -86,6 +87,7 @@ def create_app(
 
     app = FastAPI(title="stackchan-sidecar", version="0.1.0", lifespan=lifespan)
     verify_bearer = make_verifier(settings.bearer_token)
+    register_companion(app, settings)
 
     @app.get("/healthz")
     async def healthz() -> dict[str, object]:

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -1,0 +1,106 @@
+"""Companion endpoints: a static 3D mirror app + an SSE relay from the firmware.
+
+Mounted under `/companion/` (the bundled webapp) and `/v1/state-proxy` (a
+relay of the firmware's `/state/stream`). The firmware exposes SSE only on
+its own origin; rather than ask it for CORS, we proxy through the sidecar,
+keeping a single auth surface for the operator and letting the companion
+talk to localhost.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import httpx
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+from .config import Settings
+
+_LOG = logging.getLogger("stackchan_sidecar.companion")
+
+_KEEPALIVE_INTERVAL_S = 15.0
+_UPSTREAM_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=5.0, pool=5.0)
+
+
+def _resolve_static_dir() -> Path | None:
+    # sidecar/src/stackchan_sidecar/companion.py -> sidecar/web/dist
+    here = Path(__file__).resolve()
+    candidate = here.parents[2] / "web" / "dist"
+    if candidate.is_dir() and (candidate / "index.html").is_file():
+        return candidate
+    return None
+
+
+def register_companion(app: FastAPI, settings: Settings) -> None:
+    """Wire companion routes into an existing FastAPI app.
+
+    Idempotent and side-effect-light: if the static bundle is missing the
+    mount is skipped and a single warning is logged. The state-proxy SSE
+    route registers regardless so the sidecar process is still useful when
+    only the firmware bundle is rebuilt.
+    """
+    if not settings.companion_enabled:
+        _LOG.info("companion disabled via SIDECAR_COMPANION_ENABLED=false")
+        return
+
+    router = APIRouter()
+
+    @router.get("/v1/state-proxy")
+    async def state_proxy(request: Request) -> StreamingResponse:
+        upstream = settings.firmware_url.rstrip("/") + "/state/stream"
+        headers = {"Accept": "text/event-stream"}
+        if settings.firmware_token:
+            headers["Authorization"] = f"Bearer {settings.firmware_token}"
+
+        client = httpx.AsyncClient(timeout=_UPSTREAM_TIMEOUT)
+
+        async def stream() -> AsyncIterator[bytes]:
+            try:
+                async with client.stream("GET", upstream, headers=headers) as resp:
+                    if resp.status_code != 200:
+                        text = await resp.aread()
+                        _LOG.warning(
+                            "state-proxy upstream %s returned %s: %s",
+                            upstream,
+                            resp.status_code,
+                            text[:200],
+                        )
+                        yield b"event: error\ndata: upstream " + str(resp.status_code).encode() + b"\n\n"
+                        return
+                    async for chunk in resp.aiter_raw():
+                        if await request.is_disconnected():
+                            break
+                        if chunk:
+                            yield chunk
+            except httpx.HTTPError as e:
+                _LOG.warning("state-proxy transport error: %s", e)
+                yield b"event: error\ndata: transport\n\n"
+            finally:
+                await client.aclose()
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+        )
+
+    @router.get("/companion/healthz")
+    async def companion_healthz() -> dict[str, object]:
+        return {"status": "ok", "firmware_url": settings.firmware_url}
+
+    app.include_router(router)
+
+    static_dir = _resolve_static_dir()
+    if static_dir is None:
+        _LOG.warning(
+            "companion static bundle not found; run `just sidecar-companion-build` to build "
+            "sidecar/web/. The /v1/state-proxy SSE relay is still active."
+        )
+        return
+
+    app.mount("/companion", StaticFiles(directory=static_dir, html=True), name="companion")
+    _LOG.info("companion mounted: static=%s upstream=%s", static_dir, settings.firmware_url)

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -22,7 +22,6 @@ from .config import Settings
 
 _LOG = logging.getLogger("stackchan_sidecar.companion")
 
-_KEEPALIVE_INTERVAL_S = 15.0
 _UPSTREAM_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=5.0, pool=5.0)
 
 
@@ -69,7 +68,11 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
                             resp.status_code,
                             text[:200],
                         )
-                        yield b"event: error\ndata: upstream " + str(resp.status_code).encode() + b"\n\n"
+                        yield (
+                            b"event: error\ndata: upstream "
+                            + str(resp.status_code).encode()
+                            + b"\n\n"
+                        )
                         return
                     async for chunk in resp.aiter_raw():
                         if await request.is_disconnected():

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -14,7 +14,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 import httpx
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 

--- a/sidecar/src/stackchan_sidecar/config.py
+++ b/sidecar/src/stackchan_sidecar/config.py
@@ -36,6 +36,10 @@ class Settings(BaseSettings):
     openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
     deepgram_api_key: str = Field(default="", alias="DEEPGRAM_API_KEY")
 
+    firmware_url: str = Field(default="http://stackchan.local", alias="STACKCHAN_FIRMWARE_URL")
+    firmware_token: str = Field(default="", alias="STACKCHAN_FIRMWARE_TOKEN")
+    companion_enabled: bool = Field(default=True, alias="SIDECAR_COMPANION_ENABLED")
+
 
 def load_settings() -> Settings:
     settings = Settings()

--- a/sidecar/tests/test_companion.py
+++ b/sidecar/tests/test_companion.py
@@ -93,9 +93,7 @@ def test_state_proxy_relays_upstream_error_envelope(monkeypatch: pytest.MonkeyPa
 def test_register_companion_skips_static_mount_when_dist_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        "stackchan_sidecar.companion._resolve_static_dir", lambda: None
-    )
+    monkeypatch.setattr("stackchan_sidecar.companion._resolve_static_dir", lambda: None)
     app = FastAPI()
     register_companion(app, _settings())
     # SSE route still registers regardless of bundle presence.
@@ -112,9 +110,7 @@ def test_register_companion_mounts_static_when_dist_exists(
     fake_dist = tmp_path / "web" / "dist"
     fake_dist.mkdir(parents=True)
     (fake_dist / "index.html").write_text("<html><body>companion</body></html>", encoding="utf-8")
-    monkeypatch.setattr(
-        "stackchan_sidecar.companion._resolve_static_dir", lambda: fake_dist
-    )
+    monkeypatch.setattr("stackchan_sidecar.companion._resolve_static_dir", lambda: fake_dist)
 
     app = FastAPI()
     register_companion(app, _settings())

--- a/sidecar/tests/test_companion.py
+++ b/sidecar/tests/test_companion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -13,12 +14,12 @@ from .conftest import TEST_TOKEN
 
 
 def _settings(**overrides: object) -> Settings:
-    base = dict(
-        SIDECAR_BEARER_TOKEN=TEST_TOKEN,
-        ANTHROPIC_API_KEY="sk-ant-test",
-    )
+    base: dict[str, object] = {
+        "SIDECAR_BEARER_TOKEN": TEST_TOKEN,
+        "ANTHROPIC_API_KEY": "sk-ant-test",
+    }
     base.update(overrides)
-    return Settings(**base)
+    return Settings(**base)  # type: ignore[arg-type]
 
 
 def test_register_companion_noop_when_disabled() -> None:
@@ -57,7 +58,7 @@ def test_state_proxy_relays_upstream_error_envelope(monkeypatch: pytest.MonkeyPa
         async def aread(self) -> bytes:
             return b"upstream offline"
 
-        async def aiter_raw(self):  # pragma: no cover - not reached on 503
+        async def aiter_raw(self) -> AsyncIterator[bytes]:  # pragma: no cover
             if False:
                 yield b""
 

--- a/sidecar/tests/test_companion.py
+++ b/sidecar/tests/test_companion.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stackchan_sidecar.companion import register_companion
+from stackchan_sidecar.config import Settings
+
+from .conftest import TEST_TOKEN
+
+
+def _settings(**overrides: object) -> Settings:
+    base = dict(
+        SIDECAR_BEARER_TOKEN=TEST_TOKEN,
+        ANTHROPIC_API_KEY="sk-ant-test",
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def test_register_companion_noop_when_disabled() -> None:
+    app = FastAPI()
+    register_companion(app, _settings(SIDECAR_COMPANION_ENABLED=False))
+    paths = {r.path for r in app.routes}  # type: ignore[attr-defined]
+    assert "/v1/state-proxy" not in paths
+    assert "/companion/healthz" not in paths
+
+
+def test_register_companion_registers_routes_when_enabled() -> None:
+    app = FastAPI()
+    register_companion(app, _settings())
+    paths = {r.path for r in app.routes}  # type: ignore[attr-defined]
+    assert "/v1/state-proxy" in paths
+    assert "/companion/healthz" in paths
+
+
+def test_companion_healthz_returns_firmware_url() -> None:
+    app = FastAPI()
+    register_companion(app, _settings(STACKCHAN_FIRMWARE_URL="http://example.local"))
+    with TestClient(app) as c:
+        r = c.get("/companion/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["firmware_url"] == "http://example.local"
+
+
+def test_state_proxy_relays_upstream_error_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    # If the firmware refuses, the sidecar must surface a parseable SSE error
+    # frame rather than tearing down the operator's connection silently.
+    class FakeResp:
+        status_code = 503
+
+        async def aread(self) -> bytes:
+            return b"upstream offline"
+
+        async def aiter_raw(self):  # pragma: no cover - not reached on 503
+            if False:
+                yield b""
+
+    class FakeStream:
+        async def __aenter__(self) -> FakeResp:
+            return FakeResp()
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+    class FakeClient:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def stream(self, *_: object, **__: object) -> FakeStream:
+            return FakeStream()
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr("stackchan_sidecar.companion.httpx.AsyncClient", FakeClient)
+
+    app = FastAPI()
+    register_companion(app, _settings())
+    with TestClient(app) as c:
+        r = c.get("/v1/state-proxy")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+    assert b"event: error" in r.content
+    assert b"upstream 503" in r.content
+
+
+def test_register_companion_skips_static_mount_when_dist_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "stackchan_sidecar.companion._resolve_static_dir", lambda: None
+    )
+    app = FastAPI()
+    register_companion(app, _settings())
+    # SSE route still registers regardless of bundle presence.
+    paths = {r.path for r in app.routes}  # type: ignore[attr-defined]
+    assert "/v1/state-proxy" in paths
+    # No StaticFiles mount under /companion.
+    mounts = [r for r in app.routes if getattr(r, "name", None) == "companion"]
+    assert mounts == []
+
+
+def test_register_companion_mounts_static_when_dist_exists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_dist = tmp_path / "web" / "dist"
+    fake_dist.mkdir(parents=True)
+    (fake_dist / "index.html").write_text("<html><body>companion</body></html>", encoding="utf-8")
+    monkeypatch.setattr(
+        "stackchan_sidecar.companion._resolve_static_dir", lambda: fake_dist
+    )
+
+    app = FastAPI()
+    register_companion(app, _settings())
+    with TestClient(app) as c:
+        r = c.get("/companion/")
+    assert r.status_code == 200
+    assert "companion" in r.text

--- a/sidecar/web/.gitignore
+++ b/sidecar/web/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sidecar/web/README.md
+++ b/sidecar/web/README.md
@@ -1,0 +1,46 @@
+# stackchan-companion
+
+A live 3D mirror of the Stack-chan running locally on the sidecar host —
+TypeScript + [Vite](https://vite.dev/) + [three.js](https://threejs.org/).
+The sidecar's FastAPI process mounts the built bundle under `/companion/`
+and relays the firmware's SSE state stream via `/v1/state-proxy`, so the
+browser only ever talks to localhost.
+
+This is intentionally separate from the on-device operator dashboard
+(under `web/` at the repo root): that one is served from CoreS3 flash and
+must stay small; this one runs on the sidecar host, has no flash budget,
+and can afford the ~150 KB of three.js.
+
+## Build
+
+```bash
+just sidecar-companion-build   # npm install + typecheck + vite build → dist/
+```
+
+The sidecar's `register_companion` mount looks for `sidecar/web/dist/index.html`
+on startup. If it's missing the static mount is skipped but the SSE relay
+endpoint still registers, so `just sidecar-companion-build` is not a hard
+prerequisite for running the voice-agent path.
+
+## Develop
+
+```bash
+cd sidecar/web && npm run dev
+```
+
+Vite serves the page at `http://localhost:5174/` and proxies `/v1/*` to
+the sidecar at `http://localhost:8080`. The sidecar in turn proxies
+`/v1/state-proxy` from the firmware's `/state/stream`. Configure the
+firmware target with `STACKCHAN_FIRMWARE_URL` (default
+`http://stackchan.local`).
+
+## Layout
+
+```
+src/
+  main.ts            - entry: scene + state driver + RAF loop
+  scene.ts           - three.js scene (body, head, face decal, status LED)
+  face-texture.ts    - 2D-canvas port of the dashboard's schematic face glyph
+  state.ts           - SSE client + smoothed pose / idle anim drivers
+  styles.css         - HUD + canvas layout
+```

--- a/sidecar/web/index.html
+++ b/sidecar/web/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stack-chan · Companion</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <canvas id="scene"></canvas>
+      <aside id="hud">
+        <div class="row">
+          <span class="hud-label">LINK</span>
+          <span id="hud-link" class="hud-value">linking…</span>
+        </div>
+        <div class="row">
+          <span class="hud-label">EMOTION</span>
+          <span id="hud-emotion" class="hud-value">—</span>
+        </div>
+        <div class="row">
+          <span class="hud-label">POSE</span>
+          <span id="hud-pose" class="hud-value">—</span>
+        </div>
+        <div class="row">
+          <span class="hud-label">BATTERY</span>
+          <span id="hud-battery" class="hud-value">—</span>
+        </div>
+        <div class="row">
+          <span class="hud-label">WIFI</span>
+          <span id="hud-wifi" class="hud-value">—</span>
+        </div>
+      </aside>
+    </div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/sidecar/web/package-lock.json
+++ b/sidecar/web/package-lock.json
@@ -1,0 +1,1187 @@
+{
+  "name": "stackchan-companion",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stackchan-companion",
+      "version": "0.0.0",
+      "dependencies": {
+        "three": "^0.171.0"
+      },
+      "devDependencies": {
+        "@types/three": "^0.171.0",
+        "typescript": "^5.7.3",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-oLuT1SAsT+CUg/wxUTFHo0K3NtJLnx9sJhZWQJp/0uXqFpzSk1hRHmvWvpaAWSfvx2db0lVKZ5/wV0I0isD2mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.171.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.171.0.tgz",
+      "integrity": "sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/sidecar/web/package.json
+++ b/sidecar/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "stackchan-companion",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "three": "^0.171.0"
+  },
+  "devDependencies": {
+    "@types/three": "^0.171.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.7"
+  }
+}

--- a/sidecar/web/src/face-texture.ts
+++ b/sidecar/web/src/face-texture.ts
@@ -1,0 +1,205 @@
+// Port of the dashboard's schematic FaceGlyph from SVG to canvas 2D so we
+// can bind it as a THREE.CanvasTexture and project it onto the head's
+// front face. Shapes match the SVG one-to-one — see `web/src/components/FaceGlyph.tsx`.
+
+export type EyeShape = "round" | "smile" | "sleepy" | "wide" | "frown" | "x" | "heart";
+export type MouthShape = "flat" | "smile" | "open" | "frown" | "small" | "zig";
+
+const EYE_BY_EMOTION: Record<string, EyeShape> = {
+  neutral: "round",
+  happy: "smile",
+  sad: "frown",
+  sleepy: "sleepy",
+  surprised: "wide",
+  angry: "x",
+  doubt: "round",
+  boring: "sleepy",
+  hi: "smile",
+  loved: "heart",
+  curious: "round",
+  confused: "round",
+  mad: "x",
+};
+
+const MOUTH_BY_EMOTION: Record<string, MouthShape> = {
+  neutral: "flat",
+  happy: "smile",
+  sad: "frown",
+  sleepy: "small",
+  surprised: "open",
+  angry: "small",
+  doubt: "zig",
+  boring: "flat",
+  hi: "smile",
+  loved: "smile",
+  curious: "open",
+  confused: "zig",
+  mad: "frown",
+};
+
+const FACE_BG = "#f6f3e8";
+const FACE_FG = "#0d1014";
+const FACE_ACCENT = "#f08080";
+
+const W = 256;
+const H = 256;
+const CX_L = W * 0.35;
+const CX_R = W * 0.65;
+const CY_EYE = H * 0.44;
+const CY_MOUTH = H * 0.72;
+
+function drawEye(ctx: CanvasRenderingContext2D, cx: number, eyeOffsetX: number, eyeOffsetY: number, shape: EyeShape): void {
+  const x = cx + eyeOffsetX;
+  const y = CY_EYE + eyeOffsetY;
+  ctx.save();
+  ctx.lineWidth = 8;
+  ctx.lineCap = "round";
+  ctx.strokeStyle = FACE_FG;
+  ctx.fillStyle = FACE_FG;
+  switch (shape) {
+    case "round":
+      ctx.beginPath();
+      ctx.ellipse(x, y, 11, 14, 0, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    case "smile":
+      ctx.beginPath();
+      ctx.moveTo(x - 20, y);
+      ctx.quadraticCurveTo(x, y - 25, x + 20, y);
+      ctx.stroke();
+      break;
+    case "sleepy":
+      ctx.beginPath();
+      ctx.moveTo(x - 20, y);
+      ctx.lineTo(x + 20, y);
+      ctx.stroke();
+      break;
+    case "wide":
+      ctx.beginPath();
+      ctx.arc(x, y, 17, 0, Math.PI * 2);
+      ctx.stroke();
+      break;
+    case "frown":
+      ctx.beginPath();
+      ctx.moveTo(x - 20, y - 12);
+      ctx.quadraticCurveTo(x, y + 13, x + 20, y - 12);
+      ctx.stroke();
+      break;
+    case "x":
+      ctx.beginPath();
+      ctx.moveTo(x - 14, y - 14);
+      ctx.lineTo(x + 14, y + 14);
+      ctx.moveTo(x - 14, y + 14);
+      ctx.lineTo(x + 14, y - 14);
+      ctx.stroke();
+      break;
+    case "heart": {
+      ctx.fillStyle = FACE_ACCENT;
+      ctx.strokeStyle = FACE_ACCENT;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(x, y + 12);
+      ctx.lineTo(x - 17, y - 5);
+      ctx.arc(x - 8.5, y - 8.5, 9, Math.PI, Math.PI * 1.5);
+      ctx.arc(x + 8.5, y - 8.5, 9, Math.PI * 1.5, Math.PI * 2);
+      ctx.closePath();
+      ctx.fill();
+      break;
+    }
+  }
+  ctx.restore();
+}
+
+function drawMouth(ctx: CanvasRenderingContext2D, shape: MouthShape): void {
+  const x = W / 2;
+  const y = CY_MOUTH;
+  ctx.save();
+  ctx.lineWidth = 9;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.strokeStyle = FACE_ACCENT;
+  ctx.fillStyle = FACE_ACCENT;
+  switch (shape) {
+    case "smile":
+      ctx.beginPath();
+      ctx.moveTo(x - 32, y - 8);
+      ctx.quadraticCurveTo(x, y + 24, x + 32, y - 8);
+      ctx.stroke();
+      break;
+    case "open":
+      ctx.beginPath();
+      ctx.ellipse(x, y + 6, 16, 18, 0, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    case "frown":
+      ctx.beginPath();
+      ctx.moveTo(x - 30, y + 16);
+      ctx.quadraticCurveTo(x, y - 16, x + 30, y + 16);
+      ctx.stroke();
+      break;
+    case "small":
+      ctx.lineWidth = 7;
+      ctx.beginPath();
+      ctx.moveTo(x - 14, y);
+      ctx.lineTo(x + 14, y);
+      ctx.stroke();
+      break;
+    case "zig":
+      ctx.lineWidth = 6;
+      ctx.beginPath();
+      ctx.moveTo(x - 28, y);
+      ctx.lineTo(x - 14, y - 10);
+      ctx.lineTo(x, y + 4);
+      ctx.lineTo(x + 14, y - 10);
+      ctx.lineTo(x + 28, y);
+      ctx.stroke();
+      break;
+    case "flat":
+    default:
+      ctx.beginPath();
+      ctx.moveTo(x - 24, y);
+      ctx.lineTo(x + 24, y);
+      ctx.stroke();
+      break;
+  }
+  ctx.restore();
+}
+
+function drawCheeks(ctx: CanvasRenderingContext2D): void {
+  ctx.save();
+  ctx.fillStyle = FACE_ACCENT;
+  ctx.globalAlpha = 0.65;
+  ctx.beginPath();
+  ctx.arc(W * 0.22, H * 0.62, 12, 0, Math.PI * 2);
+  ctx.arc(W * 0.78, H * 0.62, 12, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+export type FacePainter = {
+  canvas: HTMLCanvasElement;
+  draw: (emotion: string, eyeOffsetX?: number, eyeOffsetY?: number) => void;
+};
+
+export function createFacePainter(): FacePainter {
+  const canvas = document.createElement("canvas");
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext("2d")!;
+
+  const draw = (emotion: string, eyeOffsetX = 0, eyeOffsetY = 0): void => {
+    ctx.save();
+    ctx.fillStyle = FACE_BG;
+    ctx.fillRect(0, 0, W, H);
+    drawCheeks(ctx);
+    const eye = EYE_BY_EMOTION[emotion] ?? "round";
+    const mouth = MOUTH_BY_EMOTION[emotion] ?? "flat";
+    drawEye(ctx, CX_L, eyeOffsetX, eyeOffsetY, eye);
+    drawEye(ctx, CX_R, eyeOffsetX, eyeOffsetY, eye);
+    drawMouth(ctx, mouth);
+    ctx.restore();
+  };
+
+  draw("neutral");
+  return { canvas, draw };
+}

--- a/sidecar/web/src/main.ts
+++ b/sidecar/web/src/main.ts
@@ -20,7 +20,6 @@ connectStream("/v1/state-proxy", state);
 
 window.addEventListener("resize", scene.resize);
 
-let lastEmotion = "";
 let lastT = performance.now() / 1000;
 
 function frame(): void {
@@ -41,14 +40,11 @@ function frame(): void {
   const breath = Math.sin(now * 0.6) * 0.018;
   scene.scene.position.y = breath;
 
-  // Refresh face decal only when emotion changes — eye offset is cheap so
-  // we redraw on every frame to keep the microsaccade live.
-  const emo = state.snapshot?.emotion ?? "neutral";
-  if (emo !== lastEmotion || state.snapshot != null) {
-    scene.face.draw(emo, state.eyeOffsetX, state.eyeOffsetY);
-    scene.faceTexture.needsUpdate = true;
-    lastEmotion = emo;
-  }
+  // Redraw the face every frame so the microsaccade offset stays live.
+  // The eye/mouth shape lookup is two object reads, cheaper than tracking
+  // a "did the emotion change" guard that bypassed itself anyway.
+  scene.face.draw(state.snapshot?.emotion ?? "neutral", state.eyeOffsetX, state.eyeOffsetY);
+  scene.faceTexture.needsUpdate = true;
 
   setStatusTone(scene.status, batteryTone(state.snapshot));
 

--- a/sidecar/web/src/main.ts
+++ b/sidecar/web/src/main.ts
@@ -1,0 +1,75 @@
+import { buildScene, setStatusTone } from "./scene";
+import {
+  batteryTone,
+  connectStream,
+  createState,
+  tickPose,
+  tickSaccade,
+} from "./state";
+
+const canvas = document.getElementById("scene") as HTMLCanvasElement;
+const hudLink = document.getElementById("hud-link")!;
+const hudEmotion = document.getElementById("hud-emotion")!;
+const hudPose = document.getElementById("hud-pose")!;
+const hudBattery = document.getElementById("hud-battery")!;
+const hudWifi = document.getElementById("hud-wifi")!;
+
+const scene = buildScene(canvas);
+const state = createState();
+connectStream("/v1/state-proxy", state);
+
+window.addEventListener("resize", scene.resize);
+
+let lastEmotion = "";
+let lastT = performance.now() / 1000;
+
+function frame(): void {
+  requestAnimationFrame(frame);
+
+  const now = performance.now() / 1000;
+  const dt = Math.min(now - lastT, 0.1);
+  lastT = now;
+  state.t = now;
+
+  tickPose(state, dt);
+  tickSaccade(state, now, dt);
+
+  scene.head.rotation.y = state.pan;
+  scene.head.rotation.x = state.tilt;
+
+  // Breath: gentle vertical bob, ~10 mm peak-to-peak at ~6 BPM equivalent.
+  const breath = Math.sin(now * 0.6) * 0.018;
+  scene.scene.position.y = breath;
+
+  // Refresh face decal only when emotion changes — eye offset is cheap so
+  // we redraw on every frame to keep the microsaccade live.
+  const emo = state.snapshot?.emotion ?? "neutral";
+  if (emo !== lastEmotion || state.snapshot != null) {
+    scene.face.draw(emo, state.eyeOffsetX, state.eyeOffsetY);
+    scene.faceTexture.needsUpdate = true;
+    lastEmotion = emo;
+  }
+
+  setStatusTone(scene.status, batteryTone(state.snapshot));
+
+  hudLink.textContent = state.conn;
+  hudLink.dataset.conn = state.conn;
+  hudEmotion.textContent = (state.snapshot?.emotion ?? "—").toUpperCase();
+  if (state.snapshot) {
+    const p = state.snapshot.head_actual ?? state.snapshot.head_pose;
+    hudPose.textContent = `${p.pan_deg.toFixed(0)}° / ${p.tilt_deg.toFixed(0)}°`;
+    const b = state.snapshot.battery;
+    hudBattery.textContent = b.percent != null ? `${b.percent}%` : "—";
+    hudWifi.textContent = state.snapshot.wifi.connected
+      ? (state.snapshot.wifi.ip ?? "up")
+      : "down";
+  } else {
+    hudPose.textContent = "—";
+    hudBattery.textContent = "—";
+    hudWifi.textContent = "—";
+  }
+
+  scene.renderer.render(scene.scene, scene.camera);
+}
+
+frame();

--- a/sidecar/web/src/scene.ts
+++ b/sidecar/web/src/scene.ts
@@ -1,0 +1,135 @@
+import {
+  AmbientLight,
+  BoxGeometry,
+  CanvasTexture,
+  Color,
+  CylinderGeometry,
+  DirectionalLight,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  PointLight,
+  Scene,
+  SphereGeometry,
+  SRGBColorSpace,
+  WebGLRenderer,
+} from "three";
+import { createFacePainter, type FacePainter } from "./face-texture";
+
+const BODY_COLOR = 0x1a1d22;
+const FACE_BG = 0xf6f3e8;
+const ACCENT = 0xf08080;
+
+export type SceneHandles = {
+  scene: Scene;
+  camera: PerspectiveCamera;
+  renderer: WebGLRenderer;
+  head: Group;
+  face: FacePainter;
+  faceTexture: CanvasTexture;
+  status: Mesh;
+  resize: () => void;
+  dispose: () => void;
+};
+
+export function buildScene(canvas: HTMLCanvasElement): SceneHandles {
+  const scene = new Scene();
+  scene.background = new Color(0x0b0e13);
+
+  const camera = new PerspectiveCamera(32, 1, 0.1, 50);
+  camera.position.set(0, 0.6, 6.2);
+  camera.lookAt(0, 0.3, 0);
+
+  const renderer = new WebGLRenderer({ canvas, antialias: true, alpha: false });
+  renderer.outputColorSpace = SRGBColorSpace;
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+  // Lighting — ambient + a key with a coral rim that nods to Stack-chan's cheek.
+  scene.add(new AmbientLight(0xffffff, 0.55));
+  const key = new DirectionalLight(0xffffff, 0.9);
+  key.position.set(4, 6, 5);
+  scene.add(key);
+  const rim = new PointLight(ACCENT, 0.35, 12);
+  rim.position.set(-3, 2, -1.5);
+  scene.add(rim);
+
+  // Body (CoreS3 chassis). Slightly taller than wide.
+  const bodyMat = new MeshStandardMaterial({ color: BODY_COLOR, roughness: 0.62, metalness: 0.08 });
+  const body = new Mesh(new BoxGeometry(1.5, 1.45, 1.0), bodyMat);
+  body.position.y = -0.55;
+  scene.add(body);
+
+  // Status LED on the chassis front — tinted by /state battery + wifi.
+  const statusMat = new MeshBasicMaterial({ color: 0x5fc88f });
+  const status = new Mesh(new SphereGeometry(0.07, 16, 16), statusMat);
+  status.position.set(0.55, -0.95, 0.51);
+  scene.add(status);
+
+  // Neck post — small cylinder bridging body and head pivot.
+  const neckMat = new MeshStandardMaterial({ color: 0x2a2e36, roughness: 0.7 });
+  const neck = new Mesh(new CylinderGeometry(0.12, 0.16, 0.32, 16), neckMat);
+  neck.position.y = 0.1;
+  scene.add(neck);
+
+  // Head group — pan = rotation.y, tilt = rotation.x. Pivot at neck top.
+  const head = new Group();
+  head.position.y = 0.55;
+  scene.add(head);
+
+  const headBody = new Mesh(new BoxGeometry(1.45, 1.05, 0.95), bodyMat);
+  head.add(headBody);
+
+  // Face decal: a slightly inset plane in front of the head box.
+  const face = createFacePainter();
+  const faceTexture = new CanvasTexture(face.canvas);
+  faceTexture.colorSpace = SRGBColorSpace;
+  faceTexture.needsUpdate = true;
+
+  const faceMat = new MeshStandardMaterial({
+    color: FACE_BG,
+    map: faceTexture,
+    roughness: 0.35,
+    metalness: 0.0,
+    emissive: 0xffffff,
+    emissiveMap: faceTexture,
+    emissiveIntensity: 0.18,
+  });
+  const facePlane = new Mesh(new BoxGeometry(1.18, 0.85, 0.02), faceMat);
+  facePlane.position.set(0, 0, 0.485);
+  head.add(facePlane);
+
+  // Two tiny coral accents at the chassis bottom edge — a nod to the
+  // brand-mark on the dashboard's sidebar.
+  const accentMat = new MeshBasicMaterial({ color: ACCENT });
+  const leftDot = new Mesh(new SphereGeometry(0.04, 10, 10), accentMat);
+  leftDot.position.set(-0.55, -1.18, 0.51);
+  scene.add(leftDot);
+  const rightDot = leftDot.clone();
+  rightDot.position.x = 0.55;
+  scene.add(rightDot);
+
+  const resize = (): void => {
+    const parent = canvas.parentElement;
+    const w = parent?.clientWidth ?? window.innerWidth;
+    const h = parent?.clientHeight ?? window.innerHeight;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+  };
+  resize();
+
+  const dispose = (): void => {
+    renderer.dispose();
+    faceTexture.dispose();
+  };
+
+  return { scene, camera, renderer, head, face, faceTexture, status, resize, dispose };
+}
+
+export function setStatusTone(mesh: Mesh, tone: "ok" | "warn" | "bad"): void {
+  const mat = mesh.material as MeshBasicMaterial;
+  const hex = tone === "ok" ? 0x5fc88f : tone === "warn" ? 0xe6a155 : 0xe2625a;
+  mat.color.setHex(hex);
+}

--- a/sidecar/web/src/state.ts
+++ b/sidecar/web/src/state.ts
@@ -25,6 +25,9 @@ export type StateModel = {
   // Microsaccade eye offset on the face decal (pixels).
   eyeOffsetX: number;
   eyeOffsetY: number;
+  eyeTargetX: number;
+  eyeTargetY: number;
+  nextSaccadeAt: number;
   // Idle breath phase, drives a tiny body bob.
   t: number;
 };
@@ -44,6 +47,9 @@ export function createState(): StateModel {
     tilt: 0,
     eyeOffsetX: 0,
     eyeOffsetY: 0,
+    eyeTargetX: 0,
+    eyeTargetY: 0,
+    nextSaccadeAt: 0,
     t: 0,
   };
 }
@@ -112,18 +118,13 @@ export function tickPose(model: StateModel, dt: number): void {
   model.tilt += ((t.tilt_deg * DEG) - model.tilt) * k;
 }
 
-let nextSaccade = 0;
-let saccadeTarget = { x: 0, y: 0 };
-
 export function tickSaccade(model: StateModel, now: number, dt: number): void {
-  if (now >= nextSaccade) {
-    saccadeTarget = {
-      x: (Math.random() - 0.5) * 2 * SACCADE_AMPL_PX,
-      y: (Math.random() - 0.5) * 2 * SACCADE_AMPL_PX,
-    };
-    nextSaccade = now + SACCADE_MIN_S + Math.random() * (SACCADE_MAX_S - SACCADE_MIN_S);
+  if (now >= model.nextSaccadeAt) {
+    model.eyeTargetX = (Math.random() - 0.5) * 2 * SACCADE_AMPL_PX;
+    model.eyeTargetY = (Math.random() - 0.5) * 2 * SACCADE_AMPL_PX;
+    model.nextSaccadeAt = now + SACCADE_MIN_S + Math.random() * (SACCADE_MAX_S - SACCADE_MIN_S);
   }
   const k = 1 - Math.exp(-10 * dt);
-  model.eyeOffsetX += (saccadeTarget.x - model.eyeOffsetX) * k;
-  model.eyeOffsetY += (saccadeTarget.y - model.eyeOffsetY) * k;
+  model.eyeOffsetX += (model.eyeTargetX - model.eyeOffsetX) * k;
+  model.eyeOffsetY += (model.eyeTargetY - model.eyeOffsetY) * k;
 }

--- a/sidecar/web/src/state.ts
+++ b/sidecar/web/src/state.ts
@@ -1,0 +1,129 @@
+// Types mirror crates/stackchan-core's AvatarSnapshot wire format.
+export type Pose = { pan_deg: number; tilt_deg: number };
+
+export type AvatarSnapshot = {
+  emotion: string;
+  mood: string;
+  face_geometry: string;
+  decorator: string | null;
+  head_pose: Pose;
+  head_actual: Pose | null;
+  battery: { percent: number | null; voltage_mv: number | null };
+  wifi: { connected: boolean; ip: string | null };
+  audio: { volume_pct: number; muted: boolean };
+  camera_mode: boolean;
+};
+
+export type ConnState = "linking" | "live" | "down";
+
+export type StateModel = {
+  snapshot: AvatarSnapshot | null;
+  conn: ConnState;
+  // Smoothed view-state — radians, lerped toward target each frame.
+  pan: number;
+  tilt: number;
+  // Microsaccade eye offset on the face decal (pixels).
+  eyeOffsetX: number;
+  eyeOffsetY: number;
+  // Idle breath phase, drives a tiny body bob.
+  t: number;
+};
+
+const DEG = Math.PI / 180;
+
+const SACCADE_MIN_S = 0.5;
+const SACCADE_MAX_S = 1.5;
+const SACCADE_AMPL_PX = 1.6;
+const LERP_RATE = 6.0;
+
+export function createState(): StateModel {
+  return {
+    snapshot: null,
+    conn: "linking",
+    pan: 0,
+    tilt: 0,
+    eyeOffsetX: 0,
+    eyeOffsetY: 0,
+    t: 0,
+  };
+}
+
+export function connectStream(url: string, model: StateModel): () => void {
+  let es: EventSource | null = null;
+  let retry: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
+
+  const open = (): void => {
+    if (closed) return;
+    es = new EventSource(url);
+    es.onopen = () => {
+      model.conn = "live";
+    };
+    es.onmessage = (ev) => {
+      try {
+        model.snapshot = JSON.parse(ev.data) as AvatarSnapshot;
+      } catch {
+        // partial payloads can land during reconnect — drop quietly
+      }
+    };
+    es.onerror = () => {
+      model.conn = "down";
+      es?.close();
+      es = null;
+      if (!closed) retry = setTimeout(open, 1500);
+    };
+  };
+
+  open();
+  return () => {
+    closed = true;
+    if (retry != null) clearTimeout(retry);
+    es?.close();
+  };
+}
+
+export function targetPose(model: StateModel): Pose {
+  const s = model.snapshot;
+  if (!s) return { pan_deg: 0, tilt_deg: 0 };
+  // head_actual reflects the SCServos' reported position; head_pose is the
+  // commanded target. Mirror actual so the model lags reality the way the
+  // physical robot does — feels more alive than tracking the command.
+  return s.head_actual ?? s.head_pose;
+}
+
+export function batteryTone(s: AvatarSnapshot | null): "ok" | "warn" | "bad" {
+  if (!s) return "bad";
+  if (!s.wifi.connected) return "bad";
+  const p = s.battery.percent;
+  if (p == null) return "warn";
+  if (p < 15) return "bad";
+  if (p < 40) return "warn";
+  return "ok";
+}
+
+// Lerp current pan/tilt toward the snapshot's pose; spring-like.
+export function tickPose(model: StateModel, dt: number): void {
+  const t = targetPose(model);
+  const k = 1 - Math.exp(-LERP_RATE * dt);
+  // Stack-chan: +pan = head right (operator POV), +tilt = head up. Three.js
+  // camera looks from +Z toward origin, so +pan maps to -rotation.y and
+  // +tilt maps to +rotation.x.
+  model.pan += ((-t.pan_deg * DEG) - model.pan) * k;
+  model.tilt += ((t.tilt_deg * DEG) - model.tilt) * k;
+}
+
+let nextSaccade = 0;
+let saccadeTarget = { x: 0, y: 0 };
+
+export function tickSaccade(model: StateModel, now: number, dt: number): void {
+  if (now >= nextSaccade) {
+    saccadeTarget = {
+      x: (Math.random() - 0.5) * 2 * SACCADE_AMPL_PX,
+      y: (Math.random() - 0.5) * 2 * SACCADE_AMPL_PX,
+    };
+    nextSaccade = now + SACCADE_MIN_S + Math.random() * (SACCADE_MAX_S - SACCADE_MIN_S);
+  }
+  const k = 1 - Math.exp(-10 * dt);
+  model.eyeOffsetX += (saccadeTarget.x - model.eyeOffsetX) * k;
+  model.eyeOffsetY += (saccadeTarget.y - model.eyeOffsetY) * k;
+}

--- a/sidecar/web/src/styles.css
+++ b/sidecar/web/src/styles.css
@@ -1,0 +1,87 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0e13;
+  --fg: #f4f4eb;
+  --fg-muted: #8a9099;
+  --accent: #f08080;
+  --border: rgba(255, 255, 255, 0.08);
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--fg);
+  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+#app {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+}
+
+#scene {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+#hud {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  background: rgba(11, 14, 19, 0.7);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  min-width: 200px;
+  font-family: var(--mono);
+}
+
+#hud .row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.hud-label {
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  color: var(--fg-muted);
+}
+
+.hud-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+  word-break: break-all;
+}
+
+#hud-link[data-conn="live"] {
+  color: #5fc88f;
+}
+
+#hud-link[data-conn="down"] {
+  color: #e2625a;
+}
+
+#hud-link[data-conn="linking"] {
+  color: var(--accent);
+}

--- a/sidecar/web/tsconfig.json
+++ b/sidecar/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "useDefineForClassFields": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/sidecar/web/vite.config.ts
+++ b/sidecar/web/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+
+// FastAPI mounts dist/ under `/companion/`, so emit relative URLs.
+// Dev server proxies /v1/* to the local sidecar (defaults to :8080).
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5174,
+    proxy: {
+      "/v1": "http://localhost:8080",
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- New TypeScript + three.js webapp under `sidecar/web/` that the FastAPI sidecar mounts at `/companion/`, with a `/v1/state-proxy` SSE relay so the browser only talks to localhost.
- Intentionally separate from the on-device dashboard (`web/` at repo root): the operator console stays small and flash-resident; the companion runs on the sidecar host with no flash budget and can afford ~120 KB of three.js.
- Scene is hand-built primitives — CoreS3-shaped body box, head box with a `CanvasTexture` face decal, status LED, coral chassis accents. The face decal is a 2D-canvas port of the dashboard's schematic `FaceGlyph`, so emotion shapes match exactly across both surfaces.

**State plumbing:**
- Browser connects to `/v1/state-proxy` on the sidecar; the sidecar streams raw SSE chunks from `STACKCHAN_FIRMWARE_URL/state/stream` (default `http://stackchan.local`). No CORS needed on the firmware.
- Head rotation lerps toward `head_actual` (the SCServo's reported position, not the commanded value) so the 3D model lags reality the way the physical robot does — feels more alive.
- Idle behaviors layered on top: sinusoidal body bob for breath, microsaccades on the eye decal at 0.5–1.5 s intervals (sourced from the gaze-constants memory).
- Chassis status LED tints green / amber / red against battery percent + wifi link.

**Lifecycle:**
- Mount gated on `SIDECAR_COMPANION_ENABLED` (default on).
- Falls back to SSE-only when the static bundle is missing, so the voice-agent path keeps working without `just sidecar-companion-build`.

**Bundle:** 477 KB (120 KB gzipped) — three.js + ~8 KB of app code.

## Test plan
- [x] `cd sidecar && uv run pytest -q` — 94 passed, includes 6 new companion tests covering enable flag, route registration, healthz body, upstream-error envelope, missing-dist fallback, and static mount when dist exists.
- [x] `just sidecar-companion-build` — produces `sidecar/web/dist/index.html` + assets.
- [ ] Manual: run sidecar with `STACKCHAN_FIRMWARE_URL=http://stackchan.local`, open `http://localhost:8080/companion/`, confirm the 3D Stack-chan rotates with the live device, face decal mirrors emotion, breath/saccade play, status LED reflects battery/wifi.
- [ ] Manual: stop the firmware mid-session, confirm HUD shows `LINK down` and the sidecar SSE relay reconnects when firmware returns.
- [ ] Manual: set `SIDECAR_COMPANION_ENABLED=false`, confirm `/companion/` 404s and `/v1/listen` still works.