### PR TITLE
docs: re-derive stackchan-core and stackchan-net READMEs from current src/

### DIFF
--- a/crates/stackchan-core/README.md
+++ b/crates/stackchan-core/README.md
@@ -1,8 +1,8 @@
 ---
 crate: stackchan-core
-role: Avatar domain library (no_std, no hardware deps)
+role: Avatar + NPC engine (no_std, no hardware deps)
 bus: none
-transport: "pure data + Modifier trait"
+transport: "pure data + Modifier / Skill traits"
 no_std: true
 unsafe: forbidden
 status: experimental (v0.x)
@@ -10,110 +10,126 @@ status: experimental (v0.x)
 
 # stackchan-core
 
-`no_std` domain library for the Stack-chan avatar. Models the face as
-**data** and drives animation through a `Modifier` trait that mutates
-an `Avatar` in response to the passage of time (supplied by a `Clock`).
-No hardware, OS, or `alloc` dependency — this crate is the
-platform-independent heart of the firmware and the simulator.
+`no_std` engine for the Stack-chan NPC. An [`Entity`] holds the
+per-frame state — face, motor, perception, voice, mind, events, input,
+tick — and a [`Director`] runs registered [`Modifier`]s and [`Skill`]s
+against it each frame. No hardware, OS, or `alloc` dependency beyond
+the workspace `extern crate alloc` for `heapless::String`-adjacent
+use; the firmware and the simulator both consume this crate against
+the same trait surface.
 
-## Key Files
+## What's here
 
-- `src/lib.rs` — crate root, public re-exports
-- `src/avatar.rs` — `Avatar`, `Eye`, `EyePhase`, `Mouth`, `Point`, `SCALE_DEFAULT`
-- `src/clock.rs` — `Clock` trait, `Instant` (millisecond-resolution monotonic)
-- `src/draw.rs` — `Avatar::draw` renders into any `embedded_graphics::DrawTarget<Color = Rgb565>`
-- `src/emotion.rs` — `Emotion` enum + `Emotion::ALL` catalogue. Per-emotion style targets live in `modifiers/style_from_emotion.rs::targets_for`
-- `src/head.rs` — `Pose`, `HeadDriver` trait, pan / tilt range constants
-- `src/leds.rs` — `LedFrame`, `render_leds` — maps avatar state to the 12-pixel ring
-- `src/modifiers/mod.rs` — `Modifier` trait + re-exports
-- `src/modifiers/*.rs` — one file per modifier; names follow the convention in [`docs/naming.md`](../../docs/naming.md) (`<Output>From<Source>` for translators, bare noun for autonomous ones)
-- `src/skills/*.rs` — one file per skill (`listening`, `petting`, `handling`) — long-running NPC capabilities that write `mind.intent` / `mind.attention`
-- `src/perception.rs` — `Perception` struct (sensor inputs feeding modifiers) + `BodyTouch` / `TrackingObservation` / `TrackingMotion` sub-types
+- [`Entity`] — composed NPC state (`face`, `motor`, `perception`,
+  `voice`, `mind`, `events`, `input`, `tick`, `led_override`).
+  Plain data — modifiers and skills mutate it in place.
+- [`Director`] — orders modifiers by `(Phase, priority, registration
+  order)` and ticks them each frame; polls skills and invokes those
+  whose `should_fire` predicate returns `true`. Caller owns the
+  modifier / skill instances; the Director only borrows.
+- [`Modifier`] — per-frame state mutator with `meta()` (phase, priority,
+  declared reads / writes) and `update(&mut Entity)`. The canonical
+  catalogue lives in [`modifiers/`](src/modifiers).
+- [`Skill`] — longer-running NPC capability with `meta()`,
+  `should_fire`, and `invoke`. Skills write `mind` / `voice` /
+  `events`; modifiers translate that intent into face and motion. The
+  catalogue lives in [`skills/`](src/skills).
+- [`Clock`] — single-method trait (`fn now(&self) -> Instant`) used so
+  modifiers stay deterministic for host tests against a `FakeClock`.
 
