### PR TITLE
fix(net): reject redaction sentinel on disk-loaded configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,11 @@ section summarises the milestone work in human terms.
 - Greptile-driven post-merge fix on the ESP-NOW TX path: the
   dispatcher no longer starves under inbound traffic and no longer
   latches a NaN pose into the delta-comparison cache.
+- `STACKCHAN.RON` parser rejects shadowed fields at every level.
+  Previously the bare RON parser silently last-wins'd on a
+  duplicate key, so a hand-edited file with `psk: "real", psk:
+  "***"` would associate with the second value; the JSON twin
+  already rejected, and the two paths are now in lockstep.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,15 @@ section summarises the milestone work in human terms.
   duplicate key, so a hand-edited file with `psk: "real", psk:
   "***"` would associate with the second value; the JSON twin
   already rejected, and the two paths are now in lockstep.
+- `STACKCHAN.RON` parser rejects the redaction sentinel `"***"` on
+  disk for `wifi.psk`, `auth.token`, `esp_now.pmk_hex`,
+  `esp_now.lmk_hex`, and `behavior.agent_sidecar_token`. The
+  sentinel is a "preserve current value" wire marker for the
+  `PUT /settings` merge path — on disk there's nothing to merge
+  against, so a literal `"***"` is almost always operator copy-
+  paste from a redacted `GET /settings` body that forgot to put
+  the real secret back. Fail fast at load with a clear error
+  instead of silently trying to associate Wi-Fi with PSK = `"***"`.
 
 ### Documentation
 

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -239,14 +239,54 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws_and_comments();
             match key {
-                "wifi" => wifi = Some(self.parse_wifi()?),
-                "mdns" => mdns = Some(self.parse_mdns()?),
-                "time" => time = Some(self.parse_time()?),
-                "auth" => auth = Some(self.parse_auth()?),
-                "audio" => audio = Some(self.parse_audio()?),
-                "tracker" => tracker = Some(self.parse_tracker()?),
-                "esp_now" => esp_now = Some(self.parse_esp_now()?),
-                "behavior" => behavior = Some(self.parse_behavior()?),
+                "wifi" => {
+                    if wifi.is_some() {
+                        return Err(bare_err("duplicate top-level field", "wifi"));
+                    }
+                    wifi = Some(self.parse_wifi()?);
+                }
+                "mdns" => {
+                    if mdns.is_some() {
+                        return Err(bare_err("duplicate top-level field", "mdns"));
+                    }
+                    mdns = Some(self.parse_mdns()?);
+                }
+                "time" => {
+                    if time.is_some() {
+                        return Err(bare_err("duplicate top-level field", "time"));
+                    }
+                    time = Some(self.parse_time()?);
+                }
+                "auth" => {
+                    if auth.is_some() {
+                        return Err(bare_err("duplicate top-level field", "auth"));
+                    }
+                    auth = Some(self.parse_auth()?);
+                }
+                "audio" => {
+                    if audio.is_some() {
+                        return Err(bare_err("duplicate top-level field", "audio"));
+                    }
+                    audio = Some(self.parse_audio()?);
+                }
+                "tracker" => {
+                    if tracker.is_some() {
+                        return Err(bare_err("duplicate top-level field", "tracker"));
+                    }
+                    tracker = Some(self.parse_tracker()?);
+                }
+                "esp_now" => {
+                    if esp_now.is_some() {
+                        return Err(bare_err("duplicate top-level field", "esp_now"));
+                    }
+                    esp_now = Some(self.parse_esp_now()?);
+                }
+                "behavior" => {
+                    if behavior.is_some() {
+                        return Err(bare_err("duplicate top-level field", "behavior"));
+                    }
+                    behavior = Some(self.parse_behavior()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -289,9 +329,24 @@ impl<'a> Parser<'a> {
             self.skip_ws_and_comments();
             let value = self.parse_string()?;
             match key {
-                "ssid" => ssid = Some(value),
-                "psk" => psk = Some(value),
-                "country" => country = Some(value),
+                "ssid" => {
+                    if ssid.is_some() {
+                        return Err(bare_err("duplicate wifi field", "ssid"));
+                    }
+                    ssid = Some(value);
+                }
+                "psk" => {
+                    if psk.is_some() {
+                        return Err(bare_err("duplicate wifi field", "psk"));
+                    }
+                    psk = Some(value);
+                }
+                "country" => {
+                    if country.is_some() {
+                        return Err(bare_err("duplicate wifi field", "country"));
+                    }
+                    country = Some(value);
+                }
                 other => return Err(bare_err("unknown wifi field", other)),
             }
             self.skip_ws_and_comments();
@@ -321,7 +376,12 @@ impl<'a> Parser<'a> {
             self.skip_ws_and_comments();
             let value = self.parse_string()?;
             match key {
-                "hostname" => hostname = Some(value),
+                "hostname" => {
+                    if hostname.is_some() {
+                        return Err(bare_err("duplicate mdns field", "hostname"));
+                    }
+                    hostname = Some(value);
+                }
                 other => return Err(bare_err("unknown mdns field", other)),
             }
             self.skip_ws_and_comments();
@@ -349,8 +409,18 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws_and_comments();
             match key {
-                "tz" => tz = Some(self.parse_string()?),
-                "sntp_servers" => sntp_servers = Some(self.parse_string_list()?),
+                "tz" => {
+                    if tz.is_some() {
+                        return Err(bare_err("duplicate time field", "tz"));
+                    }
+                    tz = Some(self.parse_string()?);
+                }
+                "sntp_servers" => {
+                    if sntp_servers.is_some() {
+                        return Err(bare_err("duplicate time field", "sntp_servers"));
+                    }
+                    sntp_servers = Some(self.parse_string_list()?);
+                }
                 other => return Err(bare_err("unknown time field", other)),
             }
             self.skip_ws_and_comments();
@@ -381,7 +451,12 @@ impl<'a> Parser<'a> {
             self.skip_ws_and_comments();
             let value = self.parse_string()?;
             match key {
-                "token" => token = Some(value),
+                "token" => {
+                    if token.is_some() {
+                        return Err(bare_err("duplicate auth field", "token"));
+                    }
+                    token = Some(value);
+                }
                 other => return Err(bare_err("unknown auth field", other)),
             }
             self.skip_ws_and_comments();
@@ -419,8 +494,18 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws_and_comments();
             match key {
-                "volume_pct" => volume_pct = Some(self.parse_u8()?),
-                "muted" => muted = Some(self.parse_bool()?),
+                "volume_pct" => {
+                    if volume_pct.is_some() {
+                        return Err(bare_err("duplicate audio field", "volume_pct"));
+                    }
+                    volume_pct = Some(self.parse_u8()?);
+                }
+                "muted" => {
+                    if muted.is_some() {
+                        return Err(bare_err("duplicate audio field", "muted"));
+                    }
+                    muted = Some(self.parse_bool()?);
+                }
                 other => return Err(bare_err("unknown audio field", other)),
             }
             self.skip_ws_and_comments();
@@ -459,13 +544,39 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws_and_comments();
             match key {
-                "fov_h_deg" => pan_fov = Some(self.parse_f32()?),
-                "fov_v_deg" => tilt_fov = Some(self.parse_f32()?),
+                "fov_h_deg" => {
+                    if pan_fov.is_some() {
+                        return Err(bare_err("duplicate tracker field", "fov_h_deg"));
+                    }
+                    pan_fov = Some(self.parse_f32()?);
+                }
+                "fov_v_deg" => {
+                    if tilt_fov.is_some() {
+                        return Err(bare_err("duplicate tracker field", "fov_v_deg"));
+                    }
+                    tilt_fov = Some(self.parse_f32()?);
+                }
                 "target_smoothing_alpha" => {
+                    if alpha.is_some() {
+                        return Err(bare_err(
+                            "duplicate tracker field",
+                            "target_smoothing_alpha",
+                        ));
+                    }
                     alpha = Some(self.parse_f32()?);
                 }
-                "flip_x" => flip_x = Some(self.parse_bool()?),
-                "flip_y" => flip_y = Some(self.parse_bool()?),
+                "flip_x" => {
+                    if flip_x.is_some() {
+                        return Err(bare_err("duplicate tracker field", "flip_x"));
+                    }
+                    flip_x = Some(self.parse_bool()?);
+                }
+                "flip_y" => {
+                    if flip_y.is_some() {
+                        return Err(bare_err("duplicate tracker field", "flip_y"));
+                    }
+                    flip_y = Some(self.parse_bool()?);
+                }
                 other => return Err(bare_err("unknown tracker field", other)),
             }
             self.skip_ws_and_comments();
@@ -503,12 +614,42 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws_and_comments();
             match key {
-                "enabled" => enabled = Some(self.parse_bool()?),
-                "pmk_hex" => pmk_hex = Some(self.parse_string()?),
-                "peer_mac" => peer_mac = Some(self.parse_string()?),
-                "lmk_hex" => lmk_hex = Some(self.parse_string()?),
-                "channel" => channel = Some(self.parse_optional_u8()?),
-                "tx_rate_hz" => tx_rate_hz = Some(self.parse_u8()?),
+                "enabled" => {
+                    if enabled.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "enabled"));
+                    }
+                    enabled = Some(self.parse_bool()?);
+                }
+                "pmk_hex" => {
+                    if pmk_hex.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "pmk_hex"));
+                    }
+                    pmk_hex = Some(self.parse_string()?);
+                }
+                "peer_mac" => {
+                    if peer_mac.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "peer_mac"));
+                    }
+                    peer_mac = Some(self.parse_string()?);
+                }
+                "lmk_hex" => {
+                    if lmk_hex.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "lmk_hex"));
+                    }
+                    lmk_hex = Some(self.parse_string()?);
+                }
+                "channel" => {
+                    if channel.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "channel"));
+                    }
+                    channel = Some(self.parse_optional_u8()?);
+                }
+                "tx_rate_hz" => {
+                    if tx_rate_hz.is_some() {
+                        return Err(bare_err("duplicate esp_now field", "tx_rate_hz"));
+                    }
+                    tx_rate_hz = Some(self.parse_u8()?);
+                }
                 other => return Err(bare_err("unknown esp_now field", other)),
             }
             self.skip_ws_and_comments();
