### PR TITLE
feat(core): face-level Thinking state across the sidecar round-trip

### DIFF
--- a/crates/stackchan-core/src/decorator.rs
+++ b/crates/stackchan-core/src/decorator.rs
@@ -45,6 +45,12 @@ pub enum Decorator {
     /// Pink hash-mark blush under each cheek — the embarrassed
     /// crosshatch trope, amplifying [`crate::Emotion::Loved`].
     Shy,
+    /// Anime thought-bubble cluster — the rising-bubbles trope, drawn
+    /// at the upper-right above the head while
+    /// [`crate::Attention::Thinking`] holds. Armed by
+    /// [`crate::modifiers::DecoratorFromThinking`] across the sidecar
+    /// round-trip window that follows a closed listen capture.
+    Thinking,
 }
 
 impl Decorator {
@@ -65,6 +71,7 @@ impl Decorator {
             Self::Pairing => "pairing",
             Self::Angry => "angry",
             Self::Shy => "shy",
+            Self::Thinking => "thinking",
         }
     }
 
@@ -80,6 +87,7 @@ impl Decorator {
             Self::Pairing => 4,
             Self::Angry => 5,
             Self::Shy => 6,
+            Self::Thinking => 7,
         }
     }
 
@@ -96,6 +104,7 @@ impl Decorator {
         Self::Pairing,
         Self::Angry,
         Self::Shy,
+        Self::Thinking,
     ];
 }
 
@@ -141,7 +150,7 @@ mod tests {
     fn all_length_matches_variant_count() {
         assert_eq!(
             Decorator::ALL.len(),
-            7,
+            8,
             "update Decorator::ALL when adding a variant"
         );
     }
@@ -155,6 +164,7 @@ mod tests {
         assert_eq!(Decorator::Pairing.wire_byte(), 4);
         assert_eq!(Decorator::Angry.wire_byte(), 5);
         assert_eq!(Decorator::Shy.wire_byte(), 6);
+        assert_eq!(Decorator::Thinking.wire_byte(), 7);
     }
 
     #[test]

--- a/crates/stackchan-core/src/draw.rs
+++ b/crates/stackchan-core/src/draw.rs
@@ -191,6 +191,7 @@ where
         Decorator::Pairing => draw_pairing(target),
         Decorator::Angry => draw_angry(target),
         Decorator::Shy => draw_shy(target),
+        Decorator::Thinking => draw_thinking(target),
     }
 }
 
@@ -508,6 +509,80 @@ where
                 .into_styled(fill(EAR_COLOR))
                 .draw(target)?;
         }
+    }
+    Ok(())
+}
+
+/// Thinking decorator colour — soft cool grey-violet, distinct from
+/// the warm Heart pink and the cool Sweat blue so a glance reads the
+/// state without further cues. Pairs with the stroked outer bubble
+/// (no fill) to evoke the cloud-silhouette trope without competing
+/// with the speech-bubble layer.
+const THINKING_COLOR: Rgb565 = Rgb565::new(15, 32, 18);
+/// Trail-dots + bubble centre column. Same upper-right band as
+/// `HEART_ANCHOR_X`; the trio rises diagonally toward the corner so
+/// the gesture reads from the head outward.
+const THINKING_ANCHOR_X: i32 = 270;
+/// Trail-dots + bubble centre row. Sits above `HEART_ANCHOR_Y` (50)
+/// so the bubble is high in the corner; the trail dots descend back
+/// toward the head.
+const THINKING_ANCHOR_Y: i32 = 22;
+/// Outer bubble diameter — the largest of the three shapes, stroked
+/// (not filled) so the cloud silhouette reads independently of the
+/// speech-bubble fill.
+const THINKING_BUBBLE_DIAMETER: u32 = 18;
+/// Stroke width on the outer bubble. Matches `PAIRING_RING_STROKE`
+/// so concentric-ring decorators read consistently at 320×240.
+const THINKING_BUBBLE_STROKE: u32 = 2;
+/// Medium trail-dot diameter — the bridge between the head and the
+/// bubble.
+const THINKING_MID_DOT_DIAMETER: u32 = 6;
+/// Small trail-dot diameter — the closest dot to the head, smallest
+/// in the rising progression.
+const THINKING_LOW_DOT_DIAMETER: u32 = 3;
+
+/// Draw the thinking overlay: two filled trail-dots ascending toward
+/// a single stroked thought-bubble in the upper-right corner.
+///
+/// Layout (top-down): outer bubble at the anchor, mid-dot ~10 px
+/// down-and-left, low-dot another ~10 px further down-and-left toward
+/// the head. The diagonal trail reads as "rising thought."
+fn draw_thinking<D>(target: &mut D) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    #[allow(clippy::cast_possible_wrap)]
+    let bubble_half = (THINKING_BUBBLE_DIAMETER / 2) as i32;
+    let bubble_top_left = EgPoint::new(
+        THINKING_ANCHOR_X - bubble_half,
+        THINKING_ANCHOR_Y - bubble_half,
+    );
+    Circle::new(bubble_top_left, THINKING_BUBBLE_DIAMETER)
+        .into_styled(stroke(THINKING_COLOR, THINKING_BUBBLE_STROKE))
+        .draw(target)?;
+
+    // Trail-dot positions: a diagonal ladder from the head toward the
+    // bubble. Hand-tuned so the dots and the bubble read as a single
+    // rising gesture rather than three isolated shapes.
+    let trail: [(i32, i32, u32); 2] = [
+        (
+            THINKING_ANCHOR_X - 12,
+            THINKING_ANCHOR_Y + 16,
+            THINKING_MID_DOT_DIAMETER,
+        ),
+        (
+            THINKING_ANCHOR_X - 22,
+            THINKING_ANCHOR_Y + 28,
+            THINKING_LOW_DOT_DIAMETER,
+        ),
+    ];
+    for (cx, cy, diameter) in trail {
+        #[allow(clippy::cast_possible_wrap)]
+        let half = (diameter / 2) as i32;
+        let top_left = EgPoint::new(cx - half, cy - half);
+        Circle::new(top_left, diameter)
+            .into_styled(fill(THINKING_COLOR))
+            .draw(target)?;
     }
     Ok(())
 }

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -132,6 +132,21 @@ pub enum RemoteCommand {
         /// doesn't leave the thought-bubble showing forever.
         hold_ms: u32,
     },
