### PR TITLE
test(core): pick non-default values in with_db_window test (greptile P1 follow-up)

### DIFF
--- a/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
+++ b/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
@@ -517,9 +517,12 @@ mod tests {
 
     #[test]
     fn with_db_window_overrides_silence_and_full() {
-        let m = MouthFromAudio::new().with_db_window(-50.0, -10.0);
-        assert!((m.silence_db - -50.0).abs() < f32::EPSILON);
-        assert!((m.full_db - -10.0).abs() < f32::EPSILON);
+        // Pick values distinct from DEFAULT_SILENCE_DB / DEFAULT_FULL_DB
+        // so a no-op `with_db_window` would fail this test — otherwise
+        // the assertion is vacuous (the defaults already satisfy it).
+        let m = MouthFromAudio::new().with_db_window(-40.0, -20.0);
+        assert!((m.silence_db - -40.0).abs() < f32::EPSILON);
+        assert!((m.full_db - -20.0).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #444's `with_db_window_overrides_silence_and_full` used `-50.0 / -10.0`, which are exactly `DEFAULT_SILENCE_DB` / `DEFAULT_FULL_DB`. A no-op implementation of `with_db_window` would still pass the test. Switch to `-40.0 / -20.0` so the assertion only holds when the builder actually stores the new values.

## Test plan

- [x] `cargo test -p stackchan-core --lib modifiers::mouth_from_audio::with_db_window` — passes
- [x] `just check` green