### PR TITLE
test(core): drop vacuously-true biases.len() assertion (greptile P2 follow-up)

### DIFF
--- a/crates/stackchan-core/src/modifiers/head_from_emotion.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_emotion.rs
@@ -508,7 +508,6 @@ mod tests {
         //      are intentionally close).
         use alloc::vec::Vec;
         let biases: Vec<HeadBias> = Emotion::ALL.iter().map(|&e| targets_for(e)).collect();
-        assert_eq!(biases.len(), Emotion::ALL.len());
         for (i, a) in biases.iter().enumerate() {
             for (j, b) in biases.iter().enumerate().skip(i + 1) {
                 assert!(


### PR DESCRIPTION
## Summary

Greptile flagged that PR #452's `assert_eq!(biases.len(), Emotion::ALL.len())` is vacuously true — `biases` is built by collecting one-for-one over `Emotion::ALL` so the lengths match by construction.

Drop the dead assertion. The per-pair inequality loop is the real contract.

## Test plan

- [x] `cargo test -p stackchan-core --lib modifiers::head_from_emotion::targets_for` passes
- [x] `just check` green