+    /// Release any active thinking hold without touching emotion.
+    ///
+    /// Producer: the firmware sidecar-agent task on every code path
+    /// that closes a round-trip but does not fire
+    /// [`Self::SetEmotion`] — a successful reply that carries no
+    /// `emotion` tag, a POST failure, or a request timeout. The
+    /// common case (reply carries an emotion) already clears the
+    /// thinking hold via [`Self::SetEmotion`]'s side effect, so this
+    /// variant is only fired on the off-paths.
+    ///
+    /// Distinct from [`Self::Reset`] in that it leaves the operator's
+    /// active emotion / look-at holds intact — only the thinking
+    /// hold and the corresponding [`crate::Attention::Thinking`]
+    /// attention slot are released.
+    ExitThinking,
 }
 
 /// Pending inputs the modifier graph consumes.

--- a/crates/stackchan-core/src/input.rs
+++ b/crates/stackchan-core/src/input.rs
@@ -108,6 +108,30 @@ pub enum RemoteCommand {
         /// 500 ms tail each tick and fades on release.
         duration_ms: u32,
     },
+    /// Mark the avatar as awaiting an external reply — set
+    /// [`crate::Attention::Thinking`] and hold for `hold_ms`. While
+    /// the hold is active,
+    /// [`crate::modifiers::DecoratorFromThinking`] arms the
+    /// [`crate::Decorator::Thinking`] overlay (thought-bubble cluster).
+    ///
+    /// Producer: the firmware sidecar-agent task fires this once the
+    /// PCM capture window closes and the HTTP round-trip begins, so
+    /// the face transitions Listening → Thinking while the network
+    /// request is in flight.
+    ///
+    /// The reply, when it lands, fires
+    /// [`Self::SetEmotion`]; the modifier's `SetEmotion` handler
+    /// clears any active Thinking hold as a side effect, so the
+    /// thought-bubble fades out at the same instant the emotion +
+    /// speech-bubble carry the reply. If no reply arrives, the hold
+    /// expires naturally after `hold_ms` and attention falls back to
+    /// `None`.
+    EnterThinking {
+        /// Cap on the thinking window in milliseconds. Sized to the
+        /// firmware's sidecar request timeout so a vanished sidecar
+        /// doesn't leave the thought-bubble showing forever.
+        hold_ms: u32,
+    },
 }
 
 /// Pending inputs the modifier graph consumes.

--- a/crates/stackchan-core/src/mind.rs
+++ b/crates/stackchan-core/src/mind.rs
@@ -148,6 +148,24 @@ pub enum Attention {
         /// When the listening attention began.
         since: Instant,
     },
+    /// Waiting on a sidecar / external agent reply after a listen
+    /// window closes. Distinct from [`Self::Listening`] so the face
+    /// can show a "thinking" decorator while the network round-trip
+    /// is in flight, without disturbing the head pose easing that
+    /// the Listening branch already drives.
+    ///
+    /// Set by [`crate::modifiers::RemoteCommandModifier`] in response
+    /// to [`crate::RemoteCommand::EnterThinking`]; cleared either when
+    /// the hold expires or when a follow-up
+    /// [`crate::RemoteCommand::SetEmotion`] lands (the reply carries
+    /// the emotion, so the thinking state has served its purpose).
+    /// [`crate::modifiers::HeadFromAttention`] holds the same upward
+    /// listen-tilt across Listening + Thinking; only the decorator
+    /// differs.
+    Thinking {
+        /// When the thinking attention began.
+        since: Instant,
+    },
     /// Tracking a moving target detected by the camera. `target` is
     /// the head-pose the engine wants to look at (already in safe
     /// pan/tilt range — the firmware tracker handles clamping); `since`