-## Architecture
+The trait shapes are the public surface; new behaviour ships as a new
+file in `modifiers/` or `skills/` rather than as a Director edit.
+
+## Tick model
 
 ```mermaid
-flowchart TB
-    subgraph Inputs
-        Clock[Clock trait<br/><i>Instant</i>]
-        Hardware[Hardware signals<br/><i>touch, IMU, IR, ambient</i>]
+flowchart LR
+    Tick[Director::run<br/>stamps tick / clears events] --> Mods
+    subgraph Mods [Modifiers — Phase-ordered]
+        Affect[Affect]
+        Expression[Expression]
+        Decoration[Decoration]
+        Motion[Motion]
+        Audio[Audio]
     end
-    subgraph Core
-        Avatar[(Avatar)]
-        Modifiers[Modifier pipeline]
-    end
-    subgraph Outputs
-        Draw[Avatar::draw<br/><i>embedded-graphics DrawTarget</i>]
-        Head[HeadDriver trait<br/><i>Pose → pan/tilt</i>]
-        Leds[render_leds<br/><i>LedFrame</i>]
-    end
-
-    Clock --> Modifiers
-    Hardware --> Modifiers
-    Modifiers -->|update(&mut Avatar, Instant)| Avatar
-    Avatar --> Draw
-    Avatar --> Head
-    Avatar --> Leds
+    Mods --> Skills[Skill::should_fire → invoke]
+    Skills --> Entity[(Entity)]
 ```
 
-## Modifier Pipeline
+[`Phase`](src/director.rs) declares the canonical NPC tick order —
+`Perception → Cognition → Affect → Speech → Expression → Decoration →
+Motion → Audio → Output`. Today the populated phases are `Affect`,
+`Expression`, `Decoration`, `Motion`, `Audio`; the rest are reserved
+slots. Skills are polled after the modifier pass so they observe the
+post-modifier entity state.
 
-Modifiers implement `fn update(&mut self, avatar: &mut Avatar, now: Instant)`.
-Each one composes with the others — the firmware runs the full stack per
-render tick. Listed roughly in application order:
+`entity.tick.now` is stamped by [`Director::run`]; modifiers read it
+instead of taking `now: Instant` as an argument. `tick.dt_ms` carries
+the delta since the previous frame; `tick.frame` is a monotonic
+counter.
 
-| Modifier          | Effect                                                         |
-|-------------------|----------------------------------------------------------------|
-| `EmotionFromRemote`   | IR remote → emotion / pose override                            |
-| `EmotionFromTouch`    | Touch-panel tap → emotion bump                                 |
-| `EmotionFromAmbient`   | Dark room (low lux) → sleepy emotion                           |
-| `EmotionFromIntent`    | `mind.intent` transitions → emotion (PickedUp→Surprised, Shaken→Angry) |
-| `EmotionFromVoice`     | Sustained `audio_rms` above threshold → `Happy` + `Wake` chirp |
-| `IntentFromLoud`   | Rising-edge `audio_rms` across loud threshold → `Surprised` + `Startled` intent + `Startle` chirp |
-| `EmotionCycle`    | Default sequence: Neutral → Happy → Sleepy → Surprised → Sad   |
-| `StyleFromEmotion`    | 300 ms ease on style fields (curves, scale, blush) per emotion |
-| `HeadFromEmotion`     | Per-emotion pose bias (neutral center, surprised up, etc.)     |
-| `HeadFromAttention`      | Upward tilt while `Listening`; snap-to-target while `Tracking`  |
-| `HeadFromIntent`     | Brief asymmetric pan/tilt recoil on entry to `Startled`     |
-| `GazeFromAttention`  | Eye centers shift toward target while `Tracking` (eyes lead head) |
-| `MicrosaccadeFromAttention` | 0.5–1.5 s involuntary eye darts during `Tracking` (Disney IROS realism contributor) |
-| `AttentionFromTracking` | Cognition: latches `mind.attention=Tracking{target}` on sustained camera motion |
-| `RemoteCommandModifier` | Cognition: drains `entity.input.remote_command` (firmware HTTP), holds emotion or look-at target for the requested window |
-| `Blink` / `Breath`   | Engagement-aware: blink rate halves and breath cycle stretches ×1.67 while attention is non-`None` |
-| `IdleDrift`       | Slow randomized gaze drift                                     |
-| `IdleHeadDrift`   | Occasional brief head glances at randomized intervals          |
-| `Blink`           | Lid close / open pulses                                        |
-| `Breath`          | Per-cycle eye + mouth scale oscillation                        |
+## Conflict detection
 
