### PR TITLE
test(core): cover battery_overlay constructors + meta

### DIFF
--- a/crates/stackchan-core/src/modifiers/battery_overlay.rs
+++ b/crates/stackchan-core/src/modifiers/battery_overlay.rs
@@ -162,4 +162,38 @@ mod tests {
         m.update(&mut e);
         assert!(!e.face.battery_overlay.expect("set").charging);
     }
+
+    #[test]
+    fn new_and_default_construct_disabled_instance() {
+        // Both `new()` and `Default::default()` should produce a
+        // disabled modifier that no-ops when ticked.
+        for ctor_name in ["new", "default"] {
+            let mut m = if ctor_name == "new" {
+                BatteryOverlayFromPerception::new()
+            } else {
+                BatteryOverlayFromPerception::default()
+            };
+            let mut e = Entity::default();
+            e.perception.battery_percent = Some(50);
+            m.update(&mut e);
+            assert!(
+                e.face.battery_overlay.is_none(),
+                "{ctor_name}: disabled modifier must not write overlay",
+            );
+        }
+    }
+
+    #[test]
+    fn modifier_meta_advertises_battery_overlay_writes() {
+        // Pin the meta surface so Director's assert_only_writes
+        // enforcement keeps matching the actual writes inside update.
+        let m = BatteryOverlayFromPerception::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "BatteryOverlayFromPerception");
+        assert_eq!(meta.phase, Phase::Decoration);
+        assert_eq!(meta.priority, 5);
+        assert!(meta.reads.contains(&Field::BatteryPercent));
+        assert!(meta.reads.contains(&Field::UsbPowerPresent));
+        assert_eq!(meta.writes, &[Field::BatteryOverlay]);
+    }
 }


### PR DESCRIPTION
## Summary

`battery_overlay.rs` was 88%/92% (lines/regions). The `pub const fn new()`, the `Default` impl, and the `meta()` accessor were 0-execution.

**Coverage delta:**
- lines: 88.10% → **100.00%**
- regions: 92.31% → **100.00%**

**Adds 2 tests:**
- `new_and_default_construct_disabled_instance` — exercises both constructors and confirms each produces a disabled, no-op modifier.
- `modifier_meta_advertises_battery_overlay_writes` — pins the meta surface (name, phase, priority, reads, writes) so Director's `assert_only_writes` enforcement keeps matching the actual writes.

## Test plan

- [x] `cargo test -p stackchan-core --lib modifiers::battery_overlay::` — 7 pass
- [x] `just check` green