### PR TITLE
test(tts): cover default len_hint impl

### DIFF
--- a/crates/stackchan-tts/src/source.rs
+++ b/crates/stackchan-tts/src/source.rs
@@ -116,4 +116,24 @@ mod tests {
         let src = ZeroSource { remaining: 42 };
         assert_eq!(src.len_hint(), Some(42));
     }
+
+    /// Source that only implements the required method, so it inherits
+    /// the default `len_hint` (`None`) and `lip_sync` (`None`).
+    struct MinimalSource;
+
+    impl AudioSource for MinimalSource {
+        fn fill(&mut self, _buf: &mut [i16]) -> usize {
+            0
+        }
+    }
+
+    #[test]
+    fn len_hint_defaults_to_none_for_streaming_sources() {
+        // The trait's default `len_hint` returns None — pinning the
+        // contract for streaming sources that don't know their length.
+        // ZeroSource overrides this; MinimalSource intentionally
+        // doesn't, so the default arm fires.
+        let src = MinimalSource;
+        assert_eq!(src.len_hint(), None);
+    }
 }


### PR DESCRIPTION
## Summary

`source.rs` was 94%/90% regions/lines. The trait's default `len_hint` (returns `None` for streaming sources) was 0-execution because `ZeroSource` overrides it.

**Coverage delta on `source.rs`:**
- lines: 90.91% → **92.50%**
- regions: 94.55% → **95.38%**

Adds a `MinimalSource` that only implements the required `fill` method so the default `len_hint` arm fires.

## Test plan

- [x] `cargo test -p stackchan-tts --lib source::` — 4 pass
- [x] `just check` green