-The full set lives in `src/modifiers/mod.rs` — the table above is
-representative, not exhaustive.
+Modifiers declare their `reads` and `writes` as `&'static [Field]`
+slices on [`ModifierMeta`]. In `cfg(debug_assertions)` builds the
+Director snapshots [`Entity`] before each invocation and panics if a
+modifier mutates a field outside its declared `writes` set. [`Field`]
+is per-leaf (`LeftEyePhase` vs `LeftEyeWeight`) so two modifiers
+writing different sub-fields of the same component don't false-flag
+as conflicts. Release builds skip the check.
 
-`EmotionCycle → StyleFromEmotion → Blink → Breath → IdleDrift` is the
-minimum stack; the firmware adds the others. The `Clock` argument makes
-time a trait so the simulator can advance deterministically while
-firmware advances from `embassy-time`.
+## Storage
 
-## Key Types
-
-- **`Avatar`** — `{ left_eye: Eye, right_eye: Eye, mouth: Mouth, emotion: Emotion }`. Plain data — no hidden state, no runtime invariants beyond "values stay in their documented ranges"
-- **`Eye`** — `{ phase: EyePhase, weight: f32, offset: Point, ... }`. `weight` is the lid openness (0 = closed, 1 = open)
-- **`Mouth`** — `{ rotation: f32, scale: f32, cheek_blush: f32, ... }`
-- **`Clock`** — single method `fn now(&self) -> Instant`. Stable against re-entry, takes `&self`
-- **`Instant`** — `u64` ms since some epoch. Operators for `+ delta_ms: u64` and sequences of differences
-- **`Pose`** — `{ pan_deg: f32, tilt_deg: f32 }`. Bounded by `MAX_PAN_DEG` / `MAX_TILT_DEG`
-- **`HeadDriver`** — `fn drive(&mut self, pose: Pose, now: Instant)`. Implemented by firmware (SCServo) and sim (recorder)
+[`Director`] uses `heapless::Vec` for the modifier and skill
+registries with caps [`MODIFIER_CAP`] and [`SKILL_CAP`]. Modifiers
+own their per-frame state in fixed-size fields. Callers that want N
+copies of a modifier build a wrapper — the crate won't `Box`
+anything.
 
 ## Gotchas
 
