### PR TITLE
test(core): bolster decorator_from_shake — re-arm + clobber + boot-into-shaken pins

### DIFF
--- a/crates/stackchan-core/src/modifiers/decorator_from_shake.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_shake.rs
@@ -144,4 +144,74 @@ mod tests {
         }
         assert!(entity.face.decorator.is_none());
     }
+
+    #[test]
+    fn re_arm_after_intent_clears_and_returns_to_shaken() {
+        // Two distinct shake events separated by a non-shaken frame
+        // must each arm Dizzy with a fresh expiry. Otherwise the edge
+        // detector would silently miss the second shake of a
+        // double-shake gesture.
+        let mut entity = Entity::default();
+        let mut m = DecoratorFromShake::with_hold_ms(4_000);
+
+        step(&mut m, &mut entity, Intent::Idle, 0);
+        step(&mut m, &mut entity, Intent::Shaken, 33);
+        let first = entity.face.decorator.expect("first shake arms").expires_at;
+
+        // Intent clears (post-shake settle) so the edge detector
+        // re-arms on the next Shaken frame.
+        step(&mut m, &mut entity, Intent::Idle, 1_000);
+
+        step(&mut m, &mut entity, Intent::Shaken, 5_000);
+        let second = entity
+            .face
+            .decorator
+            .expect("second shake re-arms")
+            .expires_at;
+
+        assert!(
+            second > first,
+            "second arm should produce a later expiry ({second:?} vs {first:?})"
+        );
+        assert_eq!(second, Instant::from_millis(5_000 + 4_000));
+    }
+
+    #[test]
+    fn shake_overwrites_existing_decorator_on_edge() {
+        // The edge handler unconditionally writes `face.decorator` —
+        // a Heart from a recent petting moment is replaced by Dizzy
+        // on a rising shake edge. Cross-modifier priority lives in
+        // `meta.priority`, not in any conditional inside `update`.
+        let mut entity = Entity::default();
+        entity.face.decorator = Some(DecoratorState::hold_for(
+            Decorator::Heart,
+            Instant::from_millis(0),
+            5_000,
+        ));
+        let mut m = DecoratorFromShake::new();
+        step(&mut m, &mut entity, Intent::Idle, 0);
+        step(&mut m, &mut entity, Intent::Shaken, 33);
+        let state = entity.face.decorator.expect("decorator should be present");
+        assert_eq!(
+            state.kind,
+            Decorator::Dizzy,
+            "Dizzy must overwrite the prior Heart on the rising shake edge"
+        );
+    }
+
+    #[test]
+    fn boot_directly_into_shaken_arms_on_first_tick() {
+        // `last_intent` starts as `None`, so the very first frame
+        // observed-as-Shaken is treated as a rising edge. Pins this
+        // behavior: a device powered on while being shaken (e.g. in
+        // a bag mid-transit) lands on Dizzy immediately rather than
+        // waiting for a subsequent non-shaken frame to disambiguate
+        // the edge.
+        let mut entity = Entity::default();
+        let mut m = DecoratorFromShake::new();
+        step(&mut m, &mut entity, Intent::Shaken, 0);
+        let state = entity.face.decorator.expect("boot-into-shaken arms Dizzy");
+        assert_eq!(state.kind, Decorator::Dizzy);
+        assert_eq!(state.expires_at, Instant::from_millis(DIZZY_HOLD_MS));
+    }
 }

--- a/crates/stackchan-core/src/modifiers/decorator_from_shake.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_shake.rs
@@ -197,6 +197,11 @@ mod tests {
             Decorator::Dizzy,
             "Dizzy must overwrite the prior Heart on the rising shake edge"
         );
+        assert_eq!(
+            state.expires_at,
+            Instant::from_millis(33 + DIZZY_HOLD_MS),
+            "expiry must be anchored to the shake edge, not inherited from the Heart it replaced"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three coverage additions to \`DecoratorFromShake\`, closing the same invariant gaps that #407 pinned for \`DecoratorFromLoud\`. Same cluster, same shape — continues the modifier-coverage bolster rhythm.

- \`re_arm_after_intent_clears_and_returns_to_shaken\` — pins Idle → Shaken → Idle → Shaken arms twice. Without this, a regression that broke the \`last_intent\` reset path would silently swallow the second event of a double-shake gesture.
- \`shake_overwrites_existing_decorator_on_edge\` — pins last-write-wins on \`face.decorator\`. A prior \`Heart\` from a recent petting moment is replaced by \`Dizzy\` on the rising shake edge; cross-modifier priority lives in \`meta.priority\`, not in any \`update\` conditional.
- \`boot_directly_into_shaken_arms_on_first_tick\` — pins the \`None\`-initial-state semantic. A device powered on mid-shake (e.g. in a bag in transit) lands on \`Dizzy\` immediately rather than waiting for a non-shaken frame to anchor the edge.

## Test plan

- [x] \`cargo test -p stackchan-core --lib decorator_from_shake\` — 6 passed
- [x] \`just check\` — all host gates green