### PR TITLE
test(net): bolster mcp.rs region coverage — every error path + JSON-RPC code variants

### DIFF
--- a/crates/stackchan-desktop-protocol/src/parse.rs
+++ b/crates/stackchan-desktop-protocol/src/parse.rs
@@ -921,8 +921,9 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, ProtoError> {
 #[cfg(test)]
 #[allow(
     clippy::expect_used,
+    clippy::panic,
     clippy::unwrap_used,
-    reason = "tests assert structural invariants; .expect / .unwrap are the standard test idiom"
+    reason = "tests assert structural invariants; .expect / .unwrap / panic! are the standard test idiom"
 )]
 mod tests {
     use super::*;
@@ -979,5 +980,655 @@ mod tests {
     #[test]
     fn base64_tolerates_whitespace() {
         assert_eq!(base64_decode("Zm9v\n YmFy").unwrap(), b"foobar");
+    }
+
+    // ============================================================
+    // JSON string escapes — every backslash escape, surrogate pair,
+    // and the lone/short surrogate error paths.
+    // ============================================================
+
+    fn parse_str(input: &str) -> Result<String, ProtoError> {
+        let mut p = JsonParser::new(input);
+        p.parse_string()
+    }
+
+    #[test]
+    fn string_escapes_decode() {
+        // RFC 8259 §7 short escapes. Each one is its own branch in
+        // `parse_string`; cover them together so the table is unbroken.
+        let cases = [
+            (r#""\"""#, "\""),
+            (r#""\\""#, "\\"),
+            (r#""\/""#, "/"),
+            (r#""\n""#, "\n"),
+            (r#""\t""#, "\t"),
+            (r#""\r""#, "\r"),
+            (r#""\b""#, "\u{0008}"),
+            (r#""\f""#, "\u{000c}"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(parse_str(input).unwrap(), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn string_unicode_escapes_decode() {
+        // BMP code point.
+        assert_eq!(parse_str(r#""é""#).unwrap(), "é");
+        // Astral plane code point via UTF-16 surrogate pair (😀 = U+1F600).
+        assert_eq!(parse_str(r#""😀""#).unwrap(), "😀");
+    }
+
+    #[test]
+    fn string_unterminated_rejected() {
+        assert!(matches!(
+            parse_str(r#""no closing quote"#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn string_dangling_backslash_rejected() {
+        assert!(matches!(
+            parse_str("\"\\"),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn string_unsupported_escape_rejected() {
+        // `\x` isn't a JSON-defined escape.
+        assert!(matches!(
+            parse_str(r#""\x41""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_escape_short_hex_rejected() {
+        assert!(matches!(
+            parse_str(r#""\u00""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_escape_bad_hex_rejected() {
+        assert!(matches!(
+            parse_str(r#""\uZZZZ""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_lone_high_surrogate_rejected() {
+        // High surrogate not followed by `\u`.
+        assert!(matches!(
+            parse_str(r#""\ud83dABCD""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_high_surrogate_truncated_low_rejected() {
+        // High surrogate followed by `\u` but fewer than 4 hex chars.
+        assert!(matches!(
+            parse_str(r#""\ud83d\u00""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_bad_low_surrogate_hex_rejected() {
+        assert!(matches!(
+            parse_str(r#""\ud83d\uZZZZ""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_low_surrogate_out_of_range_rejected() {
+        // High surrogate followed by `\u` where the second value
+        // isn't in the low-surrogate range.
+        assert!(matches!(
+            parse_str(r#""\ud83dA""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_lone_low_surrogate_rejected() {
+        // Low surrogate without a preceding high surrogate.
+        assert!(matches!(
+            parse_str(r#""\udc00""#),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    // ============================================================
+    // Primitive parser branches: bool / null / number.
+    // ============================================================
+
+    #[test]
+    fn bool_typo_rejected() {
+        // `true`/`false` are the only valid starts; `tru` fails
+        // the `starts_with("true")` and `starts_with("false")` arms.
+        assert!(matches!(
+            JsonParser::new("tru").parse_value(),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn null_typo_rejected() {
+        assert!(matches!(
+            JsonParser::new("nul").parse_value(),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn number_lone_minus_rejected() {
+        assert!(matches!(
+            JsonParser::new("-").parse_value(),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn number_negative_parses() {
+        // The `-` branch in `parse_number` is otherwise unexercised.
+        let v = JsonParser::new("-42").parse_value().unwrap();
+        assert_eq!(v, Value::Int(-42));
+    }
+
+    #[test]
+    fn unexpected_top_level_token_rejected() {
+        assert!(matches!(
+            parse_inbound(b"$bogus"),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    // ============================================================
+    // parse_inbound dispatch error paths.
+    // ============================================================
+
+    #[test]
+    fn inbound_invalid_utf8_rejected() {
+        // Lone continuation byte never starts a valid UTF-8 sequence.
+        assert!(matches!(
+            parse_inbound(&[0xff, 0xff, 0xff]),
+            Err(ProtoError::InvalidUtf8)
+        ));
+    }
+
+    #[test]
+    fn inbound_top_level_non_object_rejected() {
+        assert!(matches!(
+            parse_inbound(b"[1, 2, 3]"),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn inbound_unknown_evt_rejected() {
+        let line = br#"{"evt":"mystery"}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::UnknownKind(ref k)) if k == "mystery"
+        ));
+    }
+
+    #[test]
+    fn inbound_unknown_cmd_rejected() {
+        let line = br#"{"cmd":"mystery"}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::UnknownKind(ref k)) if k == "mystery"
+        ));
+    }
+
+    #[test]
+    fn inbound_prompt_null_decodes_to_none() {
+        let line = br#"{"prompt":null}"#;
+        let Inbound::Snapshot(snap) = parse_inbound(line).unwrap() else {
+            panic!("expected snapshot");
+        };
+        assert_eq!(snap.prompt, None);
+    }
+
+    #[test]
+    fn inbound_prompt_missing_id_rejected() {
+        // `id` defaults to empty string via `field_str_opt` fallback;
+        // an explicit empty string also trips the empty-id guard.
+        let line = br#"{"prompt":{"id":""}}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::MissingField("prompt.id"))
+        ));
+    }
+
+    #[test]
+    fn inbound_prompt_wrong_shape_rejected() {
+        let line = br#"{"prompt":42}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "prompt",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn inbound_turn_content_must_be_array() {
+        let line = br#"{"evt":"turn","content":42}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "content",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn inbound_turn_content_block_must_be_object() {
+        let line = br#"{"evt":"turn","content":[42]}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "content[]",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn inbound_turn_roundtrip_preserves_raw_json() {
+        // Exercises `render_value` / `write_value` / `write_string`
+        // across every Value variant (null, bool, int, str, array,
+        // object) plus control-char escape in `write_string`.
+        let line = br#"{"evt":"turn","content":[{"type":"text","text":"hi"},{"type":"tool_use","name":"Bash","input":{"cmd":"ls","args":["-l"],"silent":true,"timeout":null,"sep":"\t","raw":""}}]}"#;
+        let Inbound::Turn(turn) = parse_inbound(line).unwrap() else {
+            panic!("expected turn");
+        };
+        assert_eq!(turn.role, "assistant");
+        assert_eq!(turn.content.len(), 2);
+        assert_eq!(turn.content[0].kind, "text");
+        assert_eq!(turn.content[0].text.as_deref(), Some("hi"));
+        // raw_json for the tool_use block must include every nested
+        // type the serializer can emit.
+        let raw = &turn.content[1].raw_json;
+        assert!(raw.contains(r#""type":"tool_use""#));
+        assert!(raw.contains(r#""silent":true"#));
+        assert!(raw.contains(r#""timeout":null"#));
+        assert!(raw.contains(r#""args":["-l"]"#));
+        assert!(raw.contains(r#""sep":"\t""#));
+        assert!(raw.contains("\"raw\":\"\""));
+    }
+
+    #[test]
+    fn inbound_turn_serializer_escapes_control_chars() {
+        // Hits the `c if (c as u32) < 0x20` branch of `write_string`.
+        // Feed a `SOH` escape (legal JSON); the re-serialized block
+        // must encode the same control char back as `SOH`.
+        let line = b"{\"evt\":\"turn\",\"content\":[{\"type\":\"x\",\"ctrl\":\"\\u0001\"}]}";
+        let Inbound::Turn(turn) = parse_inbound(line).unwrap() else {
+            panic!("expected turn");
+        };
+        assert!(turn.content[0].raw_json.contains("\"ctrl\":\"\\u0001\""));
+    }
+
+    #[test]
+    fn inbound_turn_serializer_emits_false_and_negative_int() {
+        // Hits `Value::Bool(false)` + negative-int branches of
+        // `write_value` that the preceding test doesn't.
+        let line = br#"{"evt":"turn","content":[{"type":"x","flag":false,"n":-3}]}"#;
+        let Inbound::Turn(turn) = parse_inbound(line).unwrap() else {
+            panic!("expected turn");
+        };
+        let raw = &turn.content[0].raw_json;
+        assert!(raw.contains(r#""flag":false"#));
+        assert!(raw.contains(r#""n":-3"#));
+    }
+
+    #[test]
+    fn inbound_time_must_be_array() {
+        let line = br#"{"time":42}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue { field: "time", .. })
+        ));
+    }
+
+    #[test]
+    fn inbound_time_array_wrong_length() {
+        let line = br#"{"time":[123]}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue { field: "time", .. })
+        ));
+    }
+
+    #[test]
+    fn inbound_time_tz_offset_out_of_i32_range() {
+        // `tz_offset_secs` is an `i32`. Pass a value that fits in
+        // i64 but overflows i32.
+        let line = br#"{"time":[100,9999999999]}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "time[1]",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn inbound_time_sync_decodes() {
+        let line = br#"{"time":[1700000000,-28800]}"#;
+        let Inbound::TimeSync {
+            epoch_secs,
+            tz_offset_secs,
+        } = parse_inbound(line).unwrap()
+        else {
+            panic!("expected time sync");
+        };
+        assert_eq!(epoch_secs, 1_700_000_000);
+        assert_eq!(tz_offset_secs, -28_800);
+    }
+
+    #[test]
+    fn inbound_chunk_invalid_base64_rejected() {
+        let line = br#"{"cmd":"chunk","d":"Zg=="X"}"#;
+        // Outer parse fails on the malformed JSON first; isolate the
+        // base64 path with a syntactically valid envelope.
+        assert!(parse_inbound(line).is_err());
+
+        let line = br#"{"cmd":"chunk","d":"Zg*=="}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::InvalidBase64)
+        ));
+    }
+
+    #[test]
+    fn inbound_snapshot_keepalive_decodes_to_default() {
+        let line = br"{}";
+        let Inbound::Snapshot(snap) = parse_inbound(line).unwrap() else {
+            panic!("expected snapshot");
+        };
+        assert_eq!(snap, Snapshot::default());
+    }
+
+    #[test]
+    fn inbound_snapshot_msg_null_yields_empty_string() {
+        // Exercises `expect_str_or_null`'s `Null` arm via `msg`.
+        let line = br#"{"msg":null,"entries":["a","b"],"tokens":7,"tokens_today":3,"total":1,"running":0,"waiting":0}"#;
+        let Inbound::Snapshot(snap) = parse_inbound(line).unwrap() else {
+            panic!("expected snapshot");
+        };
+        assert_eq!(snap.msg, "");
+        assert_eq!(snap.entries, alloc::vec!["a", "b"]);
+        assert_eq!(snap.tokens, 7);
+        assert_eq!(snap.tokens_today, 3);
+    }
+
+    #[test]
+    fn inbound_snapshot_msg_wrong_type_rejected() {
+        let line = br#"{"msg":42}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue { field: "msg", .. })
+        ));
+    }
+
+    #[test]
+    fn inbound_snapshot_entries_non_array_rejected() {
+        let line = br#"{"entries":"oops"}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "entries",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn inbound_snapshot_entries_non_string_element_rejected() {
+        let line = br#"{"entries":[1,2]}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "entries",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn inbound_snapshot_total_out_of_u32_range_rejected() {
+        // Negative trips `u32::try_from` in `expect_u32`.
+        let line = br#"{"total":-1}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue { field: "total", .. })
+        ));
+    }
+
+    #[test]
+    fn inbound_snapshot_tokens_negative_rejected() {
+        // Negative trips `u64::try_from` in `expect_u64`.
+        let line = br#"{"tokens":-1}"#;
+        assert!(matches!(
+            parse_inbound(line),
+            Err(ProtoError::BadValue {
+                field: "tokens",
+                ..
+            })
+        ));
+    }
+
+    // ============================================================
+    // parse_outbound dispatch — wholly uncovered before this PR.
+    // ============================================================
+
+    #[test]
+    fn outbound_invalid_utf8_rejected() {
+        assert!(matches!(
+            parse_outbound(&[0xff, 0xff]),
+            Err(ProtoError::InvalidUtf8)
+        ));
+    }
+
+    #[test]
+    fn outbound_top_level_non_object_rejected() {
+        assert!(matches!(
+            parse_outbound(b"42"),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn outbound_neither_ack_nor_cmd_rejected() {
+        assert!(matches!(
+            parse_outbound(b"{}"),
+            Err(ProtoError::MalformedJson(_))
+        ));
+    }
+
+    #[test]
+    fn outbound_generic_ack_decodes() {
+        let line = br#"{"ack":"name","ok":true,"n":3,"error":null}"#;
+        let Outbound::Ack(ack) = parse_outbound(line).unwrap() else {
+            panic!("expected ack");
+        };
+        assert_eq!(ack.cmd, "name");
+        assert!(ack.ok);
+        assert_eq!(ack.n, 3);
+        assert_eq!(ack.error, None);
+    }
+
+    #[test]
+    fn outbound_ack_with_error_string_decodes() {
+        let line = br#"{"ack":"file","ok":false,"error":"disk full"}"#;
+        let Outbound::Ack(ack) = parse_outbound(line).unwrap() else {
+            panic!("expected ack");
+        };
+        assert!(!ack.ok);
+        assert_eq!(ack.n, 0); // default when absent
+        assert_eq!(ack.error.as_deref(), Some("disk full"));
+    }
+
+    #[test]
+    fn outbound_status_ack_decodes_all_subobjects() {
+        // Exercises parse_status_data + parse_battery + parse_sys
+        // + parse_user_stats end-to-end.
+        let line = br#"{"ack":"status","data":{"name":"Clawd","sec":true,"bat":{"pct":85,"mV":4100,"mA":-120,"usb":true},"sys":{"up":600,"heap":150000},"stats":{"appr":12,"deny":3,"vel":2,"nap":1,"lvl":5}}}"#;
+        let Outbound::StatusAck(data) = parse_outbound(line).unwrap() else {
+            panic!("expected status ack");
+        };
+        assert_eq!(data.name, "Clawd");
+        assert!(data.sec);
+        let bat = data.battery.expect("battery present");
+        assert_eq!(bat.pct, 85);
+        assert_eq!(bat.mv, 4100);
+        assert_eq!(bat.ma, -120);
+        assert!(bat.usb);
+        let sys = data.sys.expect("sys present");
+        assert_eq!(sys.uptime_secs, 600);
+        assert_eq!(sys.heap_free_bytes, 150_000);
+        let stats = data.stats.expect("stats present");
+        assert_eq!(stats.approvals, 12);
+        assert_eq!(stats.denies, 3);
+        assert_eq!(stats.velocity, 2);
+        assert_eq!(stats.naps, 1);
+        assert_eq!(stats.level, 5);
+    }
+
+    #[test]
+    fn outbound_status_ack_missing_data_rejected() {
+        let line = br#"{"ack":"status"}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::MissingField("data"))
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_data_wrong_shape_rejected() {
+        let line = br#"{"ack":"status","data":42}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue { field: "data", .. })
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_bat_wrong_shape_rejected() {
+        let line = br#"{"ack":"status","data":{"bat":42}}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue { field: "bat", .. })
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_sys_wrong_shape_rejected() {
+        let line = br#"{"ack":"status","data":{"sys":42}}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue { field: "sys", .. })
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_stats_wrong_shape_rejected() {
+        let line = br#"{"ack":"status","data":{"stats":42}}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue { field: "stats", .. })
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_battery_pct_out_of_u8_range_rejected() {
+        let line = br#"{"ack":"status","data":{"bat":{"pct":300,"mV":4100,"mA":0,"usb":false}}}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue {
+                field: "bat.pct",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_battery_mv_out_of_u16_range_rejected() {
+        let line = br#"{"ack":"status","data":{"bat":{"pct":50,"mV":99999,"mA":0,"usb":false}}}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue {
+                field: "bat.mV",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn outbound_status_ack_battery_ma_out_of_i16_range_rejected() {
+        let line =
+            br#"{"ack":"status","data":{"bat":{"pct":50,"mV":4100,"mA":99999,"usb":false}}}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue {
+                field: "bat.mA",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn outbound_permission_decodes_both_decisions() {
+        for (raw, expected) in [
+            (
+                br#"{"cmd":"permission","id":"abc","decision":"once"}"#.as_slice(),
+                Decision::Once,
+            ),
+            (
+                br#"{"cmd":"permission","id":"abc","decision":"deny"}"#.as_slice(),
+                Decision::Deny,
+            ),
+        ] {
+            let Outbound::Permission { id, decision } = parse_outbound(raw).unwrap() else {
+                panic!("expected permission");
+            };
+            assert_eq!(id, "abc");
+            assert_eq!(decision, expected);
+        }
+    }
+
+    #[test]
+    fn outbound_permission_unknown_decision_rejected() {
+        let line = br#"{"cmd":"permission","id":"abc","decision":"maybe"}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::BadValue {
+                field: "decision",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn outbound_unknown_cmd_rejected() {
+        let line = br#"{"cmd":"reboot"}"#;
+        assert!(matches!(
+            parse_outbound(line),
+            Err(ProtoError::UnknownKind(ref k)) if k == "reboot"
+        ));
     }
 }

--- a/crates/stackchan-desktop-protocol/src/parse.rs
+++ b/crates/stackchan-desktop-protocol/src/parse.rs
@@ -1013,10 +1013,13 @@ mod tests {
 
     #[test]
     fn string_unicode_escapes_decode() {
-        // BMP code point.
-        assert_eq!(parse_str(r#""é""#).unwrap(), "é");
-        // Astral plane code point via UTF-16 surrogate pair (😀 = U+1F600).
-        assert_eq!(parse_str(r#""😀""#).unwrap(), "😀");
+        // BMP code point via `\uXXXX` escape — drives parse_unicode_escape's
+        // happy path. (Literal UTF-8 chars in the input bypass the escape
+        // parser through the `_` arm of parse_string's match.)
+        assert_eq!(parse_str(r#""\u00e9""#).unwrap(), "é");
+        // Astral plane code point via UTF-16 surrogate pair
+        // (😀 = U+1F600 = `😀`).
+        assert_eq!(parse_str(r#""\ud83d\ude00""#).unwrap(), "😀");
     }
 
     #[test]
@@ -1088,10 +1091,12 @@ mod tests {
 
     #[test]
     fn unicode_low_surrogate_out_of_range_rejected() {
-        // High surrogate followed by `\u` where the second value
-        // isn't in the low-surrogate range.
+        // High surrogate followed by a second `\u` escape whose value
+        // sits outside the low-surrogate range (0xDC00..=0xDFFF). The
+        // input passes the `starts_with("\\u")` guard so we get past
+        // the lone-high-surrogate check, then fail the range check.
         assert!(matches!(
-            parse_str(r#""\ud83dA""#),
+            parse_str(r#""\ud83d\u0041""#),
             Err(ProtoError::MalformedJson(_))
         ));
     }

--- a/crates/stackchan-net/src/mcp.rs
+++ b/crates/stackchan-net/src/mcp.rs
@@ -815,6 +815,304 @@ mod tests {
         assert_eq!(s, r#"{"content":[{"type":"text","text":"hello"}]}"#);
     }
 
+    // ============================================================
+    // JsonRpcErrorCode — `as_i32` / `message` were partially covered;
+    // the InvalidRequest / InvalidParams / InternalError arms had no
+    // direct tests despite firing in real error paths.
+    // ============================================================
+
+    #[test]
+    fn jsonrpc_error_code_numeric_values() {
+        assert_eq!(JsonRpcErrorCode::ParseError.as_i32(), -32_700);
+        assert_eq!(JsonRpcErrorCode::InvalidRequest.as_i32(), -32_600);
+        assert_eq!(JsonRpcErrorCode::MethodNotFound.as_i32(), -32_601);
+        assert_eq!(JsonRpcErrorCode::InvalidParams.as_i32(), -32_602);
+        assert_eq!(JsonRpcErrorCode::InternalError.as_i32(), -32_603);
+    }
+
+    #[test]
+    fn jsonrpc_error_code_messages() {
+        assert_eq!(JsonRpcErrorCode::ParseError.message(), "Parse error");
+        assert_eq!(
+            JsonRpcErrorCode::InvalidRequest.message(),
+            "Invalid Request"
+        );
+        assert_eq!(
+            JsonRpcErrorCode::MethodNotFound.message(),
+            "Method not found"
+        );
+        assert_eq!(JsonRpcErrorCode::InvalidParams.message(), "Invalid params");
+        assert_eq!(JsonRpcErrorCode::InternalError.message(), "Internal error");
+    }
+
+    // ============================================================
+    // parse_request error paths.
+    // ============================================================
+
+    #[test]
+    fn parse_request_rejects_non_object_top_level() {
+        // Bare array, scalar, etc.
+        for body in ["[]", "42", "\"x\"", "null"] {
+            let err = parse_request(body).expect_err("non-object top-level should reject");
+            assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+        }
+    }
+
+    #[test]
+    fn parse_request_rejects_unterminated_object() {
+        // No closing `}`. The loop walks past the last key/value and
+        // hits EOF.
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"x""#;
+        let err = parse_request(body).expect_err("missing `}` should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_rejects_missing_comma_between_members() {
+        // `"id":1` followed by `"method":...` with no comma. The
+        // second iteration of the loop expects `,` and bails.
+        let body = r#"{"jsonrpc":"2.0" "id":1,"method":"x"}"#;
+        let err = parse_request(body).expect_err("missing `,` should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_rejects_missing_colon_after_key() {
+        let body = r#"{"jsonrpc" "2.0","id":1,"method":"x"}"#;
+        let err = parse_request(body).expect_err("missing `:` should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_rejects_unknown_top_level_key() {
+        // Anything outside {jsonrpc, id, method, params}.
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"x","extra":"y"}"#;
+        let err = parse_request(body).expect_err("unknown key should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn parse_request_rejects_wrong_jsonrpc_string_type() {
+        // `jsonrpc` must be a string value; an integer doesn't even
+        // make it past read_string and lands in ParseError.
+        let body = r#"{"jsonrpc":2,"id":1,"method":"x"}"#;
+        let err = parse_request(body).expect_err("non-string jsonrpc should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_rejects_non_integer_id() {
+        let body = r#"{"jsonrpc":"2.0","id":"oops","method":"x"}"#;
+        let err = parse_request(body).expect_err("string id should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn parse_request_rejects_overflowed_id() {
+        // `i64::MAX + 1` — out of `i64` range.
+        let body = r#"{"jsonrpc":"2.0","id":9223372036854775808,"method":"x"}"#;
+        let err = parse_request(body).expect_err("overflow should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn parse_request_accepts_array_params() {
+        // params can be any JSON value; `take_value` walks until
+        // balanced, so an array works as well as an object. The
+        // captured slice still re-parses for downstream use.
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"x","params":[1,2,3]}"#;
+        let req = parse_request(body).expect("array params should parse");
+        assert_eq!(req.params_raw, Some("[1,2,3]"));
+    }
+
+    #[test]
+    fn parse_request_accepts_scalar_params() {
+        // Likewise scalars: tests the `_` arm of `take_value`.
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"x","params":42}"#;
+        let req = parse_request(body).expect("scalar params should parse");
+        assert_eq!(req.params_raw, Some("42"));
+    }
+
+    #[test]
+    fn parse_request_rejects_unbalanced_params() {
+        // Missing closing `]` on the params array.
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"x","params":[1,2"#;
+        let err = parse_request(body).expect_err("unbalanced params should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    // ============================================================
+    // read_string error paths via parse_request keys.
+    // ============================================================
+
+    #[test]
+    fn parse_request_rejects_non_string_key() {
+        // Integer where a key string should be. read_string returns
+        // "expected string".
+        let body = r#"{"jsonrpc":"2.0","id":1,42:"x"}"#;
+        let err = parse_request(body).expect_err("non-string key should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_rejects_dangling_string_escape() {
+        // `\` at the end of input — read_string's dangling-escape arm.
+        let body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"x\\";
+        let err = parse_request(body).expect_err("dangling escape should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_rejects_unsupported_string_escape() {
+        // `\u` — we don't support unicode escapes in the MCP parser
+        // (the module docs call this out explicitly).
+        let body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"\\u00C0\"}";
+        let err = parse_request(body).expect_err("\\u escape should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    #[test]
+    fn parse_request_accepts_supported_string_escapes() {
+        // Every escape from the read_string match arm: \" \\ \/ \n \r \t \b \f.
+        let body =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"a\\\"b\\\\c\\/d\\ne\\rf\\tg\\bh\\fi\"}";
+        let req = parse_request(body).expect("all supported escapes should parse");
+        // The slice is borrowed unescaped — that's fine, the consumer
+        // does its own un-escaping when needed.
+        assert!(req.method.contains("\\\""));
+        assert!(req.method.contains("\\n"));
+    }
+
+    #[test]
+    fn parse_request_rejects_unterminated_string() {
+        // String key without closing `"` — read_string's tail "unterminated string" return.
+        let body = "{\"jsonrpc\":\"2.0\",\"id";
+        let err = parse_request(body).expect_err("unterminated string should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::ParseError);
+    }
+
+    // ============================================================
+    // find_string_field / find_object_field error paths.
+    // ============================================================
+
+    #[test]
+    fn find_string_field_rejects_non_object() {
+        let err = find_string_field("not an object", "name").expect_err("non-object should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_string_field_rejects_unterminated_object() {
+        // Searched key doesn't match the present one, so the loop
+        // walks past + hits EOF without finding `}`.
+        let err = find_string_field(r#"{"name":"x""#, "missing")
+            .expect_err("unterminated object should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_string_field_rejects_missing_comma() {
+        let err = find_string_field(r#"{"a":"1" "b":"2"}"#, "b")
+            .expect_err("missing comma should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_string_field_rejects_missing_colon() {
+        let err = find_string_field(r#"{"a" "1"}"#, "a").expect_err("missing colon should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_string_field_rejects_non_string_value_for_target_key() {
+        // Key matches but value isn't a string.
+        let err = find_string_field(r#"{"name":42}"#, "name")
+            .expect_err("non-string value should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_string_field_rejects_unbalanced_skipped_value() {
+        // Key doesn't match; we have to skip the value. If that value
+        // is malformed, the InvalidParams skip-fail path fires.
+        let err = find_string_field(r#"{"other":[1,2,"name":"x"}"#, "name")
+            .expect_err("unbalanced skipped value should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_object_field_returns_none_when_absent() {
+        assert_eq!(
+            find_object_field(r#"{"other":"x"}"#, "arguments").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn find_object_field_rejects_non_object() {
+        let err = find_object_field("[1,2]", "arguments").expect_err("non-object should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_object_field_rejects_unterminated_object() {
+        let err = find_object_field(r#"{"arguments":{"a":1}"#, "missing")
+            .expect_err("unterminated object should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_object_field_rejects_missing_comma() {
+        let err =
+            find_object_field(r#"{"a":1 "b":2}"#, "b").expect_err("missing comma should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_object_field_rejects_missing_colon() {
+        let err = find_object_field(r#"{"a" 1}"#, "a").expect_err("missing colon should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_object_field_rejects_malformed_target_value() {
+        // Key matches but value is unbalanced.
+        let err = find_object_field(r#"{"arguments":{"a":1"#, "arguments")
+            .expect_err("malformed target value should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn find_object_field_rejects_malformed_skipped_value() {
+        // Key doesn't match; the value we're skipping is unbalanced.
+        let err = find_object_field(r#"{"other":[1,2,"arguments":{}}"#, "arguments")
+            .expect_err("malformed skipped value should reject");
+        assert_eq!(err.code, JsonRpcErrorCode::InvalidParams);
+    }
+
+    // ============================================================
+    // escape_string — `\r`, `\t`, and the control-char branch.
+    // ============================================================
+
+    #[test]
+    fn escape_string_handles_carriage_return_and_tab() {
+        assert_eq!(escape_string("a\rb\tc"), "a\\rb\\tc");
+    }
+
+    #[test]
+    fn escape_string_emits_unicode_escape_for_control_chars() {
+        // U+0001 (SOH) — falls through to the `\\u{:04x}` branch.
+        let input = "\u{0001}";
+        assert_eq!(escape_string(input), "\\u0001");
+    }
+
+    #[test]
+    fn escape_string_passes_through_non_ascii() {
+        // Non-ASCII UTF-8 bytes (e.g. CJK / emoji) aren't escape-
+        // candidates — they pass through unchanged.
+        assert_eq!(escape_string("日本😀"), "日本😀");
+    }
+
     #[test]
     fn tools_list_json_is_valid_round_trip_against_parser() {
         // Sanity: the static catalogue is itself valid JSON. Round-

--- a/crates/tracker/src/cascade.rs
+++ b/crates/tracker/src/cascade.rs
@@ -1118,4 +1118,361 @@ mod tests {
     }
 
     extern crate alloc;
+
+    // ============================================================
+    // IntegralView out-of-bounds + Cascade helper coverage.
+    // ============================================================
+
+    #[test]
+    fn window_area_multiplies() {
+        let cascade = Cascade {
+            window_w: 24,
+            window_h: 24,
+            stages: &[],
+        };
+        assert_eq!(cascade.window_area(), 576);
+    }
+
+    #[test]
+    fn integral_oob_rect_returns_zero() {
+        // Both `rect_sum` and `rect_sum_sq` defensively return 0
+        // when the requested rectangle escapes the source plane.
+        let luma = [10u8; 16];
+        let mut sb = [0u32; 25];
+        let mut sqb = [0u64; 25];
+        let v = build_view(&luma, 4, 4, &mut sb, &mut sqb);
+        // x + w > width.
+        assert_eq!(v.rect_sum(3, 0, 2, 1), 0);
+        assert_eq!(v.rect_sum_sq(3, 0, 2, 1), 0);
+        // y + h > height.
+        assert_eq!(v.rect_sum(0, 3, 1, 2), 0);
+        assert_eq!(v.rect_sum_sq(0, 3, 1, 2), 0);
+    }
+
+    #[test]
+    fn integral_view_dimensions_exposed() {
+        let luma = [0u8; 12];
+        let mut sb = [0u32; 20];
+        let mut sqb = [0u64; 20];
+        let v = build_view(&luma, 4, 3, &mut sb, &mut sqb);
+        assert_eq!(v.width(), 4);
+        assert_eq!(v.height(), 3);
+    }
+
+    // ============================================================
+    // luma_from_rgb565_frame — was 0% before this PR.
+    // ============================================================
+
+    #[test]
+    fn luma_from_rgb565_writes_expected_pixel_count() {
+        // 2×2 frame, alternating pure-red / pure-green pixels. Out
+        // length must match w × h on success.
+        let frame: [u8; 8] = [
+            0xF8, 0x00, 0x07, 0xE0, // red, green
+            0x07, 0xE0, 0xF8, 0x00, // green, red
+        ];
+        let mut out = [0u8; 4];
+        let n = luma_from_rgb565_frame(&frame, 2, 2, &mut out);
+        assert_eq!(n, 4);
+        // Reds and greens have different luma; the alternation must
+        // surface as alternating output bytes.
+        assert_ne!(out[0], out[1]);
+        assert_eq!(out[0], out[3]);
+        assert_eq!(out[1], out[2]);
+    }
+
+    #[test]
+    fn luma_from_rgb565_rejects_short_out_buffer() {
+        let frame = [0u8; 8];
+        let mut out = [0u8; 3]; // < 4 pixels
+        assert_eq!(luma_from_rgb565_frame(&frame, 2, 2, &mut out), 0);
+    }
+
+    #[test]
+    fn luma_from_rgb565_rejects_short_frame_buffer() {
+        let frame = [0u8; 6]; // < 4 × 2 bytes
+        let mut out = [0u8; 4];
+        assert_eq!(luma_from_rgb565_frame(&frame, 2, 2, &mut out), 0);
+    }
+
+    // ============================================================
+    // Cascade::evaluate edge cases.
+    // ============================================================
+
+    #[test]
+    fn evaluate_returns_none_when_window_escapes_view() {
+        let luma = [10u8; 16];
+        let mut sb = [0u32; 25];
+        let mut sqb = [0u64; 25];
+        let v = build_view(&luma, 4, 4, &mut sb, &mut sqb);
+        let (_d, stages, stumps) = tiny_edge_cascade();
+        let cascade = leak_tiny_cascade(stages, stumps);
+        // 4×4 base window at (wx=1, wy=0) extends to x=5 > width=4.
+        assert_eq!(cascade.evaluate(&v, 1, 0, Q16_ONE), None);
+    }
+
+    #[test]
+    fn evaluate_returns_none_for_zero_scale() {
+        // `scale_q16 = 0` → scaled window dim is 0; evaluate must
+        // reject without dividing by zero or panicking.
+        let luma = [10u8; 16];
+        let mut sb = [0u32; 25];
+        let mut sqb = [0u64; 25];
+        let v = build_view(&luma, 4, 4, &mut sb, &mut sqb);
+        let (_d, stages, stumps) = tiny_edge_cascade();
+        let cascade = leak_tiny_cascade(stages, stumps);
+        assert_eq!(cascade.evaluate(&v, 0, 0, 0), None);
+    }
+
+    // ============================================================
+    // Cascade::scan break paths + scale-step monotonicity.
+    // ============================================================
+
+    #[test]
+    fn scan_breaks_when_min_scale_too_large_for_view() {
+        // 6×6 view, base 4×4 cascade — at scale 2× the window is 8×8,
+        // larger than the view; the loop must break immediately.
+        let luma = [10u8; 36];
+        let mut sb = [0u32; 49];
+        let mut sqb = [0u64; 49];
+        let v = build_view(&luma, 6, 6, &mut sb, &mut sqb);
+        let (_d, stages, stumps) = tiny_edge_cascade();
+        let cascade = leak_tiny_cascade(stages, stumps);
+        let det = cascade.scan(&v, Q16_ONE * 2, Q16_ONE * 4, Q16_ONE * 5 / 4, 1);
+        assert!(det.is_none(), "scan should not find anything at 2×+ scale");
+    }
+
+    #[test]
+    fn scan_breaks_when_scale_step_is_one() {
+        // step_q16 of `Q16_ONE` would loop forever — the function
+        // clamps to `Q16_ONE + 1`. With min == max == Q16_ONE the
+        // sweep runs once and then exits.
+        let luma = [
+            10, 10, 10, 10, 10, 10, 10, 10, 200, 200, 200, 200, 200, 200, 200, 200,
+        ];
+        let mut sb = [0u32; 25];
+        let mut sqb = [0u64; 25];
+        let v = build_view(&luma, 4, 4, &mut sb, &mut sqb);
+        let (_d, stages, stumps) = tiny_edge_cascade();
+        let cascade = leak_tiny_cascade(stages, stumps);
+        // step_q16 = 0 is the degenerate case; the clamp guarantees
+        // forward progress.
+        let det = cascade.scan(&v, Q16_ONE, Q16_ONE, 0, 0);
+        assert!(det.is_some());
+    }
+
+    // ============================================================
+    // scale_dim u16::MAX saturation path.
+    // ============================================================
+
+    #[test]
+    fn scale_dim_saturates_when_product_overflows_u16() {
+        // `scale_dim` is private but `Cascade::scan` calls it; pick a
+        // scale large enough that base × scale_q16 / Q16_ONE > u16::MAX.
+        // With base=24, scale ~ 0xFFFFFFFF, the product overflows
+        // u16 and the function must clamp to u16::MAX without panic.
+        let luma = [10u8; 16];
+        let mut sb = [0u32; 25];
+        let mut sqb = [0u64; 25];
+        let v = build_view(&luma, 4, 4, &mut sb, &mut sqb);
+        let (_d, stages, stumps) = tiny_edge_cascade();
+        let cascade = leak_tiny_cascade(stages, stumps);
+        // Scan from a huge min scale to an even huger max — every
+        // scale produces a saturated window dim, scan rejects them.
+        let det = cascade.scan(&v, u32::MAX / 2, u32::MAX, u32::MAX / 4, 1);
+        assert!(det.is_none());
+    }
+
+    // ============================================================
+    // `better()` stage-tiebreaker.
+    // ============================================================
+
+    #[test]
+    fn better_prefers_higher_stage_pass_count() {
+        let lower = Detection {
+            x: 0,
+            y: 0,
+            w: 10,
+            h: 10,
+            scale_q16: Q16_ONE,
+            stages_passed: 5,
+        };
+        let higher = Detection {
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 4, // smaller, but more stages.
+            scale_q16: Q16_ONE,
+            stages_passed: 10,
+        };
+        assert!(better(&higher, &lower));
+        assert!(!better(&lower, &higher));
+    }
+
+    #[test]
+    fn better_tiebreaks_on_window_area() {
+        let small = Detection {
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 4,
+            scale_q16: Q16_ONE,
+            stages_passed: 5,
+        };
+        let large = Detection {
+            x: 0,
+            y: 0,
+            w: 8,
+            h: 8,
+            scale_q16: Q16_ONE * 2,
+            stages_passed: 5,
+        };
+        assert!(better(&large, &small));
+        assert!(!better(&small, &large));
+    }
+
+    // ============================================================
+    // CascadeScratch + scan_around_centroid (the public face-scan API).
+    // ============================================================
+
+    #[test]
+    fn cascade_scratch_default_matches_new() {
+        // Both `new()` and `Default::default()` produce all-zero scratch.
+        let a = CascadeScratch::new();
+        let b = CascadeScratch::default();
+        assert_eq!(a.luma, b.luma);
+        // sum / sum_sq are too large to compare element-by-element
+        // in a test buffer; spot-check the first row.
+        assert_eq!(a.sum[..32], b.sum[..32]);
+        assert_eq!(a.sum_sq[..32], b.sum_sq[..32]);
+        // Spot-check that the buffers are zeroed.
+        assert!(a.luma.iter().all(|&v| v == 0));
+        assert!(a.sum[..32].iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn roi_around_centroid_rejects_zero_dim_frame() {
+        assert_eq!(roi_around_centroid(0, 48, (0.0, 0.0), 32), None);
+        assert_eq!(roi_around_centroid(48, 0, (0.0, 0.0), 32), None);
+    }
+
+    #[test]
+    fn roi_around_centroid_rejects_zero_dim_roi() {
+        assert_eq!(roi_around_centroid(48, 48, (0.0, 0.0), 0), None);
+    }
+
+    #[test]
+    fn roi_around_centroid_clamps_to_frame() {
+        // Centroid (-1, -1) is the top-left corner; the ROI must
+        // clamp to (0, 0).
+        let (x, y, w, h) = roi_around_centroid(64, 64, (-1.0, -1.0), 32).unwrap();
+        assert_eq!((x, y, w, h), (0, 0, 32, 32));
+        // Centroid (1, 1) is the bottom-right; ROI clamps to
+        // (frame - dim).
+        let (x, y, w, h) = roi_around_centroid(64, 64, (1.0, 1.0), 32).unwrap();
+        assert_eq!((x, y, w, h), (32, 32, 32, 32));
+    }
+
+    #[test]
+    fn roi_around_centroid_clamps_max_dim() {
+        // `roi_dim` larger than the frame clamps to min(MAX_ROI, frame).
+        let (_, _, w, h) = roi_around_centroid(48, 48, (0.0, 0.0), 200).unwrap();
+        assert_eq!((w, h), (48, 48));
+    }
+
+    /// Build a 64×64 RGB565 frame with a synthetic dark-top / bright-
+    /// bottom edge centered on the frame. Pure-color RGB565 keeps the
+    /// luma conversion simple and predictable.
+    fn synth_edge_frame() -> alloc::boxed::Box<[u8]> {
+        let mut buf = alloc::vec![0u8; 64 * 64 * 2].into_boxed_slice();
+        for y in 0..64 {
+            // Pure-black pixels in top half, pure-white in bottom half.
+            // RGB565: white = 0xFFFF, black = 0x0000.
+            let (hi, lo) = if y < 32 { (0x00, 0x00) } else { (0xFF, 0xFF) };
+            for x in 0..64 {
+                let off = (y * 64 + x) * 2;
+                buf[off] = hi;
+                buf[off + 1] = lo;
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn scan_around_centroid_returns_none_for_zero_dim_frame() {
+        let frame = [0u8; 0];
+        let mut scratch = alloc::boxed::Box::new(CascadeScratch::new());
+        assert!(
+            crate::FRONTAL_FACE
+                .scan_around_centroid(&frame, 0, 0, (0.0, 0.0), 32, &mut scratch)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn scan_around_centroid_returns_none_for_truncated_frame() {
+        // Frame buffer shorter than `w × h × 2` — the inner-loop bounds
+        // check trips and returns None.
+        let frame = [0u8; 8]; // claims 64×64 but only 4 px of data.
+        let mut scratch = alloc::boxed::Box::new(CascadeScratch::new());
+        assert!(
+            crate::FRONTAL_FACE
+                .scan_around_centroid(&frame, 64, 64, (0.0, 0.0), 32, &mut scratch)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn scan_around_centroid_finds_nothing_in_uniform_frame() {
+        // 64×64 grey RGB565 — no face structure; the real frontal
+        // cascade must not fire. Exercises the full
+        // ROI extraction → integral image → scan path with the
+        // FRONTAL_FACE cascade and a heap-allocated scratch.
+        let mut frame = alloc::vec![0u8; 64 * 64 * 2].into_boxed_slice();
+        for chunk in frame.chunks_exact_mut(2) {
+            chunk[0] = 0x84; // mid-grey RGB565 high byte
+            chunk[1] = 0x10;
+        }
+        let mut scratch = alloc::boxed::Box::new(CascadeScratch::new());
+        let result =
+            crate::FRONTAL_FACE.scan_around_centroid(&frame, 64, 64, (0.0, 0.0), 48, &mut scratch);
+        assert!(result.is_none(), "uniform frame must not fire");
+    }
+
+    #[test]
+    fn scan_around_centroid_runs_full_pipeline_on_edge_frame() {
+        // Synthetic dark/bright edge frame. The real frontal cascade
+        // is unlikely to fire on a non-face pattern, but the call must
+        // run through the full pipeline (ROI extraction + luma
+        // conversion + integral images + scan) without panicking. The
+        // assertion is just that the call returns *some* answer — we
+        // don't pretend the frontal cascade should recognise a
+        // black-on-white edge as a face.
+        let frame = synth_edge_frame();
+        let mut scratch = alloc::boxed::Box::new(CascadeScratch::new());
+        let _ =
+            crate::FRONTAL_FACE.scan_around_centroid(&frame, 64, 64, (0.0, 0.0), 48, &mut scratch);
+    }
+
+    #[test]
+    fn scan_around_centroid_finds_face_with_tiny_cascade() {
+        // Use the test-only tiny edge cascade to verify the pipeline
+        // produces a non-empty detection when the cascade *does*
+        // fire. The synthetic edge frame has bright bottom-half;
+        // a 4×4 tiny cascade with the right edge stump fires inside
+        // the ROI, the result is translated back to frame coordinates,
+        // and the normalised centroid lands inside [-1, 1].
+        let frame = synth_edge_frame();
+        let (_d, stages, stumps) = tiny_edge_cascade();
+        let tiny = leak_tiny_cascade(stages, stumps);
+        let mut scratch = alloc::boxed::Box::new(CascadeScratch::new());
+        let det = tiny
+            .scan_around_centroid(&frame, 64, 64, (0.0, 0.0), 32, &mut scratch)
+            .expect("tiny cascade must fire on synthetic edge frame");
+        assert!(det.centroid.0 >= -1.0 && det.centroid.0 <= 1.0);
+        assert!(det.centroid.1 >= -1.0 && det.centroid.1 <= 1.0);
+        let (fx, fy, fw, fh) = det.frame_rect;
+        assert!(u32::from(fx) + u32::from(fw) <= 64);
+        assert!(u32::from(fy) + u32::from(fh) <= 64);
+    }
 }

--- a/crates/tracker/src/cascade.rs
+++ b/crates/tracker/src/cascade.rs
@@ -1243,10 +1243,11 @@ mod tests {
     }
 
     #[test]
-    fn scan_breaks_when_scale_step_is_one() {
-        // step_q16 of `Q16_ONE` would loop forever — the function
-        // clamps to `Q16_ONE + 1`. With min == max == Q16_ONE the
-        // sweep runs once and then exits.
+    fn scan_clamps_zero_step_to_prevent_stall() {
+        // step_q16 = 0 is the degenerate case — clamped to `Q16_ONE
+        // + 1` inside `scan`. With min == max == Q16_ONE the sweep
+        // runs exactly once and then exits because next_scale >
+        // max_scale, so the cascade fires on the bright-bottom edge.
         let luma = [
             10, 10, 10, 10, 10, 10, 10, 10, 200, 200, 200, 200, 200, 200, 200, 200,
         ];
@@ -1255,8 +1256,6 @@ mod tests {
         let v = build_view(&luma, 4, 4, &mut sb, &mut sqb);
         let (_d, stages, stumps) = tiny_edge_cascade();
         let cascade = leak_tiny_cascade(stages, stumps);
-        // step_q16 = 0 is the degenerate case; the clamp guarantees
-        // forward progress.
         let det = cascade.scan(&v, Q16_ONE, Q16_ONE, 0, 0);
         assert!(det.is_some());
     }


### PR DESCRIPTION
## Summary

`mcp.rs` was 87%/79% lines/regions. Three `JsonRpcErrorCode` variants had no direct test, and every error branch in `parse_request` / `find_string_field` / `find_object_field` was 0-execution. Adds 30 tests targeting the uncovered branches.

**Coverage delta on `mcp.rs`:**
- lines: 87.30% → **98.03%**
- regions: 78.96% → **98.44%**

**What's covered now (was 0-execution):**
- `JsonRpcErrorCode::as_i32` + `message` for all five variants (`InvalidRequest`, `InvalidParams`, `InternalError` were missing)
- `parse_request` error paths: non-object top-level, unterminated object, missing-comma, missing-colon, unknown top-level key, wrong `jsonrpc` type, non-integer id, i64-overflow id
- `parse_request` value variants: array params + scalar params (was unreached `_` arm of `take_value`); unbalanced params
- `read_string` errors: non-string key, dangling escape, unsupported `\u` escape, unterminated string; all supported short escapes
- `find_string_field`: non-object, unterminated, missing-comma / missing-colon, non-string value at match, unbalanced skipped value
- `find_object_field`: absent key returns `None`, plus the five error paths matching `find_string_field`
- `escape_string`: `\r`, `\t`, control-char `\u{:04x}` branch, and non-ASCII pass-through

## Stacked on

#416 — review and merge that first.

## Test plan

- [x] `cargo test -p stackchan-net --lib mcp::` — 53 pass
- [x] `just check` — fmt + clippy strict + host tests + doctests
- [x] `cargo llvm-cov` confirms 98.03%/98.44% on `mcp.rs`