### PR TITLE
test(core): cover Instant - Instant Sub impl

### DIFF
--- a/crates/stackchan-core/src/clock.rs
+++ b/crates/stackchan-core/src/clock.rs
@@ -93,4 +93,16 @@ mod tests {
         let after = end + 1000;
         assert_eq!(after.as_millis(), u64::MAX);
     }
+
+    #[test]
+    fn instant_sub_returns_saturating_duration() {
+        // The `impl Sub for Instant` delegates to
+        // `saturating_duration_since` — direct subtraction returns
+        // the same non-negative duration.
+        let a = Instant::from_millis(100);
+        let b = Instant::from_millis(40);
+        assert_eq!(a - b, 60);
+        // Reverse order saturates at zero rather than wrapping.
+        assert_eq!(b - a, 0);
+    }
 }


### PR DESCRIPTION
## Summary

The `impl Sub for Instant` delegated to `saturating_duration_since` but had no direct call site, leaving 100%→90% headroom on the clock module.

**Coverage delta on `clock.rs`:**
- lines: 90.91% → **100.00%**
- regions: 90.00% → **100.00%**

## Test plan

- [x] `cargo test -p stackchan-core --lib clock::` — 4 pass
- [x] `just check` green