### PR TITLE
test(intent-from-body-touch): cover with_mapping, Default, meta

### DIFF
--- a/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
@@ -437,12 +437,11 @@ mod tests {
             ..GestureMapping::DEFAULT
         };
         let mut m = IntentFromBodyTouch::new().with_mapping(mapping);
-        let mut entity = Entity::default();
-        entity.perception.body_touch = Some(BodyTouch {
+        let mut entity = entity_with_touch(Some(BodyTouch {
             centre: 2,
             ..BodyTouch::default()
-        });
-        m.update(&mut entity);
+        }));
+        run(&mut m, &mut entity, 100);
         assert_eq!(entity.mind.affect.emotion, Emotion::Loved);
     }
 

--- a/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
+++ b/crates/stackchan-core/src/modifiers/intent_from_body_touch.rs
@@ -426,4 +426,46 @@ mod tests {
         // Position with no touch is zero.
         assert_eq!(BodyTouch::default().position(), 0);
     }
+
+    #[test]
+    fn with_mapping_overrides_press_emotions() {
+        // Swap centre press to Loved and check the press path picks up
+        // the override. Confirms with_mapping reaches the gesture
+        // table at runtime.
+        let mapping = GestureMapping {
+            press_centre: Emotion::Loved,
+            ..GestureMapping::DEFAULT
+        };
+        let mut m = IntentFromBodyTouch::new().with_mapping(mapping);
+        let mut entity = Entity::default();
+        entity.perception.body_touch = Some(BodyTouch {
+            centre: 2,
+            ..BodyTouch::default()
+        });
+        m.update(&mut entity);
+        assert_eq!(entity.mind.affect.emotion, Emotion::Loved);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_default = <IntentFromBodyTouch as Default>::default();
+        let from_new = IntentFromBodyTouch::new();
+        assert_eq!(from_default.mapping, from_new.mapping);
+        assert_eq!(from_default.swipe_delta, from_new.swipe_delta);
+        assert_eq!(from_default.hold_ms, from_new.hold_ms);
+    }
+
+    #[test]
+    fn meta_declares_affect_phase_and_gesture_writes() {
+        let m = IntentFromBodyTouch::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "IntentFromBodyTouch");
+        assert_eq!(meta.phase, Phase::Affect);
+        assert_eq!(meta.priority, 0);
+        assert_eq!(meta.reads, &[Field::BodyTouch]);
+        assert_eq!(
+            meta.writes,
+            &[Field::Emotion, Field::Autonomy, Field::Gesture],
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Adds tests for the previously uncovered \`with_mapping\` builder, \`Default::default()\`, and the \`meta()\` contract.
- Coverage on \`crates/stackchan-core/src/modifiers/intent_from_body_touch.rs\`: 96.52% → 99.66% lines / 96.91% → 99.62% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::intent_from_body_touch\` (13/13 pass)