### PR TITLE
test(dance-player): cover Default + meta

### DIFF
--- a/crates/stackchan-core/src/modifiers/dance_player.rs
+++ b/crates/stackchan-core/src/modifiers/dance_player.rs
@@ -593,4 +593,28 @@ mod tests {
         player.update(&mut entity);
         assert_eq!(entity.motor.head_pose.pan_deg, -10.0);
     }
+
+    #[test]
+    fn default_matches_new() {
+        let from_default = <DancePlayer as Default>::default();
+        let from_new = DancePlayer::new();
+        // Both start with no active script.
+        assert!(from_default.active.is_none());
+        assert!(from_new.active.is_none());
+    }
+
+    #[test]
+    fn meta_declares_motion_phase_with_dance_writes() {
+        let m = DancePlayer::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "DancePlayer");
+        assert_eq!(meta.phase, Phase::Motion);
+        assert_eq!(meta.priority, 40);
+        assert!(meta.writes.contains(&Field::HeadPose));
+        assert!(meta.writes.contains(&Field::Emotion));
+        assert!(meta.writes.contains(&Field::Decorator));
+        assert!(meta.writes.contains(&Field::LedOverride));
+        assert!(meta.writes.contains(&Field::DanceScript));
+        assert!(meta.reads.contains(&Field::DanceScript));
+    }
 }

--- a/crates/stackchan-core/src/modifiers/dance_player.rs
+++ b/crates/stackchan-core/src/modifiers/dance_player.rs
@@ -598,9 +598,16 @@ mod tests {
     fn default_matches_new() {
         let from_default = <DancePlayer as Default>::default();
         let from_new = DancePlayer::new();
-        // Both start with no active script.
+        // Pin every field — covers the diff-and-undo state too, not
+        // just the script slot. A future #[derive(Default)] swap with
+        // different field defaults would surface here.
         assert!(from_default.active.is_none());
         assert!(from_new.active.is_none());
+        assert!((from_default.last_pan_deg - from_new.last_pan_deg).abs() < f32::EPSILON);
+        assert!((from_default.last_tilt_deg - from_new.last_tilt_deg).abs() < f32::EPSILON);
+        assert_eq!(from_default.held_emotion, from_new.held_emotion);
+        assert_eq!(from_default.held_decorator, from_new.held_decorator);
+        assert_eq!(from_default.held_led, from_new.held_led);
     }
 
     #[test]
@@ -610,11 +617,19 @@ mod tests {
         assert_eq!(meta.name, "DancePlayer");
         assert_eq!(meta.phase, Phase::Motion);
         assert_eq!(meta.priority, 40);
-        assert!(meta.writes.contains(&Field::HeadPose));
-        assert!(meta.writes.contains(&Field::Emotion));
-        assert!(meta.writes.contains(&Field::Decorator));
-        assert!(meta.writes.contains(&Field::LedOverride));
-        assert!(meta.writes.contains(&Field::DanceScript));
-        assert!(meta.reads.contains(&Field::DanceScript));
+        // Full slice equality on both reads and writes — catches any
+        // future drop or reorder.
+        assert_eq!(meta.reads, &[Field::HeadPose, Field::DanceScript],);
+        assert_eq!(
+            meta.writes,
+            &[
+                Field::HeadPose,
+                Field::Emotion,
+                Field::Autonomy,
+                Field::Decorator,
+                Field::LedOverride,
+                Field::DanceScript,
+            ],
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Same closer-the-gap pattern: direct tests for \`Default\` and \`meta()\`.
- Coverage on \`crates/stackchan-core/src/modifiers/dance_player.rs\`: 96.61% → 96.74% regions. Lines metric is dominated by the script-load-from-input path + decorator keyframe paths — those need fuller end-to-end tests and are deferred.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::dance_player\` (11/11 pass)