### PR TITLE
feat(web): Reset-to-defaults buttons on Tracker + Head offsets sections

### DIFF
--- a/web/src/components/Calibration.tsx
+++ b/web/src/components/Calibration.tsx
@@ -278,6 +278,9 @@ export function Calibration() {
         <button type="button" onClick={() => void loadSettings()}>
           Reload
         </button>
+        <button type="button" onClick={() => setTracker(TRACKER_DEFAULT)} title="Revert local edits to firmware defaults (does not persist; click Save to apply).">
+          Reset to defaults
+        </button>
       </div>
 
       <h3>Head offsets</h3>
@@ -315,6 +318,9 @@ export function Calibration() {
         </button>
         <button type="button" onClick={() => void loadOffsets()}>
           Reload
+        </button>
+        <button type="button" onClick={() => setOffsets(HEAD_OFFSETS_DEFAULT)} title="Revert local edits to zero (does not persist; click Save to apply).">
+          Reset to zero
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

Small UX polish for the Calibration dashboard page (`web/src/components/Calibration.tsx`). The component already covers the full calibration surface end-to-end — camera capture, tracker FOV / smoothing / flips, head yaw / tilt sliders, save buttons. The one tactile gap during a bench session is reverting local edits without committing them: the only path was to drag every slider back manually or click Reload (which fetches the *persisted* value, blowing away local edits along the way).

Two new buttons, each scoped to its section:

- **Tracker → "Reset to defaults"** — resets local tracker state to `TRACKER_DEFAULT` (mirrors the firmware's `TrackerSettings::DEFAULT` shape from `stackchan-net::config`).
- **Head offsets → "Reset to zero"** — resets local offsets to `{ yaw_offset_deg: 0, tilt_offset_deg: 0 }`.

Neither button persists; the operator still clicks Save to apply. Tooltips explain the "local-only" semantics so an accidental click during a session is recoverable (one undo).

## Test plan

- [x] `just web-build` — typecheck + bundle clean (`web/dist/index.html.gz` regenerated, 25.6 KB gzipped)
- [x] `just check` — workspace gates clean