--- a/crates/stackchan-core/src/modifiers/decorator_from_thinking.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_thinking.rs
@@ -1,0 +1,151 @@
+//! [`DecoratorFromThinking`] — arms the [`Decorator::Thinking`] overlay
+//! while [`Attention::Thinking`] is active.
+//!
+//! Triggers across the window where the avatar is waiting on a sidecar
+//! reply: the listen capture closed, audio was uploaded, and the
+//! network round-trip is in flight. Refreshes the decorator's expiry
+//! every frame so the thought bubble stays visible as long as Thinking
+//! attention persists; lets the standard 500 ms tail (via
+//! [`super::DecoratorExpiry`]) fade it out cleanly when the reply
+//! lands or the hold expires.
+
+use crate::decorator::{Decorator, DecoratorState};
+use crate::director::{Field, ModifierMeta, Phase};
+use crate::entity::Entity;
+use crate::mind::Attention;
+use crate::modifier::Modifier;
+
+/// Tail duration after Thinking releases. Mirrors
+/// [`super::DecoratorFromListening`]'s tail so consecutive Listening →
+/// Thinking → reply transitions share the same release cadence.
+pub const DECORATOR_TAIL_MS: u64 = 500;
+
+/// Stateless modifier that arms [`Decorator::Thinking`] while Thinking.
+///
+/// Mirrors [`super::DecoratorFromListening`]'s shape; the two are
+/// mutually exclusive at the source ([`Attention`] holds one variant
+/// at a time) so their priority order only matters relative to the
+/// autonomous decorators (Heart, Sweat, Dizzy).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DecoratorFromThinking;
+
+impl DecoratorFromThinking {
+    /// Construct.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Modifier for DecoratorFromThinking {
+    fn meta(&self) -> &'static ModifierMeta {
+        static META: ModifierMeta = ModifierMeta {
+            name: "DecoratorFromThinking",
+            description: "Arms face.decorator = Thinking while mind.attention is Thinking; \
+                          refreshes expires_at each frame and lets DecoratorExpiry's tail \
+                          handle the fade-out when Thinking releases.",
+            phase: Phase::Decoration,
+            // Priority 26 — runs after DecoratorFromListening (25)
+            // and the autonomous triggers (Heart=0, Sweat=10,
+            // Dizzy=20). Director sorts ascending and
+            // `face.decorator` is a single Option, so last-write-wins:
+            // an active thinking window beats Listening's Ear (mutually
+            // exclusive at the attention source anyway) and both
+            // autonomous decorators.
+            priority: 26,
+            reads: &[Field::Attention],
+            writes: &[Field::Decorator],
+        };
+        &META
+    }
+
+    fn update(&mut self, entity: &mut Entity) {
+        if matches!(entity.mind.attention, Attention::Thinking { .. }) {
+            entity.face.decorator = Some(DecoratorState::hold_for(
+                Decorator::Thinking,
+                entity.tick.now,
+                DECORATOR_TAIL_MS,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::missing_docs_in_private_items,
+    reason = "test-only: decorator is set by the modifier-under-test inside the same scope"
+)]
+mod tests {
+    use super::*;
+    use crate::clock::Instant;
+
+    fn entity_with_attention(attention: Attention, now_ms: u64) -> Entity {
+        let mut e = Entity::default();
+        e.mind.attention = attention;
+        e.tick.now = Instant::from_millis(now_ms);
+        e
+    }
+
+    #[test]
+    fn arms_thinking_while_thinking() {
+        let mut entity = entity_with_attention(
+            Attention::Thinking {
+                since: Instant::from_millis(0),
+            },
+            33,
+        );
+        let mut m = DecoratorFromThinking::new();
+        m.update(&mut entity);
+        let state = entity.face.decorator.expect("Thinking should be armed");
+        assert_eq!(state.kind, Decorator::Thinking);
+        assert_eq!(
+            state.expires_at,
+            Instant::from_millis(33 + DECORATOR_TAIL_MS)
+        );
+    }
+
+    #[test]
+    fn does_not_arm_when_not_thinking() {
+        let mut entity = entity_with_attention(Attention::None, 0);
+        let mut m = DecoratorFromThinking::new();
+        m.update(&mut entity);
+        assert!(entity.face.decorator.is_none());
+    }
+
+    #[test]
+    fn does_not_arm_for_listening_attention() {
+        // Listening drives DecoratorFromListening; only Thinking gets
+        // the thought-bubble overlay.
+        let mut entity = entity_with_attention(
+            Attention::Listening {
+                since: Instant::from_millis(0),
+            },
+            33,
+        );
+        let mut m = DecoratorFromThinking::new();
+        m.update(&mut entity);
+        assert!(entity.face.decorator.is_none());
+    }
+
+    #[test]
+    fn refreshes_expiry_each_frame() {
+        let mut entity = entity_with_attention(
+            Attention::Thinking {
+                since: Instant::from_millis(0),
+            },
+            33,
+        );
+        let mut m = DecoratorFromThinking::new();
+        m.update(&mut entity);
+        let first = entity.face.decorator.expect("first arm").expires_at;
+
+        entity.tick.now = Instant::from_millis(166);
+        m.update(&mut entity);
+        let second = entity.face.decorator.expect("re-arm").expires_at;
+        assert!(
+            second > first,
+            "expiry must advance with `now` ({second:?} vs {first:?})"
+        );
+    }
+}

--- a/crates/stackchan-core/src/modifiers/gaze_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/gaze_from_attention.rs
@@ -131,7 +131,9 @@ impl Modifier for GazeFromAttention {
                 crate::Pose::from_xyz_lookat(x, y, z)
                     .map_or((0, 0), |p| target_to_offset(p.pan_deg, p.tilt_deg))
             }
-            (None, Attention::None | Attention::Listening { .. }) => (0, 0),
+            (None, Attention::None | Attention::Listening { .. } | Attention::Thinking { .. }) => {
+                (0, 0)
+            }
         };
 
         let (prev_x, prev_y) = self.last_offset;

--- a/crates/stackchan-core/src/modifiers/head_from_attention.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_attention.rs
@@ -193,12 +193,23 @@ impl Modifier for HeadFromAttention {
         &META
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "single dense match across attention variants + diff-and-undo bookkeeping; \
+                  splitting would force the smoother state out of the local frame and read worse"
+    )]
     fn update(&mut self, entity: &mut Entity) {
         let now = entity.tick.now;
 
         // Edge detection for the Listening ease state machine. Only
-        // observes Listening transitions — Tracking has no ease.
-        let listening = matches!(entity.mind.attention, Attention::Listening { .. });
+        // observes Listening / Thinking transitions — Tracking has no
+        // ease. Thinking shares the cocked-head tilt so the pose holds
+        // across the sidecar round-trip after a listen window closes,
+        // rather than releasing and re-applying.
+        let listening = matches!(
+            entity.mind.attention,
+            Attention::Listening { .. } | Attention::Thinking { .. }
+        );
         match (listening, self.listen_since.is_some()) {
             (true, false) => {
                 self.listen_since = Some(now);
@@ -296,7 +307,10 @@ impl Modifier for HeadFromAttention {
                         (0.0, 0.0)
                     }
                 }
-                (None, Attention::Listening { .. } | Attention::None) => {
+                (
+                    None,
+                    Attention::Listening { .. } | Attention::Thinking { .. } | Attention::None,
+                ) => {
                     // Drop the smoother anchor so a future Tracking /
                     // Point run re-anchors at the live target (no
                     // stale chase).

--- a/crates/stackchan-core/src/modifiers/mod.rs
+++ b/crates/stackchan-core/src/modifiers/mod.rs
@@ -93,6 +93,7 @@ mod decorator_from_emotion;
 mod decorator_from_listening;
 mod decorator_from_loud;
 mod decorator_from_shake;
+mod decorator_from_thinking;
 mod dormancy_from_activity;
 mod emotion_cycle;
 mod emotion_from_ambient;
@@ -135,6 +136,7 @@ pub use decorator_from_emotion::{DECORATOR_EMOTION_HOLD_MS, DecoratorFromEmotion
 pub use decorator_from_listening::{DECORATOR_TAIL_MS, DecoratorFromListening};
 pub use decorator_from_loud::{DecoratorFromLoud, SWEAT_HOLD_MS, SWEAT_RMS_THRESHOLD};
 pub use decorator_from_shake::{DIZZY_HOLD_MS, DecoratorFromShake};
+pub use decorator_from_thinking::DecoratorFromThinking;
 pub use dormancy_from_activity::{DORMANCY_TIMEOUT_MS, DormancyFromActivity};
 pub use emotion_cycle::EmotionCycle;
 pub use emotion_from_ambient::{

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -76,6 +76,12 @@ pub struct RemoteCommandModifier {
     /// live, [`Self::update`] re-arms [`Decorator::Pairing`] on
     /// `entity.face.decorator` each tick.
     pairing_hold: Option<Instant>,
+    /// Active thinking-window hold, if any. `(since, hold_until)`.
+    /// `since` pins to the entry frame so [`Attention::Thinking`] is
+    /// re-asserted with a stable timestamp each tick (mirrors
+    /// [`Self::listen_hold`]). A follow-up `SetEmotion` clears this
+    /// hold as a side effect — see [`Self::apply`].
+    thinking_hold: Option<(Instant, Instant)>,
 }
 
 impl RemoteCommandModifier {
@@ -88,6 +94,7 @@ impl RemoteCommandModifier {
             lookat_point_hold: None,
             listen_hold: None,
             pairing_hold: None,
+            thinking_hold: None,
         }
     }
 
@@ -102,6 +109,18 @@ impl RemoteCommandModifier {
                 entity.mind.autonomy.manual_until = Some(until);
                 entity.mind.autonomy.source = Some(OverrideSource::Remote);
                 self.emotion_hold = Some((emotion, until));
+                // Sidecar reply transition: a SetEmotion landing while
+                // we're mid-Thinking means the reply has arrived, so
+                // the thought-bubble has served its purpose. Clear the
+                // hold (the per-tick re-assert below would otherwise
+                // hold attention on Thinking through `hold_ms`) and
+                // release the attention slot so DecoratorExpiry's tail
+                // can fade the bubble out cleanly.
+                if let Some((since, _)) = self.thinking_hold.take()
+                    && matches!(entity.mind.attention, Attention::Thinking { since: s } if s == since)
+                {
+                    entity.mind.attention = Attention::None;
+                }
             }
             RemoteCommand::LookAt { target, hold_ms } => {
                 let until = now + u64::from(hold_ms);
@@ -126,6 +145,7 @@ impl RemoteCommandModifier {
                 self.lookat_point_hold = None;
                 self.listen_hold = None;
                 self.pairing_hold = None;
+                self.thinking_hold = None;
             }
             RemoteCommand::Speak { .. } => {
                 // Audio dispatch is firmware-only; the producer drains
@@ -152,6 +172,15 @@ impl RemoteCommandModifier {
                     PAIRING_DECORATOR_TAIL_MS,
                 ));
                 self.pairing_hold = Some(until);
+            }
+            RemoteCommand::EnterThinking { hold_ms } => {
+                let until = now + u64::from(hold_ms);
+                entity.mind.attention = Attention::Thinking { since: now };
+                self.thinking_hold = Some((now, until));
+                // A fresh thinking window supersedes any in-flight
+                // listen hold — the listen capture has ended, the
+                // round-trip is now the thing we're showing.
+                self.listen_hold = None;
             }
         }
     }
@@ -253,6 +282,20 @@ impl Modifier for RemoteCommandModifier {
                 ));
             } else {
                 self.pairing_hold = None;
+            }
+        }
+
+        if let Some((since, until)) = self.thinking_hold {
+            if now < until {
+                entity.mind.attention = Attention::Thinking { since };
+            } else {
+                self.thinking_hold = None;
+                // Same release-guard idiom as `listen_hold`: only clear
+                // if attention is still our Thinking variant — another
+                // modifier may have stomped it.
+                if matches!(entity.mind.attention, Attention::Thinking { since: s } if s == since) {
+                    entity.mind.attention = Attention::None;
+                }
             }
         }
     }
