### PR TITLE
chore(firmware): clean up rustdoc baseline — 48 warnings → 0

### DIFF
--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -229,7 +229,7 @@ impl defmt::Format for PostError {
 /// - Wait for [`PTT_TRIGGER`].
 /// - Drain pre-trigger pubsub backlog.
 /// - Accumulate frames for `duration_ms` (clamped to
-///   [`CAPTURE_DURATION_CAP_MS`]).
+///   `CAPTURE_DURATION_CAP_MS`).
 /// - POST the PCM to `sidecar_url`.
 /// - Surface the reply via toast; fire `SetEmotion` if tagged.
 ///

--- a/crates/stackchan-firmware/src/audio.rs
+++ b/crates/stackchan-firmware/src/audio.rs
@@ -24,15 +24,15 @@
 //! 7. Run RX + TX loops concurrently inside the same embassy task via
 //!    `embassy_futures::join`:
 //!    - RX (`run_rms_loop`): pop DMA samples, compute linear RMS over
-//!      each [`RMS_WINDOW_SAMPLES`]-sample window, normalise against
+//!      each `RMS_WINDOW_SAMPLES`-sample window, normalise against
 //!      full-scale i16, publish on [`AUDIO_RMS_SIGNAL`].
-//!    - TX (`run_tx_loop`): play queued [`AudioClip`]s back-to-back,
+//!    - TX (`run_tx_loop`): play queued `AudioClip`s back-to-back,
 //!      filling with digital silence between/after clips so the
 //!      AW88298 stays clock-locked. Higher-level code (low-battery
 //!      alerts, pickup chirps, startle chirps, etc.) enqueues clips
-//!      via [`try_enqueue_clip`] and the typed
-//!      [`try_enqueue_wake_chirp`] / [`try_enqueue_pickup_chirp`] /
-//!      [`try_enqueue_startle_chirp`] / [`try_enqueue_low_battery_alert`]
+//!      via `try_enqueue_clip` and the typed
+//!      `try_enqueue_wake_chirp` / `try_enqueue_pickup_chirp` /
+//!      `try_enqueue_startle_chirp` / `try_enqueue_low_battery_alert`
 //!      helpers.
 //!
 //! This matches esp-bsp's ordering in `bsp_audio_codec_microphone_init`:
@@ -483,12 +483,12 @@ pub const AUDIO_FRAME_MAX_SUBSCRIBERS: usize = 4;
 
 /// Maximum simultaneous publishers on [`AUDIO_FRAME_PUBSUB`].
 ///
-/// Only [`run_rms_loop`] produces frames; pinned at `1` to make the
+/// Only `run_rms_loop` produces frames; pinned at `1` to make the
 /// single-producer contract explicit at the type level and catch an
 /// accidental second publisher at compile time.
 pub const AUDIO_FRAME_MAX_PUBLISHERS: usize = 1;
 
-/// One PCM capture frame published by [`run_rms_loop`].
+/// One PCM capture frame published by `run_rms_loop`.
 ///
 /// Mono 16-bit signed samples at [`SAMPLE_RATE_HZ`]. Each frame is
 /// `AUDIO_FRAME_SAMPLES` long; consumers reassemble a continuous
@@ -506,7 +506,7 @@ pub struct AudioFrame {
     pub sequence: u32,
 }
 
-/// PCM capture pub-sub — single-publisher ([`run_rms_loop`]) /
+/// PCM capture pub-sub — single-publisher (`run_rms_loop`) /
 /// multi-subscriber.
 ///
 /// Each subscriber gets its own read cursor; a lagging subscriber
@@ -537,7 +537,7 @@ pub static AUDIO_FRAME_CAPTURED: AtomicU32 = AtomicU32::new(0);
 /// `true` while the TX feeder has a clip in flight.
 ///
 /// Set / cleared once per DMA push (~32 ms cadence) inside
-/// [`run_tx_loop`]. The render task reads this each frame and gates
+/// `run_tx_loop`. The render task reads this each frame and gates
 /// `entity.perception.audio_rms` to `None` while playing — without
 /// the gate, the speaker output would re-trigger sound-reactive
 /// modifiers (`EmotionFromVoice` / `IntentFromLoud`) on its own chirps.

--- a/crates/stackchan-firmware/src/ble/bonds.rs
+++ b/crates/stackchan-firmware/src/ble/bonds.rs
@@ -4,7 +4,7 @@
 //! straight into an encrypted link without re-running the passkey
 //! dance. Each successful pairing appends to the in-memory bond
 //! list trouble-host maintains; we mirror the list onto SD so the
-//! next boot can re-register them via [`Stack::add_bond_information`].
+//! next boot can re-register them via `Stack::add_bond_information`.
 //!
 //! ## Wire format
 //!

--- a/crates/stackchan-firmware/src/ble/desktop.rs
+++ b/crates/stackchan-firmware/src/ble/desktop.rs
@@ -76,7 +76,7 @@ impl DesktopSession {
     /// through the parser, and publish each parsed [`Inbound`] onto
     /// [`DESKTOP_INBOUND`].
     ///
-    /// Parse failures are counted in [`Self::parse_failures`] and
+    /// Parse failures are counted in `Self::parse_failures` and
     /// logged at `warn` level. The connection is NOT torn down on
     /// parse failure: per spec the desktop is forward-compatible
     /// authority over the schema, and the right firmware response

--- a/crates/stackchan-firmware/src/ble/mod.rs
+++ b/crates/stackchan-firmware/src/ble/mod.rs
@@ -33,7 +33,7 @@
 //!
 //! Pairing: LE Secure Connections with `IoCapabilities::DisplayOnly`.
 //! On the first `PassKeyDisplay` event the 6-digit passkey is latched
-//! into [`PASSKEY_DISPLAY`] and the render task overlays it on the
+//! into `PASSKEY_DISPLAY` and the render task overlays it on the
 //! LCD. Bonds are persisted to the SD card via [`bonds`] so a
 //! re-paired peer skips the passkey dance.
 //!

--- a/crates/stackchan-firmware/src/button.rs
+++ b/crates/stackchan-firmware/src/button.rs
@@ -1,7 +1,7 @@
 //! AXP2101 power-button polling task — short-tap + long-press routing.
 //!
 //! Polls the AXP2101's `IRQ_STATUS_1` at 50 ms (20 Hz) for the
-//! [`IRQ_PRESS_EDGE_BIT`] / [`IRQ_RELEASE_EDGE_BIT`] flags
+//! `IRQ_PRESS_EDGE_BIT` / `IRQ_RELEASE_EDGE_BIT` flags
 //! ([`axp2101::IRQ_PRESS_EDGE_BIT`] etc), times the gap in software,
 //! and routes the result:
 //!

--- a/crates/stackchan-firmware/src/crash.rs
+++ b/crates/stackchan-firmware/src/crash.rs
@@ -76,7 +76,7 @@ static RECORDING: AtomicBool = AtomicBool::new(false);
 /// # Safety
 ///
 /// Touches the `static mut CRASH_LATCH`. Panic handlers run with
-/// every other CPU activity suspended, and [`RECORDING`] serialises
+/// every other CPU activity suspended, and `RECORDING` serialises
 /// re-entrant calls.
 pub fn record_panic(info: &PanicInfo<'_>) {
     if RECORDING.swap(true, Ordering::SeqCst) {

--- a/crates/stackchan-firmware/src/desktop_permission.rs
+++ b/crates/stackchan-firmware/src/desktop_permission.rs
@@ -18,7 +18,7 @@
 //! Single taps are too easy to fat-finger on a device that lives on
 //! a desk surrounded by other things. The pattern instead requires
 //! two taps of the same zone within
-//! [`TAP_TWICE_WINDOW_MS`] for a decision to commit. The left zone
+//! `TAP_TWICE_WINDOW_MS` for a decision to commit. The left zone
 //! decides **deny**, the right zone decides **approve once** (the
 //! only two values the wire protocol carries today). The center
 //! zone clears any armed half-tap.

--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -19,7 +19,7 @@
 //! | Pan   | 1 (yaw)     | `+pan_deg` → bigger step count |
 //! | Tilt  | 2 (pitch)   | `+tilt_deg` → bigger step count |
 //!
-//! Invert a direction by flipping [`PAN_DIRECTION`] / [`TILT_DIRECTION`]
+//! Invert a direction by flipping `PAN_DIRECTION` / `TILT_DIRECTION`
 //! to `-1.0`. The sign-discovery step is the first bench-test with a
 //! real unit; until then both default to `+1.0`.
 //!

--- a/crates/stackchan-firmware/src/ir.rs
+++ b/crates/stackchan-firmware/src/ir.rs
@@ -9,7 +9,7 @@
 //! ## CoreS3 pin caveat
 //!
 //! The memory cheat-sheet doesn't list the IR receiver's GPIO, so
-//! [`IR_RX_PIN`] is a best-guess `GPIO21` — the pin most commonly used
+//! `IR_RX_PIN` is a best-guess `GPIO21` — the pin most commonly used
 //! on M5Stack boards for IR RX. Flash the firmware and, if no IR
 //! frames decode even with a working remote + `ir-bench`, update
 //! the const against the actual CoreS3 schematic.
@@ -34,7 +34,7 @@ use ir_nec::{NecCommand, Pulse};
 /// Raw NEC commands decoded from the IR receiver: IR task → render task.
 ///
 /// The render task drains via [`Signal::try_take`] each frame and calls
-/// [`stackchan_core::modifiers::EmotionFromRemote::queue`] with the
+/// `stackchan_core::modifiers::EmotionFromRemote::queue` with the
 /// `(address, command)` pair. Signal semantics (latest wins, no backlog)
 /// mean if the user mashes buttons between render ticks, only the most
 /// recent command actually acts — acceptable for an emotion-control UX.

--- a/crates/stackchan-firmware/src/net/esp_now.rs
+++ b/crates/stackchan-firmware/src/net/esp_now.rs
@@ -13,10 +13,10 @@
 //! 3. RX: honour the pairing window — when [`PAIR_WINDOW`] is signalled
 //!    (by `POST /pair`), accept frames from senders that aren't on
 //!    the static-peer allowlist; outside the window, drop them.
-//! 4. TX: every [`TX_TICK_MS`] poll the avatar snapshot; emit a
+//! 4. TX: every `TX_TICK_MS` poll the avatar snapshot; emit a
 //!    `PoseMirror` frame when the pose moved by more than
-//!    [`POSE_TX_EPSILON_DEG`], and a `Heartbeat` frame at
-//!    [`HEARTBEAT_INTERVAL_MS`] cadence (skipped when a pose-mirror
+//!    `POSE_TX_EPSILON_DEG`, and a `Heartbeat` frame at
+//!    `HEARTBEAT_INTERVAL_MS` cadence (skipped when a pose-mirror
 //!    went out in the same tick — they double as liveness).
 //!
 //! TX targets the broadcast MAC. ESP-NOW broadcast can't be encrypted,

--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -51,7 +51,7 @@ use super::wifi::{WIFI_LINK_WATCH, WifiLinkState};
 
 /// Latest-wins pose lifted from a leader's mDNS TXT record.
 ///
-/// Set by [`serve_loop`] whenever an inbound multicast packet
+/// Set by `serve_loop` whenever an inbound multicast packet
 /// carries a TXT record matching the configured
 /// `behavior.follower_leader_hostname`. Drained by the follower
 /// task ([`crate::net::mdns_follower::follower_task`]) which

--- a/crates/stackchan-firmware/src/net/mdns_follower.rs
+++ b/crates/stackchan-firmware/src/net/mdns_follower.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Hold duration
 //!
-//! The leader's [`PoseAnnouncer`] beats at most every
+//! The leader's `PoseAnnouncer` beats at most every
 //! [`POSE_HEARTBEAT_INTERVAL_MS`] (1 s) even when stationary, so
 //! a 1.5 s hold guarantees the follower never falls back to
 //! autonomy mid-stream from a single dropped multicast packet.

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -367,7 +367,7 @@ static LAST_PUBLISHED: Mutex<CriticalSectionRawMutex, core::cell::Cell<Option<Av
 ///
 /// Called once per render tick by the render task. Only publishes
 /// when the snapshot has actually changed AND
-/// [`PUBLISH_MIN_INTERVAL_MS`] has elapsed since the last publish.
+/// `PUBLISH_MIN_INTERVAL_MS` has elapsed since the last publish.
 ///
 /// Cheap when no subscribers are connected (the publisher's
 /// `publish_immediate` returns immediately if the channel has no

--- a/crates/stackchan-firmware/src/reminders.rs
+++ b/crates/stackchan-firmware/src/reminders.rs
@@ -4,7 +4,7 @@
 //! pairs a fire deadline (monotonic [`Instant`]) with a phrase to play
 //! when the deadline arrives. A 1 Hz embassy task drains due entries
 //! and dispatches them through the same
-//! [`REMOTE_COMMAND_SIGNAL`](crate::net::http::REMOTE_COMMAND_SIGNAL)
+//! [`REMOTE_COMMAND_SIGNAL`]
 //! that HTTP / MCP / ESP-NOW use, so the audio path stays uniform.
 //!
 //! ## Why monotonic, not wall-clock
@@ -165,7 +165,7 @@ fn drain_due(now: Instant) -> Vec<Reminder, MAX_REMINDERS> {
     })
 }
 
-/// Embassy task — drains due reminders at [`REMINDER_TICK`] cadence
+/// Embassy task — drains due reminders at `REMINDER_TICK` cadence
 /// and dispatches each through `REMOTE_COMMAND_SIGNAL` as a
 /// [`RemoteCommand::Speak`]. The signal is single-waker, so a burst
 /// of simultaneously-due reminders fires sequentially with one tick

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -14,7 +14,7 @@
 //! atomic-write-tested via `STACKCHAN.RON`, and already covered by
 //! the offline-first fallback (the firmware boots fine without an
 //! SD). A future swap to a real NVS backend is a backend-only
-//! change — the public API of [`RuntimeState`] / [`load`] / [`save`]
+//! change — the public API of [`RuntimeState`] / `load` / `save`
 //! stays the same.
 //!
 //! ## Wire format

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -84,7 +84,7 @@ static SHARED_STORAGE: Mutex<CriticalSectionRawMutex, StorageHolder> =
 pub static CONFIG_SNAPSHOT: Mutex<CriticalSectionRawMutex, Option<stackchan_net::Config>> =
     Mutex::new(None);
 
-/// Move `storage` into [`SHARED_STORAGE`], replacing whatever was
+/// Move `storage` into `SHARED_STORAGE`, replacing whatever was
 /// there. Called once from the boot path after a successful mount.
 pub async fn install_storage(storage: FirmwareStorage) {
     SHARED_STORAGE.lock().await.0 = Some(storage);
@@ -376,7 +376,7 @@ where
     ///
     /// [`StorageError::Read`] on a partial / failed read,
     /// [`StorageError::TooLarge`] if the file exceeds
-    /// [`MAX_RUNTIME_BYTES`], [`StorageError::NotUtf8`] if the bytes
+    /// `MAX_RUNTIME_BYTES`, [`StorageError::NotUtf8`] if the bytes
     /// don't decode as UTF-8.
     pub fn read_runtime(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
         let volume = self
@@ -420,7 +420,7 @@ where
     ///
     /// [`StorageError::Read`] on a partial / failed read,
     /// [`StorageError::TooLarge`] if the file exceeds
-    /// [`MAX_SESSION_UUID_BYTES`], [`StorageError::NotUtf8`] if the
+    /// `MAX_SESSION_UUID_BYTES`, [`StorageError::NotUtf8`] if the
     /// bytes don't decode as UTF-8.
     pub fn read_session_uuid(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
         let volume = self
@@ -451,7 +451,7 @@ where
     ///
     /// [`StorageError::Write`] on any underlying write failure,
     /// [`StorageError::TooLarge`] if `uuid` exceeds
-    /// [`MAX_SESSION_UUID_BYTES`].
+    /// `MAX_SESSION_UUID_BYTES`.
     pub fn write_session_uuid(&mut self, uuid: &str) -> Result<(), StorageError> {
         if uuid.len() > MAX_SESSION_UUID_BYTES as usize {
             return Err(StorageError::TooLarge);
@@ -470,7 +470,7 @@ where
     ///
     /// [`StorageError::Read`] on a partial / failed read,
     /// [`StorageError::TooLarge`] if the file exceeds
-    /// [`MAX_DEVICE_NAME_BYTES`], [`StorageError::NotUtf8`] if the
+    /// `MAX_DEVICE_NAME_BYTES`, [`StorageError::NotUtf8`] if the
     /// bytes don't decode as UTF-8.
     pub fn read_device_name(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
         let volume = self
@@ -507,7 +507,7 @@ where
     ///
     /// [`StorageError::Write`] on any underlying write failure,
     /// [`StorageError::TooLarge`] if `name` exceeds
-    /// [`MAX_DEVICE_NAME_BYTES`].
+    /// `MAX_DEVICE_NAME_BYTES`.
     pub fn write_device_name(&mut self, name: &str) -> Result<(), StorageError> {
         if name.len() > MAX_DEVICE_NAME_BYTES as usize {
             return Err(StorageError::TooLarge);
@@ -526,7 +526,7 @@ where
     ///
     /// [`StorageError::Read`] on a partial read,
     /// [`StorageError::TooLarge`] if the file exceeds
-    /// [`MAX_BONDS_BYTES`].
+    /// `MAX_BONDS_BYTES`.
     pub fn read_bonds(&mut self) -> Result<Vec<u8>, StorageError> {
         let volume = self
             .mgr
@@ -556,7 +556,7 @@ where
     ///
     /// [`StorageError::Read`] on a partial read,
     /// [`StorageError::TooLarge`] if the file exceeds
-    /// [`MAX_WAKE_WORD_BYTES`].
+    /// `MAX_WAKE_WORD_BYTES`.
     pub fn read_wake_word_model(&mut self) -> Result<Vec<u8>, StorageError> {
         let volume = self
             .mgr
@@ -612,7 +612,7 @@ where
     ///
     /// [`StorageError::Read`] on a partial / failed read,
     /// [`StorageError::TooLarge`] if the file exceeds
-    /// [`MAX_CRASH_BYTES`], [`StorageError::NotUtf8`] if the bytes
+    /// `MAX_CRASH_BYTES`, [`StorageError::NotUtf8`] if the bytes
     /// don't decode as UTF-8.
     pub fn read_crash(&mut self) -> Result<Option<alloc::string::String>, StorageError> {
         let volume = self
@@ -749,7 +749,7 @@ where
     ///
     /// [`StorageError::Write`] on any underlying write failure,
     /// [`StorageError::TooLarge`] if `data` exceeds
-    /// [`MAX_BONDS_BYTES`].
+    /// `MAX_BONDS_BYTES`.
     pub fn write_bonds(&mut self, data: &[u8]) -> Result<(), StorageError> {
         // `usize > MAX_BONDS_BYTES as usize` is the strictly-stronger
         // form: covers both targets where `usize` is 32 bits (firmware,

--- a/crates/stackchan-firmware/src/wake_word.rs
+++ b/crates/stackchan-firmware/src/wake_word.rs
@@ -24,7 +24,7 @@
 //! When the output score crosses the operator-supplied threshold
 //! (`behavior.wake_word_threshold`, default `100`), the task
 //! signals [`crate::net::http::REMOTE_COMMAND_SIGNAL`] with
-//! [`RemoteCommand::StartListen`] for [`POST_WAKE_CAPTURE_MS`]. The
+//! [`RemoteCommand::StartListen`] for `POST_WAKE_CAPTURE_MS`. The
 //! render loop drains the signal and applies the same effects as
 //! an operator-initiated `POST /listen`: trigger the sidecar PCM
 //! capture *and* hand the variant to the modifier graph so the

--- a/crates/stackchan-firmware/src/watchdog.rs
+++ b/crates/stackchan-firmware/src/watchdog.rs
@@ -3,7 +3,7 @@
 //!
 //! Each periodic producer task (audio RMS loop, IMU, ambient, power,
 //! head) calls [`Channel::beat`] once per loop iteration. Every
-//! [`WATCHDOG_PERIOD_MS`], the watchdog task reads each counter, diffs
+//! `WATCHDOG_PERIOD_MS`, the watchdog task reads each counter, diffs
 //! against the previous poll, and emits a `defmt::warn!` if the actual
 //! delta falls below the channel's expected minimum.
 //!
@@ -31,7 +31,7 @@ const WATCHDOG_PERIOD_MS: u64 = 5_000;
 /// One monitored producer task.
 ///
 /// Cadence-aware: `min_per_window` is the smallest beat count we accept
-/// inside a [`WATCHDOG_PERIOD_MS`] poll window before we consider the
+/// inside a `WATCHDOG_PERIOD_MS` poll window before we consider the
 /// channel silent. Set conservatively (~50% of nominal) to absorb
 /// scheduler jitter without false-positives.
 pub struct Channel {
@@ -42,7 +42,7 @@ pub struct Channel {
     /// Counter value at the previous watchdog poll. The watchdog task
     /// swaps this in `check_and_reset`.
     last_polled: AtomicU32,
-    /// Minimum beats expected per [`WATCHDOG_PERIOD_MS`] window.
+    /// Minimum beats expected per `WATCHDOG_PERIOD_MS` window.
     min_per_window: u32,
 }
 
@@ -86,7 +86,7 @@ impl Channel {
 //   power  @ 1000 ms     → 5 nominal    → min 3
 //   head   @ 20 ms       → 250 nominal  → min 150
 
-/// Audio RX-RMS loop. Beats once per published [`AudioRms`] sample
+/// Audio RX-RMS loop. Beats once per published `AudioRms` sample
 /// (~one per 33 ms window).
 pub static AUDIO: Channel = Channel::new("audio", 75);
 /// BMI270 IMU polling loop. Beats once per 10 ms iteration.
@@ -103,7 +103,7 @@ pub static HEAD: Channel = Channel::new("head", 150);
 pub struct TaskHealth {
     /// Channel name. Stable identifier the dashboard renders.
     pub name: &'static str,
-    /// Beats observed in the last [`WATCHDOG_PERIOD_MS`] window.
+    /// Beats observed in the last `WATCHDOG_PERIOD_MS` window.
     pub delta: u32,
     /// Minimum acceptable beats per window — below this is stale.
     pub min_per_window: u32,


### PR DESCRIPTION
## Summary

The firmware crate's rustdoc gate has been silently broken on main per the v0.2.0 progress memory (\"_About a dozen errors..._\"; the count had grown to **48 warnings across 19 files** by this PR). CI excludes the firmware crate from the workspace rustdoc gate, so the rot was invisible — and it drowned out any *new* broken doc link a future PR might introduce.

Two patterns of warning, both fixed by dropping the `[...]` intra-doc-link syntax and keeping the backticks for visual emphasis:

- **public-docs-link-to-private** (~30 cases) — a `pub` item's doc comment references a private constant or function via `` [`X`] ``. The link is unclickable on the generated HTML; rustdoc warns under `rustdoc::private_intra_doc_links`. Dropping the brackets keeps `` `X` `` as inline code with no broken link. Affected: `agent_sidecar.rs`, `audio.rs`, `ble/`, `crash.rs`, `desktop_permission.rs`, `head.rs`, `net/esp_now.rs`, `net/mdns.rs`, `net/snapshot.rs`, `reminders.rs`, `storage.rs` (8 `MAX_*_BYTES` constants), `wake_word.rs`, `watchdog.rs`.
- **unresolved link** (~17 cases) — the symbol was renamed or never existed. `try_enqueue_wake_chirp` / `try_enqueue_pickup_chirp` / `try_enqueue_startle_chirp` / `try_enqueue_low_battery_alert` / `try_enqueue_clip` / `AudioClip` (older audio-clip API surface), `PoseAnnouncer` (never a type — the doc was aspirational), `AudioRms` (renamed to `AudioFrame`), `IRQ_PRESS_EDGE_BIT` / `IRQ_RELEASE_EDGE_BIT` (private), `IR_RX_PIN` (private), `Stack::add_bond_information` (lives in trouble-host), `EmotionFromRemote::queue` (the method was renamed), `load` / `save` (replaced with `RuntimeState`'s associated functions). Same fix — drop the brackets.

One redundant-explicit-link-target in `reminders.rs` (the explicit URL was identical to the auto-resolved label) collapsed too.

**Net result:** zero warnings under `RUSTDOCFLAGS=-D warnings cargo +esp doc --no-deps`. A future PR that introduces a real broken doc link will surface in isolation instead of being lost in baseline noise.

## Test plan

- [x] `RUSTDOCFLAGS=-D warnings cargo +esp doc --no-deps` from `crates/stackchan-firmware/` — clean
- [x] `just check` — workspace gates green (this PR doesn't touch host crates)
- [x] `cargo +esp clippy --release -- -D warnings` — clean (incremental)

## Why not document-private-items

`rustdoc --document-private-items` would resolve the private-link warnings by expanding the doc visibility to include the targets. But it also doubles the generated HTML and surfaces every internal symbol on the public handbook page, which isn't what readers of the firmware crate's docs want. Dropping the link syntax keeps the docs internally consistent and visually unchanged on the rendered output.