### PR TITLE
fix(sidecar): cross-language sidecar + web hardening pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,30 @@ section summarises the milestone work in human terms.
 - Greptile-driven post-merge fix on the ESP-NOW TX path: the
   dispatcher no longer starves under inbound traffic and no longer
   latches a NaN pose into the delta-comparison cache.
+- Python sidecar + web dashboard hardening. `SessionStatus` is
+  now keyed by `session_id` so two firmware units posting to the
+  same sidecar don't clobber each other's `thinking` / `done`
+  state (unit B's `mark_thinking` no longer overwrites unit A's
+  in-flight snapshot). `GET /v1/session-status` accepts an
+  optional `?session_id=` filter; the default still returns the
+  most-recently-updated session so single-unit setups are
+  unaffected. Content-type validator also rejects non-mono audio
+  (`channels=2` body decoded as mono int16 would produce garbage
+  transcription; the firmware always sends `channels=1` but the
+  gate is the right place to catch operator-supplied test bodies
+  too). New `audio_channels_unsupported` error code. The retry
+  classifier narrows from `httpx.HTTPError` to
+  `httpx.TransportError` so URL / protocol misconfiguration
+  surfaces immediately instead of burning the attempt budget.
+  Dashboard `StatusBar` collapses its 5 polite `aria-live`
+  regions to one wrapper region (concurrent announcers were
+  fighting for the screen-reader queue every SSE tick), the
+  Calibration `Reset to defaults` button now honestly tooltips
+  "host-side fallback values" (previously claimed firmware
+  defaults), and `connectStream` uses exponential backoff with
+  jitter (1.5 s → 30 s, ±25%) so N tabs reconnecting after a
+  firmware restart fan out instead of synchronising on the
+  boundary.
 
 ### Documentation
 

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -29,6 +29,7 @@ _MAX_BODY_BYTES = 30 * 16000 * 2 + 1024
 _MIN_BODY_BYTES = 640  # 20 ms @ 16 kHz mono s16; anything smaller is operator error
 _EXPECTED_SAMPLE_RATE = 16000
 _RATE_RE = re.compile(r"\brate=(\d+)", re.IGNORECASE)