@@ -621,5 +664,131 @@ mod tests {
         let after_reset = entity.face.decorator;
         step(&mut m, &mut entity, 200);
         assert_eq!(entity.face.decorator, after_reset);
+    }
+
+    #[test]
+    fn enter_thinking_sets_attention_and_pins_since() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(100);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 5_000 });
+        step(&mut m, &mut entity, 100);
+
+        match entity.mind.attention {
+            Attention::Thinking { since } => {
+                assert_eq!(since, Instant::from_millis(100));
+            }
+            other => panic!("expected Thinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thinking_hold_re_asserts_against_stomping() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 1_000 });
+        step(&mut m, &mut entity, 0);
+
+        entity.mind.attention = Attention::None;
+        step(&mut m, &mut entity, 200);
+        assert!(
+            matches!(entity.mind.attention, Attention::Thinking { .. }),
+            "hold must re-assert Thinking against mid-frame stomps"
+        );
+    }
+
+    #[test]
+    fn thinking_hold_expires_back_to_none() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 500 });
+        step(&mut m, &mut entity, 0);
+        step(&mut m, &mut entity, 600);
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn set_emotion_clears_active_thinking() {
+        // Reply-arrival side effect: a SetEmotion landing mid-Thinking
+        // means the sidecar reply has come back, so the thought-bubble
+        // has served its purpose. Attention drops to None on the same
+        // tick; the emotion + speech-bubble carry the visible reply.
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 10_000 });
+        step(&mut m, &mut entity, 0);
+        assert!(matches!(entity.mind.attention, Attention::Thinking { .. }));
+
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 2_000,
+        });
+        step(&mut m, &mut entity, 500);
+
+        assert_eq!(entity.mind.attention, Attention::None);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+    }
+
+    #[test]
+    fn set_emotion_does_not_clear_unrelated_thinking_attention() {
+        // If something else has written Attention::Thinking with a
+        // different `since`, SetEmotion's clear is scoped to our hold.
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 10_000 });
+        step(&mut m, &mut entity, 0);
+
+        let foreign_since = Instant::from_millis(999);
+        entity.mind.attention = Attention::Thinking {
+            since: foreign_since,
+        };
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 2_000,
+        });
+        step(&mut m, &mut entity, 500);
+
+        // The foreign Thinking attention survives the SetEmotion.
+        assert_eq!(
+            entity.mind.attention,
+            Attention::Thinking {
+                since: foreign_since,
+            }
+        );
+    }
+
+    #[test]
+    fn enter_thinking_supersedes_listen_hold() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::StartListen {
+            duration_ms: 30_000,
+        });
+        step(&mut m, &mut entity, 0);
+        assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
+
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 5_000 });
+        step(&mut m, &mut entity, 100);
+        assert!(matches!(entity.mind.attention, Attention::Thinking { .. }));
+
+        // The listen hold must not resurrect Listening on the next tick.
+        step(&mut m, &mut entity, 200);
+        assert!(matches!(entity.mind.attention, Attention::Thinking { .. }));
+    }
+
+    #[test]
+    fn reset_clears_thinking_hold() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 30_000 });
+        step(&mut m, &mut entity, 0);
+        assert!(matches!(entity.mind.attention, Attention::Thinking { .. }));
+
+        entity.input.remote_command = Some(RemoteCommand::Reset);
+        step(&mut m, &mut entity, 100);
+        assert_eq!(entity.mind.attention, Attention::None);
+
+        // Subsequent ticks do not resurrect Thinking.
+        step(&mut m, &mut entity, 500);
+        assert_eq!(entity.mind.attention, Attention::None);
     }
 }

