### PR TITLE
test(emotion-from-remote): cover Default + meta

### DIFF
--- a/crates/stackchan-core/src/modifiers/emotion_from_remote.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_remote.rs
@@ -238,4 +238,23 @@ mod tests {
         remote.update(&mut entity);
         assert_eq!(entity.mind.affect.emotion, Emotion::Happy);
     }
+
+    #[test]
+    fn default_matches_new() {
+        let from_default = <EmotionFromRemote as Default>::default();
+        let from_new = EmotionFromRemote::new();
+        assert_eq!(from_default.mapping.len(), from_new.mapping.len());
+    }
+
+    #[test]
+    fn meta_declares_affect_phase_and_autonomy_write() {
+        let m = EmotionFromRemote::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "EmotionFromRemote");
+        assert_eq!(meta.phase, Phase::Affect);
+        assert_eq!(meta.priority, -90);
+        assert!(meta.writes.contains(&Field::Emotion));
+        assert!(meta.writes.contains(&Field::Autonomy));
+        assert!(meta.reads.contains(&Field::RemotePending));
+    }
 }

--- a/crates/stackchan-core/src/modifiers/emotion_from_remote.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_remote.rs
@@ -243,18 +243,25 @@ mod tests {
     fn default_matches_new() {
         let from_default = <EmotionFromRemote as Default>::default();
         let from_new = EmotionFromRemote::new();
-        assert_eq!(from_default.mapping.len(), from_new.mapping.len());
+        // Slice equality, not just length: catches a future Default
+        // that returns a non-empty mapping of matching length.
+        assert_eq!(from_default.mapping, from_new.mapping);
     }
 
     #[test]
-    fn meta_declares_affect_phase_and_autonomy_write() {
+    fn meta_declares_affect_phase_and_full_reads_writes() {
         let m = EmotionFromRemote::new();
         let meta = m.meta();
         assert_eq!(meta.name, "EmotionFromRemote");
         assert_eq!(meta.phase, Phase::Affect);
         assert_eq!(meta.priority, -90);
-        assert!(meta.writes.contains(&Field::Emotion));
-        assert!(meta.writes.contains(&Field::Autonomy));
-        assert!(meta.reads.contains(&Field::RemotePending));
+        // Full contract pin — including Autonomy in reads (update
+        // checks manual_until) and RemotePending in writes (.take()
+        // clears it on consume).
+        assert_eq!(meta.reads, &[Field::Autonomy, Field::RemotePending]);
+        assert_eq!(
+            meta.writes,
+            &[Field::Emotion, Field::Autonomy, Field::RemotePending],
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Same closer-the-gap pattern as #463–#467: direct tests for \`Default::default()\` and \`meta()\`.
- Coverage on \`crates/stackchan-core/src/modifiers/emotion_from_remote.rs\`: 93.81% → 100.00% lines / 95.59% → 100.00% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::emotion_from_remote\` (8/8 pass)
- [x] llvm-cov delta verified