### PR TITLE
test(aw9523): cover From<E> for Error<E> blanket conversion

### DIFF
--- a/crates/aw9523/src/lib.rs
+++ b/crates/aw9523/src/lib.rs
@@ -285,4 +285,16 @@ mod tests {
         // Datasheet requires ≥10 µs on RESX; we use 20 ms to match M5Stack.
         assert!(RESET_PULSE_MS >= 1);
     }
+
+    #[test]
+    fn error_from_blanket_wraps_in_i2c_variant() {
+        // The `impl From<E> for Error<E>` blanket — every `?` operator
+        // in the driver routes the bus error through this conversion.
+        // The mock uses `Infallible`, so the runtime path can't be
+        // reached during tests; exercise the impl directly.
+        let err: Error<&'static str> = "bus go boom".into();
+        match err {
+            Error::I2c(s) => assert_eq!(s, "bus go boom"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`aw9523/src/lib.rs` was 88%/94% regions/lines. The bus-error wrapper that the `?` operator routes through was 0-execution because the existing test harness uses `Infallible` — the runtime conversion path can't fire. A direct exercise of the impl plugs the gap.

**Coverage delta on `aw9523/src/lib.rs`:**
- lines: 94.69% → **98.02%**
- regions: 88.62% → **91.55%**

(The remaining 8.5% of regions are if-let `else` arms inside the mock harness that fire only for `Operation::Read` ops the AW9523 driver never issues — coverage instrumentation noise, not reachable production code.)

## Test plan

- [x] `cargo test -p aw9523 --lib` — 5 pass
- [x] `just check` green