### PR TITLE
fix(sidecar): polish — LLM SDK retries off + Events.tsx no-stack poll

### DIFF
--- a/sidecar/src/stackchan_sidecar/llm/anthropic.py
+++ b/sidecar/src/stackchan_sidecar/llm/anthropic.py
@@ -49,7 +49,7 @@ class AnthropicLLM:
     ) -> None:
         # `max_retries=0` disables the SDK's internal retry loop:
         # our `retry_with_timeout` already owns the retry policy,
-        # and stacking SDK retries on top would produce up to 2×2
+        # and stacking SDK retries on top would produce up to 2x2
         # attempts per call and make the per-attempt timeout
         # math opaque.
         self._client = anthropic.AsyncAnthropic(api_key=api_key, max_retries=0)

--- a/sidecar/src/stackchan_sidecar/llm/anthropic.py
+++ b/sidecar/src/stackchan_sidecar/llm/anthropic.py
@@ -47,7 +47,12 @@ class AnthropicLLM:
         model: str = "claude-haiku-4-5",
         max_tokens: int = 400,
     ) -> None:
-        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        # `max_retries=0` disables the SDK's internal retry loop:
+        # our `retry_with_timeout` already owns the retry policy,
+        # and stacking SDK retries on top would produce up to 2×2
+        # attempts per call and make the per-attempt timeout
+        # math opaque.
+        self._client = anthropic.AsyncAnthropic(api_key=api_key, max_retries=0)
         self._model = model
         self._max_tokens = max_tokens
 

--- a/sidecar/src/stackchan_sidecar/llm/openai.py
+++ b/sidecar/src/stackchan_sidecar/llm/openai.py
@@ -51,7 +51,11 @@ class OpenAILLM:
         model: str = "gpt-4o-mini",
         max_tokens: int = 400,
     ) -> None:
-        self._client = openai.AsyncOpenAI(api_key=api_key)
+        # `max_retries=0`: see `AnthropicLLM.__init__` — our
+        # `retry_with_timeout` owns the retry policy. Stacking SDK
+        # retries on top would burn the per-attempt timeout budget
+        # invisibly.
+        self._client = openai.AsyncOpenAI(api_key=api_key, max_retries=0)
         self._model = model
         self._max_tokens = max_tokens
 

--- a/web/src/components/Events.tsx
+++ b/web/src/components/Events.tsx
@@ -20,7 +20,12 @@ function kindClass(k: EventEntry["kind"]): string {
 
 export function Events() {
   const [data, setData] = createSignal<EventsResponse | null>(null);
-  let timer: ReturnType<typeof setInterval> | null = null;
+  // setTimeout self-reschedule instead of setInterval: a slow
+  // `/events` fetch (firmware busy, network lag) would otherwise
+  // queue a second tick on the prior interval boundary while the
+  // first is still in flight, stacking N concurrent requests.
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let cancelled = false;
 
   const tick = async () => {
     try {
@@ -29,15 +34,19 @@ export function Events() {
       setData((await res.json()) as EventsResponse);
     } catch (e) {
       showToast(`/events: ${(e as Error).message}`, true);
+    } finally {
+      if (!cancelled) {
+        timer = setTimeout(() => void tick(), POLL_MS);
+      }
     }
   };
 
   onMount(() => {
     void tick();
-    timer = setInterval(tick, POLL_MS);
   });
   onCleanup(() => {
-    if (timer != null) clearInterval(timer);
+    cancelled = true;
+    if (timer != null) clearTimeout(timer);
   });
 
   return (


### PR DESCRIPTION
## Summary

Two deferred S-tier items from the v0.2.0 audit, bundled into a small follow-up:

- **LLM SDK retry budget**: \`max_retries=0\` on both \`AsyncAnthropic\` and \`AsyncOpenAI\`. The SDKs default to \`max_retries=2\`; stacked with our \`retry_with_timeout(max_attempts=2)\` that's up to 2×2 = 4 attempts per call and the per-attempt timeout math becomes opaque. \`retry_with_timeout\` now owns the policy.
- **Events.tsx poll stacking**: \`setInterval\` over an async \`tick\` queued a second fetch on the prior interval boundary while the first was still in flight. Switch to \`setTimeout\` self-reschedule after \`await\`.

## Test plan

- [x] \`uv run pytest\` (107 sidecar tests pass)
- [x] \`npm run build\` (web bundle builds, dist/ updated)