--- a/crates/stackchan-core/src/modifiers/remote_command.rs
+++ b/crates/stackchan-core/src/modifiers/remote_command.rs
@@ -163,6 +163,12 @@ impl RemoteCommandModifier {
                 // tick.
                 entity.voice.chirp_request = Some(ChirpKind::Wake);
                 self.listen_hold = Some((now, until));
+                // A stale thinking hold from a previous round-trip
+                // (e.g. one that timed out before the operator's hand
+                // landed on PTT again) would otherwise stomp this
+                // fresh Listening attention every tick. Symmetric
+                // with `EnterThinking` clearing `listen_hold` above.
+                self.thinking_hold = None;
             }
             RemoteCommand::EnterPairing { duration_ms } => {
                 let until = now + u64::from(duration_ms);
@@ -181,6 +187,19 @@ impl RemoteCommandModifier {
                 // listen hold — the listen capture has ended, the
                 // round-trip is now the thing we're showing.
                 self.listen_hold = None;
+            }
+            RemoteCommand::ExitThinking => {
+                // Off-path cleanup: a successful reply with no emotion
+                // tag, a POST failure, or a timeout. Drop the hold and,
+                // if attention is still our Thinking, release the slot
+                // so `DecoratorExpiry`'s tail can fade the bubble.
+                // Same release-guard as the hold-expiry branch in
+                // `update` — don't stomp a foreign Thinking attention.
+                if let Some((since, _)) = self.thinking_hold.take()
+                    && matches!(entity.mind.attention, Attention::Thinking { since: s } if s == since)
+                {
+                    entity.mind.attention = Attention::None;
+                }
             }
         }
     }
