### PR TITLE
feat(sidecar): companion UX polish — shared tokens, a11y, empty + reduced-motion

### DIFF
--- a/sidecar/web/index.html
+++ b/sidecar/web/index.html
@@ -10,18 +10,18 @@
     <div id="app">
       <canvas id="scene"></canvas>
 
-      <aside id="hud">
+      <aside id="hud" aria-label="Device telemetry">
         <div class="row">
           <span class="hud-label">LINK</span>
-          <span id="hud-link" class="hud-value">linking…</span>
+          <span id="hud-link" class="hud-value" aria-live="polite">linking…</span>
         </div>
         <div class="row">
           <span class="hud-label">AGENT</span>
-          <span id="hud-agent" class="hud-value">linking…</span>
+          <span id="hud-agent" class="hud-value" aria-live="polite">linking…</span>
         </div>
         <div class="row">
           <span class="hud-label">EMOTION</span>
-          <span id="hud-emotion" class="hud-value">—</span>
+          <span id="hud-emotion" class="hud-value" aria-live="polite">—</span>
         </div>
         <div class="row">
           <span class="hud-label">POSE</span>
@@ -29,13 +29,21 @@
         </div>
         <div class="row">
           <span class="hud-label">BATTERY</span>
-          <span id="hud-battery" class="hud-value">—</span>
+          <span id="hud-battery" class="hud-value" aria-live="polite">—</span>
         </div>
         <div class="row">
           <span class="hud-label">WIFI</span>
-          <span id="hud-wifi" class="hud-value">—</span>
+          <span id="hud-wifi" class="hud-value" aria-live="polite">—</span>
         </div>
       </aside>
+
+      <div id="empty-overlay" class="empty-overlay hidden" role="status" aria-live="polite">
+        <div class="empty-overlay-title">Waiting for device</div>
+        <div class="empty-overlay-sub">
+          Sidecar is proxying /state/stream and /session-status. Make sure the
+          firmware is reachable at STACKCHAN_FIRMWARE_URL.
+        </div>
+      </div>
 
       <div id="thinking" class="thinking hidden" aria-live="polite">
         <span class="thinking-dot"></span>
@@ -55,9 +63,9 @@
         </div>
       </div>
 
-      <div id="controls" class="controls">
-        <button id="ptt" class="ptt" type="button" aria-label="Start listen window">
-          <span class="ptt-icon">●</span>
+      <div id="controls" class="controls" role="group" aria-label="Operator controls">
+        <button id="ptt" class="ptt" type="button" aria-label="Open a listen window on the device">
+          <span class="ptt-icon" aria-hidden="true">●</span>
           <span class="ptt-label">PUSH TO LISTEN</span>
         </button>
         <div id="chips" class="chips" role="toolbar" aria-label="Emotion presets"></div>

--- a/sidecar/web/src/main.ts
+++ b/sidecar/web/src/main.ts
@@ -33,6 +33,14 @@ connectAgentStream("/v1/session-status", state);
 
 window.addEventListener("resize", scene.resize);
 
+// Skip DOM mutation when the text hasn't changed. aria-live spans use
+// MutationObserver-like semantics, so a no-op assignment can still
+// re-announce on some screen readers — this avoids that without forcing
+// every caller to remember an inline equality guard.
+function setText(el: HTMLElement, value: string): void {
+  if (el.textContent !== value) el.textContent = value;
+}
+
 // Respect prefers-reduced-motion for the breath bob + saccade jitter.
 // The pose lerp + emotion-driven face still need to track state — the
 // preference affects ambient idle motion, not informative motion.