@@ -529,6 +670,7 @@ impl<'a> Parser<'a> {
 
     /// Parse the `behavior: (...)` block. All fields default to
     /// `false` if absent.
+    #[allow(clippy::too_many_lines)] // one match arm per flag; splitting helpers wouldn't read clearer
     fn parse_behavior(&mut self) -> Result<BehaviorConfig, ConfigError> {
         self.expect_char('(')?;
         let mut soliloquy_enabled: Option<bool> = None;
@@ -553,20 +695,90 @@ impl<'a> Parser<'a> {
             self.expect_char(':')?;
             self.skip_ws_and_comments();
             match key {
-                "soliloquy_enabled" => soliloquy_enabled = Some(self.parse_bool()?),
-                "hourly_chime_enabled" => hourly_chime_enabled = Some(self.parse_bool()?),
-                "battery_icon_enabled" => battery_icon_enabled = Some(self.parse_bool()?),
-                "toast_overlay_enabled" => toast_overlay_enabled = Some(self.parse_bool()?),
-                "auto_torque_release_ms" => auto_torque_release_ms = Some(self.parse_u32()?),
-                "audio_debug_udp_target" => audio_debug_udp_target = Some(self.parse_string()?),
-                "agent_sidecar_url" => agent_sidecar_url = Some(self.parse_string()?),
-                "agent_sidecar_token" => agent_sidecar_token = Some(self.parse_string()?),
+                "soliloquy_enabled" => {
+                    if soliloquy_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "soliloquy_enabled"));
+                    }
+                    soliloquy_enabled = Some(self.parse_bool()?);
+                }
+                "hourly_chime_enabled" => {
+                    if hourly_chime_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "hourly_chime_enabled"));
+                    }
+                    hourly_chime_enabled = Some(self.parse_bool()?);
+                }
+                "battery_icon_enabled" => {
+                    if battery_icon_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "battery_icon_enabled"));
+                    }
+                    battery_icon_enabled = Some(self.parse_bool()?);
+                }
+                "toast_overlay_enabled" => {
+                    if toast_overlay_enabled.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "toast_overlay_enabled",
+                        ));
+                    }
+                    toast_overlay_enabled = Some(self.parse_bool()?);
+                }
+                "auto_torque_release_ms" => {
+                    if auto_torque_release_ms.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "auto_torque_release_ms",
+                        ));
+                    }
+                    auto_torque_release_ms = Some(self.parse_u32()?);
+                }
+                "audio_debug_udp_target" => {
+                    if audio_debug_udp_target.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "audio_debug_udp_target",
+                        ));
+                    }
+                    audio_debug_udp_target = Some(self.parse_string()?);
+                }
+                "agent_sidecar_url" => {
+                    if agent_sidecar_url.is_some() {
+                        return Err(bare_err("duplicate behavior field", "agent_sidecar_url"));
+                    }
+                    agent_sidecar_url = Some(self.parse_string()?);
+                }
+                "agent_sidecar_token" => {
+                    if agent_sidecar_token.is_some() {
+                        return Err(bare_err("duplicate behavior field", "agent_sidecar_token"));
+                    }
+                    agent_sidecar_token = Some(self.parse_string()?);
+                }
                 "follower_leader_hostname" => {
+                    if follower_leader_hostname.is_some() {
+                        return Err(bare_err(
+                            "duplicate behavior field",
+                            "follower_leader_hostname",
+                        ));
+                    }
                     follower_leader_hostname = Some(self.parse_string()?);
                 }