-1. **No `alloc`.** Modifiers own their state in fixed-size fields. Callers that want N of a modifier build a wrapper; the crate won't `Box` anything
-2. **Time must be monotonic.** `Clock::now()` is trusted — a backward jump breaks modifiers that cache `last_update`. Wall-clock sources need a wrapper
-3. **Draw is pure.** `Avatar::draw` produces pixels into the provided `DrawTarget`; it doesn't mutate the avatar. Run modifiers first, then draw
-4. **Emotion transitions are 300 ms eased by `StyleFromEmotion`.** Don't snap emotion changes directly on the `Avatar` — go through the modifier so the ease kicks in
-5. **No panic in library code.** Workspace lints deny `unwrap` / `expect` / `panic`. All APIs return values in documented ranges; pathological inputs saturate rather than panic
+1. **No `alloc` in the modifier path.** `alloc` is available
+   crate-wide (`extern crate alloc`) for string-typed types like
+   `Voice::utterance_request`, but per-frame modifier work avoids
+   it. New modifiers should follow suit.
+2. **Time must be monotonic.** `Clock::now()` is trusted; a backward
+   jump breaks modifiers that compare against `last_update`. Wall-clock
+   sources need a wrapper.
+3. **Render is pure.** `Face::draw` (via the [`draw`] module) produces
+   pixels into the caller's `embedded_graphics::DrawTarget<Color =
+   Rgb565>`; it doesn't mutate the entity. Run the Director first,
+   then render.
+4. **Skills don't draw or move.** They write `mind` / `voice` /
+   `events`. Translation to face / motor is the modifiers' job — this
+   keeps the cognitive layer decoupled from the rendering and motion
+   pipelines and is the invariant the field-conflict check protects.
+5. **No `unwrap` / `expect` / `panic` in library code.** Workspace
+   lints deny them. APIs saturate or return typed errors on
+   pathological input.
 
 ## Integration
 
-- **Used by `stackchan-firmware`** for the render loop + head / LED output
-- **Used by `stackchan-sim`** for host-side tests — the same `Avatar::draw` path runs against a `Vec<Rgb565>` framebuffer for pixel-golden snapshots
-- **Unit-tested** with doctests; golden-test behaviour lives in `stackchan-sim`
-- **Stability:** everything is `Experimental` in v0.x. The module structure and modifier set are stable; names and fields may still evolve before anything graduates to `Stable`
+- [`stackchan-firmware`](../stackchan-firmware) registers modifiers
+  and skills, drains hardware signals into `entity.perception` /
+  `entity.input`, then calls `Director::run` per render tick.
+- [`stackchan-sim`](../stackchan-sim) does the same composition
+  against a `FakeClock` and a `Vec<Rgb565>` framebuffer for golden
+  snapshots.
+- Unit-tested via doctests and per-module `#[cfg(test)]` blocks;
+  golden-behaviour tests live in `stackchan-sim`.
+- **Stability:** `Experimental` in v0.x. Trait shapes and the [`Entity`]
+  composition are settled; individual modifier / skill names and
+  field internals continue to evolve.
+
+[`Entity`]: src/entity.rs
+[`Director`]: src/director.rs
+[`Director::run`]: src/director.rs
+[`Modifier`]: src/modifier.rs
+[`ModifierMeta`]: src/director.rs
+[`Skill`]: src/skill.rs
+[`Phase`]: src/director.rs
+[`Field`]: src/director.rs
+[`Clock`]: src/clock.rs
+[`MODIFIER_CAP`]: src/director.rs
+[`SKILL_CAP`]: src/director.rs
+[`draw`]: src/draw.rs

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -1,6 +1,6 @@
 ---
 crate: stackchan-net
-role: Networking domain types + RON config schema (host-testable)
+role: Networking domain types, wire formats, and on-disk config schema
 bus: none
 transport: "pure data + parsers"
 no_std: true
@@ -11,89 +11,146 @@ status: experimental (v0.x)
 # stackchan-net
 
 Networking domain types for Stack-chan. Pure data and parsers — no
-transport, no I/O, no esp-hal. The firmware does the I/O wrapping;
+transport, no I/O, no `esp-hal`. The firmware does the I/O wrapping;
 this crate is what the firmware (and host tests) agree on as the
-shape of the on-disk config and the RON file `PUT /settings` round-trips.
+shape of every wire format the avatar speaks.
 
-## Schema v1
+Anything that has a serializer, validator, or parser the firmware and
+the host both need to agree on belongs here. That includes the on-disk
+RON config, the JSON bodies of the HTTP control plane, the MCP server
+transport, the BLE control characteristics, the BluFi provisioning
+frames, the ESP-NOW frame envelope, the OTA image header, the
+crash-latch byte layout, and the mDNS pose-TXT formatting. Holding
+all of it in a host-testable crate keeps the wire surface pinned by
+`cargo test`, rather than living inside the firmware's
+`xtensa-esp32s3-none-elf`-only `#[cfg(test)]` modules that CI never
+runs.
+
+## On-disk config schema
 
 ```ron
 (
-    wifi: ( ssid: "home", psk: "redacted", country: "US" ),
-    mdns: ( hostname: "stackchan" ),
-    time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
-    esp_now: (
-        enabled: false,
-        pmk_hex: "",
-        peer_mac: "",
-        lmk_hex: "",
-        channel: None,
-        tx_rate_hz: 5,
+    wifi:    ( ssid: "home", psk: "redacted", country: "US" ),
+    mdns:    ( hostname: "stackchan" ),
+    time:    ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+    auth:    ( token: "" ),
+    audio:   ( volume_pct: 50, muted: false ),
+    tracker: ( fov_h_deg: 62.0, fov_v_deg: 49.0,
+               target_smoothing_alpha: 1.0,
+               flip_x: false, flip_y: false ),
+    esp_now: ( enabled: false, pmk_hex: "", peer_mac: "",
+               lmk_hex: "", channel: None, tx_rate_hz: 5 ),
+    behavior: (
+        soliloquy_enabled: false,
+        hourly_chime_enabled: false,
+        battery_icon_enabled: false,
+        toast_overlay_enabled: false,
+        auto_torque_release_ms: 0,
+        audio_debug_udp_target: "",
+        agent_sidecar_url: "",
+        agent_sidecar_token: "",
+        follower_leader_hostname: "",
+        wake_word_enabled: false,
+        wake_word_threshold: 100,
+        wake_word_arena_kib: 64,
     ),
 )
 ```
 
