### PR TITLE
test(attention-from-tracking): cover meta() field set

### DIFF
--- a/crates/stackchan-core/src/modifiers/attention_from_tracking.rs
+++ b/crates/stackchan-core/src/modifiers/attention_from_tracking.rs
@@ -888,4 +888,18 @@ mod tests {
             from_new.face_release_misses,
         );
     }
+
+    #[test]
+    fn meta_declares_cognition_phase_with_attention_writes() {
+        let m = AttentionFromTracking::new();
+        let meta = m.meta();
+        assert_eq!(meta.name, "AttentionFromTracking");
+        assert_eq!(meta.phase, Phase::Cognition);
+        assert_eq!(meta.priority, 0);
+        assert_eq!(
+            meta.reads,
+            &[Field::Tracking, Field::Attention, Field::Engagement],
+        );
+        assert_eq!(meta.writes, &[Field::Attention, Field::Engagement]);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a meta() test pinning phase = Cognition + priority 0 + the full Tracking/Attention/Engagement read/write set. Same pattern used across the other modifier coverage PRs.
- Coverage on \`crates/stackchan-core/src/modifiers/attention_from_tracking.rs\`: 97.83% → 97.87% lines / 95.50% → 95.58% regions. Residual gaps are test-internal panic! arms.

## Test plan
- [x] \`cargo test -p stackchan-core --lib modifiers::attention_from_tracking\` (19/19 pass)