### PR TITLE
test(decorator-from-body-touch): cover Default + meta

### DIFF
--- a/crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs
@@ -199,4 +199,23 @@ mod tests {
             "re-armed expiry should be later than the original ({second:?} vs {first:?})"
         );
     }
+
+    #[test]
+    fn default_matches_new_hold() {
+        let from_default = <DecoratorFromBodyTouch as Default>::default();
+        let from_new = DecoratorFromBodyTouch::new();
+        assert_eq!(from_default.hold_ms, from_new.hold_ms);
+        assert_eq!(from_default.hold_ms, HEART_HOLD_MS);
+    }
+
+    #[test]
+    fn meta_declares_decoration_phase_and_decorator_write() {
+        let m = DecoratorFromBodyTouch::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "DecoratorFromBodyTouch");
+        assert_eq!(meta.phase, Phase::Decoration);
+        assert_eq!(meta.priority, 0);
+        assert_eq!(meta.writes, &[Field::Decorator]);
+        assert_eq!(meta.reads, &[Field::BodyTouch, Field::Emotion]);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds direct tests for \`Default::default()\` and \`meta()\` — the two arms behavioural tests bypassed by calling \`new()\` / \`with_hold_ms()\` and \`update()\` directly.
- Coverage on \`crates/stackchan-core/src/modifiers/decorator_from_body_touch.rs\`: 94.23% → 100.00% lines / 95.04% → 100.00% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::decorator_from_body_touch\` (6/6 pass)
- [x] \`just check\` clean
- [x] llvm-cov delta verified