### PR TITLE
test(audio-features): cover quantize Default trait surface

### DIFF
--- a/crates/stackchan-audio-features/src/quantize.rs
+++ b/crates/stackchan-audio-features/src/quantize.rs
@@ -178,4 +178,13 @@ mod tests {
         assert!((p.scale - 0.5).abs() < f32::EPSILON);
         assert_eq!(p.zero_point, -25);
     }
+
+    #[test]
+    fn default_trait_yields_documented_baseline() {
+        // <QuantParams as Default>::default() delegates to DEFAULT;
+        // assert structural equality so the trait surface stays pinned.
+        let from_default = <QuantParams as Default>::default();
+        assert!((from_default.scale - QuantParams::DEFAULT.scale).abs() < f32::EPSILON);
+        assert_eq!(from_default.zero_point, QuantParams::DEFAULT.zero_point);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a direct test for \`<QuantParams as Default>::default()\` so the trait surface is pinned distinct from \`QuantParams::DEFAULT\`.
- Coverage on \`crates/stackchan-audio-features/src/quantize.rs\`: 94.20% → 99.16% lines / 96.43% → 100.00% regions. Residual line is a test-internal panic-formatter arg.

## Test plan
- [x] \`cargo test -p stackchan-audio-features --lib quantize\` (8/8 pass)