+_CHANNELS_RE = re.compile(r"\bchannels=(\d+)", re.IGNORECASE)
 
 
 def _failure(
@@ -75,11 +76,18 @@ def _audio_failure(code: ErrorCode, *, request_id: str, session_id: str) -> JSON
 def _validate_content_type(content_type: str) -> ErrorCode | None:
     if not content_type.lower().startswith("audio/l16"):
         return ErrorCode.BAD_CONTENT_TYPE
-    match = _RATE_RE.search(content_type)
-    if match is None:
-        return None
-    if int(match.group(1)) != _EXPECTED_SAMPLE_RATE:
+    rate_match = _RATE_RE.search(content_type)
+    if rate_match is not None and int(rate_match.group(1)) != _EXPECTED_SAMPLE_RATE:
         return ErrorCode.AUDIO_RATE_UNSUPPORTED
+    # `channels` defaults to 1 when absent — matches the firmware
+    # `audio/L16;rate=16000;channels=1` Content-Type and the
+    # downstream STT contract. A `channels=2` body would otherwise
+    # be reinterpreted as mono int16 in `_transcribe_sync`'s
+    # `np.frombuffer(pcm, dtype=np.int16)` — interleaved stereo
+    # decoded as mono yields garbage transcription.
+    channels_match = _CHANNELS_RE.search(content_type)
+    if channels_match is not None and int(channels_match.group(1)) != 1:
+        return ErrorCode.AUDIO_CHANNELS_UNSUPPORTED
     return None
 
 

--- a/sidecar/src/stackchan_sidecar/companion.py
+++ b/sidecar/src/stackchan_sidecar/companion.py
@@ -27,7 +27,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from .config import Settings
-from .session_status import SessionStatus, snapshot_to_dict
+from .session_status import SessionStatus, Snapshot, snapshot_to_dict
 
 _LOG = logging.getLogger("stackchan_sidecar.companion")
 
@@ -114,21 +114,22 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
         status: SessionStatus | None = getattr(request.app.state, "session_status", None)
         if status is None:
             raise HTTPException(status_code=503, detail="session-status not initialised")
+        # Optional `?session_id=<id>` filter: subscribers in a
+        # multi-unit deployment can pin to one device's view. When
+        # absent the stream emits the most-recently-updated session,
+        # matching the single-unit shape the companion app was
+        # built for.
+        session_id = request.query_params.get("session_id")
 
         async def stream() -> AsyncIterator[bytes]:
-            # Initial frame so a fresh subscriber paints the right state
-            # without waiting for the next transition.
-            yield _format_status(status.get())
-            # Short timeout keeps us responsive to client disconnects on
-            # ASGI servers that don't immediately cancel the generator;
-            # also acts as the SSE keepalive heartbeat for proxies.
+            yield _format_status(status.get(session_id))
             while not await request.is_disconnected():
                 try:
                     await asyncio.wait_for(status.changed(), timeout=2.0)
                 except TimeoutError:
                     yield b": keepalive\n\n"
                     continue
-                yield _format_status(status.get())
+                yield _format_status(status.get(session_id))
 
         return StreamingResponse(
             stream(),
@@ -192,9 +193,7 @@ def register_companion(app: FastAPI, settings: Settings) -> None:
 
 
 def _format_status(snapshot: object) -> bytes:
-    # `SessionStatus.get()` returns a frozen dataclass; reuse the helper
-    # so the wire shape stays the test-asserted one.
-    from .session_status import Snapshot
-
+    # `SessionStatus.get()` returns a frozen dataclass; reuse the
+    # helper so the wire shape stays the test-asserted one.
     payload = snapshot_to_dict(snapshot) if isinstance(snapshot, Snapshot) else {}
     return b"data: " + json.dumps(payload, separators=(",", ":")).encode() + b"\n\n"

--- a/sidecar/src/stackchan_sidecar/errors.py
+++ b/sidecar/src/stackchan_sidecar/errors.py
@@ -29,6 +29,7 @@ class ErrorCode(StrEnum):
     BAD_CONTENT_TYPE = "bad_content_type"
     BAD_CONTENT_LENGTH = "bad_content_length"
     AUDIO_RATE_UNSUPPORTED = "audio_rate_unsupported"
+    AUDIO_CHANNELS_UNSUPPORTED = "audio_channels_unsupported"
     AUDIO_EMPTY = "audio_empty"
     AUDIO_TOO_SMALL = "audio_too_small"
     AUDIO_TOO_LARGE = "audio_too_large"
@@ -58,6 +59,9 @@ _FAILURES: dict[ErrorCode, FailureKind] = {
     ),
     ErrorCode.AUDIO_RATE_UNSUPPORTED: FailureKind(
         ErrorCode.AUDIO_RATE_UNSUPPORTED, Stage.AUDIO, "need 16kHz audio", Emotion.NEUTRAL
+    ),
+    ErrorCode.AUDIO_CHANNELS_UNSUPPORTED: FailureKind(
+        ErrorCode.AUDIO_CHANNELS_UNSUPPORTED, Stage.AUDIO, "need mono audio", Emotion.NEUTRAL
     ),
     ErrorCode.AUDIO_EMPTY: FailureKind(
         ErrorCode.AUDIO_EMPTY, Stage.AUDIO, "no audio received", Emotion.NEUTRAL
@@ -107,6 +111,7 @@ _HTTP_STATUS_BY_CODE: dict[ErrorCode, int] = {
     ErrorCode.BAD_CONTENT_TYPE: 415,
     ErrorCode.BAD_CONTENT_LENGTH: 400,
     ErrorCode.AUDIO_RATE_UNSUPPORTED: 415,
+    ErrorCode.AUDIO_CHANNELS_UNSUPPORTED: 415,
     ErrorCode.AUDIO_EMPTY: 400,
     ErrorCode.AUDIO_TOO_SMALL: 400,
     ErrorCode.AUDIO_TOO_LARGE: 413,

--- a/sidecar/src/stackchan_sidecar/retry.py
+++ b/sidecar/src/stackchan_sidecar/retry.py
@@ -36,12 +36,14 @@ def is_transient(exc: BaseException) -> bool:
         return True
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in _RETRYABLE_STATUS
-    # Narrow to actual transport faults; previously the
-    # `httpx.HTTPError` catch-all also covered `InvalidURL`,
-    # `UnsupportedProtocol`, `LocalProtocolError`, etc., which
-    # are configuration bugs that no retry will fix — burning
-    # `max_attempts` + the deadline budget before surfacing.
-    if isinstance(exc, httpx.TransportError):
+    # Only `NetworkError` (Connect/Read/Write/Close) is genuinely
+    # transient. `httpx.TransportError` would seem to fit but also
+    # covers `UnsupportedProtocol` and `ProtocolError`
+    # (Local/Remote) which are configuration bugs that no retry
+    # will fix — those burned `max_attempts` + the deadline budget
+    # before this narrowing. `InvalidURL` sits outside the
+    # `HTTPError` tree entirely and is intentionally not retried.
+    if isinstance(exc, httpx.NetworkError):
         return True
     if isinstance(exc, anthropic.APIConnectionError | anthropic.APITimeoutError):
         return True

--- a/sidecar/src/stackchan_sidecar/retry.py
+++ b/sidecar/src/stackchan_sidecar/retry.py
@@ -36,7 +36,12 @@ def is_transient(exc: BaseException) -> bool:
         return True
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in _RETRYABLE_STATUS
-    if isinstance(exc, httpx.HTTPError):
+    # Narrow to actual transport faults; previously the
+    # `httpx.HTTPError` catch-all also covered `InvalidURL`,
+    # `UnsupportedProtocol`, `LocalProtocolError`, etc., which
+    # are configuration bugs that no retry will fix — burning
+    # `max_attempts` + the deadline budget before surfacing.
+    if isinstance(exc, httpx.TransportError):
         return True
     if isinstance(exc, anthropic.APIConnectionError | anthropic.APITimeoutError):
         return True

--- a/sidecar/src/stackchan_sidecar/session_status.py
+++ b/sidecar/src/stackchan_sidecar/session_status.py
@@ -11,10 +11,21 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import OrderedDict
 from dataclasses import asdict, dataclass, field
 from typing import Literal
 
 State = Literal["idle", "thinking"]
+
+# Cap on the number of distinct sessions tracked simultaneously.
+# In a deployment where firmware units rotate through unique
+# session IDs (re-flash → new MAC-derived ID) the dict would
+# otherwise grow without bound. LRU eviction past this cap drops
+# the snapshot least-recently *updated* — which usually means a
+# session that hasn't `mark_thinking`'d or `mark_done`'d in
+# however long it took the cap to fill. 64 covers any reasonable
+# fleet size with margin.
+_MAX_TRACKED_SESSIONS = 64
 
 
 @dataclass(frozen=True)
@@ -54,7 +65,12 @@ class SessionStatus:
     """
 
     def __init__(self) -> None:
-        self._snapshots: dict[str, Snapshot] = {}
+        # `OrderedDict` gives us LRU eviction in O(1) on each
+        # update — `move_to_end` after every write keeps the most
+        # recently updated session at the right end; `popitem(last
+        # =False)` drops the least-recently updated when the cap
+        # is exceeded.
+        self._snapshots: OrderedDict[str, Snapshot] = OrderedDict()
         self._latest_session_id: str | None = None
         self._idle = Snapshot(state="idle")
         self._event = asyncio.Event()
@@ -88,6 +104,9 @@ class SessionStatus:
 
     def _put(self, session_id: str, snapshot: Snapshot) -> None:
         self._snapshots[session_id] = snapshot
+        self._snapshots.move_to_end(session_id)
+        while len(self._snapshots) > _MAX_TRACKED_SESSIONS:
+            self._snapshots.popitem(last=False)
         self._latest_session_id = session_id
         self._broadcast()
 

--- a/sidecar/src/stackchan_sidecar/session_status.py
+++ b/sidecar/src/stackchan_sidecar/session_status.py
@@ -38,38 +38,70 @@ class Snapshot:
 
 
 class SessionStatus:
-    """Mutable holder with a broadcast change-event.
+    """Per-session-keyed snapshot holder with a broadcast change-event.
 
-    Read-from-anywhere via [`get`][SessionStatus.get]; writes happen only
-    from the `/v1/listen` handler. SSE subscribers `await changed()` then
-    re-read.
+    Maintains one [`Snapshot`][Snapshot] per `session_id` so concurrent
+    PTT captures from multiple firmware units don't clobber each other:
+    unit B's `mark_thinking` no longer overwrites unit A's in-flight
+    state, and unit A's `mark_done` writes only against its own
+    session.
+
+    Read via [`get`][SessionStatus.get]; without a `session_id`
+    returns the most-recently-updated snapshot (matches the
+    single-unit setup the companion app was built for). With an
+    explicit `session_id` returns that unit's view. SSE subscribers
+    await [`changed`][SessionStatus.changed] then re-read.
     """
 
     def __init__(self) -> None:
-        self._snapshot = Snapshot(state="idle")
+        self._snapshots: dict[str, Snapshot] = {}
+        self._latest_session_id: str | None = None
+        self._idle = Snapshot(state="idle")
         self._event = asyncio.Event()
 
-    def get(self) -> Snapshot:
-        return self._snapshot
+    def get(self, session_id: str | None = None) -> Snapshot:
+        """Return the snapshot for `session_id`, or the most-recently-
+        updated snapshot when omitted. Falls back to the default-idle
+        snapshot when nothing has been recorded yet — preserves the
+        pre-multi-session shape where subscribers always saw *some*
+        snapshot on connect."""
+        if session_id is not None:
+            return self._snapshots.get(session_id, self._idle)
+        if self._latest_session_id is None:
+            return self._idle
+        return self._snapshots.get(self._latest_session_id, self._idle)
+
+    def all(self) -> dict[str, Snapshot]:
+        """Snapshot of every known session_id, for diagnostic surfaces
+        that want a full picture across units."""
+        return dict(self._snapshots)
 
     async def changed(self) -> None:
-        """Block until the next state change. Each subscriber awaits its own
-        view of the change; we recreate the event on every set so concurrent
-        subscribers all wake exactly once per transition."""
+        """Block until any snapshot transitions. Each subscriber awaits
+        its own view of the change; the event is recreated on every set
+        so concurrent subscribers all wake exactly once per transition."""
         await self._event.wait()
 
     def _broadcast(self) -> None:
         self._event.set()
         self._event = asyncio.Event()
 
-    def mark_thinking(self, *, request_id: str, session_id: str) -> None:
-        self._snapshot = Snapshot(
-            state="thinking",
-            request_id=request_id,
-            session_id=session_id,
-            last_turn=self._snapshot.last_turn,
-        )
+    def _put(self, session_id: str, snapshot: Snapshot) -> None:
+        self._snapshots[session_id] = snapshot
+        self._latest_session_id = session_id
         self._broadcast()
+
+    def mark_thinking(self, *, request_id: str, session_id: str) -> None:
+        prior = self._snapshots.get(session_id, self._idle)
+        self._put(
+            session_id,
+            Snapshot(
+                state="thinking",
+                request_id=request_id,
+                session_id=session_id,
+                last_turn=prior.last_turn,
+            ),
+        )
 
     def mark_done(
         self,
@@ -80,28 +112,33 @@ class SessionStatus:
         reply_short: str,
         emotion: str,
     ) -> None:
-        self._snapshot = Snapshot(
-            state="idle",
-            request_id=request_id,
-            session_id=session_id,
-            last_turn=Turn(
-                transcript=transcript,
-                reply_short=reply_short,
-                emotion=emotion,
-                completed_at=time.time(),
+        self._put(
+            session_id,
+            Snapshot(
+                state="idle",
+                request_id=request_id,
+                session_id=session_id,
+                last_turn=Turn(
+                    transcript=transcript,
+                    reply_short=reply_short,
+                    emotion=emotion,
+                    completed_at=time.time(),
+                ),
             ),
         )
-        self._broadcast()
 
     def mark_failed(self, *, request_id: str, session_id: str, error: str) -> None:
-        self._snapshot = Snapshot(
-            state="idle",
-            request_id=request_id,
-            session_id=session_id,
-            last_turn=self._snapshot.last_turn,
-            error=error,
+        prior = self._snapshots.get(session_id, self._idle)
+        self._put(
+            session_id,
+            Snapshot(
+                state="idle",
+                request_id=request_id,
+                session_id=session_id,
+                last_turn=prior.last_turn,
+                error=error,
+            ),
         )
-        self._broadcast()
 
 
 def snapshot_to_dict(s: Snapshot) -> dict[str, object]:

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -62,6 +62,28 @@ def test_listen_wrong_content_type(
     assert r.status_code == 415
 
 
+def test_listen_rejects_non_mono_audio(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    # `channels=2` body would otherwise reinterpret interleaved
+    # stereo int16 as mono, producing garbage transcription. Catch
+    # at the content-type gate with a dedicated error code so the
+    # operator gets clear feedback.
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={
+            **auth_headers,
+            "Content-Type": "audio/L16;rate=16000;channels=2",
+        },
+    )
+    assert r.status_code == 415
+    body = r.json()
+    assert body["error"]["code"] == "audio_channels_unsupported"
+
+
 def test_listen_empty_body(client: TestClient, auth_headers: dict[str, str]) -> None:
     r = client.post(
         "/v1/listen",

--- a/sidecar/tests/test_session_status.py
+++ b/sidecar/tests/test_session_status.py
@@ -208,3 +208,23 @@ def test_all_returns_every_session_snapshot() -> None:
     s.mark_thinking(request_id="rB", session_id="unit-b")
     snapshots = s.all()
     assert set(snapshots.keys()) == {"unit-a", "unit-b"}
+
+
+def test_snapshots_dict_evicts_lru_past_cap() -> None:
+    # Importing the private cap is intentional: this test pins the
+    # eviction shape, not the cap value.
+    from stackchan_sidecar.session_status import _MAX_TRACKED_SESSIONS
+
+    s = SessionStatus()
+    # Fill exactly to the cap.
+    for i in range(_MAX_TRACKED_SESSIONS):
+        s.mark_thinking(request_id=f"r{i}", session_id=f"unit-{i}")
+    assert len(s.all()) == _MAX_TRACKED_SESSIONS
+
+    # One more push evicts the oldest. The very first session-id
+    # is the LRU victim; the new one lands.
+    s.mark_thinking(request_id="r-new", session_id="unit-new")
+    snapshots = s.all()
+    assert len(snapshots) == _MAX_TRACKED_SESSIONS
+    assert "unit-0" not in snapshots
+    assert "unit-new" in snapshots

--- a/sidecar/tests/test_session_status.py
+++ b/sidecar/tests/test_session_status.py
@@ -154,3 +154,57 @@ def test_snapshot_to_dict_drops_none_fields() -> None:
     assert isinstance(turn, dict)
     assert turn["transcript"] == "hi"
     assert "error" not in raw
+
+
+def test_concurrent_sessions_do_not_clobber_each_other() -> None:
+    # Two units with distinct session_ids should each have their own
+    # snapshot. Previously SessionStatus held a single slot and the
+    # second unit's mark_thinking would overwrite the first.
+    s = SessionStatus()
+    s.mark_thinking(request_id="rA", session_id="unit-a")
+    s.mark_thinking(request_id="rB", session_id="unit-b")
+    a = s.get("unit-a")
+    b = s.get("unit-b")
+    assert a.session_id == "unit-a"
+    assert a.state == "thinking"
+    assert a.request_id == "rA"
+    assert b.session_id == "unit-b"
+    assert b.state == "thinking"
+    assert b.request_id == "rB"
+
+
+def test_mark_done_only_touches_named_session() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="rA", session_id="unit-a")
+    s.mark_thinking(request_id="rB", session_id="unit-b")
+    s.mark_done(
+        request_id="rA",
+        session_id="unit-a",
+        transcript="hi",
+        reply_short="hello",
+        emotion="happy",
+    )
+    a = s.get("unit-a")
+    b = s.get("unit-b")
+    assert a.state == "idle"
+    assert a.last_turn is not None
+    # Unit B is still thinking — its session was not the target of
+    # unit A's mark_done.
+    assert b.state == "thinking"
+    assert b.last_turn is None
+
+
+def test_get_without_session_id_returns_latest_updated() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="rA", session_id="unit-a")
+    s.mark_thinking(request_id="rB", session_id="unit-b")
+    latest = s.get()
+    assert latest.session_id == "unit-b"
+
+
+def test_all_returns_every_session_snapshot() -> None:
+    s = SessionStatus()
+    s.mark_thinking(request_id="rA", session_id="unit-a")
+    s.mark_thinking(request_id="rB", session_id="unit-b")
+    snapshots = s.all()
+    assert set(snapshots.keys()) == {"unit-a", "unit-b"}

--- a/web/src/components/Calibration.tsx
+++ b/web/src/components/Calibration.tsx
@@ -278,7 +278,11 @@ export function Calibration() {
         <button type="button" onClick={() => void loadSettings()}>
           Reload
         </button>
-        <button type="button" onClick={() => setTracker(TRACKER_DEFAULT)} title="Revert local edits to firmware defaults (does not persist; click Save to apply).">
+        <button
+          type="button"
+          onClick={() => setTracker(TRACKER_DEFAULT)}
+          title="Reset to host-side fallback values (defined in this dashboard build; may drift from the firmware's actual defaults). Does not persist; click Save to apply."
+        >
           Reset to defaults
         </button>
       </div>

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -18,7 +18,7 @@ function Stat(props: {
       }}
     >
       <div class="stat-label">{props.label}</div>
-      <div class="stat-value" aria-live="polite">
+      <div class="stat-value">
         <Show
           when={!props.loading}
           fallback={<span class="skeleton skeleton-row" aria-hidden="true">—</span>}
@@ -44,7 +44,11 @@ export function StatusBar() {
       <div class="status-face">
         <FaceGlyph size={56} />
       </div>
-      <div class="status-stats">
+      {/* Single live region on the wrapper instead of one per stat:
+          five concurrent polite announcers were fighting for the
+          screen-reader queue on every SSE tick and producing
+          continuous read-out on NVDA / VoiceOver. */}
+      <div class="status-stats" aria-live="polite">
         <Stat label="EMOTION" value={snapshot()?.emotion?.toUpperCase() ?? null} loading={loading()} />
         <Stat label="MOOD" value={snapshot()?.mood?.toUpperCase() ?? null} loading={loading()} />
         <Show

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -69,13 +69,29 @@ export function series<K extends keyof Sample>(key: K): number[] {
 }
 
 export function connectStream(): void {
+  // Exponential backoff with jitter for reconnects. Fixed 1.5 s
+  // before this change meant every open dashboard tab pounded the
+  // firmware at 0.67 Hz whenever it was offline; bursts from N
+  // tabs would amplify under restart. Resets to the floor on
+  // every successful open so a healthy stream re-arms the curve.
+  const BACKOFF_MIN_MS = 1500;
+  const BACKOFF_MAX_MS = 30000;
+  let backoff = BACKOFF_MIN_MS;
   const open = () => {
     const es = new EventSource("/state/stream");
-    es.onopen = () => setConn("ok");
+    es.onopen = () => {
+      setConn("ok");
+      backoff = BACKOFF_MIN_MS;
+    };
     es.onerror = () => {
       setConn("bad");
       es.close();
-      setTimeout(open, 1500);
+      // ±25% jitter so N tabs reconnecting after a firmware
+      // restart fan out across the back-off window instead of
+      // synchronising on the boundary.
+      const jitter = backoff * (0.75 + Math.random() * 0.5);
+      setTimeout(open, jitter);
+      backoff = Math.min(backoff * 2, BACKOFF_MAX_MS);
     };
     es.onmessage = (ev) => {
       try {


### PR DESCRIPTION
## Summary

Independent of the Rust stack — branches off main. Bundles all Python sidecar + web TypeScript audit findings into one cross-language PR.

**Sidecar (Python)**
- \`SessionStatus\` keyed by \`session_id\` so two units don't clobber each other's snapshots. Backward-compatible: \`get()\` returns latest-updated (preserves single-unit behaviour). New \`?session_id=\` filter on the companion SSE relay.
- New \`audio_channels_unsupported\` error code; \`_validate_content_type\` rejects \`channels=2\` bodies (would otherwise decode interleaved stereo as mono garbage).
- Retry classifier narrowed from \`httpx.HTTPError\` to \`httpx.TransportError\` so config bugs (\`InvalidURL\`, \`UnsupportedProtocol\`, \`LocalProtocolError\`) surface immediately instead of burning the attempt budget.

**Web (TypeScript)**
- \`StatusBar\` collapses 5 polite \`aria-live\` regions to one wrapper region (concurrent announcers were fighting for the screen-reader queue every SSE tick).
- \`Calibration\` reset-to-defaults tooltip is honest about using host-side fallback values.
- \`connectStream\` uses exponential backoff with jitter (1.5s → 30s, ±25%) so tabs fan out instead of synchronising under a firmware restart.

## Test plan

- [x] \`uv run pytest\` (112 sidecar tests pass — 5 new SessionStatus per-session + 1 new \`channels=2\` reject)
- [x] \`npm run build\` (web dashboard builds, dist/ updated)