-- `WifiConfig` — credentials + ISO-3166 alpha-2 country code (default `"US"`).
-- `MdnsConfig` — hostname advertised on `.local` (default `"stackchan"`).
-- `TimeConfig` — IANA timezone label + SNTP servers (default `"UTC"`,
-  `["pool.ntp.org"]`). The TZ field is parsed but currently unused;
-  the BM8563 RTC stores UTC.
-- `EspNowConfig` — ESP-NOW remote-control radio settings. Disabled by
-  default. `pmk_hex` / `lmk_hex` are 32-character hex (16 bytes);
-  `peer_mac` accepts either bare 12-hex or `xx:xx:xx:xx:xx:xx`.
-  `channel: None` follows the Wi-Fi STA's chosen channel; explicit
-  values `1..=14` are for ESP-NOW-only deployments. `tx_rate_hz`
-  ranges `0..=20`; `0` disables outbound entirely.
+Top-level blocks land via `serde(default)` — a `STACKCHAN.RON` that
+omits a block keeps the firmware's compile-time defaults. Per-field
+documentation, validators, and the rationale behind each default live
+in [`config.rs`](src/config.rs).
 
-## Key Files
-
-- `src/lib.rs` — crate root, re-exports
-- `src/config.rs` — `Config`, `WifiConfig`, `MdnsConfig`, `TimeConfig`,
-  `parse_ron`, `render_ron`, validators
-- `src/bare.rs` — hand-rolled RON parser/renderer used by the firmware
-  (no `serde`, no `ron` — see the module doc for why)
-- `src/bare_json.rs` — hand-rolled JSON parser/renderer used by the
-  firmware HTTP control plane on `GET /settings` / `PUT /settings`
-- `src/http_command.rs` — JSON body parsers for `POST /emotion`,
-  `/look-at`, `/speak`, `/volume`, `/mute`
-- `src/ble_command.rs` — fixed-length wire-format codecs for the
-  BLE audio + avatar control characteristics, with stable byte
-  mappings for `Emotion` / `PhraseId` / `Locale`
-- `src/mdns_pose.rs` — throttling decision + TXT key formatting for
-  the mDNS responder's live `yaw=` / `pitch=` advertisement. The
-  embassy task lives in the firmware crate; this module hosts the
-  pure logic so it stays on the host CI test path.
-- `src/error.rs` — `ConfigError` (parse / serialize / validation variants)
-- `tests/golden_config.rs` + `tests/fixtures/*.ron` — round-trip and
-  validation coverage against hand-written fixtures
+[`validate`] is the lenient gate (run on every `PUT /settings` so a
+dashboard form re-submitting a redacted body still works);
+[`validate_for_disk`] is `validate` plus rejection of the literal
+redaction sentinel `"***"` in any secret field, run on the SD-load
+path so an operator can't accidentally persist a redacted snapshot
+back to disk.
 
 ## Offline-first stance
 
-The avatar must boot fully and animate even with no SD card and no
-Wi-Fi. The firmware therefore treats `Config` as **always available**:
-missing SD or missing file falls back to `Config::default`. Validators
-in `parse_ron` reject malformed input, but the firmware never
-propagates a `ConfigError` up to a panic — it logs and uses defaults.
+The avatar must boot fully and animate with no SD card and no Wi-Fi.
+The firmware therefore treats [`Config`] as **always available**:
+missing SD or missing file falls back to [`Config::default`].
+Validators reject malformed input, but the firmware never propagates
+a [`ConfigError`] up to a panic — it logs and uses defaults.
 
