### PR TITLE
test(breath): cover new(), Default, and meta()

### DIFF
--- a/crates/stackchan-core/src/modifiers/breath.rs
+++ b/crates/stackchan-core/src/modifiers/breath.rs
@@ -233,4 +233,39 @@ mod tests {
         }
         assert_eq!(entity.face.left_eye.center.y, baseline_y);
     }
+
+    #[test]
+    fn new_defaults_to_documented_cycle_and_amplitude() {
+        let b = Breath::new();
+        assert_eq!(b.cycle_ms, DEFAULT_CYCLE_MS);
+        assert_eq!(b.amplitude_px, DEFAULT_AMPLITUDE_PX);
+        assert_eq!(b.last_offset_px, 0);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_default = <Breath as Default>::default();
+        let from_new = Breath::new();
+        assert_eq!(from_default.cycle_ms, from_new.cycle_ms);
+        assert_eq!(from_default.amplitude_px, from_new.amplitude_px);
+    }
+
+    #[test]
+    fn meta_declares_expression_phase_and_facial_writes() {
+        let m = Breath::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "Breath");
+        assert_eq!(meta.phase, Phase::Expression);
+        assert_eq!(meta.priority, 0);
+        assert_eq!(
+            meta.writes,
+            &[
+                Field::LeftEyeCenter,
+                Field::RightEyeCenter,
+                Field::MouthCenter,
+            ],
+        );
+        assert!(meta.reads.contains(&Field::BreathDepthScale));
+        assert!(meta.reads.contains(&Field::Attention));
+    }
 }

--- a/crates/stackchan-core/src/modifiers/breath.rs
+++ b/crates/stackchan-core/src/modifiers/breath.rs
@@ -248,6 +248,9 @@ mod tests {
         let from_new = Breath::new();
         assert_eq!(from_default.cycle_ms, from_new.cycle_ms);
         assert_eq!(from_default.amplitude_px, from_new.amplitude_px);
+        // last_offset_px feeds the diff-and-undo path on the first
+        // tick — a stale value would silently corrupt the first delta.
+        assert_eq!(from_default.last_offset_px, from_new.last_offset_px);
     }
 
     #[test]
@@ -265,7 +268,18 @@ mod tests {
                 Field::MouthCenter,
             ],
         );
-        assert!(meta.reads.contains(&Field::BreathDepthScale));
-        assert!(meta.reads.contains(&Field::Attention));
+        // Full reads pin — Breath reads the breath-depth scale, the
+        // attention state (to slow during engagement), and the three
+        // feature centres it then writes back to.
+        assert_eq!(
+            meta.reads,
+            &[
+                Field::BreathDepthScale,
+                Field::Attention,
+                Field::LeftEyeCenter,
+                Field::RightEyeCenter,
+                Field::MouthCenter,
+            ],
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds tests for Breath::new() (default cycle / amplitude), Default::default() parity, and the meta() declaration (phase / priority / facial writes).
- Coverage on \`crates/stackchan-core/src/modifiers/breath.rs\`: 96.61% → 99.29% lines / 97.16% → 99.05% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::breath\` (8/8 pass)