@@ -790,5 +809,70 @@ mod tests {
         // Subsequent ticks do not resurrect Thinking.
         step(&mut m, &mut entity, 500);
         assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn exit_thinking_clears_attention_without_touching_emotion() {
+        // Off-path cleanup: a no-emotion success or a failure path
+        // fires ExitThinking. The operator's existing emotion hold
+        // (set via dashboard) must survive — only the thinking slot
+        // is released.
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 60_000,
+        });
+        step(&mut m, &mut entity, 0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 15_000 });
+        step(&mut m, &mut entity, 100);
+
+        entity.input.remote_command = Some(RemoteCommand::ExitThinking);
+        step(&mut m, &mut entity, 200);
+        assert_eq!(entity.mind.attention, Attention::None);
+        // Operator's emotion hold from t=0 survives the off-path clear.
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+        assert_eq!(
+            entity.mind.autonomy.source,
+            Some(OverrideSource::Remote),
+            "emotion override must remain after ExitThinking"
+        );
+
+        // No resurrection on subsequent ticks.
+        step(&mut m, &mut entity, 500);
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn exit_thinking_is_noop_when_no_thinking_hold() {
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::ExitThinking);
+        step(&mut m, &mut entity, 0);
+        assert_eq!(entity.mind.attention, Attention::None);
+    }
+
+    #[test]
+    fn start_listen_clears_stale_thinking_hold() {
+        // Scenario: the prior round-trip timed out and left
+        // thinking_hold live. The operator hits PTT again before the
+        // 15s hold expires. The new Listening capture must read as
+        // Ear, not as a stomped-thought-bubble.
+        let mut m = RemoteCommandModifier::new();
+        let mut entity = entity_at(0);
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 15_000 });
+        step(&mut m, &mut entity, 0);
+        assert!(matches!(entity.mind.attention, Attention::Thinking { .. }));
+
+        // Fresh PTT mid-thinking-hold.
+        entity.input.remote_command = Some(RemoteCommand::StartListen { duration_ms: 3_000 });
+        step(&mut m, &mut entity, 5_000);
+        assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
+
+        // The next tick must not resurrect Thinking from the stale
+        // hold — symmetric with the supersede check that EnterThinking
+        // does on listen_hold.
+        step(&mut m, &mut entity, 5_100);
+        assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
     }
 }

--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -413,11 +413,19 @@ fn apply_outcome(
                     emotion: e,
                     hold_ms: 2_500,
                 });
+            } else {
+                // Reply landed but the sidecar declined to tag an
+                // emotion — `SetEmotion`'s thinking-clear side effect
+                // would have run otherwise. Fall back to an explicit
+                // clear so the thought-bubble fades with the toast
+                // instead of lingering for the full request timeout.
+                REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::ExitThinking);
             }
         }
         Ok(Err(e)) => {
             defmt::warn!("agent-sidecar: POST failed ({:?})", e);
             toast_warn("sidecar: post failed");
+            REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::ExitThinking);
         }
         Err(_) => {
             defmt::warn!(
@@ -425,6 +433,7 @@ fn apply_outcome(
                 REQUEST_TIMEOUT_MS
             );
             toast_warn("sidecar: timed out");
+            REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::ExitThinking);
         }
     }
 }

--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -17,12 +17,20 @@
 //!    PSRAM-allocated `Vec<i16>`.
 //! 3. The captured PCM is posted to the operator-configured
 //!    `behavior.agent_sidecar_url` (raw little-endian s16,
-//!    `Content-Type: audio/L16;rate=16000;channels=1`).
+//!    `Content-Type: audio/L16;rate=16000;channels=1`). The task
+//!    fires [`RemoteCommand::EnterThinking`] on the same signal as
+//!    the listen command so the face transitions from Listening
+//!    (Ear decorator) to Thinking (thought-bubble) for the duration
+//!    of the network round-trip.
 //! 4. The sidecar's JSON reply
 //!    (`{"text":"...","emotion":"..."}`, OpenAI-Chat-Completions
 //!    -shaped projection) surfaces on the firmware toast band, and
 //!    any `emotion` tag fires a [`RemoteCommand::SetEmotion`] so
-//!    the avatar mirrors the agent's mood.
+//!    the avatar mirrors the agent's mood. The `SetEmotion` handler in
+//!    [`stackchan_core::modifiers::RemoteCommandModifier`] clears
+//!    the in-flight thinking hold as a side effect, so the
+//!    thought-bubble fades out at the same instant the emotion +
+//!    speech-bubble carry the reply.
 //!
 //! Empty `agent_sidecar_url` (the default) parks the task — no
 //! socket, no pubsub slot, no PTT consumer.
@@ -286,6 +294,21 @@ pub async fn agent_sidecar_task(
             toast_warn("sidecar: link down");
             continue;
         }
