### PR TITLE
test(tts): bolster baked.rs coverage — len_hint paths + name + pcm_for fallthrough

### DIFF
--- a/crates/stackchan-tts/src/baked.rs
+++ b/crates/stackchan-tts/src/baked.rs
@@ -536,4 +536,90 @@ mod tests {
         let pcm = drain(Box::new(pickup_chirp()));
         assert_eq!(pcm.len(), 1600);
     }
+
+    #[test]
+    fn backend_name_is_stable_diagnostic_string() {
+        // `name` is what the router's defmt log line emits when the
+        // baked backend wins dispatch — pin the literal.
+        assert_eq!(BakedBackend::new().name(), "Baked");
+    }
+
+    #[test]
+    fn sine_table_source_len_hint_tracks_remaining_samples() {
+        // Fresh: full 3 cycles × 16 samples = 48.
+        let mut src = SineTableSource::new(SINE_1KHZ, 3);
+        assert_eq!(src.len_hint(), Some(48));
+        // After 10-sample fill: 48 − 10 = 38 remaining.
+        let mut buf = [0_i16; 10];
+        assert_eq!(src.fill(&mut buf), 10);
+        assert_eq!(src.len_hint(), Some(38));
+        // After draining all: 0.
+        let mut large = [0_i16; 64];
+        assert_eq!(src.fill(&mut large), 38);
+        assert_eq!(src.len_hint(), Some(0));
+    }
+
+    #[test]
+    fn sine_table_source_len_hint_zero_for_degenerate_sources() {
+        // Empty samples, zero cycles — both short-circuit to Some(0).
+        assert_eq!(SineTableSource::new(&[], 100).len_hint(), Some(0));
+        assert_eq!(SineTableSource::new(SINE_1KHZ, 0).len_hint(), Some(0));
+    }
+
+    #[test]
+    fn sine_sequence_len_hint_sums_remaining_segments() {
+        let seq = SineSequence::new(vec![
+            SineTableSource::new(SINE_1KHZ, 1), // 16
+            SineTableSource::new(SINE_2KHZ, 1), // 8
+        ]);
+        assert_eq!(seq.len_hint(), Some(24));
+    }
+
+    #[test]
+    fn sine_sequence_len_hint_skips_consumed_segments() {
+        // After advancing past the first segment, len_hint should
+        // reflect only the remaining ones. Drive the sequence to
+        // advance segments by exhausting the first.
+        let mut seq = SineSequence::new(vec![
+            SineTableSource::new(SINE_1KHZ, 1), // 16 samples
+            SineTableSource::new(SINE_2KHZ, 1), // 8 samples
+        ]);
+        // Drain the first segment fully.
+        let mut buf = [0_i16; 16];
+        assert_eq!(seq.fill(&mut buf), 16);
+        // First segment is exhausted; next fill will advance idx. We
+        // can't assert idx directly, but len_hint should match what
+        // remains (only the 8-sample second segment).
+        let remaining_buf_fill = drain(Box::new(SineSequence::new(vec![SineTableSource::new(
+            SINE_2KHZ, 1,
+        )])));
+        assert_eq!(remaining_buf_fill.len(), 8);
+    }
+
+    #[test]
+    fn pcm_source_len_hint_tracks_remaining_samples() {
+        // Static 8-byte buffer = 4 i16 samples.
+        const FIXTURE: &[u8] = &[0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0xFF, 0xFF];
+        let mut src = PcmSource::new(FIXTURE);
+        assert_eq!(src.len_hint(), Some(4));
+        let mut buf = [0_i16; 2];
+        assert_eq!(src.fill(&mut buf), 2);
+        assert_eq!(src.len_hint(), Some(2));
+        let mut tail = [0_i16; 4];
+        assert_eq!(src.fill(&mut tail), 2);
+        assert_eq!(src.len_hint(), Some(0));
+        // Exhausted — further fills emit nothing.
+        assert_eq!(src.fill(&mut tail), 0);
+    }
+
+    #[test]
+    fn pcm_for_returns_none_for_non_verbal_combos() {
+        // `pcm_for` is only called from `render` for verbal phrases,
+        // so the catch-all `_ => None` arm doesn't fire in production.
+        // Pin that an SFX phrase resolves to None when looked up
+        // directly — guards against a future caller accidentally
+        // routing SFX through the PCM path.
+        assert_eq!(pcm_for(Locale::En, PhraseId::WakeChirp), None);
+        assert_eq!(pcm_for(Locale::Ja, PhraseId::PickupChirp), None);
+    }
 }

--- a/crates/stackchan-tts/src/baked.rs
+++ b/crates/stackchan-tts/src/baked.rs
@@ -578,8 +578,8 @@ mod tests {
     #[test]
     fn sine_sequence_len_hint_skips_consumed_segments() {
         // After advancing past the first segment, len_hint should
-        // reflect only the remaining ones. Drive the sequence to
-        // advance segments by exhausting the first.
+        // reflect only the remaining ones — exercises the
+        // `i < self.idx { continue }` arm.
         let mut seq = SineSequence::new(vec![
             SineTableSource::new(SINE_1KHZ, 1), // 16 samples
             SineTableSource::new(SINE_2KHZ, 1), // 8 samples
@@ -587,13 +587,16 @@ mod tests {
         // Drain the first segment fully.
         let mut buf = [0_i16; 16];
         assert_eq!(seq.fill(&mut buf), 16);
-        // First segment is exhausted; next fill will advance idx. We
-        // can't assert idx directly, but len_hint should match what
-        // remains (only the 8-sample second segment).
-        let remaining_buf_fill = drain(Box::new(SineSequence::new(vec![SineTableSource::new(
-            SINE_2KHZ, 1,
-        )])));
-        assert_eq!(remaining_buf_fill.len(), 8);
+        // First segment is exhausted; issue one more fill to advance
+        // `idx` past it. `fill` probes the now-empty segment, hits
+        // the `n == 0` branch, increments idx, then writes one
+        // sample from the second segment into our probe buffer.
+        // 8 − 1 = 7 samples remain in the second segment; len_hint
+        // must skip the consumed first (the `i < self.idx` continue
+        // arm) and return Some(7).
+        let mut probe = [0_i16; 1];
+        seq.fill(&mut probe);
+        assert_eq!(seq.len_hint(), Some(7));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`baked.rs` was 86%/87% regions/lines. Every `len_hint` impl (`SineTableSource`, `SineSequence`, `PcmSource`) was 0-execution, `BakedBackend::name` was untested, and the `pcm_for` catch-all `_ => None` arm had no direct test.

**Coverage delta on `baked.rs`:**
- lines: 87.50% → **97.92%**
- regions: 86.98% → **98.17%**

**Adds 8 tests:**
- `backend_name_is_stable_diagnostic_string` — pins `"Baked"`
- `sine_table_source_len_hint_tracks_remaining_samples` — full, mid-drain, fully-drained
- `sine_table_source_len_hint_zero_for_degenerate_sources` — empty table + zero cycles
- `sine_sequence_len_hint_sums_remaining_segments` — straight sum
- `sine_sequence_len_hint_skips_consumed_segments` — pins that drained segments don't contribute
- `pcm_source_len_hint_tracks_remaining_samples` — full, mid-drain, exhausted
- `pcm_for_returns_none_for_non_verbal_combos` — direct lookup of SFX `(Locale, PhraseId)` combos returns `None` (defensive pin against a future caller accidentally routing SFX through the PCM path)

## Test plan

- [x] `cargo test -p stackchan-tts --lib baked::` — 17 pass
- [x] `just check` green
- [x] `cargo llvm-cov` confirms 97.92%/98.17% on `baked.rs`