### PR TITLE
docs: cross-linking pass + add audio-debug / dance to index

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,6 +161,18 @@ binary opens an `egui` + `winit` window and runs the modifier stack at
 ~30 s build → flash → boot loop
 (`cargo run -p stackchan-sim --bin viz --features viz`).
 
+## Related
+
+- [Modifier authoring guide](modifiers) — adding a new behavior to the engine.
+- [Naming conventions](naming) — `Intent` / `Modifier` / `Skill` /
+  `ChirpKind` / `OverrideSource` rules with citations.
+- [Signal channels](signals) — the typed `Signal<…, T>` plumbing
+  between peripheral tasks and the render task.
+- [HTTP control plane](http) — what the firmware's task graph
+  exposes to LAN operators.
+- [Typed-error catalog](errors) — every driver crate's `Error<E>`
+  enum surfaced as defmt log lines.
+
 [`Entity`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/entity.rs
 [`Director`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/director.rs
 [`Modifier`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/modifier.rs

--- a/docs/audio-debug.md
+++ b/docs/audio-debug.md
@@ -54,3 +54,12 @@ stream is ~32 KB/s of UDP traffic.
 The stream is **plaintext UDP** on the LAN; not suitable for a shared
 network. Leave the field empty in any deployment outside a controlled
 bench.
+
+## Related
+
+- [Behavior flags](behavior) — `audio_debug_udp_target` is one of
+  the live-reloadable `behavior:` block fields.
+- [Voice agent onboarding](voice) — the wake-word + sidecar loop
+  uses the same audio capture path tapped here.
+- [Sidecar agent](sidecar) — the agent the wake-word path forwards
+  audio to once `audio_debug_udp_target` confirms capture works.

--- a/docs/dance.md
+++ b/docs/dance.md
@@ -1,3 +1,7 @@
+---
+title: Dance choreography
+---
+
 # Dance choreography
 
 Stackchan-kai accepts a JSON keyframe stream over `POST /dance` and
@@ -78,3 +82,12 @@ script's overrides are released on the same tick the new one anchors.
   treats unset fields as "carry the prior value forward" rather than
   "clear", so a 200 ms emotion-only beat doesn't disturb a 50 ms
   motion sweep running underneath.
+
+## Related
+
+- [HTTP control plane](http) — `POST /dance` route alongside the
+  full LAN-side surface.
+- [Modifier authoring guide](modifiers) — `DancePlayer` is one of
+  the high-priority overrides registered in `Phase::Motion`.
+- [Naming conventions](naming) — `NamedMotion` (`greet` / `nod` /
+  `shake` / `laugh`) follows the same vocabulary as `play_motion`.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -144,3 +144,10 @@ When adding a variant to a driver crate's `Error`:
    debugging. Logs that just say "bad chip ID" without the byte are
    hard to triage.
 3. Update this catalog in the same PR.
+
+## Related
+
+- [Architecture overview](architecture) — where the per-peripheral
+  tasks live and how they wrap errors for `defmt`.
+- [Behavior flags](behavior) — `ConfigError` variants surface through
+  `parse_ron` on the `STACKCHAN.RON` load path.

--- a/docs/http.md
+++ b/docs/http.md
@@ -479,3 +479,15 @@ caps the concurrent SSE consumers. An SSE connection that arrives
 when no subscriber slot is free gets `503 stream slots exhausted`
 back. The two constants are coupled — bumping concurrency requires
 raising both.
+
+## Related
+
+- [Behavior flags](behavior) — operator-visible fields persisted
+  through `PUT /settings`.
+- [Signal channels](signals) — the typed `Signal<…, T>` plumbing
+  the render task drains before each `/state` snapshot; SSE uses
+  `PubSubChannel` for multi-subscriber `/state/stream` fan-out.
+- [Sidecar agent](sidecar) — the agent that lives outside the
+  firmware and talks to it over HTTP.
+- [Dance choreography](dance) — wire format for the `POST /dance`
+  keyframe stream.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,10 @@ driver crates.
 - [Modifier authoring guide](modifiers) — adding a new behavior to the engine.
 - [Naming conventions](naming) — rules for `Intent` / `Modifier` / `Skill` / `ChirpKind` / `OverrideSource` names, with citations.
 - [Signal channels](signals) — the typed `Signal<…, T>` pattern that wires sensors to the render task.
+- [Dance choreography](dance) — JSON keyframe stream over `POST /dance`, channel-wise sampling semantics, and DancePlayer lifecycle.
 - [Voice agent](voice) — wake-word + sidecar onboarding flow. Start here when enabling the voice path.
 - [Sidecar agent](sidecar) — wire protocol for the operator-supplied HTTP agent that handles STT + LLM + emotion-tagging.
+- [UDP audio debug](audio-debug) — tee the microphone capture to a LAN UDP target for `aplay` / `nc` inspection.
 - [Typed-error catalog](errors) — every driver crate's `Error<E>` enum.
 
 ## Source layout

--- a/docs/modifiers.md
+++ b/docs/modifiers.md
@@ -135,4 +135,15 @@ directly; they go through `mind` / `voice` / `events` and modifiers in
 later phases translate that into rendered face and physical motion.
 The current population lives at `crates/stackchan-core/src/skills/`.
 
+## Related
+
+- [Naming conventions](naming) — Rule B for modifier names and Rule C
+  for skill names; apply before opening the PR.
+- [Architecture overview](architecture) — `Director`, `Phase` ordering,
+  and where modifiers sit in the task graph.
+- [Behavior flags](behavior) — operator-visible toggles for shipping
+  modifiers (the `behavior:` block in `STACKCHAN.RON`).
+- [Signal channels](signals) — sensor inputs that perception-reading
+  modifiers consume through `entity.perception`.
+
 [`Director`]: https://github.com/andymai/stackchan-kai/blob/main/crates/stackchan-core/src/director.rs

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -199,3 +199,10 @@ why in the module-level doc comment, and update this file with the
 new pattern if it recurs.
 
 The convention exists to be useful, not to be bureaucratic.
+
+## Related
+
+- [Modifier authoring guide](modifiers) — where Rule B applies in
+  practice when adding a new modifier.
+- [Architecture overview](architecture) — `Phase` enum + `Director`
+  ordering that the names sit inside.

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -74,3 +74,13 @@ counter doesn't advance enough relative to its expected cadence, the
 watchdog logs `WARN watchdog: channel '<name>' silent`. See
 [architecture](architecture) for the full task graph and watchdog
 placement.
+
+## Related
+
+- [Architecture overview](architecture) — boot sequence and task
+  graph that the signal table sits inside.
+- [HTTP control plane](http) — SSE fan-out at `/state/stream` is
+  the deliberate `PubSubChannel` exception to the latest-wins
+  `Signal` pattern.
+- [Modifier authoring guide](modifiers) — how to consume signals
+  through `entity.perception` from a new modifier.


### PR DESCRIPTION
## Summary

The handbook had eight of eleven pages in `index.md` but `audio-debug.md` and `dance.md` weren't listed, and most non-index pages had no See also footer back into the handbook. Adds:

- **index**: entries for `dance` + `audio-debug`
- **architecture**: Related → modifiers, naming, signals, http, errors
- **modifiers**: Related → naming (Rules B/C), architecture, behavior, signals
- **naming**: Related → modifiers, architecture
- **signals**: Related → architecture, http (PubSubChannel exception), modifiers
- **http**: Related → behavior, signals, sidecar, dance
- **errors**: Related → architecture, behavior (ConfigError surface)
- **dance**: title frontmatter + Related → http, modifiers (DancePlayer is a high-priority Phase::Motion override), naming (NamedMotion vocabulary)
- **audio-debug**: Related → behavior, voice, sidecar

No content rewrites — these add See also footers and fix the index gap. Existing inline cross-links (voice ↔ sidecar, behavior ↔ sidecar/voice/audio-debug) already covered the voice-onboarding axis.

## Test plan

- [x] Every cross-link path resolves to an existing `docs/*.md` file
- [x] Jekyll-style `[label](page)` (no `.md` suffix) used throughout for consistency with the existing index
- [x] No content rewrites — additive only