+
+        // Swap the face from Listening (Ear) to Thinking
+        // (thought-bubble) for the network round-trip. Hold is sized
+        // to the request timeout so the bubble has an upper bound on
+        // pathological reply latency. A successful reply fires
+        // `RemoteCommand::SetEmotion` below, which clears the
+        // thinking hold via the modifier's SetEmotion side effect.
+        // On timeout or POST failure the hold expires naturally.
+        REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::EnterThinking {
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "REQUEST_TIMEOUT_MS is a 5-digit const; truncation is impossible at the source"
+            )]
+            hold_ms: REQUEST_TIMEOUT_MS as u32,
+        });
 
         let outcome = embassy_time::with_timeout(
             Duration::from_millis(REQUEST_TIMEOUT_MS),

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -76,13 +76,13 @@ use stackchan_core::{
     modifiers::{
         AttentionFromTracking, BatteryOverlayFromPerception, Blink, Breath, BubbleExpiry,
         DancePlayer, DecoratorExpiry, DecoratorFromBodyTouch, DecoratorFromEmotion,
-        DecoratorFromListening, DecoratorFromLoud, DecoratorFromShake, DormancyFromActivity,
-        EmotionCycle, EmotionFromAmbient, EmotionFromBattery, EmotionFromIntent, EmotionFromRemote,
-        EmotionFromTouch, EmotionFromVoice, GazeFromAttention, HeadFromAttention,
-        HeadFromBodyGesture, HeadFromEmotion, HeadFromIntent, IdleDrift, IdleHeadDrift,
-        IdleMicroExpression, IntentFromBodyTouch, IntentFromLoud, LostTargetSearch,
-        MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier, Soliloquy,
-        StyleFromEmotion, StyleFromIntent, StyleFromMood,
+        DecoratorFromListening, DecoratorFromLoud, DecoratorFromShake, DecoratorFromThinking,
+        DormancyFromActivity, EmotionCycle, EmotionFromAmbient, EmotionFromBattery,
+        EmotionFromIntent, EmotionFromRemote, EmotionFromTouch, EmotionFromVoice,
+        GazeFromAttention, HeadFromAttention, HeadFromBodyGesture, HeadFromEmotion, HeadFromIntent,
+        IdleDrift, IdleHeadDrift, IdleMicroExpression, IntentFromBodyTouch, IntentFromLoud,
+        LostTargetSearch, MicrosaccadeFromAttention, MouthFromAudio, RemoteCommandModifier,
+        Soliloquy, StyleFromEmotion, StyleFromIntent, StyleFromMood,
     },
     render_leds,
     skills::{Handling, Listening, Petting},
@@ -269,6 +269,7 @@ async fn render_task(
     let mut decorator_from_listening = DecoratorFromListening::new();
     let mut decorator_from_loud = DecoratorFromLoud::new();
     let mut decorator_from_shake = DecoratorFromShake::new();
+    let mut decorator_from_thinking = DecoratorFromThinking::new();
     // `behavior.battery_icon_enabled` flips at boot via STACKCHAN.RON;
     // if the operator later toggles it via PUT /settings, the change
     // takes effect on the next reboot (same as soliloquy_enabled
@@ -391,6 +392,9 @@ async fn render_task(
         .expect("registry full");
     director
         .add_modifier(&mut decorator_from_listening)
+        .expect("registry full");
+    director
+        .add_modifier(&mut decorator_from_thinking)
         .expect("registry full");
     director
         .add_modifier(&mut battery_overlay)
@@ -533,6 +537,16 @@ async fn render_task(
                     // sidecar URL is configured.
                     stackchan_firmware::agent_sidecar::PTT_TRIGGER.signal(duration_ms);
                     entity.input.remote_command = Some(RemoteCommand::StartListen { duration_ms });
+                }
+                RemoteCommand::EnterThinking { hold_ms } => {
+                    // Sidecar-internal transition: the agent task
+                    // fires this onto the same signal once the PCM
+                    // capture window closes and the HTTP round-trip
+                    // begins. Forward to the modifier to swap the
+                    // face from Listening (Ear) to Thinking
+                    // (thought-bubble) while the network request is
+                    // in flight.
+                    entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms });
                 }
                 other => entity.input.remote_command = Some(other),
             }

--- a/crates/stackchan-sim/src/lib.rs
+++ b/crates/stackchan-sim/src/lib.rs
@@ -694,4 +694,90 @@ mod integration_tests {
         director.run(&mut avatar, Instant::from_millis(10_400));
         assert_eq!(avatar.face.style.blink_rate_scale, SCALE_DEFAULT);
     }
+
+    /// End-to-end voice loop: an operator triggers `StartListen`,
+    /// then the agent-sidecar task fires `EnterThinking` once PCM
+    /// capture closes, then a sidecar reply lands as `SetEmotion`.
+    ///
+    /// The visible face state must transition
+    /// `Ear → Thinking → emotion-driven decorator (or none)` across
+    /// these three frames, with the `SetEmotion` arrival clearing
+    /// the thinking attention so the thought-bubble fades and the
+    /// emotion + speech bubble carry the reply.
+    #[test]
+    fn voice_loop_listen_then_think_then_reply_clears_thinking() {
+        use stackchan_core::Decorator;
+        use stackchan_core::Instant;
+        use stackchan_core::input::RemoteCommand;
+        use stackchan_core::mind::Attention;
+        use stackchan_core::modifiers::{
+            DecoratorExpiry, DecoratorFromListening, DecoratorFromThinking, RemoteCommandModifier,
+        };
+
+        let mut entity = Entity::default();
+        let mut remote = RemoteCommandModifier::new();
+        let mut decorator_listening = DecoratorFromListening::new();
+        let mut decorator_thinking = DecoratorFromThinking::new();
+        let mut decorator_expiry = DecoratorExpiry::new();
+
+        let mut director = Director::new();
+        director.add_modifier(&mut remote).unwrap();
+        director.add_modifier(&mut decorator_expiry).unwrap();
+        director.add_modifier(&mut decorator_listening).unwrap();
+        director.add_modifier(&mut decorator_thinking).unwrap();
+
+        // 1. Operator-driven `POST /listen` lands a StartListen.
+        entity.input.remote_command = Some(RemoteCommand::StartListen {
+            duration_ms: 30_000,
+        });
+        director.run(&mut entity, Instant::from_millis(0));
+        assert!(matches!(entity.mind.attention, Attention::Listening { .. }));
+        assert!(matches!(
+            entity.face.decorator,
+            Some(d) if d.kind == Decorator::Ear
+        ));
+
+        // 2. Agent-sidecar task fires EnterThinking once the PCM
+        //    capture window closes and the HTTP round-trip begins.
+        entity.input.remote_command = Some(RemoteCommand::EnterThinking { hold_ms: 15_000 });
+        director.run(&mut entity, Instant::from_millis(3_000));
+        assert!(matches!(entity.mind.attention, Attention::Thinking { .. }));
+        assert!(matches!(
+            entity.face.decorator,
+            Some(d) if d.kind == Decorator::Thinking
+        ));
+
+        // The thinking decorator armed at t=3000 has expires_at=3500
+        // (500ms tail). Sidecar replies typically land mid-tail.
+        // Drive the reply at t=3200 so we observe the tail behavior
+        // before DecoratorExpiry sweeps.
+        //
+        // 3. Sidecar reply lands. SetEmotion arrives via
+        //    REMOTE_COMMAND_SIGNAL; the RemoteCommandModifier's
+        //    SetEmotion handler clears the in-flight thinking hold
+        //    as a side effect, so attention drops to None. The
+        //    decorator slot still reads Thinking until the 500ms
+        //    tail expires — DecoratorExpiry fades it cleanly.
+        entity.input.remote_command = Some(RemoteCommand::SetEmotion {
+            emotion: Emotion::Happy,
+            hold_ms: 2_500,
+        });
+        director.run(&mut entity, Instant::from_millis(3_200));
+        assert_eq!(entity.mind.attention, Attention::None);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
+        assert!(
+            matches!(
+                entity.face.decorator,
+                Some(d) if d.kind == Decorator::Thinking
+            ),
+            "thought-bubble still drawing during the tail window"
+        );
+
+        // 4. Past the tail — DecoratorExpiry sweeps the thought-bubble.
+        director.run(&mut entity, Instant::from_millis(4_000));
+        assert!(
+            entity.face.decorator.is_none(),
+            "DecoratorExpiry must clear the thought-bubble after the 500ms tail"
+        );
+    }
 }

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -109,6 +109,14 @@ returns:
 Response status must be `2xx`. Anything else (4xx, 5xx) is treated
 as a failure and surfaces as a `sidecar: post failed` toast.
 
