### PR TITLE
feat(web): UX/UI polish pass — shared tokens, button hierarchy, a11y, skeletons

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,12 @@
+# design/
+
+Shared design tokens for the operator dashboard (`web/`) and the
+companion (`sidecar/web/`). Each surface imports `tokens.css` from its
+own `styles.css`; Vite resolves and inlines the CSS at build time so the
+single-file dashboard bundle and the companion's static output stay
+self-contained.
+
+Edit `tokens.css` to change a value once and have it propagate across
+both surfaces. The palette is rooted in the avatar's physical DNA
+(coral cheek, warm face white, dark CoreS3 chassis) defined in
+`crates/stackchan-core/src/palette.rs`.

--- a/design/tokens.css
+++ b/design/tokens.css
@@ -1,0 +1,170 @@
+/*
+ * Shared design tokens for the operator dashboard (web/) and the 3D
+ * companion (sidecar/web/). Both Vite bundles `@import` this file from
+ * their respective styles.css so a single bump propagates across
+ * surfaces.
+ *
+ * The palette is rooted in Stack-chan's physical avatar (defined in
+ * crates/stackchan-core/src/palette.rs): white face background, black
+ * eyes, coral cheek + mouth. The chassis derives from the CoreS3's
+ * dark ABS plastic.
+ */
+
+:root {
+  color-scheme: dark;
+
+  /* ─── Surface palette (dark; CoreS3 chassis DNA) ─────────────── */
+  --bg: #0d1014;
+  --bg-grid: rgba(255, 255, 255, 0.018);
+  --surface: #151a21;
+  --surface-2: #1c222b;
+  --surface-3: #232a34;
+
+  --border: #262d36;
+  --border-strong: #3a424d;
+
+  /* ─── Foreground (warm face-white DNA) ───────────────────────── */
+  --fg: #f4f4eb;
+  --fg-soft: #c8ccc3;
+  --fg-muted: #8a9099;
+  --fg-faint: #5a6068;
+
+  /* ─── Accent — Stack-chan coral cheek ────────────────────────── */
+  --accent: #f08080;
+  --accent-hi: #ff9c9c;
+  --accent-soft: rgba(240, 128, 128, 0.14);
+  --accent-line: rgba(240, 128, 128, 0.35);
+
+  /* ─── Status semantics ───────────────────────────────────────── */
+  --ok: #5fc88f;
+  --warn: #e6a155;
+  --bad: #e2625a;
+
+  /* ─── Face DNA (used in glyphs + 3D scene) ──────────────────── */
+  --face-bg: #f6f3e8;
+  --face-fg: #0d1014;
+  --face-accent: #f08080;
+
+  /* ─── Typography ─────────────────────────────────────────────── */
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, "Roboto Mono", monospace;
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+
+  /* Modular scale rooted at 14 px body (1.143 ratio). */
+  --text-2xs: 10px;
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 18px;
+  --text-2xl: 22px;
+
+  --leading-tight: 1.2;
+  --leading-snug: 1.35;
+  --leading-base: 1.5;
+
+  --tracking-tight: 0.2px;
+  --tracking-base: 0.4px;
+  --tracking-wide: 1.2px;
+  --tracking-wider: 1.6px;
+
+  /* ─── Spacing (4 px base, 8-step) ────────────────────────────── */
+  --space-0: 0;
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 6px;
+  --space-4: 8px;
+  --space-5: 10px;
+  --space-6: 12px;
+  --space-7: 14px;
+  --space-8: 16px;
+  --space-10: 20px;
+  --space-12: 24px;
+  --space-16: 32px;
+
+  /* ─── Radii ─────────────────────────────────────────────────── */
+  --radius-xs: 2px;
+  --radius-sm: 3px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+
+  /* ─── Motion ────────────────────────────────────────────────── */
+  --ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --transition-instant: 60ms var(--ease);
+  --transition-fast: 100ms var(--ease);
+  --transition-base: 180ms var(--ease);
+  --transition-slow: 320ms var(--ease);
+
+  /* ─── Elevation ─────────────────────────────────────────────── */
+  --shadow-pop: 0 1px 0 rgba(0, 0, 0, 0.35);
+  --shadow-lift: 0 6px 16px rgba(0, 0, 0, 0.32);
+  --shadow-deep: 0 12px 28px rgba(0, 0, 0, 0.48);
+
+  /* ─── Focus ring ────────────────────────────────────────────── */
+  --focus-ring: 2px solid var(--accent);
+  --focus-offset: 2px;
+
+  /* ─── Z-index ───────────────────────────────────────────────── */
+  --z-sticky: 10;
+  --z-toast: 50;
+  --z-overlay: 200;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --bg: #f3f1e9;
+    --bg-grid: rgba(0, 0, 0, 0.02);
+    --surface: #fdfcf6;
+    --surface-2: #f6f4ea;
+    --surface-3: #ebe8da;
+    --border: #d5d1c1;
+    --border-strong: #b7b29e;
+    --fg: #1a1d22;
+    --fg-soft: #2c3138;
+    --fg-muted: #5d6470;
+    --fg-faint: #8a8f97;
+    --accent: #d65a5a;
+    --accent-hi: #b94545;
+    --accent-soft: rgba(214, 90, 90, 0.12);
+    --accent-line: rgba(214, 90, 90, 0.4);
+    --ok: #2f9a64;
+    --warn: #9d6420;
+    --bad: #b04438;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-instant: 0s;
+    --transition-fast: 0s;
+    --transition-base: 0s;
+    --transition-slow: 0s;
+  }
+
+  /*
+   * Anything that uses animation-name (link-pulse, thinking-dot,
+   * sparkline draw-in) must respect this too. Reduced-motion users
+   * still get state changes but no oscillation.
+   */
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0s !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ─── Visually-hidden helper for screen-reader-only labels ────── */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,8 +45,8 @@ const NAV_KEYS = Object.fromEntries(SECTIONS.map((s) => [s.hotkey, s.id]));
 function PageHead(props: { title: string; tag?: string }) {
   return (
     <div class="page-head">
-      <h2 class="page-title">{props.title}</h2>
-      <div class="page-rule" />
+      <h2 class="page-title" aria-live="polite">{props.title}</h2>
+      <div class="page-rule" aria-hidden="true" />
       <Show when={props.tag}>{(t) => <span class="page-tag">{t()}</span>}</Show>
     </div>
   );
@@ -173,7 +173,7 @@ export function App() {
     <>
       <div class="shell">
         <Sidebar />
-        <div class="main">
+        <main class="main" aria-label="Operator console">
           <StatusBar />
           <CrashBanner />
           <div class="content">
@@ -218,7 +218,7 @@ export function App() {
               </Match>
             </Switch>
           </div>
-        </div>
+        </main>
       </div>
       <Toast />
       <Show when={overlay()}>

--- a/web/src/components/Emotion.tsx
+++ b/web/src/components/Emotion.tsx
@@ -47,7 +47,12 @@ export function Emotion() {
             </button>
           )}
         </For>
-        <button onClick={resetEmotion} style="margin-left:auto" data-shortcut="reset">
+        <button
+          class="btn-primary"
+          style="margin-left:auto"
+          onClick={resetEmotion}
+          data-shortcut="reset"
+        >
           Reset
         </button>
       </div>

--- a/web/src/components/Events.tsx
+++ b/web/src/components/Events.tsx
@@ -43,7 +43,15 @@ export function Events() {
   return (
     <section>
       <h2>Events</h2>
-      <Show when={data()} fallback={<small>waiting for first poll…</small>}>
+      <Show
+        when={data()}
+        fallback={
+          <div class="empty">
+            <div class="empty-title">No events yet</div>
+            <small>/events polls every 3 s.</small>
+          </div>
+        }
+      >
         {(s) => (
           <>
             <div class="tl-head">

--- a/web/src/components/Recovery.tsx
+++ b/web/src/components/Recovery.tsx
@@ -52,8 +52,9 @@ export function Recovery() {
         </button>
         <button
           type="button"
+          class="btn-danger"
           onClick={factoryReset}
-          style="margin-left:auto;border-color:var(--bad);color:var(--bad)"
+          style="margin-left:auto"
         >
           Factory reset…
         </button>

--- a/web/src/components/Sensors.tsx
+++ b/web/src/components/Sensors.tsx
@@ -40,7 +40,15 @@ export function Sensors() {
   return (
     <section>
       <h2>Sensors</h2>
-      <Show when={data()} fallback={<small>waiting for first poll…</small>}>
+      <Show
+        when={data()}
+        fallback={
+          <div class="empty">
+            <div class="empty-title">No sensor reads yet</div>
+            <small>/sensors polls every 1 s.</small>
+          </div>
+        }
+      >
         {(s) => (
           <dl class="row">
             <dt>IMU accel (g)</dt>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -13,7 +13,7 @@ export function Sidebar(props: { onNavigate?: () => void }) {
         </div>
       </div>
 
-      <nav class="nav">
+      <nav class="nav" aria-label="Sections">
         <For each={SECTIONS}>
           {(s) => (
             <button
@@ -21,6 +21,7 @@ export function Sidebar(props: { onNavigate?: () => void }) {
               class="nav-item"
               classList={{ active: section() === s.id }}
               aria-current={section() === s.id ? "page" : undefined}
+              aria-label={`${s.label} (press g then ${s.hotkey})`}
               onClick={() => {
                 goto(s.id);
                 props.onNavigate?.();
@@ -39,13 +40,23 @@ export function Sidebar(props: { onNavigate?: () => void }) {
       </nav>
 
       <div class="sidebar-foot">
-        <div class="link-status" classList={{ ok: conn() === "ok", bad: conn() === "bad" }}>
-          <span class="link-dot" />
+        <div
+          class="link-status"
+          classList={{ ok: conn() === "ok", bad: conn() === "bad" }}
+          role="status"
+          aria-live="polite"
+        >
+          <span class="link-dot" aria-hidden="true" />
           <span class="link-label">
             {conn() === "ok" ? "LINK UP" : conn() === "bad" ? "LINK DOWN" : "LINKING"}
           </span>
         </div>
-        <div class="link-host">{snapshot()?.wifi.ip ?? "stackchan.local"}</div>
+        <div class="link-host" aria-label="Device address">
+          {snapshot()?.wifi.ip ?? "stackchan.local"}
+        </div>
+        <div class="link-hint">
+          Press <kbd>?</kbd> for shortcuts
+        </div>
       </div>
     </aside>
   );

--- a/web/src/components/Speak.tsx
+++ b/web/src/components/Speak.tsx
@@ -73,7 +73,7 @@ export function Speak() {
           class="btn-primary"
           classList={{ "is-loading": busy() }}
           aria-busy={busy()}
-          disabled={busy()}
+          aria-disabled={busy()}
           onClick={send}
         >
           Speak

--- a/web/src/components/Speak.tsx
+++ b/web/src/components/Speak.tsx
@@ -19,13 +19,18 @@ const LOCALES = ["en", "ja"] as const;
 export function Speak() {
   const [phrase, setPhrase] = createSignal<(typeof PHRASES)[number]>("greeting");
   const [locale, setLocale] = createSignal<(typeof LOCALES)[number]>("en");
+  const [busy, setBusy] = createSignal(false);
 
   const send = async () => {
+    if (busy()) return;
+    setBusy(true);
     try {
       await postJson("/speak", { phrase: phrase(), locale: locale() });
       showToast(`speak ${phrase()} (${locale()})`);
     } catch (e) {
       showToast((e as Error).message, true);
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -63,7 +68,14 @@ export function Speak() {
         </label>
       </div>
       <div class="btn-row" style="margin-top:8px">
-        <button type="button" onClick={send}>
+        <button
+          type="button"
+          class="btn-primary"
+          classList={{ "is-loading": busy() }}
+          aria-busy={busy()}
+          disabled={busy()}
+          onClick={send}
+        >
           Speak
         </button>
       </div>

--- a/web/src/components/State.tsx
+++ b/web/src/components/State.tsx
@@ -2,24 +2,36 @@ import { Show } from "solid-js";
 import { snapshot } from "../store";
 
 function Skeleton(props: { width?: string }) {
-  return <span class="skeleton skeleton-row" style={props.width ? `min-width:${props.width}` : ""}>—</span>;
+  // aria-hidden so the em-dash placeholder isn't announced; the parent
+  // dd is still in the a11y tree but conveys no information until the
+  // real value arrives.
+  return (
+    <span
+      class="skeleton skeleton-row"
+      style={props.width ? `min-width:${props.width}` : ""}
+      aria-hidden="true"
+    >
+      —
+    </span>
+  );
 }
 
 export function State() {
+  const s = () => snapshot();
   return (
     <section aria-label="State">
       <h2>State</h2>
       <dl class="row">
         <dt>Emotion</dt>
         <dd>
-          <Show when={snapshot()?.emotion} fallback={<Skeleton width="6ch" />}>
-            {(e) => e()}
+          <Show when={s() != null} fallback={<Skeleton width="6ch" />}>
+            {s()?.emotion || <Skeleton width="6ch" />}
           </Show>
         </dd>
         <dt>Mood</dt>
         <dd>
-          <Show when={snapshot()?.mood} fallback={<Skeleton width="6ch" />}>
-            {(m) => m()}
+          <Show when={s() != null} fallback={<Skeleton width="6ch" />}>
+            {s()?.mood || <Skeleton width="6ch" />}
           </Show>
         </dd>
         <dt>Decorator</dt>

--- a/web/src/components/State.tsx
+++ b/web/src/components/State.tsx
@@ -1,20 +1,32 @@
 import { Show } from "solid-js";
 import { snapshot } from "../store";
 
+function Skeleton(props: { width?: string }) {
+  return <span class="skeleton skeleton-row" style={props.width ? `min-width:${props.width}` : ""}>—</span>;
+}
+
 export function State() {
   return (
-    <section>
+    <section aria-label="State">
       <h2>State</h2>
       <dl class="row">
         <dt>Emotion</dt>
-        <dd>{snapshot()?.emotion ?? "—"}</dd>
+        <dd>
+          <Show when={snapshot()?.emotion} fallback={<Skeleton width="6ch" />}>
+            {(e) => e()}
+          </Show>
+        </dd>
         <dt>Mood</dt>
-        <dd>{snapshot()?.mood ?? "—"}</dd>
+        <dd>
+          <Show when={snapshot()?.mood} fallback={<Skeleton width="6ch" />}>
+            {(m) => m()}
+          </Show>
+        </dd>
         <dt>Decorator</dt>
-        <dd>{snapshot()?.decorator ?? "—"}</dd>
+        <dd>{snapshot()?.decorator ?? <small style="opacity:0.7">none</small>}</dd>
         <dt>Head pose</dt>
         <dd>
-          <Show when={snapshot()} fallback="—">
+          <Show when={snapshot()} fallback={<Skeleton width="14ch" />}>
             {(s) => {
               const p = s().head_pose;
               const a = s().head_actual;
@@ -27,7 +39,7 @@ export function State() {
         </dd>
         <dt>Battery</dt>
         <dd>
-          <Show when={snapshot()} fallback="—">
+          <Show when={snapshot()} fallback={<Skeleton width="8ch" />}>
             {(s) => {
               const b = s().battery;
               const pct = b.percent != null ? `${b.percent}%` : "—";
@@ -38,7 +50,7 @@ export function State() {
         </dd>
         <dt>Wi-Fi</dt>
         <dd>
-          <Show when={snapshot()} fallback="—">
+          <Show when={snapshot()} fallback={<Skeleton width="10ch" />}>
             {(s) => {
               const w = s().wifi;
               return w.connected ? `up @ ${w.ip ?? "—"}` : "down";

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -19,7 +19,10 @@ function Stat(props: {
     >
       <div class="stat-label">{props.label}</div>
       <div class="stat-value" aria-live="polite">
-        <Show when={!props.loading} fallback={<span class="skeleton skeleton-row">—</span>}>
+        <Show
+          when={!props.loading}
+          fallback={<span class="skeleton skeleton-row" aria-hidden="true">—</span>}
+        >
           {props.value ?? "—"}
         </Show>
       </div>

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -2,11 +2,27 @@ import { Show } from "solid-js";
 import { snapshot } from "../store";
 import { FaceGlyph } from "./FaceGlyph";
 
-function Stat(props: { label: string; value: string; tone?: "ok" | "warn" | "bad" }) {
+function Stat(props: {
+  label: string;
+  value: string | null;
+  tone?: "ok" | "warn" | "bad";
+  loading?: boolean;
+}) {
   return (
-    <div class="stat" classList={{ "is-ok": props.tone === "ok", "is-warn": props.tone === "warn", "is-bad": props.tone === "bad" }}>
+    <div
+      class="stat"
+      classList={{
+        "is-ok": props.tone === "ok",
+        "is-warn": props.tone === "warn",
+        "is-bad": props.tone === "bad",
+      }}
+    >
       <div class="stat-label">{props.label}</div>
-      <div class="stat-value">{props.value}</div>
+      <div class="stat-value" aria-live="polite">
+        <Show when={!props.loading} fallback={<span class="skeleton skeleton-row">—</span>}>
+          {props.value ?? "—"}
+        </Show>
+      </div>
     </div>
   );
 }
@@ -19,17 +35,18 @@ function batteryTone(pct: number | null): "ok" | "warn" | "bad" | undefined {
 }
 
 export function StatusBar() {
+  const loading = () => snapshot() == null;
   return (
-    <header class="status-bar">
+    <header class="status-bar" aria-label="Live device telemetry">
       <div class="status-face">
         <FaceGlyph size={56} />
       </div>
       <div class="status-stats">
-        <Stat label="EMOTION" value={snapshot()?.emotion?.toUpperCase() ?? "—"} />
-        <Stat label="MOOD" value={snapshot()?.mood?.toUpperCase() ?? "—"} />
+        <Stat label="EMOTION" value={snapshot()?.emotion?.toUpperCase() ?? null} loading={loading()} />
+        <Stat label="MOOD" value={snapshot()?.mood?.toUpperCase() ?? null} loading={loading()} />
         <Show
           when={snapshot()}
-          fallback={<Stat label="POSE" value="—" />}
+          fallback={<Stat label="POSE" value={null} loading />}
         >
           {(s) => {
             const p = s().head_pose;
@@ -38,7 +55,7 @@ export function StatusBar() {
         </Show>
         <Show
           when={snapshot()}
-          fallback={<Stat label="BATTERY" value="—" />}
+          fallback={<Stat label="BATTERY" value={null} loading />}
         >
           {(s) => {
             const b = s().battery;
@@ -48,14 +65,14 @@ export function StatusBar() {
         </Show>
         <Show
           when={snapshot()}
-          fallback={<Stat label="WIFI" value="—" />}
+          fallback={<Stat label="WIFI" value={null} loading />}
         >
           {(s) => {
             const w = s().wifi;
             return (
               <Stat
                 label="WIFI"
-                value={w.connected ? w.ip ?? "up" : "down"}
+                value={w.connected ? (w.ip ?? "up") : "down"}
                 tone={w.connected ? "ok" : "bad"}
               />
             );
@@ -63,7 +80,7 @@ export function StatusBar() {
         </Show>
         <Show
           when={snapshot()}
-          fallback={<Stat label="AUDIO" value="—" />}
+          fallback={<Stat label="AUDIO" value={null} loading />}
         >
           {(s) => {
             const a = s().audio;

--- a/web/src/components/Telemetry.tsx
+++ b/web/src/components/Telemetry.tsx
@@ -38,7 +38,12 @@ export function Telemetry() {
       <h2>Telemetry</h2>
       <Show
         when={snapshot()}
-        fallback={<small>waiting for first SSE sample…</small>}
+        fallback={
+          <div class="empty">
+            <div class="empty-title">No telemetry yet</div>
+            <small>Cards fill in once samples arrive on /state/stream.</small>
+          </div>
+        }
       >
         <div class="spark-grid">
           <SparkCard

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,14 +1,16 @@
-import { Show } from "solid-js";
-import { toast } from "../store";
+import { For } from "solid-js";
+import { toasts } from "../store";
 
 export function Toast() {
   return (
-    <Show when={toast()}>
-      {(t) => (
-        <div class={`toast show${t().bad ? " bad" : ""}`} role="status">
-          {t().msg}
-        </div>
-      )}
-    </Show>
+    <div class="toast-stack" role="status" aria-live="polite" aria-atomic="false">
+      <For each={toasts()}>
+        {(t) => (
+          <div class={`toast show${t.bad ? " bad" : ""}`} role={t.bad ? "alert" : undefined}>
+            {t.msg}
+          </div>
+        )}
+      </For>
+    </div>
   );
 }

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -6,18 +6,27 @@ export type ConnState = "connecting" | "ok" | "bad";
 export const [snapshot, setSnapshot] = createSignal<AvatarSnapshot | null>(null);
 export const [conn, setConn] = createSignal<ConnState>("connecting");
 
-export type Toast = { msg: string; bad: boolean; id: number } | null;
-const [toastVal, setToastVal] = createSignal<Toast>(null);
-let toastTimer: ReturnType<typeof setTimeout> | null = null;
+export type Toast = { msg: string; bad: boolean; id: number };
+const [toastList, setToastList] = createSignal<readonly Toast[]>([]);
 let toastSeq = 0;
 
-export const toast = toastVal;
+const MAX_TOASTS = 3;
+const TOAST_TTL_MS = 2800;
+
+export const toasts = toastList;
 
 export function showToast(msg: string, bad = false): void {
   toastSeq += 1;
-  setToastVal({ msg, bad, id: toastSeq });
-  if (toastTimer != null) clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => setToastVal(null), 2500);
+  const id = toastSeq;
+  setToastList((curr) => {
+    const next = [...curr, { msg, bad, id }];
+    // Drop oldest if we've stacked beyond the cap so the screen doesn't
+    // fill up during a burst of failures.
+    return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+  });
+  setTimeout(() => {
+    setToastList((curr) => curr.filter((t) => t.id !== id));
+  }, TOAST_TTL_MS);
 }
 
 // Rolling window of SSE samples. ~2 min at the firmware's ~1 Hz cadence;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,58 +1,8 @@
+@import url("../../design/tokens.css");
+
+/* Dashboard-specific tokens. */
 :root {
-  color-scheme: dark;
-
-  --bg: #0d1014;
-  --bg-grid: rgba(255, 255, 255, 0.018);
-  --surface: #151a21;
-  --surface-2: #1c222b;
-  --surface-3: #232a34;
-
-  --border: #262d36;
-  --border-strong: #3a424d;
-
-  --fg: #f4f4eb;
-  --fg-soft: #c8ccc3;
-  --fg-muted: #8a9099;
-  --fg-faint: #5a6068;
-
-  --accent: #f08080;
-  --accent-hi: #ff9c9c;
-  --accent-soft: rgba(240, 128, 128, 0.14);
-  --accent-line: rgba(240, 128, 128, 0.35);
-
-  --ok: #5fc88f;
-  --warn: #e6a155;
-  --bad: #e2625a;
-
-  --face-bg: #f6f3e8;
-  --face-fg: #0d1014;
-  --face-accent: #f08080;
-
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, "Roboto Mono", monospace;
-  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-
   --rail: 232px;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color-scheme: light;
-    --bg: #f3f1e9;
-    --bg-grid: rgba(0, 0, 0, 0.02);
-    --surface: #fdfcf6;
-    --surface-2: #f6f4ea;
-    --surface-3: #ebe8da;
-    --border: #d5d1c1;
-    --border-strong: #b7b29e;
-    --fg: #1a1d22;
-    --fg-soft: #2c3138;
-    --fg-muted: #5d6470;
-    --fg-faint: #8a8f97;
-    --accent: #d65a5a;
-    --accent-hi: #b94545;
-    --accent-soft: rgba(214, 90, 90, 0.12);
-    --accent-line: rgba(214, 90, 90, 0.4);
-  }
 }
 
 * {
@@ -72,7 +22,7 @@ body {
     linear-gradient(var(--bg-grid) 1px, transparent 1px) 0 0 / 24px 24px,
     var(--bg);
   color: var(--fg);
-  font: 14px/1.5 var(--sans);
+  font: var(--text-md) / var(--leading-base) var(--font-sans);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -83,6 +33,12 @@ button {
 
 a {
   color: var(--accent);
+}
+
+:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-offset);
+  border-radius: var(--radius-xs);
 }
 
 /* ─── Shell ─────────────────────────────────────────────────────── */
@@ -100,14 +56,25 @@ a {
 }
 
 .content {
-  padding: 18px 24px 80px;
+  padding: var(--space-10) var(--space-12) 80px;
   max-width: 1060px;
   width: 100%;
   margin: 0 auto;
 }
 
 .content > section + section {
-  margin-top: 14px;
+  margin-top: var(--space-7);
+}
+
+/* Section page transition — gentle fade-in on switch. Respects
+   prefers-reduced-motion via the global override in tokens.css. */
+.content > * {
+  animation: page-in var(--transition-base) both;
+}
+
+@keyframes page-in {
+  from { opacity: 0; transform: translateY(2px); }
+  to { opacity: 1; transform: none; }
 }
 
 /* ─── Sidebar ───────────────────────────────────────────────────── */
@@ -117,54 +84,53 @@ a {
   top: 0;
   align-self: start;
   height: 100vh;
-  background:
-    linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
+  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-2) 100%);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  padding: 16px 12px 12px;
-  gap: 12px;
+  padding: var(--space-8) var(--space-6) var(--space-6);
+  gap: var(--space-6);
 }
 
 .brand {
   display: grid;
   grid-template-columns: 40px 1fr;
-  gap: 10px;
+  gap: var(--space-5);
   align-items: center;
-  padding: 6px 6px 12px;
+  padding: var(--space-3) var(--space-3) var(--space-6);
   border-bottom: 1px solid var(--border);
 }
 
 .brand-mark {
   width: 40px;
   height: 40px;
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   background: var(--face-bg);
   color: var(--face-fg);
   display: grid;
   place-items: center;
-  font: 600 14px/1 var(--mono);
+  font: 600 var(--text-md) / 1 var(--font-mono);
   letter-spacing: 0.5px;
-  box-shadow: inset 0 0 0 1px var(--accent-line), 0 1px 0 rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 0 0 1px var(--accent-line), var(--shadow-pop);
 }
 
 .brand-name {
-  font: 600 12px/1 var(--mono);
-  letter-spacing: 1.5px;
+  font: 600 var(--text-sm) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wider);
   color: var(--fg);
 }
 
 .brand-sub {
-  font: 11px/1.2 var(--mono);
+  font: var(--text-xs) / var(--leading-tight) var(--font-mono);
   color: var(--fg-muted);
   margin-top: 3px;
-  letter-spacing: 0.4px;
+  letter-spacing: var(--tracking-base);
 }
 
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
   flex: 1;
 }
 
@@ -172,15 +138,18 @@ a {
   display: grid;
   grid-template-columns: 20px 1fr auto;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: var(--space-5);
+  padding: var(--space-4) var(--space-5);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   color: var(--fg-soft);
   text-align: left;
   cursor: pointer;
-  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .nav-item:hover {
@@ -199,39 +168,38 @@ a {
 }
 
 .nav-glyph {
-  font: 14px/1 var(--mono);
+  font: var(--text-md) / 1 var(--font-mono);
   color: var(--fg-muted);
   text-align: center;
 }
 
 .nav-label {
-  font: 13px/1 var(--sans);
-  font-weight: 500;
+  font: 500 var(--text-base) / 1 var(--font-sans);
 }
 
 .nav-key {
-  font: 10px/1 var(--mono);
+  font: var(--text-2xs) / 1 var(--font-mono);
   color: var(--fg-faint);
   letter-spacing: 0.5px;
   padding: 3px 5px;
   border: 1px solid var(--border);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--surface);
 }
 
 .sidebar-foot {
-  padding: 10px 6px;
+  padding: var(--space-5) var(--space-3);
   border-top: 1px solid var(--border);
   display: grid;
-  gap: 4px;
+  gap: var(--space-2);
 }
 
 .link-status {
   display: flex;
   align-items: center;
   gap: 7px;
-  font: 11px/1 var(--mono);
-  letter-spacing: 1px;
+  font: var(--text-xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--fg-muted);
 }
 
@@ -240,35 +208,46 @@ a {
   height: 8px;
   border-radius: 50%;
   background: var(--fg-faint);
-  box-shadow: 0 0 0 0 var(--accent);
 }
 
 .link-status.ok .link-dot {
   background: var(--ok);
   box-shadow: 0 0 8px rgba(95, 200, 143, 0.5);
-  animation: pulse 1.8s ease-in-out infinite;
+  animation: link-pulse 1.8s ease-in-out infinite;
 }
 
 .link-status.bad .link-dot {
   background: var(--bad);
 }
 
-.link-status.ok {
-  color: var(--ok);
-}
-
-.link-status.bad {
-  color: var(--bad);
-}
+.link-status.ok { color: var(--ok); }
+.link-status.bad { color: var(--bad); }
 
 .link-host {
-  font: 11px/1 var(--mono);
+  font: var(--text-xs) / 1 var(--font-mono);
   color: var(--fg-faint);
-  letter-spacing: 0.3px;
+  letter-spacing: var(--tracking-tight);
   word-break: break-all;
 }
 
-@keyframes pulse {
+.link-hint {
+  font: var(--text-2xs) / 1 var(--font-mono);
+  color: var(--fg-faint);
+  letter-spacing: var(--tracking-base);
+  margin-top: var(--space-2);
+}
+
+.link-hint kbd {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 1px 4px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--surface);
+  color: var(--fg-soft);
+}
+
+@keyframes link-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.55; }
 }
@@ -278,12 +257,12 @@ a {
 .status-bar {
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: var(--z-sticky);
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 18px;
+  gap: var(--space-10);
   align-items: center;
-  padding: 14px 24px;
+  padding: var(--space-7) var(--space-12);
   background: linear-gradient(180deg, rgba(13, 16, 20, 0.92), rgba(13, 16, 20, 0.78));
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
@@ -303,35 +282,36 @@ a {
 
 .face-glyph {
   display: block;
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
 }
 
 .status-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-  gap: 12px;
+  gap: var(--space-6);
   align-items: center;
 }
 
 .stat {
   display: grid;
-  gap: 2px;
-  padding: 4px 0;
+  gap: var(--space-1);
+  padding: var(--space-2) 0;
   border-left: 2px solid var(--border);
-  padding-left: 10px;
+  padding-left: var(--space-5);
 }
 
 .stat-label {
-  font: 10px/1 var(--mono);
-  letter-spacing: 1.2px;
+  font: var(--text-2xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--fg-faint);
 }
 
 .stat-value {
-  font: 600 14px/1.1 var(--mono);
+  font: 600 var(--text-md) / 1.1 var(--font-mono);
   color: var(--fg);
   font-variant-numeric: tabular-nums;
   word-break: break-all;
+  transition: color var(--transition-fast);
 }
 
 .stat.is-ok { border-left-color: var(--ok); }
@@ -343,20 +323,16 @@ a {
 
 /* ─── Section pages ─────────────────────────────────────────────── */
 
-.page {
-  display: contents;
-}
-
 .page-head {
   display: flex;
   align-items: baseline;
-  gap: 10px;
-  margin: 8px 0 12px;
-  padding: 0 2px;
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+  padding: 0 var(--space-1);
 }
 
 .page-title {
-  font: 600 13px/1 var(--mono);
+  font: 600 var(--text-base) / 1 var(--font-mono);
   letter-spacing: 2px;
   text-transform: uppercase;
   color: var(--fg);
@@ -370,12 +346,12 @@ a {
 }
 
 .page-tag {
-  font: 10px/1 var(--mono);
-  letter-spacing: 1px;
+  font: var(--text-2xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--accent);
   padding: 4px 6px;
   border: 1px solid var(--accent-line);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   background: var(--accent-soft);
 }
 
@@ -385,19 +361,19 @@ section {
   position: relative;
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 14px 16px;
+  border-radius: var(--radius-lg);
+  padding: var(--space-7) var(--space-8);
 }
 
 section h2 {
-  margin: 0 0 10px;
-  font: 600 11px/1 var(--mono);
-  letter-spacing: 1.5px;
+  margin: 0 0 var(--space-5);
+  font: 600 var(--text-xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
   color: var(--accent);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 
 section h2::before {
@@ -410,7 +386,7 @@ section h2::before {
   box-shadow: 0 0 6px var(--accent-line);
 }
 
-/* HUD corner brackets on cards */
+/* HUD corner brackets on cards. */
 section::before,
 section::after {
   content: "";
@@ -434,53 +410,53 @@ section::after {
   border-width: 0 1px 1px 0;
 }
 
-/* ─── Rows, grids, controls ─────────────────────────────────────── */
+/* ─── Rows, grids ───────────────────────────────────────────────── */
 
 .row {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 6px 14px;
+  gap: var(--space-3) var(--space-7);
   align-items: baseline;
 }
 
 .row dt {
   color: var(--fg-muted);
-  font: 11px/1.2 var(--mono);
-  letter-spacing: 0.4px;
+  font: var(--text-xs) / var(--leading-tight) var(--font-mono);
+  letter-spacing: var(--tracking-base);
   text-transform: uppercase;
 }
 
 .row dd {
   margin: 0;
-  font: 13px/1.4 var(--mono);
+  font: var(--text-base) / var(--leading-snug) var(--font-mono);
   color: var(--fg);
   font-variant-numeric: tabular-nums;
 }
 
-.grid {
-  display: grid;
-  gap: 10px;
-}
-
-.grid-2 {
-  grid-template-columns: 1fr 1fr;
-}
+.grid { display: grid; gap: var(--space-5); }
+.grid-2 { grid-template-columns: 1fr 1fr; }
 
 .btn-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-3);
 }
 
+/* ─── Buttons ───────────────────────────────────────────────────── */
+
 button {
-  padding: 6px 12px;
+  padding: var(--space-3) var(--space-6);
   border: 1px solid var(--border-strong);
   background: var(--surface-2);
   color: var(--fg);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font: 13px/1.2 var(--sans);
-  transition: border-color 80ms ease, background 80ms ease, color 80ms ease;
+  font: var(--text-base) / 1.2 var(--font-sans);
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast),
+    color var(--transition-fast),
+    transform var(--transition-instant);
 }
 
 button:hover {
@@ -488,21 +464,74 @@ button:hover {
   color: var(--accent);
 }
 
-button:active {
-  background: var(--accent);
-  color: var(--bg);
-  border-color: var(--accent);
+button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
-button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
-}
-
-button:disabled {
+button:disabled,
+button[aria-disabled="true"] {
   opacity: 0.45;
   cursor: not-allowed;
+  pointer-events: none;
 }
+
+/* Primary action — solid accent. Use for the section's main verb
+   (Speak, Reset, Save, Apply). */
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+.btn-primary:hover {
+  background: var(--accent-hi);
+  border-color: var(--accent-hi);
+  color: var(--bg);
+}
+
+/* Danger — destructive (Recovery). */
+.btn-danger {
+  border-color: rgba(226, 98, 90, 0.55);
+  color: var(--bad);
+}
+
+.btn-danger:hover {
+  background: var(--bad);
+  border-color: var(--bad);
+  color: var(--bg);
+}
+
+/* Loading spinner for in-flight POSTs. Components add aria-busy=true
+   and `.is-loading` and the body remains readable while a thin spinner
+   crosses the right edge. */
+.btn.is-loading,
+button.is-loading {
+  position: relative;
+  color: transparent !important;
+  pointer-events: none;
+}
+
+.btn.is-loading::after,
+button.is-loading::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  color: var(--accent);
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(1turn); }
+}
+
+/* ─── Inputs ────────────────────────────────────────────────────── */
 
 input[type="text"],
 input[type="password"],
@@ -510,13 +539,14 @@ input[type="number"],
 input[type="search"],
 select,
 textarea {
-  font: 13px/1.4 var(--mono);
-  padding: 6px 8px;
+  font: var(--text-base) / var(--leading-snug) var(--font-mono);
+  padding: var(--space-3) var(--space-4);
   border: 1px solid var(--border-strong);
   background: var(--surface-2);
   color: var(--fg);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   width: 100%;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 input:focus,
@@ -529,9 +559,9 @@ textarea:focus {
 
 label {
   display: grid;
-  gap: 4px;
-  font: 11px/1.2 var(--mono);
-  letter-spacing: 0.4px;
+  gap: var(--space-2);
+  font: var(--text-xs) / var(--leading-tight) var(--font-mono);
+  letter-spacing: var(--tracking-base);
   text-transform: uppercase;
   color: var(--fg-muted);
 }
@@ -542,7 +572,7 @@ input[type="range"] {
   width: 100%;
   height: 6px;
   background: var(--surface-3);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   outline: none;
   border: 1px solid var(--border);
 }
@@ -573,8 +603,8 @@ input[type="range"]::-moz-range-thumb {
 .status {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font: 11px/1 var(--mono);
+  gap: var(--space-3);
+  font: var(--text-xs) / 1 var(--font-mono);
   letter-spacing: 0.5px;
   color: var(--fg-muted);
 }
@@ -598,16 +628,56 @@ input[type="range"]::-moz-range-thumb {
 
 small {
   color: var(--fg-muted);
-  font: 11px/1.4 var(--mono);
-  letter-spacing: 0.3px;
+  font: var(--text-xs) / var(--leading-snug) var(--font-mono);
+  letter-spacing: var(--tracking-tight);
+}
+
+/* ─── Skeletons (first-load placeholders) ───────────────────────── */
+
+.skeleton {
+  display: inline-block;
+  background: linear-gradient(
+    90deg,
+    var(--surface-2) 0%,
+    var(--surface-3) 50%,
+    var(--surface-2) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-sm);
+  color: transparent;
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  to { background-position: -200% 0; }
+}
+
+.skeleton-row {
+  display: inline-block;
+  min-width: 4ch;
+  height: 1em;
+  vertical-align: middle;
+}
+
+/* ─── Empty state ───────────────────────────────────────────────── */
+
+.empty {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-6) 0;
+  color: var(--fg-muted);
+  font: var(--text-xs) / var(--leading-snug) var(--font-mono);
+  text-align: center;
+}
+
+.empty-title {
+  color: var(--fg-soft);
+  letter-spacing: var(--tracking-base);
 }
 
 /* ─── Sparkline ─────────────────────────────────────────────────── */
 
-.sparkline {
-  display: block;
-  overflow: visible;
-}
+.sparkline { display: block; overflow: visible; }
 
 .sparkline-axis {
   stroke: var(--border-strong);
@@ -618,11 +688,11 @@ small {
 
 .spark-card {
   display: grid;
-  gap: 4px;
-  padding: 8px 10px;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-5);
   background: var(--surface-2);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .spark-head {
@@ -632,13 +702,13 @@ small {
 }
 
 .spark-label {
-  font: 10px/1 var(--mono);
-  letter-spacing: 1.2px;
+  font: var(--text-2xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--fg-faint);
 }
 
 .spark-value {
-  font: 600 13px/1 var(--mono);
+  font: 600 var(--text-base) / 1 var(--font-mono);
   color: var(--fg);
   font-variant-numeric: tabular-nums;
 }
@@ -646,14 +716,14 @@ small {
 .spark-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 10px;
+  gap: var(--space-5);
 }
 
 /* ─── Pose pad ──────────────────────────────────────────────────── */
 
 .pose-pad-wrap {
   display: grid;
-  gap: 8px;
+  gap: var(--space-4);
 }
 
 .pose-pad {
@@ -663,26 +733,20 @@ small {
   aspect-ratio: 320 / 200;
   background: var(--surface-2);
   border: 1px solid var(--border-strong);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   touch-action: none;
   cursor: crosshair;
+  transition: border-color var(--transition-fast);
 }
 
-.pose-pad .pad-bg {
-  fill: var(--surface-2);
+.pose-pad:hover,
+.pose-pad:focus-visible {
+  border-color: var(--accent);
 }
 
-.pose-pad .pad-grid {
-  stroke: var(--border);
-  stroke-width: 1;
-  opacity: 0.6;
-}
-
-.pose-pad .pad-axis {
-  stroke: var(--border-strong);
-  stroke-width: 1;
-  opacity: 0.9;
-}
+.pose-pad .pad-bg { fill: var(--surface-2); }
+.pose-pad .pad-grid { stroke: var(--border); stroke-width: 1; opacity: 0.6; }
+.pose-pad .pad-axis { stroke: var(--border-strong); stroke-width: 1; opacity: 0.9; }
 
 .pose-pad .pad-cmd circle:first-child {
   fill: var(--accent);
@@ -710,59 +774,48 @@ small {
 }
 
 .pose-pad .pad-label {
-  font: 10px var(--mono);
-  letter-spacing: 1px;
+  font: var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   fill: var(--fg-faint);
 }
 
-.pose-pad .pad-label-r {
-  text-anchor: end;
-}
+.pose-pad .pad-label-r { text-anchor: end; }
 
-.pad-center {
-  justify-self: start;
-}
-
-.status-bar-aux {
-  display: grid;
-  grid-template-columns: 90px 90px;
-  gap: 10px;
-  align-items: center;
-}
+.pad-center { justify-self: start; }
 
 /* ─── Event timeline ────────────────────────────────────────────── */
 
 .tl-head {
   display: flex;
   align-items: baseline;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
 }
 
 .tl-count {
-  font: 700 22px/1 var(--mono);
+  font: 700 var(--text-2xl) / 1 var(--font-mono);
   color: var(--accent);
   font-variant-numeric: tabular-nums;
 }
 
 .tl-count-label {
-  font: 10px/1 var(--mono);
-  letter-spacing: 1.2px;
+  font: var(--text-2xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--fg-faint);
 }
 
 .tl-legend {
   margin-left: auto;
   display: flex;
-  gap: 10px;
-  font: 10px/1 var(--mono);
+  gap: var(--space-5);
+  font: var(--text-2xs) / 1 var(--font-mono);
   letter-spacing: 0.5px;
 }
 
 .tl-legend-item {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-2);
   color: var(--fg-muted);
 }
 
@@ -781,7 +834,7 @@ small {
 .timeline {
   position: relative;
   margin: 0;
-  padding: 4px 0 4px 0;
+  padding: var(--space-2) 0;
   list-style: none;
   max-height: 360px;
   overflow-y: auto;
@@ -801,10 +854,10 @@ small {
   position: relative;
   display: grid;
   grid-template-columns: 78px 16px max-content 1fr;
-  gap: 8px;
+  gap: var(--space-4);
   align-items: baseline;
-  padding: 6px 4px;
-  border-radius: 3px;
+  padding: var(--space-3) var(--space-2);
+  border-radius: var(--radius-sm);
 }
 
 .tl-row:hover {
@@ -812,7 +865,7 @@ small {
 }
 
 .tl-time {
-  font: 11px/1.3 var(--mono);
+  font: var(--text-xs) / var(--leading-snug) var(--font-mono);
   color: var(--fg-faint);
   text-align: right;
   font-variant-numeric: tabular-nums;
@@ -833,8 +886,8 @@ small {
 .tl-row.tl-warn .tl-dot { background: var(--bad); box-shadow: 0 0 6px rgba(226, 98, 90, 0.55); }
 
 .tl-kind {
-  font: 10px/1.3 var(--mono);
-  letter-spacing: 1px;
+  font: var(--text-2xs) / var(--leading-snug) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   color: var(--fg-muted);
 }
@@ -843,35 +896,44 @@ small {
 .tl-row.tl-warn .tl-kind { color: var(--bad); }
 
 .tl-msg {
-  font: 12px/1.5 var(--mono);
+  font: var(--text-sm) / var(--leading-base) var(--font-mono);
   color: var(--fg);
   word-break: break-word;
 }
 
-/* ─── Toast ────────────────────────────────────────────────────── */
+/* ─── Toast (stack) ─────────────────────────────────────────────── */
+
+.toast-stack {
+  position: fixed;
+  bottom: var(--space-10);
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  gap: var(--space-3);
+  z-index: var(--z-toast);
+  max-width: min(560px, calc(100vw - var(--space-8)));
+  pointer-events: none;
+}
 
 .toast {
-  position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translate(-50%, 8px);
+  pointer-events: auto;
   background: var(--surface);
   border: 1px solid var(--accent-line);
   border-left: 3px solid var(--accent);
-  padding: 8px 14px;
-  border-radius: 4px;
-  font: 12px/1 var(--mono);
-  letter-spacing: 0.4px;
+  padding: var(--space-4) var(--space-7);
+  border-radius: var(--radius-md);
+  font: var(--text-sm) / var(--leading-snug) var(--font-mono);
+  letter-spacing: var(--tracking-base);
   color: var(--fg);
   opacity: 0;
-  transition: opacity 0.18s ease, transform 0.18s ease;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.5);
-  z-index: 100;
+  transform: translateY(8px);
+  transition: opacity var(--transition-base), transform var(--transition-base);
+  box-shadow: var(--shadow-lift);
 }
 
 .toast.show {
   opacity: 1;
-  transform: translate(-50%, 0);
+  transform: none;
 }
 
 .toast.bad {
@@ -890,22 +952,23 @@ small {
   -webkit-backdrop-filter: blur(4px);
   display: grid;
   place-items: center;
-  z-index: 200;
+  z-index: var(--z-overlay);
 }
 
 .kbd-panel {
   background: var(--surface);
   border: 1px solid var(--accent-line);
-  border-radius: 6px;
-  padding: 24px 28px;
+  border-radius: var(--radius-lg);
+  padding: var(--space-12) var(--space-16);
   min-width: 320px;
   max-width: 520px;
+  box-shadow: var(--shadow-deep);
 }
 
 .kbd-panel h3 {
-  margin: 0 0 16px;
-  font: 600 12px/1 var(--mono);
-  letter-spacing: 1.5px;
+  margin: 0 0 var(--space-8);
+  font: 600 var(--text-sm) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wider);
   color: var(--accent);
   text-transform: uppercase;
 }
@@ -913,8 +976,8 @@ small {
 .kbd-grid {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 6px 18px;
-  font: 12px/1.4 var(--mono);
+  gap: var(--space-3) var(--space-10);
+  font: var(--text-sm) / var(--leading-snug) var(--font-mono);
 }
 
 .kbd-grid dt {
@@ -930,32 +993,25 @@ small {
 /* ─── Mobile ───────────────────────────────────────────────────── */
 
 @media (max-width: 768px) {
-  :root {
-    --rail: 100%;
-  }
+  :root { --rail: 100%; }
 
-  .shell {
-    grid-template-columns: 1fr;
-  }
+  .shell { grid-template-columns: 1fr; }
 
   .sidebar {
     position: relative;
     height: auto;
-    padding: 10px 12px;
+    padding: var(--space-5) var(--space-6);
     border-right: none;
     border-bottom: 1px solid var(--border);
   }
 
-  .brand {
-    border-bottom: none;
-    padding-bottom: 6px;
-  }
+  .brand { border-bottom: none; padding-bottom: var(--space-3); }
 
   .nav {
     flex-direction: row;
     overflow-x: auto;
     scrollbar-width: thin;
-    padding-bottom: 4px;
+    padding-bottom: var(--space-2);
   }
 
   .nav-item {
@@ -963,24 +1019,17 @@ small {
     grid-template-columns: auto auto;
   }
 
-  .nav-key {
-    display: none;
-  }
-
-  .sidebar-foot {
-    display: none;
-  }
+  .nav-key { display: none; }
+  .sidebar-foot { display: none; }
 
   .status-bar {
-    padding: 12px 14px;
+    padding: var(--space-6) var(--space-7);
     grid-template-columns: 1fr;
   }
 
-  .status-stats {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  .status-stats { grid-template-columns: repeat(2, 1fr); }
 
-  .content {
-    padding: 14px 14px 60px;
-  }
+  .content { padding: var(--space-7) var(--space-7) 60px; }
+
+  .kbd-panel { padding: var(--space-10) var(--space-10); min-width: 0; }
 }


### PR DESCRIPTION
First half of a comprehensive UX/UI polish across both surfaces. A follow-up PR will retarget the 3D companion's styles onto the same token set.

## Summary

**Shared tokens (`design/tokens.css`)**
- New repo-root tokens file that both the operator dashboard (`web/`) and the 3D companion (`sidecar/web/`) will import via Vite. Spacing (`--space-1…16`), typography (`--text-2xs…2xl`, leading/tracking), motion (`--transition-instant…slow` + reduced-motion zero override), radii, focus ring, elevation, z-index.
- Palette rooted in Stack-chan's avatar (coral cheek, warm face white, dark CoreS3 chassis) — same values as before, just lifted out of the dashboard's local `:root`.

**Dashboard visual rhythm**
- Every `padding` / `margin` / `gap` in `web/src/styles.css` now resolves through the spacing scale.
- Typography unified — `font: var(--text-md) / var(--leading-base) var(--font-sans)` family idiom replaces inline px sizes scattered across 30+ rules.
- Motion scattered timings collapsed onto `--transition-fast`/`-base`; `prefers-reduced-motion` zeroes them and `animation-duration: 0.001ms` for keyframes (link pulse, thinking dots).

**Interaction states**
- Button hierarchy: default `.btn` (ghost), new `.btn-primary` (solid coral — Speak, Reset), new `.btn-danger` (Factory reset). Active state gets a 1 px translate.
- `.is-loading` modifier hides the label and renders an inline spinner. Speak adopts it during the `/speak` round-trip with `aria-busy`.
- `:focus-visible` rings everywhere via shared tokens.

**A11y pass**
- `<main aria-label="Operator console">` + `<nav aria-label="Sections">` landmarks.
- `aria-live="polite"` on the stat values, page title, and link-status block so updates announce without spamming.
- Nav buttons get descriptive `aria-label` including the chord hotkey ("Status (press g then s)").
- Decorative dots / glyphs get `aria-hidden`. Toast container becomes `aria-live` with `role="alert"` only on error toasts.

**Empty + error states**
- Skeleton placeholders (`.skeleton`, `.skeleton-row`) replace bare `—` on State + StatusBar — pulsing shimmer instead of dead glyphs on first load.
- Telemetry / Sensors / Events get proper `.empty` blocks with a title + secondary line ("No events yet" + "/events polls every 3 s") instead of `<small>waiting for first poll…</small>`.

**Toast queue**
- Single overwriting toast → stack of up to 3 with per-id TTL (2.8 s). Burst of failures no longer hides earlier messages. Container is `aria-live="polite"`; error toasts get `role="alert"`.

**Discoverability**
- Sidebar foot shows `Press ? for shortcuts` with a styled `<kbd>` hint.

**Bundle:** 23.8 KB → 25.5 KB gzipped (+1.7 KB across tokens, polish CSS, skeletons, spinner, toast-stack styles).

## Test plan
- [x] `cd web && npm run typecheck` — passes.
- [x] `cd web && npm run build` — bundle 25.5 KB gzipped.
- [ ] Manual: open `web/dist/index.html` against a live device:
  - [ ] First load before SSE: skeletons shimmer on State + StatusBar; "No telemetry yet" empty block on Telemetry; "Press ? for shortcuts" hint visible.
  - [ ] Press `?`: shortcut overlay opens; focus moves to panel; Esc restores focus to prior element.
  - [ ] Press Speak: button label hides, spinner spins, button restores on response.
  - [ ] Trigger several failures in quick succession (kill device): toasts stack instead of replacing.
  - [ ] Light vs dark `prefers-color-scheme` both render correctly.
  - [ ] `prefers-reduced-motion: reduce` (DevTools rendering tab): pulse / spinner / page-in transitions become instant; functional state still visible.
  - [ ] Sidebar `<kbd>?</kbd>` hint shows; the `?` shortcut still toggles overlay.
  - [ ] Resize to <768px: sidebar collapses to horizontal scroll; status bar wraps to single column.
- [ ] Tab through the page: every interactive control has a visible focus ring (default 2 px coral outline, --focus-offset).
- [ ] Screen reader: nav announces "Status, page" / "Behavior (press g then b)"; section switches announce title; stat changes announce politely without flooding.