### PR TITLE
test(core): exhaustive Emotion to HeadBias mapping coverage

### DIFF
--- a/crates/stackchan-core/src/modifiers/head_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_emotion.rs
@@ -495,4 +495,30 @@ mod tests {
         assert_eq!(b.pan_deg, 10.0);
         assert_eq!(b.tilt_deg, -5.0);
     }
+
+    #[test]
+    fn targets_for_returns_unique_bias_for_every_emotion() {
+        // Iterate every Emotion::ALL entry to:
+        //   1. Exercise every arm of the targets_for match.
+        //   2. Pin that no two emotions land on identical biases —
+        //      clippy::match_same_arms catches the source-level
+        //      duplicate but a clever future re-tune could
+        //      accidentally collide two variants at the same numeric
+        //      value (e.g. Loved at 3.5 / Hi at 4.0 / Happy at 3.0
+        //      are intentionally close).
+        use alloc::vec::Vec;
+        let biases: Vec<HeadBias> = Emotion::ALL.iter().map(|&e| targets_for(e)).collect();
+        assert_eq!(biases.len(), Emotion::ALL.len());
+        for (i, a) in biases.iter().enumerate() {
+            for (j, b) in biases.iter().enumerate().skip(i + 1) {
+                assert!(
+                    a != b,
+                    "{:?} and {:?} share bias ({:?})",
+                    Emotion::ALL[i],
+                    Emotion::ALL[j],
+                    a,
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`head_from_emotion` was 94% regions / 77% lines. Existing tests only exercised Neutral / Happy / Sad / Sleepy / Surprised; every other Emotion variant arm of `targets_for` was 0-execution.

**Coverage delta on `head_from_emotion.rs`:**
- lines: 77.91% → **97.63%**
- regions: 94.93% → **97.89%**

**Adds** `targets_for_returns_unique_bias_for_every_emotion`:
- iterates `Emotion::ALL` so every arm fires
- pins that no two emotions land on identical `(pan, tilt)` — a silent collision would let two emotions share a bias and read identically on the head servos

## Test plan

- [x] `cargo test -p stackchan-core --lib modifiers::head_from_emotion::` — 10 pass
- [x] `just check` green