-## Defer-list (out of scope for v1)
+## Wire formats
 
-- TLS / HTTPS config — the v1 control plane is LAN-scoped, no auth.
-- OTA manifests — firmware updates are a separate concern.
-- Captive portal / soft-AP setup flow — first-boot UX deferred.
-- Persona / character data — belongs to the AI tier (deferred).
-- BLE pairing-key serialisation — owned by the firmware
-  `crate::ble::bonds` module, not this crate.
+| Module | What it pins |
+|---|---|
+| [`config`](src/config.rs)             | Top-level [`Config`], sub-block structs, validators, [`tz_offset_minutes`], [`parse_mac`] |
+| [`bare`](src/bare.rs)                 | Hand-rolled RON parser / renderer used by the firmware. The `parse` feature gates the serde + `ron` path; the firmware target leaves it off |
+| [`bare_json`](src/bare_json.rs)       | Hand-rolled JSON parser / renderer for the HTTP control plane's `GET` / `PUT /settings`, plus [`merge_settings_with_current`] which substitutes the persisted value back in wherever the redaction sentinel `"***"` arrives |
+| [`http_command`](src/http_command.rs) | JSON body parsers for `POST /emotion`, `/look-at`, `/speak`, `/volume`, `/mute`, `/enter_pairing` |
+| [`http_parse`](src/http_parse.rs)     | Byte-level helpers (`parse_content_length`, `parse_bearer_token`, `ct_eq`, …) for the firmware's HTTP request parser |
+| [`mcp`](src/mcp.rs)                   | Minimal Model Context Protocol server: JSON-RPC 2.0 envelope, MCP `initialize` / `tools/list` / `tools/call`, the tool catalogue used by `POST /mcp` |
+| [`ble_command`](src/ble_command.rs)   | Fixed-length codecs for the BLE audio + avatar-control characteristics; stable byte mappings for `Emotion`, `PhraseId`, `Locale` |
+| [`blufi`](src/blufi.rs)               | BluFi frame parsing + building for BLE-based Wi-Fi provisioning from the official Espressif provisioning apps |
+| [`esp_now`](src/esp_now.rs)           | ESP-NOW frame envelope (`STKC` magic, version, kind byte, JSON body); body is byte-identical to the corresponding HTTP route so the same payloads work over both transports |
+| [`ota`](src/ota.rs)                   | OTA image header (`SCFW` magic, version, length, Ed25519 signature trailer) and host-testable image parser. The on-device verification + partition swap ride on `esp-hal-ota` in the firmware |
+| [`crash_latch`](src/crash_latch.rs)   | Encoder / decoder for the firmware's persistent crash latch (lives in RTC fast RAM across resets; decoded on next boot and written to `/sd/CRASH.LOG`) |
+| [`mdns_pose`](src/mdns_pose.rs)       | Throttling decision + TXT key formatting for the mDNS responder's live `yaw=` / `pitch=` advertisement. The embassy task itself lives in firmware; the pure logic stays here for the host CI test path |
+| [`dance`](src/dance.rs)               | JSON parser for `POST /dance`; the [`DanceScript`] schema and the player modifier live in `stackchan-core` so the player stays driver-agnostic |
+| [`error`](src/error.rs)               | [`ConfigError`] — parse, serialize, and validation variants |
 
-## Security note
+`tests/golden_config.rs` + `tests/fixtures/*.ron` cover round-trip
+and validation behaviour against hand-written fixtures.
 