-                "wake_word_enabled" => wake_word_enabled = Some(self.parse_bool()?),
-                "wake_word_threshold" => wake_word_threshold = Some(self.parse_i8()?),
-                "wake_word_arena_kib" => wake_word_arena_kib = Some(self.parse_u32()?),
+                "wake_word_enabled" => {
+                    if wake_word_enabled.is_some() {
+                        return Err(bare_err("duplicate behavior field", "wake_word_enabled"));
+                    }
+                    wake_word_enabled = Some(self.parse_bool()?);
+                }
+                "wake_word_threshold" => {
+                    if wake_word_threshold.is_some() {
+                        return Err(bare_err("duplicate behavior field", "wake_word_threshold"));
+                    }
+                    wake_word_threshold = Some(self.parse_i8()?);
+                }
+                "wake_word_arena_kib" => {
+                    if wake_word_arena_kib.is_some() {
+                        return Err(bare_err("duplicate behavior field", "wake_word_arena_kib"));
+                    }
+                    wake_word_arena_kib = Some(self.parse_u32()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -1452,5 +1664,163 @@ mod tests {
         assert!(rendered.contains(r#""back\\slash and \"quote\"""#));
         let reparsed = parse_ron_bare(&rendered).unwrap();
         assert_eq!(reparsed.wifi.ssid, "back\\slash and \"quote\"");
+    }
+
+    // ============================================================
+    // Duplicate-key rejection — schema parity with bare_json.rs.
+    // A hand-edited RON with shadowed fields would otherwise last-wins
+    // silently; the canonical hazard is `wifi: ( psk: "real", psk: "x" )`
+    // where the renderer-side redaction string `"***"` ends up
+    // overwriting a real PSK on a round-trip through `GET /settings`.
+    // ============================================================
+
+    #[test]
+    fn rejects_duplicate_top_level_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                wifi: ( ssid: "n2", psk: "p2", country: "JP" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate top-level field") && msg.contains("wifi"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_wifi_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "real", psk: "x", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate wifi field") && msg.contains("psk"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_mdns_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "a", hostname: "b" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate mdns field") && msg.contains("hostname"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_time_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", tz: "JST", sntp_servers: ["pool.ntp.org"] ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate time field") && msg.contains("tz"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_auth_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                auth: ( token: "real-token-aaaaaaaaaaaaaaaa", token: "shadow-aaaaaaaaaaaaaaaaa" ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate auth field") && msg.contains("token"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_audio_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                audio: ( volume_pct: 50, volume_pct: 60, muted: false ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate audio field") && msg.contains("volume_pct"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_tracker_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                tracker: ( fov_h_deg: 60, fov_h_deg: 50 ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate tracker field") && msg.contains("fov_h_deg"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_esp_now_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                esp_now: ( enabled: true, enabled: false ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate esp_now field") && msg.contains("enabled"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_behavior_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                behavior: ( wake_word_enabled: true, wake_word_enabled: false ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate behavior field") && msg.contains("wake_word_enabled"),
+            "got {msg}"
+        );
     }
 }

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -23,7 +23,7 @@ use core::fmt::Write as _;
 use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{
     AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
-    TrackerSettings, WifiConfig, validate,
+    TrackerSettings, WifiConfig, validate_for_disk,
 };
 use crate::error::ConfigError;
 
@@ -37,12 +37,14 @@ use crate::error::ConfigError;
 ///
 /// Returns [`ConfigError::BareParse`] on any structural mismatch
 /// (missing field, unexpected token, runaway string), then runs the
-/// shared [`validate`] gate so out-of-range values surface the same
-/// `Invalid*` variants as the host parser.
+/// strict [`validate_for_disk`] gate so out-of-range values surface
+/// the same `Invalid*` variants as the host parser, and any literal
+/// redaction sentinel (`"***"`) on a secret field surfaces as
+/// [`ConfigError::RedactionSentinelOnDisk`].
 pub fn parse_ron_bare(input: &str) -> Result<Config, ConfigError> {
     let mut p = Parser::new(input);
     let config = p.parse_config()?;
-    validate(&config)?;
+    validate_for_disk(&config)?;
     Ok(config)
 }
 
@@ -1805,6 +1807,72 @@ mod tests {
             msg.contains("duplicate esp_now field") && msg.contains("enabled"),
             "got {msg}"
         );
+    }
+
+    // ============================================================
+    // Disk-load redaction-sentinel rejection (validate_for_disk).
+    // The "***" sentinel exists as a "preserve current value" marker
+    // on the HTTP `PUT /settings` merge path. On disk it means
+    // operator copy-paste from a redacted GET; rejecting fast beats
+    // a Wi-Fi auth-fail buried deep in the boot log.
+    // ============================================================
+
+    fn assert_redaction_sentinel(input: &str) -> &'static str {
+        match parse_ron_bare(input).unwrap_err() {
+            ConfigError::RedactionSentinelOnDisk(field) => field,
+            other => panic!("expected RedactionSentinelOnDisk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_redacted_psk_on_disk() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "***", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+            )
+        "#;
+        assert_eq!(assert_redaction_sentinel(s), "wifi.psk");
+    }
+
+    #[test]
+    fn rejects_redacted_pmk_hex_on_disk() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                esp_now: ( enabled: false, pmk_hex: "***" ),
+            )
+        "#;
+        assert_eq!(assert_redaction_sentinel(s), "esp_now.pmk_hex");
+    }
+
+    #[test]
+    fn rejects_redacted_lmk_hex_on_disk() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                esp_now: ( enabled: false, lmk_hex: "***" ),
+            )
+        "#;
+        assert_eq!(assert_redaction_sentinel(s), "esp_now.lmk_hex");
+    }
+
+    #[test]
+    fn rejects_redacted_agent_sidecar_token_on_disk() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                behavior: ( agent_sidecar_token: "***" ),
+            )
+        "#;
+        assert_eq!(assert_redaction_sentinel(s), "behavior.agent_sidecar_token");
     }
 
     #[test]

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -519,16 +519,22 @@ pub fn tz_offset_minutes(tz: &str) -> Option<i32> {
 
 /// Parse + validate a RON document into a [`Config`].
 ///
+/// Disk-load entry point — runs the strict [`validate_for_disk`]
+/// gate, which is [`validate`] plus rejection of the redaction
+/// sentinel (`"***"`) in any secret field.
+///
 /// # Errors
 ///
-/// Returns [`ConfigError::Parse`] on malformed RON, or one of the
+/// Returns [`ConfigError::Parse`] on malformed RON, one of the
 /// validation variants ([`ConfigError::EmptySsid`],
 /// [`ConfigError::InvalidCountry`], [`ConfigError::InvalidHostname`],
-/// [`ConfigError::NoSntpServers`]) on out-of-range values.
+/// [`ConfigError::NoSntpServers`]) on out-of-range values, or
+/// [`ConfigError::RedactionSentinelOnDisk`] on a literal `"***"`
+/// in a secret field.
 #[cfg(feature = "parse")]
 pub fn parse_ron(input: &str) -> Result<Config, ConfigError> {
     let config: Config = ron::from_str(input)?;
-    validate(&config)?;
+    validate_for_disk(&config)?;
     Ok(config)
 }
 
@@ -611,6 +617,52 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
         return Err(ConfigError::InvalidWakeWordArenaKib);
     }
     validate_agent_sidecar_token(&config.behavior.agent_sidecar_token)?;
