### PR TITLE
feat(sidecar): agent legibility — thinking, subtitles, PTT, emotion chips

### DIFF
--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -60,19 +60,15 @@ def _failure(
     return JSONResponse(build_envelope(kind), status_code=status)
 
 
-def _audio_failure(
-    code: ErrorCode,
-    *,
-    request_id: str,
-    session_id: str,
-    session_status: SessionStatus | None = None,
-) -> JSONResponse:
+def _audio_failure(code: ErrorCode, *, request_id: str, session_id: str) -> JSONResponse:
+    # Pre-flight validation failures (bad content type, body size) happen
+    # before `mark_thinking` — the state machine never entered "thinking"
+    # for this request, so we don't poke session_status here.
     return _failure(
         code,
         request_id=request_id,
         session_id=session_id,
         status=audio_validation_status(code),
-        session_status=session_status,
     )
 
 
@@ -121,12 +117,7 @@ def create_app(
 
         ct_err = _validate_content_type(content_type)
         if ct_err is not None:
-            return _audio_failure(
-                ct_err,
-                request_id=request_id,
-                session_id=session_id,
-                session_status=session_status,
-            )
+            return _audio_failure(ct_err, request_id=request_id, session_id=session_id)
 
         declared_length = request.headers.get("content-length")
         if declared_length is not None:
@@ -137,37 +128,26 @@ def create_app(
                     ErrorCode.BAD_CONTENT_LENGTH,
                     request_id=request_id,
                     session_id=session_id,
-                    session_status=session_status,
                 )
             if declared > _MAX_BODY_BYTES:
                 return _audio_failure(
                     ErrorCode.AUDIO_TOO_LARGE,
                     request_id=request_id,
                     session_id=session_id,
-                    session_status=session_status,
                 )
 
         body = await request.body()
         if not body:
             return _audio_failure(
-                ErrorCode.AUDIO_EMPTY,
-                request_id=request_id,
-                session_id=session_id,
-                session_status=session_status,
+                ErrorCode.AUDIO_EMPTY, request_id=request_id, session_id=session_id
             )
         if len(body) > _MAX_BODY_BYTES:
             return _audio_failure(
-                ErrorCode.AUDIO_TOO_LARGE,
-                request_id=request_id,
-                session_id=session_id,
-                session_status=session_status,
+                ErrorCode.AUDIO_TOO_LARGE, request_id=request_id, session_id=session_id
             )
         if len(body) < _MIN_BODY_BYTES:
             return _audio_failure(
-                ErrorCode.AUDIO_TOO_SMALL,
-                request_id=request_id,
-                session_id=session_id,
-                session_status=session_status,
+                ErrorCode.AUDIO_TOO_SMALL, request_id=request_id, session_id=session_id
             )
 
         session_status.mark_thinking(request_id=request_id, session_id=session_id)

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from .auth import make_verifier
 from .companion import register_companion
 from .config import Settings
+from .session_status import SessionStatus
 from .errors import (
     ErrorCode,
     audio_validation_status,
@@ -36,6 +37,7 @@ def _failure(
     request_id: str,
     session_id: str,
     status: int,
+    session_status: SessionStatus | None = None,
     extra: dict[str, object] | None = None,
 ) -> JSONResponse:
     kind = failure_kind(code)
@@ -49,15 +51,28 @@ def _failure(
     if extra:
         log_extra.update(extra)
     _LOG.warning("listen.fail", extra=log_extra)
+    if session_status is not None:
+        session_status.mark_failed(
+            request_id=request_id,
+            session_id=session_id,
+            error=kind.code.value,
+        )
     return JSONResponse(build_envelope(kind), status_code=status)
 
 
-def _audio_failure(code: ErrorCode, *, request_id: str, session_id: str) -> JSONResponse:
+def _audio_failure(
+    code: ErrorCode,
+    *,
+    request_id: str,
+    session_id: str,
+    session_status: SessionStatus | None = None,
+) -> JSONResponse:
     return _failure(
         code,
         request_id=request_id,
         session_id=session_id,
         status=audio_validation_status(code),
+        session_status=session_status,
     )
 
 
@@ -86,6 +101,8 @@ def create_app(
             yield
 
     app = FastAPI(title="stackchan-sidecar", version="0.1.0", lifespan=lifespan)
+    session_status = SessionStatus()
+    app.state.session_status = session_status
     verify_bearer = make_verifier(settings.bearer_token)
     register_companion(app, settings)
 
@@ -104,7 +121,12 @@ def create_app(
 
         ct_err = _validate_content_type(content_type)
         if ct_err is not None:
-            return _audio_failure(ct_err, request_id=request_id, session_id=session_id)
+            return _audio_failure(
+                ct_err,
+                request_id=request_id,
+                session_id=session_id,
+                session_status=session_status,
+            )
 
         declared_length = request.headers.get("content-length")
         if declared_length is not None:
@@ -115,27 +137,40 @@ def create_app(
                     ErrorCode.BAD_CONTENT_LENGTH,
                     request_id=request_id,
                     session_id=session_id,
+                    session_status=session_status,
                 )
             if declared > _MAX_BODY_BYTES:
                 return _audio_failure(
                     ErrorCode.AUDIO_TOO_LARGE,
                     request_id=request_id,
                     session_id=session_id,
+                    session_status=session_status,
                 )
 
         body = await request.body()
         if not body:
             return _audio_failure(
-                ErrorCode.AUDIO_EMPTY, request_id=request_id, session_id=session_id
+                ErrorCode.AUDIO_EMPTY,
+                request_id=request_id,
+                session_id=session_id,
+                session_status=session_status,
             )
         if len(body) > _MAX_BODY_BYTES:
             return _audio_failure(
-                ErrorCode.AUDIO_TOO_LARGE, request_id=request_id, session_id=session_id
+                ErrorCode.AUDIO_TOO_LARGE,
+                request_id=request_id,
+                session_id=session_id,
+                session_status=session_status,
             )
         if len(body) < _MIN_BODY_BYTES:
             return _audio_failure(
-                ErrorCode.AUDIO_TOO_SMALL, request_id=request_id, session_id=session_id
+                ErrorCode.AUDIO_TOO_SMALL,
+                request_id=request_id,
+                session_id=session_id,
+                session_status=session_status,
             )
+
+        session_status.mark_thinking(request_id=request_id, session_id=session_id)
 
         t0 = time.perf_counter()
         deadline = time.monotonic() + settings.total_timeout_seconds
@@ -157,6 +192,7 @@ def create_app(
                 request_id=request_id,
                 session_id=session_id,
                 status=500,
+                session_status=session_status,
                 extra={"persona": settings.persona},
             )
 
@@ -176,6 +212,7 @@ def create_app(
                 request_id=request_id,
                 session_id=session_id,
                 status=200,
+                session_status=session_status,
             )
         except Exception:
             _LOG.exception(
@@ -187,6 +224,7 @@ def create_app(
                 request_id=request_id,
                 session_id=session_id,
                 status=200,
+                session_status=session_status,
             )
         stt_ms = int((time.perf_counter() - t_stt0) * 1000)
 
@@ -207,6 +245,7 @@ def create_app(
                 request_id=request_id,
                 session_id=session_id,
                 status=200,
+                session_status=session_status,
             )
         except ValueError:
             _LOG.exception(
@@ -218,6 +257,7 @@ def create_app(
                 request_id=request_id,
                 session_id=session_id,
                 status=200,
+                session_status=session_status,
             )
         except Exception:
             _LOG.exception(
@@ -229,6 +269,7 @@ def create_app(
                 request_id=request_id,
                 session_id=session_id,
                 status=200,
+                session_status=session_status,
             )
         llm_ms = int((time.perf_counter() - t_llm0) * 1000)
 
@@ -239,6 +280,14 @@ def create_app(
         store.record(
             session_id,
             Turn(user=transcript, assistant=reply.full, emotion=emotion),
+        )
+
+        session_status.mark_done(
+            request_id=request_id,
+            session_id=session_id,
+            transcript=transcript,
+            reply_short=short,
+            emotion=emotion.value,
         )
 
         _LOG.info(

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -11,7 +11,6 @@ from fastapi.responses import JSONResponse
 from .auth import make_verifier
 from .companion import register_companion
 from .config import Settings
-from .session_status import SessionStatus
 from .errors import (
     ErrorCode,
     audio_validation_status,
@@ -21,6 +20,7 @@ from .errors import (
 from .llm import Emotion, LLMProvider, sanitize_short
 from .personas import load_persona
 from .retry import StageDeadlineError, retry_with_timeout
+from .session_status import SessionStatus
 from .session_store import SessionStore, Turn, session_store_lifespan
 from .stt import STTProvider
 

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -160,9 +160,7 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
             raise HTTPException(status_code=502, detail="firmware unreachable") from None
 
         if resp.status_code >= 400:
-            _LOG.info(
-                "firmware-cmd %s returned %s: %s", name, resp.status_code, resp.text[:200]
-            )
+            _LOG.info("firmware-cmd %s returned %s: %s", name, resp.status_code, resp.text[:200])
 
         ct = resp.headers.get("content-type", "")
         payload: Any

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -125,7 +125,7 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
             while not await request.is_disconnected():
                 try:
                     await asyncio.wait_for(status.changed(), timeout=2.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     yield b": keepalive\n\n"
                     continue
                 yield _format_status(status.get())

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -1,28 +1,46 @@
-"""Companion endpoints: a static 3D mirror app + an SSE relay from the firmware.
+"""Companion endpoints: a static 3D mirror app + relays to the firmware.
 
-Mounted under `/companion/` (the bundled webapp) and `/v1/state-proxy` (a
-relay of the firmware's `/state/stream`). The firmware exposes SSE only on
-its own origin; rather than ask it for CORS, we proxy through the sidecar,
-keeping a single auth surface for the operator and letting the companion
-talk to localhost.
+Mounted under `/companion/` (the bundled webapp). Three relay routes give
+the companion everything it needs while keeping the browser bound to
+localhost:
+
+- `GET /v1/state-proxy` — SSE relay of the firmware's `/state/stream`.
+- `GET /v1/session-status` — SSE stream of the voice agent's state
+  machine (`idle` / `thinking`) plus the last completed turn.
+- `POST /v1/firmware-cmd/{listen,emotion}` — allow-listed proxies that
+  inject the firmware bearer (held by the sidecar, not the browser)
+  before forwarding.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 import httpx
-from fastapi import APIRouter, FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from .config import Settings
+from .session_status import SessionStatus, snapshot_to_dict
 
 _LOG = logging.getLogger("stackchan_sidecar.companion")
 
 _UPSTREAM_TIMEOUT = httpx.Timeout(connect=5.0, read=None, write=5.0, pool=5.0)
+_CMD_TIMEOUT = httpx.Timeout(connect=3.0, read=5.0, write=3.0, pool=3.0)
+
+# Allow-listed firmware POST endpoints reachable via /v1/firmware-cmd/.
+# Anything outside this map 404s — the proxy is intentionally not a
+# generic relay so a hostile browser can't pivot through it.
+_FIRMWARE_CMD_PATHS: dict[str, str] = {
+    "listen": "/listen",
+    "emotion": "/emotion",
+}
 
 
 def _resolve_static_dir() -> Path | None:
@@ -38,9 +56,9 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
     """Wire companion routes into an existing FastAPI app.
 
     Idempotent and side-effect-light: if the static bundle is missing the
-    mount is skipped and a single warning is logged. The state-proxy SSE
-    route registers regardless so the sidecar process is still useful when
-    only the firmware bundle is rebuilt.
+    mount is skipped and a single warning is logged. The relay routes
+    register regardless so the sidecar process is still useful when only
+    the firmware bundle is rebuilt.
     """
     if not settings.companion_enabled:
         _LOG.info("companion disabled via SIDECAR_COMPANION_ENABLED=false")
@@ -91,6 +109,72 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
             headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
         )
 
+    @router.get("/v1/session-status")
+    async def session_status_stream(request: Request) -> StreamingResponse:
+        status: SessionStatus | None = getattr(request.app.state, "session_status", None)
+        if status is None:
+            raise HTTPException(status_code=503, detail="session-status not initialised")
+
+        async def stream() -> AsyncIterator[bytes]:
+            # Initial frame so a fresh subscriber paints the right state
+            # without waiting for the next transition.
+            yield _format_status(status.get())
+            # Short timeout keeps us responsive to client disconnects on
+            # ASGI servers that don't immediately cancel the generator;
+            # also acts as the SSE keepalive heartbeat for proxies.
+            while not await request.is_disconnected():
+                try:
+                    await asyncio.wait_for(status.changed(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    yield b": keepalive\n\n"
+                    continue
+                yield _format_status(status.get())
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+        )
+
+    @router.post("/v1/firmware-cmd/{name}")
+    async def firmware_cmd(name: str, request: Request) -> JSONResponse:
+        upstream_path = _FIRMWARE_CMD_PATHS.get(name)
+        if upstream_path is None:
+            raise HTTPException(status_code=404, detail=f"unknown firmware command: {name}")
+
+        upstream = settings.firmware_url.rstrip("/") + upstream_path
+        try:
+            body = await request.json()
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="body must be JSON") from None
+
+        headers = {"Content-Type": "application/json"}
+        if settings.firmware_token:
+            headers["Authorization"] = f"Bearer {settings.firmware_token}"
+
+        try:
+            async with httpx.AsyncClient(timeout=_CMD_TIMEOUT) as client:
+                resp = await client.post(upstream, json=body, headers=headers)
+        except httpx.HTTPError as e:
+            _LOG.warning("firmware-cmd %s transport error: %s", name, e)
+            raise HTTPException(status_code=502, detail="firmware unreachable") from None
+
+        if resp.status_code >= 400:
+            _LOG.info(
+                "firmware-cmd %s returned %s: %s", name, resp.status_code, resp.text[:200]
+            )
+
+        ct = resp.headers.get("content-type", "")
+        payload: Any
+        if ct.startswith("application/json"):
+            try:
+                payload = resp.json()
+            except json.JSONDecodeError:
+                payload = {"raw": resp.text}
+        else:
+            payload = {"raw": resp.text}
+        return JSONResponse(payload, status_code=resp.status_code)
+
     @router.get("/companion/healthz")
     async def companion_healthz() -> dict[str, object]:
         return {"status": "ok", "firmware_url": settings.firmware_url}
@@ -107,3 +191,12 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
 
     app.mount("/companion", StaticFiles(directory=static_dir, html=True), name="companion")
     _LOG.info("companion mounted: static=%s upstream=%s", static_dir, settings.firmware_url)
+
+
+def _format_status(snapshot: object) -> bytes:
+    # `SessionStatus.get()` returns a frozen dataclass; reuse the helper
+    # so the wire shape stays the test-asserted one.
+    from .session_status import Snapshot
+
+    payload = snapshot_to_dict(snapshot) if isinstance(snapshot, Snapshot) else {}
+    return b"data: " + json.dumps(payload, separators=(",", ":")).encode() + b"\n\n"

--- a/sidecar/src/stackchan_sidecar/session_status.py
+++ b/sidecar/src/stackchan_sidecar/session_status.py
@@ -1,0 +1,116 @@
+"""Voice-agent state snapshot consumed by the 3D companion.
+
+The sidecar marks `thinking` on `/v1/listen` entry and `idle` on completion
+or failure. Subscribers (SSE clients) receive the current snapshot on
+connect and every subsequent state change. The holder is intentionally
+small: a dataclass + an `asyncio.Event` that flips on change so a single
+broadcast wakes every subscriber.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Literal
+
+State = Literal["idle", "thinking"]
+
+
+@dataclass(frozen=True)
+class Turn:
+    """The latest completed listen→reply round-trip."""
+
+    transcript: str
+    reply_short: str
+    emotion: str
+    completed_at: float  # seconds since epoch; useful for subtitle TTL
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    state: State
+    request_id: str | None = None
+    session_id: str | None = None
+    last_turn: Turn | None = None
+    error: str | None = None
+    updated_at: float = field(default_factory=time.time)
+
+
+class SessionStatus:
+    """Mutable holder with a broadcast change-event.
+
+    Read-from-anywhere via [`get`][SessionStatus.get]; writes happen only
+    from the `/v1/listen` handler. SSE subscribers `await changed()` then
+    re-read.
+    """
+
+    def __init__(self) -> None:
+        self._snapshot = Snapshot(state="idle")
+        self._event = asyncio.Event()
+
+    def get(self) -> Snapshot:
+        return self._snapshot
+
+    async def changed(self) -> None:
+        """Block until the next state change. Each subscriber awaits its own
+        view of the change; we recreate the event on every set so concurrent
+        subscribers all wake exactly once per transition."""
+        await self._event.wait()
+
+    def _broadcast(self) -> None:
+        self._event.set()
+        self._event = asyncio.Event()
+
+    def mark_thinking(self, *, request_id: str, session_id: str) -> None:
+        self._snapshot = Snapshot(
+            state="thinking",
+            request_id=request_id,
+            session_id=session_id,
+            last_turn=self._snapshot.last_turn,
+        )
+        self._broadcast()
+
+    def mark_done(
+        self,
+        *,
+        request_id: str,
+        session_id: str,
+        transcript: str,
+        reply_short: str,
+        emotion: str,
+    ) -> None:
+        self._snapshot = Snapshot(
+            state="idle",
+            request_id=request_id,
+            session_id=session_id,
+            last_turn=Turn(
+                transcript=transcript,
+                reply_short=reply_short,
+                emotion=emotion,
+                completed_at=time.time(),
+            ),
+        )
+        self._broadcast()
+
+    def mark_failed(
+        self, *, request_id: str, session_id: str, error: str
+    ) -> None:
+        self._snapshot = Snapshot(
+            state="idle",
+            request_id=request_id,
+            session_id=session_id,
+            last_turn=self._snapshot.last_turn,
+            error=error,
+        )
+        self._broadcast()
+
+
+def snapshot_to_dict(s: Snapshot) -> dict[str, object]:
+    """Serialize for the SSE wire (drop None turn cleanly)."""
+    raw = asdict(s)
+    if raw.get("last_turn") is None:
+        raw.pop("last_turn", None)
+    if raw.get("error") is None:
+        raw.pop("error", None)
+    return raw

--- a/sidecar/src/stackchan_sidecar/session_status.py
+++ b/sidecar/src/stackchan_sidecar/session_status.py
@@ -93,9 +93,7 @@ class SessionStatus:
         )
         self._broadcast()
 
-    def mark_failed(
-        self, *, request_id: str, session_id: str, error: str
-    ) -> None:
+    def mark_failed(self, *, request_id: str, session_id: str, error: str) -> None:
         self._snapshot = Snapshot(
             state="idle",
             request_id=request_id,

--- a/sidecar/tests/test_companion.py
+++ b/sidecar/tests/test_companion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from stackchan_sidecar.companion import register_companion
 from stackchan_sidecar.config import Settings
+from stackchan_sidecar.session_status import SessionStatus
 
 from .conftest import TEST_TOKEN
 
@@ -35,6 +37,8 @@ def test_register_companion_registers_routes_when_enabled() -> None:
     register_companion(app, _settings())
     paths = {r.path for r in app.routes}  # type: ignore[attr-defined]
     assert "/v1/state-proxy" in paths
+    assert "/v1/session-status" in paths
+    assert "/v1/firmware-cmd/{name}" in paths
     assert "/companion/healthz" in paths
 
 
@@ -119,3 +123,110 @@ def test_register_companion_mounts_static_when_dist_exists(
         r = c.get("/companion/")
     assert r.status_code == 200
     assert "companion" in r.text
+
+
+def _app_with_status(status: SessionStatus, **settings_overrides: object) -> FastAPI:
+    app = FastAPI()
+    app.state.session_status = status
+    register_companion(app, _settings(**settings_overrides))
+    return app
+
+
+def test_session_status_sse_route_resolves_against_app_state() -> None:
+    # Direct streaming-body assertions hang under httpx's ASGI transport
+    # (it doesn't propagate http.disconnect to request.is_disconnected(),
+    # so the keepalive loop never exits). The SessionStatus state machine
+    # and `_format_status` are exercised by test_session_status.py; here
+    # we just confirm the route reads `app.state.session_status` and 503s
+    # cleanly when it's absent.
+    app = FastAPI()
+    register_companion(app, _settings())
+    with TestClient(app) as c:
+        r = c.get("/v1/session-status")
+    # No app.state.session_status configured → 503, no hang.
+    assert r.status_code == 503
+
+    # With state wired the route reports text/event-stream on first byte.
+    # We can't safely consume the body in TestClient, so just check the
+    # response object's media_type via a HEAD-style probe is impossible;
+    # the route-registered assertion above covers the wire-up.
+
+
+def test_firmware_cmd_unknown_name_404s() -> None:
+    status = SessionStatus()
+    app = _app_with_status(status)
+    with TestClient(app) as c:
+        r = c.post("/v1/firmware-cmd/unknown", json={})
+    assert r.status_code == 404
+
+
+def test_firmware_cmd_forwards_body_and_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResp:
+        status_code = 200
+        text = '{"ok":true}'
+        headers = {"content-type": "application/json"}
+
+        def json(self) -> dict[str, object]:
+            return {"ok": True}
+
+    class FakeClient:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def post(self, url: str, json: object, headers: dict[str, str]) -> FakeResp:
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return FakeResp()
+
+    monkeypatch.setattr("stackchan_sidecar.companion.httpx.AsyncClient", FakeClient)
+
+    status = SessionStatus()
+    app = _app_with_status(
+        status,
+        STACKCHAN_FIRMWARE_URL="http://stackchan.example",
+        STACKCHAN_FIRMWARE_TOKEN="fw-secret",
+    )
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/firmware-cmd/emotion",
+            json={"emotion": "happy", "hold_ms": 30000},
+        )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert captured["url"] == "http://stackchan.example/emotion"
+    assert captured["json"] == {"emotion": "happy", "hold_ms": 30000}
+    assert captured["headers"]["Authorization"] == "Bearer fw-secret"  # type: ignore[index]
+
+
+def test_firmware_cmd_502_when_firmware_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    class FakeClient:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def post(self, *_: object, **__: object) -> None:
+            raise httpx.ConnectError("nope")
+
+    monkeypatch.setattr("stackchan_sidecar.companion.httpx.AsyncClient", FakeClient)
+
+    status = SessionStatus()
+    app = _app_with_status(status)
+    with TestClient(app) as c:
+        r = c.post("/v1/firmware-cmd/listen", json={"duration_ms": 4000})
+    assert r.status_code == 502

--- a/sidecar/tests/test_companion.py
+++ b/sidecar/tests/test_companion.py
@@ -166,7 +166,7 @@ def test_firmware_cmd_forwards_body_and_bearer(monkeypatch: pytest.MonkeyPatch) 
     class FakeResp:
         status_code = 200
         text = '{"ok":true}'
-        headers = {"content-type": "application/json"}
+        headers: typing.ClassVar[dict[str, str]] = {"content-type": "application/json"}
 
         def json(self) -> dict[str, object]:
             return {"ok": True}
@@ -175,7 +175,7 @@ def test_firmware_cmd_forwards_body_and_bearer(monkeypatch: pytest.MonkeyPatch) 
         def __init__(self, *_: object, **__: object) -> None:
             pass
 
-        async def __aenter__(self) -> "FakeClient":
+        async def __aenter__(self) -> FakeClient:
             return self
 
         async def __aexit__(self, *_: object) -> None:
@@ -214,7 +214,7 @@ def test_firmware_cmd_502_when_firmware_unreachable(monkeypatch: pytest.MonkeyPa
         def __init__(self, *_: object, **__: object) -> None:
             pass
 
-        async def __aenter__(self) -> "FakeClient":
+        async def __aenter__(self) -> FakeClient:
             return self
 
         async def __aexit__(self, *_: object) -> None:

--- a/sidecar/tests/test_session_status.py
+++ b/sidecar/tests/test_session_status.py
@@ -1,0 +1,122 @@
+"""Behavioural tests for the SessionStatus state holder."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from stackchan_sidecar.session_status import SessionStatus, snapshot_to_dict
+
+
+def test_initial_snapshot_is_idle() -> None:
+    s = SessionStatus()
+    snap = s.get()
+    assert snap.state == "idle"
+    assert snap.last_turn is None
+
+
+def test_mark_thinking_updates_state() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="req1", session_id="sess1")
+    snap = s.get()
+    assert snap.state == "thinking"
+    assert snap.request_id == "req1"
+    assert snap.session_id == "sess1"
+
+
+def test_mark_done_returns_to_idle_with_turn() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="req1", session_id="sess1")
+    s.mark_done(
+        request_id="req1",
+        session_id="sess1",
+        transcript="hello",
+        reply_short="hi!",
+        emotion="happy",
+    )
+    snap = s.get()
+    assert snap.state == "idle"
+    assert snap.last_turn is not None
+    assert snap.last_turn.transcript == "hello"
+    assert snap.last_turn.reply_short == "hi!"
+    assert snap.last_turn.emotion == "happy"
+
+
+def test_mark_failed_returns_to_idle_with_error() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="req1", session_id="sess1")
+    s.mark_failed(request_id="req1", session_id="sess1", error="stt_timeout")
+    snap = s.get()
+    assert snap.state == "idle"
+    assert snap.error == "stt_timeout"
+
+
+def test_mark_failed_preserves_prior_turn() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="r0", session_id="s0")
+    s.mark_done(
+        request_id="r0",
+        session_id="s0",
+        transcript="first",
+        reply_short="ok",
+        emotion="neutral",
+    )
+    s.mark_thinking(request_id="r1", session_id="s0")
+    s.mark_failed(request_id="r1", session_id="s0", error="llm_failed")
+    snap = s.get()
+    assert snap.error == "llm_failed"
+    assert snap.last_turn is not None
+    assert snap.last_turn.transcript == "first"
+
+
+@pytest.mark.asyncio
+async def test_changed_wakes_subscribers_on_transition() -> None:
+    s = SessionStatus()
+    received: list[str] = []
+
+    async def waiter() -> None:
+        await s.changed()
+        received.append(s.get().state)
+
+    task = asyncio.create_task(waiter())
+    await asyncio.sleep(0)  # yield so waiter starts blocking
+    s.mark_thinking(request_id="r1", session_id="s1")
+    await asyncio.wait_for(task, timeout=0.5)
+    assert received == ["thinking"]
+
+
+@pytest.mark.asyncio
+async def test_changed_wakes_multiple_subscribers() -> None:
+    s = SessionStatus()
+    seen: list[str] = []
+
+    async def waiter(label: str) -> None:
+        await s.changed()
+        seen.append(label)
+
+    a = asyncio.create_task(waiter("a"))
+    b = asyncio.create_task(waiter("b"))
+    await asyncio.sleep(0)
+    s.mark_thinking(request_id="r", session_id="s")
+    await asyncio.wait_for(asyncio.gather(a, b), timeout=0.5)
+    assert sorted(seen) == ["a", "b"]
+
+
+def test_snapshot_to_dict_drops_none_fields() -> None:
+    s = SessionStatus()
+    raw = snapshot_to_dict(s.get())
+    assert raw["state"] == "idle"
+    assert "last_turn" not in raw
+    assert "error" not in raw
+
+    s.mark_done(
+        request_id="r",
+        session_id="s",
+        transcript="hi",
+        reply_short="hi",
+        emotion="happy",
+    )
+    raw = snapshot_to_dict(s.get())
+    assert raw["last_turn"]["transcript"] == "hi"
+    assert "error" not in raw

--- a/sidecar/tests/test_session_status.py
+++ b/sidecar/tests/test_session_status.py
@@ -150,5 +150,7 @@ def test_snapshot_to_dict_drops_none_fields() -> None:
         emotion="happy",
     )
     raw = snapshot_to_dict(s.get())
-    assert raw["last_turn"]["transcript"] == "hi"
+    turn = raw["last_turn"]
+    assert isinstance(turn, dict)
+    assert turn["transcript"] == "hi"
     assert "error" not in raw

--- a/sidecar/tests/test_session_status.py
+++ b/sidecar/tests/test_session_status.py
@@ -103,6 +103,38 @@ async def test_changed_wakes_multiple_subscribers() -> None:
     assert sorted(seen) == ["a", "b"]
 
 
+def test_preflight_failure_does_not_broadcast(
+    fake_stt: object, fake_llm: object, settings: object
+) -> None:
+    # Pre-flight validation failures (bad content type, body size) must
+    # not poke the SessionStatus — the state machine never claimed to be
+    # "thinking" for that request. Without this guard every malformed
+    # POST would push `idle(error)` deltas to every SSE subscriber.
+    from fastapi.testclient import TestClient
+
+    from stackchan_sidecar.app import create_app
+
+    app = create_app(settings, fake_stt, fake_llm)  # type: ignore[arg-type]
+    status: SessionStatus = app.state.session_status
+
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=b"x" * 1024,
+            headers={
+                "Authorization": "Bearer test-token-do-not-use-in-prod",
+                "Content-Type": "application/octet-stream",
+            },
+        )
+    assert r.status_code in (400, 415)
+    snap = status.get()
+    assert snap.state == "idle"
+    assert snap.error is None
+    # mark_failed (which a pre-flight failure must NOT call) sets last_turn
+    # to whatever was there before — None on a fresh holder.
+    assert snap.last_turn is None
+
+
 def test_snapshot_to_dict_drops_none_fields() -> None:
     s = SessionStatus()
     raw = snapshot_to_dict(s.get())

--- a/sidecar/web/index.html
+++ b/sidecar/web/index.html
@@ -9,10 +9,15 @@
   <body>
     <div id="app">
       <canvas id="scene"></canvas>
+
       <aside id="hud">
         <div class="row">
           <span class="hud-label">LINK</span>
           <span id="hud-link" class="hud-value">linking…</span>
+        </div>
+        <div class="row">
+          <span class="hud-label">AGENT</span>
+          <span id="hud-agent" class="hud-value">linking…</span>
         </div>
         <div class="row">
           <span class="hud-label">EMOTION</span>
@@ -31,6 +36,32 @@
           <span id="hud-wifi" class="hud-value">—</span>
         </div>
       </aside>
+
+      <div id="thinking" class="thinking hidden" aria-live="polite">
+        <span class="thinking-dot"></span>
+        <span class="thinking-dot"></span>
+        <span class="thinking-dot"></span>
+        <span class="thinking-label">thinking…</span>
+      </div>
+
+      <div id="subtitle" class="subtitle hidden" aria-live="polite">
+        <div class="subtitle-row">
+          <span class="subtitle-tag">YOU</span>
+          <span id="subtitle-user" class="subtitle-text"></span>
+        </div>
+        <div class="subtitle-row">
+          <span class="subtitle-tag subtitle-tag-reply">SC</span>
+          <span id="subtitle-reply" class="subtitle-text subtitle-reply"></span>
+        </div>
+      </div>
+
+      <div id="controls" class="controls">
+        <button id="ptt" class="ptt" type="button" aria-label="Start listen window">
+          <span class="ptt-icon">●</span>
+          <span class="ptt-label">PUSH TO LISTEN</span>
+        </button>
+        <div id="chips" class="chips" role="toolbar" aria-label="Emotion presets"></div>
+      </div>
     </div>
     <script type="module" src="./src/main.ts"></script>
   </body>

--- a/sidecar/web/src/actions.ts
+++ b/sidecar/web/src/actions.ts
@@ -1,0 +1,37 @@
+// Companion → sidecar → firmware command relays. The companion never
+// holds the firmware bearer token; the sidecar injects it before the
+// proxied POST.
+
+async function firmwareCmd(name: string, body: unknown): Promise<Response> {
+  const r = await fetch(`/v1/firmware-cmd/${name}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  return r;
+}
+
+const DEFAULT_LISTEN_MS = 5000;
+const DEFAULT_HOLD_MS = 30_000;
+
+export async function startListen(durationMs: number = DEFAULT_LISTEN_MS): Promise<void> {
+  await firmwareCmd("listen", { duration_ms: durationMs });
+}
+
+export async function setEmotion(
+  emotion: string,
+  holdMs: number = DEFAULT_HOLD_MS,
+): Promise<void> {
+  await firmwareCmd("emotion", { emotion, hold_ms: holdMs });
+}
+
+export const EMOTION_CHIPS: readonly { id: string; label: string }[] = [
+  { id: "neutral", label: "Neutral" },
+  { id: "happy", label: "Happy" },
+  { id: "sad", label: "Sad" },
+  { id: "sleepy", label: "Sleepy" },
+  { id: "surprised", label: "Surprised" },
+  { id: "angry", label: "Angry" },
+  { id: "loved", label: "Loved" },
+  { id: "curious", label: "Curious" },
+] as const;

--- a/sidecar/web/src/main.ts
+++ b/sidecar/web/src/main.ts
@@ -1,6 +1,8 @@
+import { EMOTION_CHIPS, setEmotion, startListen } from "./actions";
 import { buildScene, setStatusTone } from "./scene";
 import {
   batteryTone,
+  connectAgentStream,
   connectStream,
   createState,
   tickPose,
@@ -9,17 +11,66 @@ import {
 
 const canvas = document.getElementById("scene") as HTMLCanvasElement;
 const hudLink = document.getElementById("hud-link")!;
+const hudAgent = document.getElementById("hud-agent")!;
 const hudEmotion = document.getElementById("hud-emotion")!;
 const hudPose = document.getElementById("hud-pose")!;
 const hudBattery = document.getElementById("hud-battery")!;
 const hudWifi = document.getElementById("hud-wifi")!;
 
+const thinkingEl = document.getElementById("thinking")!;
+const subtitleEl = document.getElementById("subtitle")!;
+const subtitleUserEl = document.getElementById("subtitle-user")!;
+const subtitleReplyEl = document.getElementById("subtitle-reply")!;
+
+const pttEl = document.getElementById("ptt") as HTMLButtonElement;
+const chipsEl = document.getElementById("chips")!;
+
 const scene = buildScene(canvas);
 const state = createState();
 connectStream("/v1/state-proxy", state);
+connectAgentStream("/v1/session-status", state);
 
 window.addEventListener("resize", scene.resize);
 
+// ── Controls ──────────────────────────────────────────────────────
+
+const chipButtons = new Map<string, HTMLButtonElement>();
+for (const { id, label } of EMOTION_CHIPS) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "chip";
+  btn.dataset.emotion = id;
+  btn.textContent = label;
+  btn.addEventListener("click", () => {
+    void setEmotion(id);
+  });
+  chipsEl.appendChild(btn);
+  chipButtons.set(id, btn);
+}
+
+let pttBusy = false;
+pttEl.addEventListener("click", async () => {
+  if (pttBusy) return;
+  pttBusy = true;
+  pttEl.disabled = true;
+  try {
+    await startListen();
+  } finally {
+    pttBusy = false;
+    pttEl.disabled = false;
+  }
+});
+
+// ── Subtitle TTL ──────────────────────────────────────────────────
+// Surface the latest turn for ~12 s after completion; after that hide
+// so it doesn't loiter on top of the scene forever.
+const SUBTITLE_TTL_MS = 12_000;
+let lastTurnId: number | null = null;
+let lastTurnShownAt = 0;
+
+// ── Render loop ───────────────────────────────────────────────────
+
+let lastChipActive = "";
 let lastT = performance.now() / 1000;
 
 function frame(): void {
@@ -36,7 +87,6 @@ function frame(): void {
   scene.head.rotation.y = state.pan;
   scene.head.rotation.x = state.tilt;
 
-  // Breath: gentle vertical bob, ~10 mm peak-to-peak at ~6 BPM equivalent.
   const breath = Math.sin(now * 0.6) * 0.018;
   scene.scene.position.y = breath;
 
@@ -48,8 +98,19 @@ function frame(): void {
 
   setStatusTone(scene.status, batteryTone(state.snapshot));
 
+  // ── HUD ────────────────────────────────────────────────────────
   hudLink.textContent = state.conn;
   hudLink.dataset.conn = state.conn;
+  const agentLabel =
+    state.agentConn === "live"
+      ? state.agent?.state === "thinking"
+        ? "thinking"
+        : "idle"
+      : state.agentConn;
+  hudAgent.textContent = agentLabel;
+  hudAgent.dataset.conn = state.agentConn;
+  hudAgent.dataset.state = state.agent?.state ?? "";
+
   hudEmotion.textContent = (state.snapshot?.emotion ?? "—").toUpperCase();
   if (state.snapshot) {
     const p = state.snapshot.head_actual ?? state.snapshot.head_pose;
@@ -63,6 +124,33 @@ function frame(): void {
     hudPose.textContent = "—";
     hudBattery.textContent = "—";
     hudWifi.textContent = "—";
+  }
+
+  // ── Thinking indicator ─────────────────────────────────────────
+  const thinking = state.agent?.state === "thinking";
+  thinkingEl.classList.toggle("hidden", !thinking);
+
+  // ── Active emotion chip ────────────────────────────────────────
+  const activeEmotion = state.snapshot?.emotion ?? "";
+  if (activeEmotion !== lastChipActive) {
+    chipButtons.get(lastChipActive)?.classList.remove("active");
+    chipButtons.get(activeEmotion)?.classList.add("active");
+    lastChipActive = activeEmotion;
+  }
+
+  // ── Subtitle TTL handling ──────────────────────────────────────
+  const turn = state.agent?.last_turn;
+  if (turn) {
+    if (turn.completed_at !== lastTurnId) {
+      lastTurnId = turn.completed_at;
+      lastTurnShownAt = performance.now();
+      subtitleUserEl.textContent = turn.transcript || "(silence)";
+      subtitleReplyEl.textContent = turn.reply_short;
+    }
+    const age = performance.now() - lastTurnShownAt;
+    subtitleEl.classList.toggle("hidden", age > SUBTITLE_TTL_MS);
+  } else {
+    subtitleEl.classList.add("hidden");
   }
 
   scene.renderer.render(scene.scene, scene.camera);

--- a/sidecar/web/src/state.ts
+++ b/sidecar/web/src/state.ts
@@ -1,6 +1,23 @@
 // Types mirror crates/stackchan-core's AvatarSnapshot wire format.
 export type Pose = { pan_deg: number; tilt_deg: number };
 
+// Voice agent state — wire format from /v1/session-status on the sidecar.
+export type Turn = {
+  transcript: string;
+  reply_short: string;
+  emotion: string;
+  completed_at: number;
+};
+
+export type SessionStatus = {
+  state: "idle" | "thinking";
+  request_id?: string | null;
+  session_id?: string | null;
+  last_turn?: Turn;
+  error?: string;
+  updated_at: number;
+};
+
 export type AvatarSnapshot = {
   emotion: string;
   mood: string;
@@ -19,6 +36,8 @@ export type ConnState = "linking" | "live" | "down";
 export type StateModel = {
   snapshot: AvatarSnapshot | null;
   conn: ConnState;
+  agentConn: ConnState;
+  agent: SessionStatus | null;
   // Smoothed view-state — radians, lerped toward target each frame.
   pan: number;
   tilt: number;
@@ -43,6 +62,8 @@ export function createState(): StateModel {
   return {
     snapshot: null,
     conn: "linking",
+    agentConn: "linking",
+    agent: null,
     pan: 0,
     tilt: 0,
     eyeOffsetX: 0,
@@ -54,7 +75,11 @@ export function createState(): StateModel {
   };
 }
 
-export function connectStream(url: string, model: StateModel): () => void {
+function connectSse<T>(
+  url: string,
+  onMessage: (data: T) => void,
+  setConn: (s: ConnState) => void,
+): () => void {
   let es: EventSource | null = null;
   let retry: ReturnType<typeof setTimeout> | null = null;
   let closed = false;
@@ -62,18 +87,16 @@ export function connectStream(url: string, model: StateModel): () => void {
   const open = (): void => {
     if (closed) return;
     es = new EventSource(url);
-    es.onopen = () => {
-      model.conn = "live";
-    };
+    es.onopen = () => setConn("live");
     es.onmessage = (ev) => {
       try {
-        model.snapshot = JSON.parse(ev.data) as AvatarSnapshot;
+        onMessage(JSON.parse(ev.data) as T);
       } catch {
         // partial payloads can land during reconnect — drop quietly
       }
     };
     es.onerror = () => {
-      model.conn = "down";
+      setConn("down");
       es?.close();
       es = null;
       if (!closed) retry = setTimeout(open, 1500);
@@ -86,6 +109,30 @@ export function connectStream(url: string, model: StateModel): () => void {
     if (retry != null) clearTimeout(retry);
     es?.close();
   };
+}
+
+export function connectStream(url: string, model: StateModel): () => void {
+  return connectSse<AvatarSnapshot>(
+    url,
+    (snap) => {
+      model.snapshot = snap;
+    },
+    (c) => {
+      model.conn = c;
+    },
+  );
+}
+
+export function connectAgentStream(url: string, model: StateModel): () => void {
+  return connectSse<SessionStatus>(
+    url,
+    (s) => {
+      model.agent = s;
+    },
+    (c) => {
+      model.agentConn = c;
+    },
+  );
 }
 
 export function targetPose(model: StateModel): Pose {

--- a/sidecar/web/src/styles.css
+++ b/sidecar/web/src/styles.css
@@ -74,14 +74,217 @@ body {
   word-break: break-all;
 }
 
-#hud-link[data-conn="live"] {
+.hud-value[data-conn="live"] {
   color: #5fc88f;
 }
 
-#hud-link[data-conn="down"] {
+.hud-value[data-conn="down"] {
   color: #e2625a;
 }
 
-#hud-link[data-conn="linking"] {
+.hud-value[data-conn="linking"] {
   color: var(--accent);
+}
+
+.hud-value[data-state="thinking"] {
+  color: var(--accent);
+}
+
+/* ─── Thinking indicator ────────────────────────────────────────── */
+
+.thinking {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(11, 14, 19, 0.7);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 1.2px;
+  color: var(--accent);
+  transition: opacity 0.18s ease;
+}
+
+.thinking.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.thinking-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: thinking-pulse 1.1s ease-in-out infinite;
+}
+
+.thinking-dot:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.thinking-dot:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes thinking-pulse {
+  0%, 100% { opacity: 0.25; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+/* ─── Subtitle (last turn) ──────────────────────────────────────── */
+
+.subtitle {
+  position: absolute;
+  left: 50%;
+  bottom: 100px;
+  transform: translateX(-50%);
+  display: grid;
+  gap: 6px;
+  padding: 12px 16px;
+  background: rgba(11, 14, 19, 0.78);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  max-width: min(640px, 70vw);
+  font-family: var(--mono);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.subtitle.hidden {
+  opacity: 0;
+  transform: translate(-50%, 10px);
+  pointer-events: none;
+}
+
+.subtitle-row {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.subtitle-tag {
+  font-size: 9px;
+  letter-spacing: 1.4px;
+  color: var(--fg-muted);
+  padding: 2px 4px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  text-align: center;
+}
+
+.subtitle-tag-reply {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.subtitle-text {
+  font-size: 13px;
+  color: var(--fg);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.subtitle-reply {
+  color: var(--accent);
+}
+
+/* ─── Controls (PTT + emotion chips) ───────────────────────────── */
+
+.controls {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  background: rgba(11, 14, 19, 0.72);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.ptt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  cursor: pointer;
+  font: 600 12px var(--mono);
+  letter-spacing: 1.2px;
+  transition: background 80ms ease, color 80ms ease;
+}
+
+.ptt:hover {
+  background: var(--accent);
+  color: #0b0e13;
+}
+
+.ptt:active {
+  transform: translateY(1px);
+}
+
+.ptt:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ptt-icon {
+  color: var(--accent);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.ptt:hover .ptt-icon {
+  color: #0b0e13;
+}
+
+.chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  max-width: 360px;
+}
+
+.chip {
+  font: 11px var(--mono);
+  letter-spacing: 0.6px;
+  padding: 5px 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: border-color 80ms ease, color 80ms ease, background 80ms ease;
+}
+
+.chip:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.chip.active {
+  border-color: var(--accent);
+  background: rgba(240, 128, 128, 0.14);
+  color: var(--accent);
+}
+
+.chip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
> Stacked on #390. Retarget to main once the base merges.

## Summary
Make the voice-agent state machine visible in the 3D companion, and give the operator a couple of light controls inside the companion itself.

### Sidecar additions
- `session_status.py` — small state holder (`idle` / `thinking`, last completed turn, `asyncio.Event` broadcast on change).
- `app.py` — wires `mark_thinking` / `mark_done` / `mark_failed` around the `/v1/listen` pipeline, parks the holder on `app.state.session_status` for the SSE route to read.
- `companion.py`:
  - `GET /v1/session-status` — SSE that emits the current snapshot on connect plus every state transition. Keepalive heartbeats every 2 s so reverse proxies don't idle-reap the stream.
  - `POST /v1/firmware-cmd/{listen,emotion}` — allow-listed proxy to the firmware HTTP plane. The sidecar injects `STACKCHAN_FIRMWARE_TOKEN`; the companion never holds the firmware bearer.

### Companion (sidecar/web) additions
- LLM **thinking indicator** — animated triple-dot in the top-right HUD while a `/v1/listen` round-trip is in flight.
- **Subtitle strip** — last transcript + short reply, shown for ~12 s after each turn completes.
- **Agent line** in the HUD next to the firmware link state.
- **Push-to-listen** button + **emotion preset chips** (8 presets, active chip tracks live snapshot).
- New `actions.ts` for the typed `/v1/firmware-cmd/*` calls.

### Tests
12 new pytest tests:
- `SessionStatus` state transitions (idle → thinking → idle, failed preserves prior turn, broadcast wakes multiple subscribers).
- Companion route registration for the new endpoints.
- `firmware-cmd` proxy: forwards body + injects bearer, 404s on unknown commands, 502s on transport errors.
- Wire-format helper drops `None` fields.

Suite: 94 → 106 passing.

## Test plan
- [x] `cd sidecar && uv run pytest -q` — 106 passed.
- [x] `just sidecar-companion-build` — bundle 121.5 KB gz.
- [ ] Manual: start the sidecar against a real `STACKCHAN_FIRMWARE_URL`, open `/companion/`, confirm:
  - [ ] HUD agent state flips `idle` → `thinking` → `idle` around each `/v1/listen` call.
  - [ ] Subtitle shows the spoken transcript + short reply, fades after ~12 s.
  - [ ] PTT button opens a listen window on the device (mic light should turn on).
  - [ ] Emotion chips post `/emotion`; active chip highlights when the device confirms via `/state`.
  - [ ] Killing the sidecar mid-session: HUD agent line flips to `down`, reconnects when sidecar returns.

## Notes
- Avoided full SSE-streaming tests under FastAPI's TestClient + httpx ASGITransport because neither propagates `http.disconnect` to `request.is_disconnected()`, causing the keepalive loop to never exit and the test to hang. The state machine itself and route registration are well covered; end-to-end SSE behavior gets verified manually on the device.