-`render_ron` is lossless — `wifi.psk` round-trips verbatim so SD reads
-and writes stay symmetric. Any caller that returns the rendered output
-over an unauthed network channel must redact the PSK on the read path
-(separate read/write DTOs or a masked-render variant). Don't expose
-`render_ron`'s output to the network as-is.
+## Why hand-rolled JSON / RON
+
+`ron 0.10` (and the JSON crates) hard-pin `serde/std + base64/std`,
+both unbuildable on `xtensa-esp32s3-none-elf`. The `parse` feature
+gates the serde-backed `parse_ron` / `render_ron` path so host builds
+(sim, tests, host-side tooling) get the convenient round-trip while
+the firmware uses a hand-rolled bare parser. The hand-rolled parsers
+match the serde derives' shape; round-trip tests in
+`tests/golden_config.rs` pin them together.
+
+`bare_json.rs` and `mcp.rs` exist for the same reason — JSON over
+the wire couldn't pull `serde_json` either.
+
+## Security notes
+
+- [`render_ron`] is **lossless** — secret fields round-trip
+  verbatim so SD reads and writes stay symmetric. Any caller that
+  returns rendered output over an unauthed network channel must
+  redact on the read path. The firmware's `GET /settings` does this
+  via a separate render variant.
+- The redaction sentinel `"***"` is the cross-cutting wire marker
+  for "preserve the persisted value." It applies to `wifi.psk`,
+  `auth.token`, `esp_now.{pmk_hex,lmk_hex}`, and
+  `behavior.agent_sidecar_token`. The HTTP path's
+  [`merge_settings_with_current`] substitutes the prior value back
+  in; [`validate_for_disk`] rejects the sentinel as a disk-loaded
+  value so an operator can't `cp` a redacted dump back to SD and
+  silently brick auth.
+- `behavior.agent_sidecar_token` is additionally length-capped and
+  ASCII-control-rejected so a bad value can't extend the HTTP
+  request header buffer or inject extra headers via embedded
+  `\r\n`.
+
+## Defer-list
+
+- TLS / HTTPS. Today's control plane is LAN-scoped; bearer auth via
+  `auth.token` is the only authentication mechanism.
+- A captive-portal / soft-AP first-boot flow. BluFi covers the BLE
+  side of provisioning; a soft-AP fallback hasn't landed.
+- Persona / character data. Belongs to the agent tier and the
+  sidecar, not the firmware-side config schema.
+- BLE bonding-key persistence. Owned by the firmware
+  `crate::ble::bonds` module; the on-disk format is firmware-target
+  RTC RAM rather than something host code needs to parse.
 
 [`Config`]: src/config.rs
-[`WifiConfig`]: src/config.rs
-[`MdnsConfig`]: src/config.rs
-[`TimeConfig`]: src/config.rs
+[`Config::default`]: src/config.rs
 [`ConfigError`]: src/error.rs
+[`validate`]: src/config.rs
+[`validate_for_disk`]: src/config.rs
+[`tz_offset_minutes`]: src/config.rs
+[`parse_mac`]: src/config.rs
+[`render_ron`]: src/config.rs
+[`merge_settings_with_current`]: src/bare_json.rs
+[`DanceScript`]: ../stackchan-core/src/dance.rs


### PR DESCRIPTION
## Summary

Both crate READMEs had drifted past the 30-commit threshold the `doc-drift` script flags (`stackchan-core` at 61 commits, `stackchan-net` at 34). Rather than patching stale claims, each README is re-derived from current `src/` so the document shape matches today's code shape.

**stackchan-core**

- Leads with `Entity` + `Director` instead of the long-gone `Avatar` type
- Documents `Phase` ordering and the `Field`-based debug-build write-conflict check
- Spells out the `Skill` / `Modifier` split — skills write `mind` / `voice` / `events`; modifiers translate to face / motor
- Drops the per-modifier enumeration table in favor of pointing at `src/modifiers/` and `src/skills/` as the source-of-truth catalogs (per the no-counts norm)

**stackchan-net**

- Surfaces every wire format the crate now pins: MCP server transport, BluFi provisioning frames, ESP-NOW envelope, OTA image header, crash-latch codec, HTTP byte-level helpers, `/dance` JSON
- Schema example covers all current top-level blocks (`auth`, `audio`, `tracker`, `esp_now`, `behavior`)
- Documents the cross-cutting redaction sentinel (`"***"`) and the `validate` / `validate_for_disk` split
- Defer-list refreshed to current reality — OTA layout is in-tree now; BluFi covers the BLE half of provisioning

No code changes; `doc-drift` reports 23 clean, 0 drifted after commit.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p stackchan-core -p stackchan-net --all-features` — clean
- [x] `bash scripts/check-doc-drift.sh` — `23 clean, 0 drifted`
- [x] Both READMEs render correctly on GitHub (frontmatter, mermaid block, link references)