### PR TITLE
test(si12t): drive init through with_address mock (greptile P2 follow-up)

### DIFF
--- a/crates/si12t/src/lib.rs
+++ b/crates/si12t/src/lib.rs
@@ -511,13 +511,34 @@ mod tests {
     }
 
     #[test]
-    fn with_address_overrides_default() {
-        // Alt-address constructor for boards that strap the chip to
-        // a non-default I²C address.
+    fn with_address_overrides_default_and_routes_writes() {
+        // Alt-address constructor for boards that strap the chip to a
+        // non-default I²C address. Beyond pinning the getter, drive
+        // the full init() through the mock and confirm every recorded
+        // Event::Write went to 0x42, not the default ADDRESS — guards
+        // against a regression where any I²C call hard-codes ADDRESS.
         let harness = Harness::new();
-        let bus = MockI2c { harness: &harness };
-        let chip = Si12t::with_address(bus, 0x42);
-        assert_eq!(chip.address(), 0x42);
+        let mut bus = MockI2c { harness: &harness };
+        let mut delay = MockDelay { harness: &harness };
+        let alt_address = 0x42_u8;
+        let mut chip = Si12t::with_address(&mut bus, alt_address);
+        assert_eq!(chip.address(), alt_address);
+        block_on(chip.init(&mut delay)).unwrap();
+        let writes: Vec<u8> = harness
+            .events()
+            .into_iter()
+            .filter_map(|e| match e {
+                Event::Write(addr, _) => Some(addr),
+                _ => None,
+            })
+            .collect();
+        assert!(!writes.is_empty(), "init must issue at least one write");
+        for addr in &writes {
+            assert_eq!(
+                *addr, alt_address,
+                "every init write must route to the configured address, not the default",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Greptile flagged that PR #446's `with_address_overrides_default` only checked the getter. A regression where `init()` or `write_reg` hard-coded `ADDRESS` instead of `self.address` would pass that test undetected.

Drive the full `init()` through a mock with `with_address(0x42)` and assert every recorded `Event::Write` routed to `0x42`, not the default `ADDRESS`. Renamed to `with_address_overrides_default_and_routes_writes` to make the new contract explicit.

## Test plan

- [x] `cargo test -p si12t --lib` — 9 pass
- [x] `just check` green