### PR TITLE
test(bubble-expiry): cover meta() phase + priority pin

### DIFF
--- a/crates/stackchan-core/src/modifiers/bubble_expiry.rs
+++ b/crates/stackchan-core/src/modifiers/bubble_expiry.rs
@@ -129,10 +129,10 @@ mod tests {
     }
 
     #[test]
-    fn meta_runs_first_in_decoration_phase_with_bubble_write() {
-        // BubbleExpiry must sort before trigger modifiers in
-        // Decoration so they see a clean slate. Pin phase + priority
-        // here so a future re-tune surfaces immediately.
+    fn meta_pins_decoration_phase_and_priority_minus_ten() {
+        // Pins the absolute priority value — ordering relative to
+        // sibling Decoration modifiers is enforced by the Director's
+        // priority sort, not here.
         let m = BubbleExpiry::new();
         let meta = m.meta();
         assert_eq!(meta.name, "BubbleExpiry");

--- a/crates/stackchan-core/src/modifiers/bubble_expiry.rs
+++ b/crates/stackchan-core/src/modifiers/bubble_expiry.rs
@@ -127,4 +127,18 @@ mod tests {
             "fresh bubble must survive the next sweep"
         );
     }
+
+    #[test]
+    fn meta_runs_first_in_decoration_phase_with_bubble_write() {
+        // BubbleExpiry must sort before trigger modifiers in
+        // Decoration so they see a clean slate. Pin phase + priority
+        // here so a future re-tune surfaces immediately.
+        let m = BubbleExpiry::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "BubbleExpiry");
+        assert_eq!(meta.phase, Phase::Decoration);
+        assert_eq!(meta.priority, -10);
+        assert_eq!(meta.reads, &[Field::Bubble]);
+        assert_eq!(meta.writes, &[Field::Bubble]);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a direct meta() test pinning that BubbleExpiry runs first in Decoration (priority -10) so trigger modifiers see a clean slate.
- Coverage on \`crates/stackchan-core/src/modifiers/bubble_expiry.rs\`: 95.31% → 100.00% lines / 96.47% → 100.00% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::bubble_expiry\` (5/5 pass)