### PR TITLE
test(core): pin battery_overlay reads with exact equality (greptile P2 follow-up)

### DIFF
--- a/crates/stackchan-core/src/modifiers/battery_overlay.rs
+++ b/crates/stackchan-core/src/modifiers/battery_overlay.rs
@@ -192,8 +192,7 @@ mod tests {
         assert_eq!(meta.name, "BatteryOverlayFromPerception");
         assert_eq!(meta.phase, Phase::Decoration);
         assert_eq!(meta.priority, 5);
-        assert!(meta.reads.contains(&Field::BatteryPercent));
-        assert!(meta.reads.contains(&Field::UsbPowerPresent));
+        assert_eq!(meta.reads, &[Field::BatteryPercent, Field::UsbPowerPresent]);
         assert_eq!(meta.writes, &[Field::BatteryOverlay]);
     }
 }


### PR DESCRIPTION
## Summary

PR #439's `modifier_meta_advertises_battery_overlay_writes` test pinned `meta.writes` with `assert_eq!` but used the looser `contains` for `meta.reads`. Greptile flagged the asymmetry post-merge: the stated "pin the meta surface" claim only covered writes. Tighten both to `assert_eq!`.

## Test plan

- [x] `cargo test -p stackchan-core --lib modifiers::battery_overlay::` — 7 pass
- [x] `just check` green