### PR TITLE
test(emotion-from-intent): cover Default + meta

### DIFF
--- a/crates/stackchan-core/src/modifiers/emotion_from_intent.rs
+++ b/crates/stackchan-core/src/modifiers/emotion_from_intent.rs
@@ -336,4 +336,25 @@ mod tests {
         assert_eq!(entity.mind.affect.emotion, Emotion::Angry);
         assert_eq!(entity.mind.autonomy.source, Some(OverrideSource::Shake));
     }
+
+    #[test]
+    fn default_matches_new() {
+        let from_default = <EmotionFromIntent as Default>::default();
+        let from_new = EmotionFromIntent::new();
+        assert_eq!(from_default.last_intent, from_new.last_intent);
+    }
+
+    #[test]
+    fn meta_declares_affect_phase_and_reactive_writes() {
+        let m = EmotionFromIntent::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "EmotionFromIntent");
+        assert_eq!(meta.phase, Phase::Affect);
+        assert_eq!(meta.priority, -80);
+        assert_eq!(meta.reads, &[Field::Intent, Field::Autonomy]);
+        assert_eq!(
+            meta.writes,
+            &[Field::Emotion, Field::Autonomy, Field::ChirpRequest],
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Same closer-the-gap pattern: direct tests for \`Default\` and \`meta()\`.
- Coverage on \`crates/stackchan-core/src/modifiers/emotion_from_intent.rs\`: 96.51% → 100.00% lines / 97.60% → 100.00% regions.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::emotion_from_intent\` (11/11 pass)