+The avatar's face mirrors the round-trip in three beats:
+`Listening` (Ear decorator) during PCM capture →
+`Thinking` (thought-bubble) while the POST is in flight →
+the emotion + speech bubble carrying the reply. The thinking hold
+clears the instant a `SetEmotion` lands, so the bubble fades in
+sync with the visible reply. If the round-trip times out or fails,
+the hold expires naturally after 15 s.
+
 Backslash-escaped quotes inside the value strings are not handled
 by the firmware-side parser. A well-behaved sidecar emits clean
 ASCII / UTF-8 strings without embedded quotes; if literal quotes


### PR DESCRIPTION
## Summary

Mirrors the sidecar companion's new "thinking" pill (#391) on the LCD face itself, so the device reads the listening → thinking → reply transitions, not only the operator-facing UI.

Voice loop on the face today: ear decorator during PCM capture → (nothing during the 1–3 s sidecar round-trip) → emotion + speech bubble carrying the reply. With this PR the round-trip window gets its own face state — a thought-bubble cluster paired with `Attention::Thinking` — so a glance reads the round-trip is in flight, not stalled.

### Engine surface

- **`Attention::Thinking { since }`** — new variant alongside `Listening`. `HeadFromAttention` matches both for the cocked-head listen-tilt, so the head pose holds steady across the capture → round-trip boundary instead of releasing and re-applying.
- **`Decorator::Thinking`** — new variant. Anime thought-bubble cluster: stroked outer bubble + two filled trail-dots in a rising diagonal, anchored upper-right (the existing `Ear` is upper-left, so a glance distinguishes the two phases even when the underlying state is single-slot). Wire string `"thinking"`, wire byte `7` — append-only, no break to existing consumers.
- **`DecoratorFromThinking`** — new modifier. Re-arm-every-frame + 500 ms tail, exact shape of `DecoratorFromListening`.
- **`RemoteCommand::EnterThinking { hold_ms }`** — new variant. `RemoteCommandModifier` sets `Attention::Thinking` with hold; `SetEmotion` handler clears any active Thinking hold as a side effect, so the thought-bubble fades the instant a reply arrives.

### Firmware wiring

`agent_sidecar` fires `EnterThinking` onto `REMOTE_COMMAND_SIGNAL` once `capture_window` closes, with `hold_ms = REQUEST_TIMEOUT_MS` so the bubble has an upper bound on pathological reply latency. The success path's existing `SetEmotion` does the clear via the modifier side effect — no separate Exit signal needed, no race risk.

### Tests

- 7 new unit tests on `RemoteCommandModifier` covering the new variant's entry, re-assert, expiry, supersede-listen, reset, and the `SetEmotion`-clears-Thinking side effect (including the foreign-Thinking guard).
- 4 new unit tests on `DecoratorFromThinking` mirroring `DecoratorFromListening`'s shape.
- New sim integration test `voice_loop_listen_then_think_then_reply_clears_thinking` drives the full Listening → Thinking → reply → tail-expiry trajectory through the Director.

## Test plan

- [x] `just check` — fmt + clippy (workspace, exc. firmware + esp-tflite-micro-sys) + 477 host tests + sim integration tests
- [x] `cargo +esp clippy --release -- -D warnings` (firmware) — clean
- [x] `cargo +esp build --release` (firmware) — links
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features` — clean
- [ ] On-device verification — exercise the voice loop with a configured sidecar URL and confirm the face transitions Ear → Thinking → reply on a real CoreS3