### PR TITLE
test(emotion-cycle): cover current() accessor + Default impl

### DIFF
--- a/crates/stackchan-core/src/modifiers/emotion_cycle.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_cycle.rs
@@ -252,4 +252,21 @@ mod tests {
         step(&mut cycle, &mut entity, 10_000);
         assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
     }
+
+    #[test]
+    fn current_reports_indexed_emotion_or_none_when_empty() {
+        let cycle = EmotionCycle::with_params(&[Emotion::Happy, Emotion::Sad], 1_000);
+        assert_eq!(cycle.current(), Some(Emotion::Happy));
+        let empty = EmotionCycle::with_params(&[], 1_000);
+        assert_eq!(empty.current(), None);
+    }
+
+    #[test]
+    fn default_constructs_default_sequence() {
+        let from_default = <EmotionCycle as Default>::default();
+        assert_eq!(
+            from_default.current(),
+            Some(EmotionCycle::DEFAULT_SEQUENCE[0]),
+        );
+    }
 }

--- a/crates/stackchan-core/src/modifiers/emotion_cycle.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_cycle.rs
@@ -266,7 +266,7 @@ mod tests {
         let from_default = <EmotionCycle as Default>::default();
         assert_eq!(
             from_default.current(),
-            Some(EmotionCycle::DEFAULT_SEQUENCE[0]),
+            EmotionCycle::DEFAULT_SEQUENCE.first().copied(),
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds a test exercising `EmotionCycle::current()` over both arms: populated sequence (Some) and empty slice (None).
- Adds a test pinning that `<EmotionCycle as Default>::default()` constructs against `DEFAULT_SEQUENCE` — direct `EmotionCycle::new()` calls don't count toward the `Default` trait impl in coverage.
- Coverage on `crates/stackchan-core/src/modifiers/emotion_cycle.rs`: 91.86% → 97.67% lines, 91.55% → 97.89% regions.

## Test plan
- [x] `cargo test -p stackchan-core --lib modifiers::emotion_cycle` (9/9 pass)
- [x] `just check` clean (fmt + clippy + host tests + doctests + workspace)
- [x] llvm-cov delta verified on this file