### PR TITLE
test(ltr553): cover the two uncovered branches of lux_from_channels + boundary at ratio=0.45

### DIFF
--- a/crates/ltr553/src/lib.rs
+++ b/crates/ltr553/src/lib.rs
@@ -305,7 +305,9 @@ mod tests {
 
     #[test]
     fn lux_at_ratio_0_45_boundary_uses_second_formula() {
-        // ratio = 9/(11+9) = 0.45 exactly (representable in f32).
+        // ratio = 9/(11+9) = 0.45 (rounds to the same nearest f32 as
+        // the literal `0.45`; 0.45 itself is a repeating binary
+        // fraction so neither side is bit-exact, they just agree).
         // Branch comparators use `<`, so ratio == 0.45 falls out of
         // formula 1 (`ratio < 0.45` is false) and into formula 2.
         // Pinning this so a future "<=" tweak surfaces the boundary
@@ -314,8 +316,9 @@ mod tests {
         let ch0: u16 = 11;
         let ch1: u16 = 9;
         let ratio = f32::from(ch1) / f32::from(ch0 + ch1);
-        assert!(
-            (ratio - 0.45).abs() < f32::EPSILON,
+        assert_eq!(
+            ratio.to_bits(),
+            0.45_f32.to_bits(),
             "fixture didn't land at the boundary: ratio={ratio}"
         );
         let expected = 4.2785 * f32::from(ch0) - 1.9548 * f32::from(ch1);

--- a/crates/ltr553/src/lib.rs
+++ b/crates/ltr553/src/lib.rs
@@ -276,4 +276,53 @@ mod tests {
         assert_eq!(0x9A & 0xF0, PART_ID_UPPER);
         assert_ne!(0x82 & 0xF0, PART_ID_UPPER); // not LTR-553
     }
+
+    #[test]
+    fn lux_middle_branch_uses_second_formula() {
+        // ratio = 100/(100+100) = 0.50, lands in 0.45..0.64 → formula 2.
+        let ch0 = 100;
+        let ch1 = 100;
+        let expected = 4.2785 * f32::from(ch0) - 1.9548 * f32::from(ch1);
+        let got = lux_from_channels(ch0, ch1);
+        assert!(
+            (got - expected).abs() < 0.001,
+            "got {got}, expected {expected} (mid-ratio formula)"
+        );
+    }
+
+    #[test]
+    fn lux_high_ratio_uses_third_formula() {
+        // ratio = 300/(100+300) = 0.75, lands in 0.64..0.85 → formula 3.
+        let ch0 = 100;
+        let ch1 = 300;
+        let expected = 0.5926 * f32::from(ch0) + 0.1185 * f32::from(ch1);
+        let got = lux_from_channels(ch0, ch1);
+        assert!(
+            (got - expected).abs() < 0.001,
+            "got {got}, expected {expected} (high-ratio formula)"
+        );
+    }
+
+    #[test]
+    fn lux_at_ratio_0_45_boundary_uses_second_formula() {
+        // ratio = 9/(11+9) = 0.45 exactly (representable in f32).
+        // Branch comparators use `<`, so ratio == 0.45 falls out of
+        // formula 1 (`ratio < 0.45` is false) and into formula 2.
+        // Pinning this so a future "<=" tweak surfaces the boundary
+        // ambiguity rather than silently shifting which formula
+        // applies at the cut.
+        let ch0: u16 = 11;
+        let ch1: u16 = 9;
+        let ratio = f32::from(ch1) / f32::from(ch0 + ch1);
+        assert!(
+            (ratio - 0.45).abs() < f32::EPSILON,
+            "fixture didn't land at the boundary: ratio={ratio}"
+        );
+        let expected = 4.2785 * f32::from(ch0) - 1.9548 * f32::from(ch1);
+        let got = lux_from_channels(ch0, ch1);
+        assert!(
+            (got - expected).abs() < 0.001,
+            "got {got}, expected {expected} (formula 2 at ratio=0.45 boundary)"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Lite-On's piecewise lux formula has four branches keyed on \`ratio = ch1 / (ch0 + ch1)\`. Only the first (\`ratio < 0.45\`) and last (\`ratio >= 0.85\`) had test coverage; the middle two — \`0.45..0.64\` and \`0.64..0.85\` — had no tests at all, so a regression to either constant or formula could silently produce wrong lux values for visible-plus-IR sources (the common case indoors).

- \`lux_middle_branch_uses_second_formula\` pins formula 2 at ratio=0.5.
- \`lux_high_ratio_uses_third_formula\` pins formula 3 at ratio=0.75.
- \`lux_at_ratio_0_45_boundary_uses_second_formula\` pins which side of the cut \`ratio == 0.45\` lands on. Branch comparators use \`<\`, so the boundary value falls into formula 2; a future tweak to \`<=\` would silently shift which formula applies at the cut.

This is the start of the driver-coverage sweep — ltr553 had the lowest test/src ratio (13%) of the driver crates. Follow-up PRs can add a \`MockI2c\` harness mirroring the aw9523 / si12t pattern so \`read_ambient\`/\`read_proximity\`/\`init\` get end-to-end coverage too.

## Test plan

- [x] \`cargo test -p ltr553\` — 7 passed
- [x] \`just check\` — all host gates green