+    Ok(())
+}
+
+/// Strict validator for disk-loaded configs.
+///
+/// Runs [`validate`] first, then rejects the redaction sentinel
+/// `"***"` in any secret field. The sentinel exists only as a
+/// "preserve current value" wire marker on the HTTP `PUT /settings`
+/// merge path — see [`crate::bare_json::merge_settings_with_current`].
+/// A literal `"***"` on disk is operator error: typically a copy of
+/// the body returned by `GET /settings?redact=true` dumped to SD
+/// without filling in the real secret. Without this gate the
+/// firmware would try to associate Wi-Fi with PSK = `"***"` and the
+/// only signal would be `WPA: wrong-password` deep in the auth log.
+///
+/// Use this from any disk-loading path; the HTTP-PUT pipeline must
+/// keep using [`validate`] (lenient) so a dashboard form that
+/// re-submits the redacted body still works.
+///
+/// # Errors
+///
+/// Returns [`ConfigError::RedactionSentinelOnDisk`] with the
+/// offending field name on a sentinel match. Otherwise propagates
+/// whatever [`validate`] returns.
+pub fn validate_for_disk(config: &Config) -> Result<(), ConfigError> {
+    use crate::bare_json::{
+        ESP_NOW_KEY_REDACTED, PSK_REDACTED, SIDECAR_TOKEN_REDACTED, TOKEN_REDACTED,
+    };
+    validate(config)?;
+    if config.wifi.psk == PSK_REDACTED {
+        return Err(ConfigError::RedactionSentinelOnDisk("wifi.psk"));
+    }
+    if config.auth.token == TOKEN_REDACTED {
+        return Err(ConfigError::RedactionSentinelOnDisk("auth.token"));
+    }
+    if config.esp_now.pmk_hex == ESP_NOW_KEY_REDACTED {
+        return Err(ConfigError::RedactionSentinelOnDisk("esp_now.pmk_hex"));
+    }
+    if config.esp_now.lmk_hex == ESP_NOW_KEY_REDACTED {
+        return Err(ConfigError::RedactionSentinelOnDisk("esp_now.lmk_hex"));
+    }
+    if config.behavior.agent_sidecar_token == SIDECAR_TOKEN_REDACTED {
+        return Err(ConfigError::RedactionSentinelOnDisk(
+            "behavior.agent_sidecar_token",
+        ));
+    }
     Ok(())
 }
 

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -149,4 +149,16 @@ pub enum ConfigError {
     /// the wire.
     #[error("behavior.agent_sidecar_token contains an ASCII control character")]
     AgentSidecarTokenInvalidChars,
+
+    /// A disk-loaded `Config` had the redaction sentinel (`"***"`)
+    /// in a secret field. The sentinel is meaningful only on the
+    /// HTTP `PUT /settings` merge path — on disk there's nothing to
+    /// merge against, so a literal `"***"` is operator error
+    /// (typically copy-paste from a redacted `GET /settings` body
+    /// dumped to SD without filling in the real value). Reject at
+    /// load so the device fails fast with a clear message instead
+    /// of trying to associate to Wi-Fi with PSK = `"***"`. Carries
+    /// the field name so the operator can fix the right line.
+    #[error("{0} contains the redaction sentinel \"***\" on disk — supply the real value")]
+    RedactionSentinelOnDisk(&'static str),
 }

--- a/crates/stackchan-net/tests/golden_config.rs
+++ b/crates/stackchan-net/tests/golden_config.rs
@@ -123,3 +123,79 @@ fn rejects_malformed_ron() {
     let err = parse_ron("not valid ron at all").unwrap_err();
     assert!(matches!(err, ConfigError::Parse(_)), "got {err:?}");
 }
+
+// ============================================================
+// `validate_for_disk` reachability through the serde path.
+// `parse_ron_bare` short-circuits some sentinel checks at parse
+// time (notably `auth.token`); `parse_ron` does not, so the
+// `validate_for_disk` gate is the only thing standing between a
+// disk-loaded "***" and downstream consumers. Pin both sides.
+// ============================================================
+
+/// Build a complete RON document that pins one secret field to the
+/// redaction sentinel. The serde derives demand every field of
+/// `EspNowConfig` / `BehaviorConfig`, so round-tripping
+/// `parse_ron` + `render_ron` against the full fixture is the
+/// cleanest way to produce a valid document with only one field
+/// mutated.
+fn ron_with_sentinel(mutate: impl FnOnce(&mut Config)) -> String {
+    let mut cfg = parse_ron(FULL_RON).unwrap();
+    mutate(&mut cfg);
+    render_ron(&cfg).unwrap()
+}
+
+#[test]
+fn parse_ron_rejects_redacted_psk() {
+    let ron = ron_with_sentinel(|c| c.wifi.psk = "***".to_string());
+    let err = parse_ron(&ron).unwrap_err();
+    match err {
+        ConfigError::RedactionSentinelOnDisk(field) => assert_eq!(field, "wifi.psk"),
+        other => panic!("expected RedactionSentinelOnDisk, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_ron_rejects_redacted_auth_token() {
+    // Confirms the `auth.token` arm of `validate_for_disk` is
+    // reachable. `parse_ron_bare` rejects this case earlier via
+    // `BareParse`, so the serde path is the only one that
+    // exercises this branch.
+    let ron = ron_with_sentinel(|c| c.auth.token = "***".to_string());
+    let err = parse_ron(&ron).unwrap_err();
+    match err {
+        ConfigError::RedactionSentinelOnDisk(field) => assert_eq!(field, "auth.token"),
+        other => panic!("expected RedactionSentinelOnDisk, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_ron_rejects_redacted_esp_now_pmk_hex() {
+    let ron = ron_with_sentinel(|c| c.esp_now.pmk_hex = "***".to_string());
+    let err = parse_ron(&ron).unwrap_err();
+    match err {
+        ConfigError::RedactionSentinelOnDisk(field) => assert_eq!(field, "esp_now.pmk_hex"),
+        other => panic!("expected RedactionSentinelOnDisk, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_ron_rejects_redacted_esp_now_lmk_hex() {
+    let ron = ron_with_sentinel(|c| c.esp_now.lmk_hex = "***".to_string());
+    let err = parse_ron(&ron).unwrap_err();
+    match err {
+        ConfigError::RedactionSentinelOnDisk(field) => assert_eq!(field, "esp_now.lmk_hex"),
+        other => panic!("expected RedactionSentinelOnDisk, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_ron_rejects_redacted_agent_sidecar_token() {
+    let ron = ron_with_sentinel(|c| c.behavior.agent_sidecar_token = "***".to_string());
+    let err = parse_ron(&ron).unwrap_err();
+    match err {
+        ConfigError::RedactionSentinelOnDisk(field) => {
+            assert_eq!(field, "behavior.agent_sidecar_token");
+        }
+        other => panic!("expected RedactionSentinelOnDisk, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Stacked on #489.
- The `"***"` sentinel is a wire marker for the HTTP `PUT /settings` merge path (where it means "preserve current value"). On disk there is nothing to merge against — a literal `"***"` is almost always operator copy-paste from a redacted `GET /settings` body without filling the real secret back in.
- Without a guard: firmware tries to associate Wi-Fi with PSK = `"***"` and the only signal is a buried `WPA: wrong-password`. Now: fail-fast at load with `ConfigError::RedactionSentinelOnDisk("wifi.psk")` and the operator gets a clear log line.
- New `validate_for_disk` is the strict superset of `validate`. Disk-load entry points (`parse_ron`, `parse_ron_bare`) use it. `parse_settings_json` keeps using lenient `validate` so dashboard re-PUTs still merge.
- Covers: `wifi.psk` / `auth.token` / `esp_now.pmk_hex` / `esp_now.lmk_hex` / `behavior.agent_sidecar_token`.

## Test plan

- [x] `just check` (workspace fmt + clippy + host tests + doctests)
- [x] rustdoc gate `RUSTDOCFLAGS=-Dwarnings cargo doc ...`
- [x] 4 new tests cover each newly-gated field
- [x] Existing `rejects_redacted_auth_token` test still passes (parse-time check unchanged)