### PR TITLE
test(mood): pin every (variant, multiplier) arm

### DIFF
--- a/crates/stackchan-core/src/mood.rs
+++ b/crates/stackchan-core/src/mood.rs
@@ -202,4 +202,27 @@ mod tests {
         assert_eq!(Mood::from_wire_str("NEUTRAL"), None); // case sensitive
         assert_eq!(Mood::from_wire_str("ecstatic"), None);
     }
+
+    fn near(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-6
+    }
+
+    #[test]
+    fn multiplier_table_pins_every_arm() {
+        // Pins each (variant, multiplier) pair so the per-arm match
+        // values can't drift without a test update — and so every match
+        // arm in blink/breath/drift_multiplier is exercised.
+        let table = [
+            (Mood::Neutral, 1.0_f32, 1.0_f32, 1.0_f32),
+            (Mood::Calm, 0.7, 1.2, 0.7),
+            (Mood::Playful, 1.4, 0.9, 1.3),
+            (Mood::Focus, 0.6, 0.85, 0.5),
+            (Mood::Sleepy, 0.4, 1.4, 0.4),
+        ];
+        for (m, blink, breath, drift) in table {
+            assert!(near(m.blink_multiplier(), blink), "blink for {m:?}");
+            assert!(near(m.breath_multiplier(), breath), "breath for {m:?}");
+            assert!(near(m.drift_multiplier(), drift), "drift for {m:?}");
+        }
+    }
 }

--- a/crates/stackchan-core/src/mood.rs
+++ b/crates/stackchan-core/src/mood.rs
@@ -219,6 +219,13 @@ mod tests {
             (Mood::Focus, 0.6, 0.85, 0.5),
             (Mood::Sleepy, 0.4, 1.4, 0.4),
         ];
+        // Trip-wire: extending Mood::ALL must extend this table too,
+        // otherwise the new arm's multipliers go unpinned.
+        assert_eq!(
+            table.len(),
+            Mood::ALL.len(),
+            "extend the multiplier table when adding a Mood variant",
+        );
         for (m, blink, breath, drift) in table {
             assert!(near(m.blink_multiplier(), blink), "blink for {m:?}");
             assert!(near(m.breath_multiplier(), breath), "breath for {m:?}");


### PR DESCRIPTION
## Summary
- Adds a table-driven test asserting exact blink / breath / drift multiplier values for every \`Mood\` variant. Closes the 5 uncovered match arms (Focus blink + breath; Calm / Playful / Sleepy drift).
- Pins the per-variant constants so a future tweak surfaces here rather than drifting silently into the style-from-mood chain.
- Coverage on \`crates/stackchan-core/src/mood.rs\`: 93.67% → 100.00% lines / 95.97% → 100.00% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib mood\` (18/18 pass)
- [x] \`just check\` clean
- [x] llvm-cov delta verified on this file