### PR TITLE
test(core): bolster idle_drift coverage — lockstep + distinct-seeds-diverge

### DIFF
--- a/crates/stackchan-core/src/modifiers/idle_drift.rs
+++ b/crates/stackchan-core/src/modifiers/idle_drift.rs
@@ -161,7 +161,9 @@ impl Modifier for IdleDrift {
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
-    reason = "test literals are compile-time non-zero; the unwrap can't fire"
+    clippy::similar_names,
+    reason = "test literals are compile-time non-zero; the unwrap can't fire. \
+              Paired left_/right_ delta bindings are the natural names."
 )]
 mod tests {
     use super::*;
@@ -226,5 +228,65 @@ mod tests {
         for _ in 0..100 {
             assert_eq!(a.next_u32(), b.next_u32());
         }
+    }
+
+    /// Both eyes shift by the same delta on every drift — the
+    /// lockstep invariant. Drives 20 drift cycles and asserts each
+    /// time that `right_delta == left_delta` on both axes. A future
+    /// refactor that decoupled per-eye offsets would surface here.
+    #[test]
+    fn both_eyes_shift_in_lockstep() {
+        let mut entity = at(0);
+        let left_baseline = entity.face.left_eye.center;
+        let right_baseline = entity.face.right_eye.center;
+        let mut drift = IdleDrift::with_seed(NonZeroU32::new(42).unwrap());
+
+        for i in 0..20 {
+            entity.tick.now = Instant::from_millis(i * DEFAULT_INTERVAL_MS);
+            drift.update(&mut entity);
+            let left_dx = entity.face.left_eye.center.x - left_baseline.x;
+            let left_dy = entity.face.left_eye.center.y - left_baseline.y;
+            let right_dx = entity.face.right_eye.center.x - right_baseline.x;
+            let right_dy = entity.face.right_eye.center.y - right_baseline.y;
+            assert_eq!(
+                left_dx, right_dx,
+                "tick {i}: eye-x drifts diverged — left={left_dx}, right={right_dx}"
+            );
+            assert_eq!(
+                left_dy, right_dy,
+                "tick {i}: eye-y drifts diverged — left={left_dy}, right={right_dy}"
+            );
+        }
+    }
+
+    /// Two `IdleDrift`s seeded with distinct values must produce
+    /// distinct eye positions within a handful of drift cycles. The
+    /// firmware seeds from `esp_hal::rng::Rng` per boot so multi-unit
+    /// deployments don't drift in unison; this pins the contract.
+    /// Complements `seeded_rng_is_deterministic` (which asserts same
+    /// seed → same sequence) by asserting the inverse.
+    #[test]
+    fn distinct_seeds_produce_divergent_drifts() {
+        let mut entity_a = at(0);
+        let mut entity_b = at(0);
+        let mut drift_a = IdleDrift::with_seed(NonZeroU32::new(0x1234_5678).unwrap());
+        let mut drift_b = IdleDrift::with_seed(NonZeroU32::new(0xCAFE_BABE).unwrap());
+
+        let mut diverged = false;
+        for i in 0..10 {
+            let now = Instant::from_millis(i * DEFAULT_INTERVAL_MS);
+            entity_a.tick.now = now;
+            entity_b.tick.now = now;
+            drift_a.update(&mut entity_a);
+            drift_b.update(&mut entity_b);
+            if entity_a.face.left_eye.center != entity_b.face.left_eye.center {
+                diverged = true;
+                break;
+            }
+        }
+        assert!(
+            diverged,
+            "two distinct seeds produced identical drift sequences over 10 cycles"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #402 (microsaccade tests). Same shape applied to the sister modifier `IdleDrift`, which had 4 tests covering "first tick schedules drift," "drift fires within interval," "drifts stay bounded," and same-seed determinism.

Two new tests close the remaining gaps:

- **`both_eyes_shift_in_lockstep`** — drives 20 drift cycles and asserts per-tick that `right_delta == left_delta` on both axes. Pins the documented invariant that one offset is applied to both eye centres.
- **`distinct_seeds_produce_divergent_drifts`** — complements `seeded_rng_is_deterministic` (same seed → same sequence) with its inverse (distinct seeds → distinct sequences within 10 cycles). Firmware seeds from `esp_hal::rng::Rng` at boot specifically to keep two units from drifting in unison; this pins that contract.

Extends the test-mod's existing `#[allow(clippy::unwrap_used)]` block to also allow `clippy::similar_names` for paired left_/right_ delta bindings (same precedent as #402 on microsaccade).

## Test plan

- [x] `just check` — fmt + clippy + 490 + 2 new tests, doc-drift, machete (clean)
- [x] `cargo test -p stackchan-core --lib idle_drift` — all 6 tests pass