### PR TITLE
test(audio-features): cover mel weights() accessor + Default

### DIFF
--- a/crates/stackchan-audio-features/src/mel.rs
+++ b/crates/stackchan-audio-features/src/mel.rs
@@ -265,15 +265,23 @@ mod tests {
 
     #[test]
     fn default_matches_new() {
+        // Default::default() delegates to new(); this also asserts
+        // new() is deterministic across two calls.
         let from_default = <MelFilterbank as Default>::default();
         let from_new = MelFilterbank::new();
         assert_eq!(from_default.weights().len(), from_new.weights().len());
-        // Bit-equality on the deterministic baked weights — both
-        // construction paths run the same const setup so the bytes
-        // should match exactly.
-        for (d, n) in from_default.weights().iter().zip(from_new.weights().iter()) {
-            for (a, b) in d.iter().zip(n.iter()) {
-                assert_eq!(a.to_bits(), b.to_bits());
+        for (row, (d, n)) in from_default
+            .weights()
+            .iter()
+            .zip(from_new.weights().iter())
+            .enumerate()
+        {
+            for (col, (a, b)) in d.iter().zip(n.iter()).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "weight diverged at row={row} col={col}: default={a} new={b}",
+                );
             }
         }
     }

--- a/crates/stackchan-audio-features/src/mel.rs
+++ b/crates/stackchan-audio-features/src/mel.rs
@@ -262,4 +262,34 @@ mod tests {
             "expected 1-2 non-zero mel bins, got {nonzero}: {out:?}"
         );
     }
+
+    #[test]
+    fn default_matches_new() {
+        let from_default = <MelFilterbank as Default>::default();
+        let from_new = MelFilterbank::new();
+        assert_eq!(from_default.weights().len(), from_new.weights().len());
+        // Bit-equality on the deterministic baked weights — both
+        // construction paths run the same const setup so the bytes
+        // should match exactly.
+        for (d, n) in from_default.weights().iter().zip(from_new.weights().iter()) {
+            for (a, b) in d.iter().zip(n.iter()) {
+                assert_eq!(a.to_bits(), b.to_bits());
+            }
+        }
+    }
+
+    #[test]
+    fn weights_accessor_exposes_matrix_with_full_band_coverage() {
+        let fb = MelFilterbank::new();
+        let w = fb.weights();
+        assert_eq!(w.len(), MEL_BIN_COUNT);
+        // Every filter has at least one non-zero bin — otherwise the
+        // band-edge construction has silently degenerated.
+        for (m, row) in w.iter().enumerate() {
+            assert!(
+                row.iter().any(|&x| x > 0.0),
+                "mel filter {m} has no non-zero weights",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds tests for the \`MelFilterbank::weights()\` accessor (asserts shape + per-filter non-empty rows) and the \`Default\` impl (bit-equality on the deterministic baked weights).
- Coverage on \`crates/stackchan-audio-features/src/mel.rs\`: 93.04% → ≥99% lines / 95.94% → 100.00% regions. Residual lines are panic-formatter args inside \`assert!\` messages.

## Test plan
- [x] \`cargo test -p stackchan-audio-features --lib mel\` (9/9 pass)
- [x] \`cargo clippy -p stackchan-audio-features --all-targets -- -D warnings\` clean