### PR TITLE
feat(firmware): face-level Sad reaction on sidecar failure paths

### DIFF
--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -304,11 +304,13 @@ pub async fn agent_sidecar_task(
 
         // Swap the face from Listening (Ear) to Thinking
         // (thought-bubble) for the network round-trip. Hold is sized
-        // to the request timeout so the bubble has an upper bound on
-        // pathological reply latency. A successful reply fires
-        // `RemoteCommand::SetEmotion` below, which clears the
-        // thinking hold via the modifier's SetEmotion side effect.
-        // On timeout or POST failure the hold expires naturally.
+        // to the request timeout as an upper bound on pathological
+        // reply latency. Every exit path clears the hold actively:
+        // a successful reply with an emotion tag fires `SetEmotion`
+        // (whose modifier side effect clears the hold); success
+        // without an emotion fires `ExitThinking`; and the failure /
+        // timeout paths fire `signal_failure_emotion()`, whose
+        // `SetEmotion(Sad)` clears the hold the same way.
         REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::EnterThinking {
             #[allow(
                 clippy::cast_possible_truncation,

--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -31,6 +31,12 @@
 //!    the in-flight thinking hold as a side effect, so the
 //!    thought-bubble fades out at the same instant the emotion +
 //!    speech-bubble carry the reply.
+//! 5. Every failure path (link down, POST failed, timeout) fires
+//!    [`RemoteCommand::SetEmotion`] with [`Emotion::Sad`] for a
+//!    2.5 s hold so the face visibly registers the failure
+//!    instead of just printing a toast. The same `SetEmotion`
+//!    side effect clears any in-flight thinking hold on the
+//!    paths where one was opened.
 //!
 //! Empty `agent_sidecar_url` (the default) parks the task — no
 //! socket, no pubsub slot, no PTT consumer.
@@ -292,6 +298,7 @@ pub async fn agent_sidecar_task(
         if !matches!(link.get().await, WifiLinkState::Connected) {
             defmt::warn!("agent-sidecar: link not Connected after capture; skipping POST");
             toast_warn("sidecar: link down");
+            signal_failure_emotion();
             continue;
         }
 
@@ -391,9 +398,13 @@ async fn capture_window(
     pcm
 }
 
-/// Apply the [`post_pcm`] result: surface a toast in every branch
-/// and fire [`RemoteCommand::SetEmotion`] on success when the reply
-/// carries an emotion tag.
+/// Apply the [`post_pcm`] result: surface a toast in every branch,
+/// fire [`RemoteCommand::SetEmotion`] with the tagged emotion on a
+/// successful reply, and fall back to either [`ExitThinking`] (success
+/// with no emotion tag) or a brief Sad face (POST failed, timeout) so
+/// the avatar's visible state always matches what just happened.
+///
+/// [`ExitThinking`]: stackchan_core::input::RemoteCommand::ExitThinking
 fn apply_outcome(
     outcome: Result<
         Result<(heapless::String<256>, Option<Emotion>), PostError>,
@@ -425,7 +436,7 @@ fn apply_outcome(
         Ok(Err(e)) => {
             defmt::warn!("agent-sidecar: POST failed ({:?})", e);
             toast_warn("sidecar: post failed");
-            REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::ExitThinking);
+            signal_failure_emotion();
         }
         Err(_) => {
             defmt::warn!(
@@ -433,9 +444,29 @@ fn apply_outcome(
                 REQUEST_TIMEOUT_MS
             );
             toast_warn("sidecar: timed out");
-            REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::ExitThinking);
+            signal_failure_emotion();
         }
     }
+}
+
+/// Brief face-level reaction to a sidecar failure path. Fires a
+/// short-hold [`Emotion::Sad`] so the avatar visibly registers the
+/// "I tried and couldn't" beat, complementing the warn-class toast
+/// the operator sees in the band beneath the face.
+///
+/// Doubles as the thinking-hold clear on every code path where a
+/// thinking window was opened (post-failed, timeout): the
+/// `RemoteCommandModifier` clears `Attention::Thinking` as a side
+/// effect of any `SetEmotion`, so the thought-bubble fades on the
+/// same tick the Sad face takes over. The link-down path also fires
+/// this even though no thinking window opened — the clear side effect
+/// is a no-op there, and the Sad face still reads as the failure
+/// signal.
+fn signal_failure_emotion() {
+    REMOTE_COMMAND_SIGNAL.signal(RemoteCommand::SetEmotion {
+        emotion: Emotion::Sad,
+        hold_ms: 2_500,
+    });
 }
 
 /// Sample count per body-write chunk. 512 i16 samples → 1 KiB of

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -119,8 +119,9 @@ The avatar's face mirrors the round-trip in three beats:
 `Thinking` (thought-bubble) while the POST is in flight →
 the emotion + speech bubble carrying the reply. The thinking hold
 clears the instant a `SetEmotion` lands, so the bubble fades in
-sync with the visible reply. If the round-trip times out or fails,
-the hold expires naturally after 15 s.
+sync with the visible reply. On a POST failure or timeout, the
+firmware fires `SetEmotion` with `Emotion::Sad` for 2.5 s, so the
+face visibly registers the failure on top of the warn-class toast.
 
 Backslash-escaped quotes inside the value strings are not handled
 by the firmware-side parser. A well-behaved sidecar emits clean

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -119,9 +119,10 @@ The avatar's face mirrors the round-trip in three beats:
 `Thinking` (thought-bubble) while the POST is in flight →
 the emotion + speech bubble carrying the reply. The thinking hold
 clears the instant a `SetEmotion` lands, so the bubble fades in
-sync with the visible reply. On a POST failure or timeout, the
-firmware fires `SetEmotion` with `Emotion::Sad` for 2.5 s, so the
-face visibly registers the failure on top of the warn-class toast.
+sync with the visible reply. On any failure path — link-down,
+POST failure, or timeout — the firmware fires `SetEmotion` with
+`Emotion::Sad` for 2.5 s, so the face visibly registers the
+failure on top of the warn-class toast.
 
 Backslash-escaped quotes inside the value strings are not handled
 by the firmware-side parser. A well-behaved sidecar emits clean

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -33,10 +33,11 @@ underlying audio capture path, see [UDP audio debug](audio-debug.md).
    the tag, and the reply text scrolls in the toast band beneath
    the face.
 
-If the sidecar fails or times out, the thought-bubble fades and a
-warn-class toast (`sidecar: post failed`, `sidecar: timed out`,
-`sidecar: link down`) explains what happened. The avatar returns
-to autonomous behavior on the next tick.
+If the sidecar fails or times out, the thought-bubble fades, the
+face flips to Sad for ~2.5 s, and a warn-class toast (`sidecar:
+post failed`, `sidecar: timed out`, `sidecar: link down`) explains
+what happened. The avatar returns to autonomous behavior after the
+hold expires.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Round-trip success paths got a face-level reaction in #394 (Sad face mirrors the agent's `emotion` tag, or just clear-thinking on no-emotion). Failure paths still only surfaced as a warn-class toast — the avatar's face stayed neutral and the operator had to read the toast band to know anything went wrong.

This wires every sidecar failure path to also fire `RemoteCommand::SetEmotion(Sad, 2500ms)`:

- **Link down** (Wi-Fi vanished between PTT trigger and POST) — fires Sad. No thinking window was opened on this path, so the clear-thinking side effect is a no-op.
- **POST failed** (connect/write/read/non-2xx/missing-text) — fires Sad; the SetEmotion-clears-Thinking side effect from #394 doubles as the thought-bubble fade, replacing the explicit `ExitThinking` call.
- **Timeout** (request exceeded 15 s) — same shape as POST failed.

Net behavior on every failure path is now: thought-bubble fades, face flips Sad for 2.5 s, toast carries the precise reason. The avatar returns to autonomous behavior when the 2.5 s emotion hold expires.

## Test plan

- [x] `just check` — fmt + clippy + 480 host tests, doc-drift, machete (clean)
- [x] `cargo +esp clippy --release -D warnings` (firmware) — clean
- [ ] On-device verification — point at an unreachable sidecar URL, hit `POST /listen`, observe Sad face after the 15 s timeout