@@ -117,31 +125,35 @@ function frame(): void {
   setStatusTone(scene.status, batteryTone(state.snapshot));
 
   // ── HUD ────────────────────────────────────────────────────────
-  hudLink.textContent = state.conn;
-  hudLink.dataset.conn = state.conn;
+  // Equality-guard every textContent write below. The aria-live HUD
+  // spans ride this 60 Hz loop; without the guard each frame is a DOM
+  // childList mutation that some screen readers re-announce. Pose is
+  // the exception — it has no aria-live and changes every frame anyway.
+  setText(hudLink, state.conn);
+  if (hudLink.dataset.conn !== state.conn) hudLink.dataset.conn = state.conn;
+
   const agentLabel =
     state.agentConn === "live"
       ? state.agent?.state === "thinking"
         ? "thinking"
         : "idle"
       : state.agentConn;
-  hudAgent.textContent = agentLabel;
-  hudAgent.dataset.conn = state.agentConn;
-  hudAgent.dataset.state = state.agent?.state ?? "";
+  setText(hudAgent, agentLabel);
+  if (hudAgent.dataset.conn !== state.agentConn) hudAgent.dataset.conn = state.agentConn;
+  const agentState = state.agent?.state ?? "";
+  if (hudAgent.dataset.state !== agentState) hudAgent.dataset.state = agentState;
 
-  hudEmotion.textContent = (state.snapshot?.emotion ?? "—").toUpperCase();
+  setText(hudEmotion, (state.snapshot?.emotion ?? "—").toUpperCase());
   if (state.snapshot) {
     const p = state.snapshot.head_actual ?? state.snapshot.head_pose;
     hudPose.textContent = `${p.pan_deg.toFixed(0)}° / ${p.tilt_deg.toFixed(0)}°`;
     const b = state.snapshot.battery;
-    hudBattery.textContent = b.percent != null ? `${b.percent}%` : "—";
-    hudWifi.textContent = state.snapshot.wifi.connected
-      ? (state.snapshot.wifi.ip ?? "up")
-      : "down";
+    setText(hudBattery, b.percent != null ? `${b.percent}%` : "—");
+    setText(hudWifi, state.snapshot.wifi.connected ? (state.snapshot.wifi.ip ?? "up") : "down");
   } else {
     hudPose.textContent = "—";
-    hudBattery.textContent = "—";
-    hudWifi.textContent = "—";
+    setText(hudBattery, "—");
+    setText(hudWifi, "—");
   }
 
   // ── Empty overlay ─────────────────────────────────────────────

--- a/sidecar/web/src/main.ts
+++ b/sidecar/web/src/main.ts
@@ -21,6 +21,7 @@ const thinkingEl = document.getElementById("thinking")!;
 const subtitleEl = document.getElementById("subtitle")!;
 const subtitleUserEl = document.getElementById("subtitle-user")!;
 const subtitleReplyEl = document.getElementById("subtitle-reply")!;
+const emptyEl = document.getElementById("empty-overlay")!;
 
 const pttEl = document.getElementById("ptt") as HTMLButtonElement;
 const chipsEl = document.getElementById("chips")!;
@@ -32,6 +33,11 @@ connectAgentStream("/v1/session-status", state);
 
 window.addEventListener("resize", scene.resize);
 
+// Respect prefers-reduced-motion for the breath bob + saccade jitter.
+// The pose lerp + emotion-driven face still need to track state — the
+// preference affects ambient idle motion, not informative motion.
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
 // ── Controls ──────────────────────────────────────────────────────
 
 const chipButtons = new Map<string, HTMLButtonElement>();
@@ -41,6 +47,8 @@ for (const { id, label } of EMOTION_CHIPS) {
   btn.className = "chip";
   btn.dataset.emotion = id;
   btn.textContent = label;
+  btn.setAttribute("aria-label", `Set emotion ${label}`);
+  btn.setAttribute("aria-pressed", "false");
   btn.addEventListener("click", () => {
     void setEmotion(id);
   });
@@ -52,11 +60,15 @@ let pttBusy = false;
 pttEl.addEventListener("click", async () => {
   if (pttBusy) return;
   pttBusy = true;
+  pttEl.classList.add("is-loading");
+  pttEl.setAttribute("aria-busy", "true");
   pttEl.disabled = true;
   try {
     await startListen();
   } finally {
     pttBusy = false;
+    pttEl.classList.remove("is-loading");
+    pttEl.removeAttribute("aria-busy");
     pttEl.disabled = false;
   }
 });
@@ -82,13 +94,19 @@ function frame(): void {
   state.t = now;
 
   tickPose(state, dt);
-  tickSaccade(state, now, dt);
+  if (!reducedMotion.matches) {
+    tickSaccade(state, now, dt);
+  } else {
+    state.eyeOffsetX = 0;
+    state.eyeOffsetY = 0;
+  }
 
   scene.head.rotation.y = state.pan;
   scene.head.rotation.x = state.tilt;
 
-  const breath = Math.sin(now * 0.6) * 0.018;
-  scene.scene.position.y = breath;
+  // Breath: gentle vertical bob, ~10 mm peak-to-peak. Skipped when the
+  // operator opted out of idle motion.
+  scene.scene.position.y = reducedMotion.matches ? 0 : Math.sin(now * 0.6) * 0.018;
 
   // Redraw the face every frame so the microsaccade offset stays live.
   // The eye/mouth shape lookup is two object reads, cheaper than tracking
@@ -126,6 +144,13 @@ function frame(): void {
     hudWifi.textContent = "—";
   }
 
+  // ── Empty overlay ─────────────────────────────────────────────
+  // Surfaces a hint when neither stream has produced a sample yet so
+  // a fresh visitor doesn't stare at a frozen face wondering whether
+  // the firmware is reachable.
+  const noStreams = state.snapshot == null && state.agent == null;
+  emptyEl.classList.toggle("hidden", !noStreams);
+
   // ── Thinking indicator ─────────────────────────────────────────
   const thinking = state.agent?.state === "thinking";
   thinkingEl.classList.toggle("hidden", !thinking);
@@ -133,8 +158,16 @@ function frame(): void {
   // ── Active emotion chip ────────────────────────────────────────
   const activeEmotion = state.snapshot?.emotion ?? "";
   if (activeEmotion !== lastChipActive) {
-    chipButtons.get(lastChipActive)?.classList.remove("active");
-    chipButtons.get(activeEmotion)?.classList.add("active");
+    const prev = chipButtons.get(lastChipActive);
+    const curr = chipButtons.get(activeEmotion);
+    if (prev) {
+      prev.classList.remove("active");
+      prev.setAttribute("aria-pressed", "false");
+    }
+    if (curr) {
+      curr.classList.add("active");
+      curr.setAttribute("aria-pressed", "true");
+    }
     lastChipActive = activeEmotion;
   }
 

--- a/sidecar/web/src/styles.css
+++ b/sidecar/web/src/styles.css
@@ -1,12 +1,4 @@
-:root {
-  color-scheme: dark;
-  --bg: #0b0e13;
-  --fg: #f4f4eb;
-  --fg-muted: #8a9099;
-  --accent: #f08080;
-  --border: rgba(255, 255, 255, 0.08);
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
-}
+@import url("../../../design/tokens.css");
 
 * {
   box-sizing: border-box;
@@ -20,7 +12,19 @@ body {
   overflow: hidden;
   background: var(--bg);
   color: var(--fg);
-  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font: var(--text-md) / var(--leading-base) var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button {
+  font: inherit;
+}
+
+:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-offset);
+  border-radius: var(--radius-xs);
 }
 
 #app {
@@ -37,79 +41,69 @@ body {
   display: block;
 }
 
+/* ─── HUD (top-left telemetry panel) ───────────────────────────── */
+
 #hud {
   position: absolute;
-  top: 18px;
-  left: 18px;
+  top: var(--space-8);
+  left: var(--space-8);
   display: grid;
-  gap: 8px;
-  padding: 12px 14px;
+  gap: var(--space-4);
+  padding: var(--space-6) var(--space-7);
   background: rgba(11, 14, 19, 0.7);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   min-width: 200px;
-  font-family: var(--mono);
+  font-family: var(--font-mono);
 }
 
 #hud .row {
   display: grid;
   grid-template-columns: 80px 1fr;
-  gap: 10px;
+  gap: var(--space-5);
   align-items: baseline;
 }
 
 .hud-label {
-  font-size: 10px;
-  letter-spacing: 1.2px;
+  font: var(--text-2xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--fg-muted);
 }
 
 .hud-value {
-  font-size: 13px;
-  font-weight: 600;
+  font: 600 var(--text-base) / 1 var(--font-mono);
   color: var(--fg);
   font-variant-numeric: tabular-nums;
   word-break: break-all;
+  transition: color var(--transition-fast);
 }
 
-.hud-value[data-conn="live"] {
-  color: #5fc88f;
-}
+.hud-value[data-conn="live"] { color: var(--ok); }
+.hud-value[data-conn="down"] { color: var(--bad); }
+.hud-value[data-conn="linking"] { color: var(--accent); }
+.hud-value[data-state="thinking"] { color: var(--accent); }
 
-.hud-value[data-conn="down"] {
-  color: #e2625a;
-}
-
-.hud-value[data-conn="linking"] {
-  color: var(--accent);
-}
-
-.hud-value[data-state="thinking"] {
-  color: var(--accent);
-}
-
-/* ─── Thinking indicator ────────────────────────────────────────── */
+/* ─── Thinking indicator (top-right) ───────────────────────────── */
 
 .thinking {
   position: absolute;
-  top: 18px;
-  right: 18px;
+  top: var(--space-8);
+  right: var(--space-8);
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
   background: rgba(11, 14, 19, 0.7);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid var(--accent);
-  border-radius: 4px;
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 1.2px;
+  border-radius: var(--radius-md);
+  font: var(--text-xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
   color: var(--accent);
-  transition: opacity 0.18s ease;
+  transition: opacity var(--transition-base);
 }
 
 .thinking.hidden {
@@ -125,13 +119,8 @@ body {
   animation: thinking-pulse 1.1s ease-in-out infinite;
 }
 
-.thinking-dot:nth-child(2) {
-  animation-delay: 0.18s;
-}
-
-.thinking-dot:nth-child(3) {
-  animation-delay: 0.36s;
-}
+.thinking-dot:nth-child(2) { animation-delay: 0.18s; }
+.thinking-dot:nth-child(3) { animation-delay: 0.36s; }
 
 @keyframes thinking-pulse {
   0%, 100% { opacity: 0.25; transform: scale(0.85); }
@@ -146,16 +135,18 @@ body {
   bottom: 100px;
   transform: translateX(-50%);
   display: grid;
-  gap: 6px;
-  padding: 12px 16px;
+  gap: var(--space-3);
+  padding: var(--space-6) var(--space-8);
   background: rgba(11, 14, 19, 0.78);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   max-width: min(640px, 70vw);
-  font-family: var(--mono);
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  font-family: var(--font-mono);
+  transition:
+    opacity var(--transition-slow),
+    transform var(--transition-slow);
 }
 
 .subtitle.hidden {
@@ -167,17 +158,17 @@ body {
 .subtitle-row {
   display: grid;
   grid-template-columns: 28px 1fr;
-  gap: 10px;
+  gap: var(--space-5);
   align-items: baseline;
 }
 
 .subtitle-tag {
   font-size: 9px;
-  letter-spacing: 1.4px;
+  letter-spacing: var(--tracking-wider);
   color: var(--fg-muted);
   padding: 2px 4px;
   border: 1px solid var(--border);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   text-align: center;
 }
 
@@ -187,14 +178,44 @@ body {
 }
 
 .subtitle-text {
-  font-size: 13px;
+  font: var(--text-base) / var(--leading-snug) var(--font-mono);
   color: var(--fg);
-  line-height: 1.4;
   word-break: break-word;
 }
 
-.subtitle-reply {
-  color: var(--accent);
+.subtitle-reply { color: var(--accent); }
+
+/* ─── Empty overlay (no /state yet) ────────────────────────────── */
+
+.empty-overlay {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-7) var(--space-10);
+  background: rgba(11, 14, 19, 0.78);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  text-align: center;
+  font-family: var(--font-mono);
+  transition: opacity var(--transition-base);
+}
+
+.empty-overlay.hidden { opacity: 0; pointer-events: none; }
+
+.empty-overlay-title {
+  font: 600 var(--text-sm) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  color: var(--fg-soft);
+}
+
+.empty-overlay-sub {
+  font: var(--text-xs) / var(--leading-snug) var(--font-mono);
+  color: var(--fg-muted);
 }
 
 /* ─── Controls (PTT + emotion chips) ───────────────────────────── */
@@ -202,75 +223,94 @@ body {
 .controls {
   position: absolute;
   left: 50%;
-  bottom: 18px;
+  bottom: var(--space-8);
   transform: translateX(-50%);
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 10px 14px;
+  gap: var(--space-7);
+  padding: var(--space-5) var(--space-7);
   background: rgba(11, 14, 19, 0.72);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
 }
 
 .ptt {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  background: transparent;
-  color: var(--fg);
-  border: 1px solid var(--accent);
-  border-radius: 4px;
-  cursor: pointer;
-  font: 600 12px var(--mono);
-  letter-spacing: 1.2px;
-  transition: background 80ms ease, color 80ms ease;
-}
-
-.ptt:hover {
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-7);
   background: var(--accent);
-  color: #0b0e13;
+  color: var(--bg);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font: 600 var(--text-sm) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-instant);
 }
 
-.ptt:active {
-  transform: translateY(1px);
-}
+.ptt:hover { background: var(--accent-hi); border-color: var(--accent-hi); }
+.ptt:active:not(:disabled) { transform: translateY(1px); }
 
 .ptt:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-.ptt-icon {
-  color: var(--accent);
-  font-size: 11px;
-  line-height: 1;
+.ptt.is-loading {
+  color: transparent;
+  pointer-events: none;
 }
 
-.ptt:hover .ptt-icon {
-  color: #0b0e13;
+.ptt.is-loading::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--bg);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(1turn); }
+}
+
+.ptt-icon {
+  font-size: var(--text-xs);
+  line-height: 1;
 }
 
 .chips {
   display: flex;
-  gap: 4px;
+  gap: var(--space-2);
   flex-wrap: wrap;
   max-width: 360px;
 }
 
 .chip {
-  font: 11px var(--mono);
+  font: var(--text-xs) var(--font-mono);
   letter-spacing: 0.6px;
-  padding: 5px 8px;
+  padding: var(--space-2) var(--space-4);
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   color: var(--fg-muted);
   cursor: pointer;
-  transition: border-color 80ms ease, color 80ms ease, background 80ms ease;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast),
+    transform var(--transition-instant);
 }
 
 .chip:hover {
@@ -278,13 +318,34 @@ body {
   color: var(--accent);
 }
 
+.chip:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
 .chip.active {
   border-color: var(--accent);
-  background: rgba(240, 128, 128, 0.14);
+  background: var(--accent-soft);
   color: var(--accent);
 }
 
 .chip:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* ─── Small-viewport adjustments ───────────────────────────────── */
+
+@media (max-width: 640px) {
+  #hud { padding: var(--space-5) var(--space-6); min-width: 0; }
+  #hud .row { grid-template-columns: 64px 1fr; }
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-4);
+    bottom: var(--space-6);
+    padding: var(--space-4) var(--space-5);
+  }
+  .ptt { justify-content: center; }
+  .chips { justify-content: center; max-width: none; }
+  .subtitle { bottom: 200px; max-width: calc(100vw - var(--space-10)); }
 }


### PR DESCRIPTION
> Stacked on #392. Retarget to main once the base merges.

Second half of the comprehensive UX/UI polish — the 3D companion now reads from the same `design/tokens.css` the dashboard does, and picks up the same a11y / interaction / empty-state idioms.

## Summary

**Shared tokens consumed**
- `sidecar/web/src/styles.css` `@import`s `../../../design/tokens.css`. Companion's local `:root` block is gone; spacing / typography / motion / radii / focus all resolve through the shared scale so a bump in one place propagates.

**Interaction**
- PTT picks up the `.is-loading` + `aria-busy` idiom: solid-coral button hides its label and spins an inline spinner while `/v1/firmware-cmd/listen` is in flight.
- Emotion chips reflect the live snapshot via `aria-pressed`; hover/active states standardised on shared transition tokens.

**Reduced-motion**
- Render loop now reads `matchMedia("(prefers-reduced-motion: reduce)")`. When it matches: breath bob zeros, microsaccade is skipped (eye offset clamps to 0). CSS transitions zero globally via the tokens override. The pose lerp + emotion-driven face still update — informative motion stays, ambient idle motion goes.

**Accessibility**
- `<aside aria-label="Device telemetry">` on the HUD.
- `aria-live="polite"` on link / agent / emotion / battery / wifi values; pose stays silent (it updates every frame).
- Empty-state overlay surfaces when neither stream has produced a sample, hinting that `STACKCHAN_FIRMWARE_URL` may be unreachable.
- Decorative dots/glyphs get `aria-hidden`. PTT and chips have descriptive `aria-label`s.

**Bundle:** JS 121.5 → 121.65 KB gz (negligible), CSS 1.28 → 2.51 KB gz (+1.4 KB for shared-token aliasing + new overlay/loading/empty rules), HTML 0.71 → 0.89 KB gz.

## Test plan
- [x] `just sidecar-companion-build` — bundle ~125 KB gzipped total.
- [x] `cd sidecar && uv run pytest -q` — 107 passed (no Python changes; sanity).
- [ ] Manual: run sidecar against `STACKCHAN_FIRMWARE_URL=http://stackchan.local`, open `/companion/`:
  - [ ] First load before SSE: empty overlay surfaces with hint about firmware URL.
  - [ ] Streams come up: empty overlay fades; HUD values flip from `linking…` to live state.
  - [ ] Press PTT: button label hides, spinner spins, button restores on response. `/v1/firmware-cmd/listen` fires.
  - [ ] Active emotion chip highlights match `aria-pressed=true`; rest are `false`.
  - [ ] `prefers-reduced-motion: reduce` (DevTools rendering tab): breath bob stops, no eye saccades, thinking dots become static (animation-duration zeroed by tokens). Face still tracks emotion.
  - [ ] Tab through PTT + chips: each has a visible focus ring.
  - [ ] Screen reader: HUD values announce on change without spam; PTT and chips have descriptive labels.