### PR TITLE
docs: re-derive host-crate READMEs + handbook index

### DIFF
--- a/crates/stackchan-audio-features/README.md
+++ b/crates/stackchan-audio-features/README.md
@@ -1,53 +1,136 @@
+---
+crate: stackchan-audio-features
+role: Streaming log-mel feature frontend for on-device keyword spotting
+bus: none
+transport: "i16 PCM in → MelFrame out"
+no_std: true (with alloc unused by the pipeline)
+unsafe: forbidden
+status: experimental (v0.x)
+---
+
 # stackchan-audio-features
 
-`no_std` + `alloc` audio frontend for on-device keyword spotting.
+`no_std` audio frontend for on-device keyword spotting. Implements
+the streaming feature pipeline `microWakeWord` (and most TFLite-micro
+keyword-spotting models) expect on their input tensor: 16 kHz mono
+`i16` PCM in, quantized log-mel feature frames out, one frame every
+10 ms. Pure Rust, host-testable in isolation against synthetic
+fixtures.
 
-Implements the streaming feature pipeline `microWakeWord` and most
-`TFLite-micro` keyword-spotting models expect on their input
-tensor:
+No inference. The downstream `MixConv` classifier (TFLite-micro via
+[`esp-tflite-micro-sys`](../esp-tflite-micro-sys), or a future
+pure-Rust equivalent) consumes [`MelFrame`]s but lives in the
+firmware crate. Shipping the frontend on its own means the
+inference path can swap without the DSP work moving.
 
-1. **Hann window** ([`window::HannWindow`]) — 480-sample
-   *periodic* taps (matches `numpy.hanning(N, sym=False)` /
-   `scipy.signal.windows.hann(N, sym=False)`; using the symmetric
-   form drifts a few dB per bin).
-2. **512-point real FFT** — via [`microfft`], zero-padding the
-   480 windowed samples to 512.
-3. **40-channel mel filterbank** ([`mel::MelFilterbank`]) —
-   triangular filters spanning 125 Hz to 7 500 Hz on the Slaney
-   mel scale used by `librosa`, `tensorflow.signal`, and TFLite's
-   `AudioFrontend` op.
-4. **Log + int8 quantize** ([`quantize::log_then_quantize`]) —
-   natural log with a 1e-6 floor, then asymmetric per-tensor
-   quantization with the model's `scale` and `zero_point`.
+## Pipeline
 
-`MelFrontend::push_samples` is the operator-facing entry point:
-feed any chunk size of `i16` PCM at 16 kHz mono, receive one
-`MelFrame` ([`frontend::MelFrame`]) every 10 ms via a callback.
+```mermaid
+flowchart LR
+    PCM[i16 PCM 16 kHz mono] --> Buf[push_samples — buffer to 480 / hop 160]
+    Buf --> Win[Hann window, 480 periodic taps]
+    Win --> Pad[Zero-pad to 512]
+    Pad --> FFT[Real FFT — microfft, size-512]
+    FFT --> Mag[Magnitude spectrum — 257 bins]
+    Mag --> Mel[Mel filterbank — 40 triangles, 125–7500 Hz]
+    Mel --> Log[Natural log, 1e-6 floor]
+    Log --> Q[int8 asymmetric quantize]
+    Q --> Frame[MelFrame &lbrace; features: i8 array &rbrace;]
+```
+
+Constants live in `frontend.rs` and are the single source of truth
+for cadence: `SAMPLE_RATE_HZ`, `WINDOW_SAMPLES`, `HOP_SAMPLES`,
+`FFT_SAMPLES`, `FFT_BIN_COUNT`, `MEL_BIN_COUNT`, `MEL_LOWER_HZ`,
+`MEL_UPPER_HZ`. Change one of them and the rest of the crate follows.
+
+## What's here
+
+- [`MelFrontend`] — operator-facing streaming entry point. `new()`
+  for the model's default int8 quantization; [`MelFrontend::with_quant`]
+  for a model-specific `(scale, zero_point)`. [`MelFrontend::push_samples`]
+  accepts any chunk size and drives a callback zero or more times per
+  call — once per completed hop boundary. [`MelFrontend::reset`]
+  drops the rolling buffer state (e.g. after a wake-word fire).
+- [`MelFrame`] — one frame of int8 mel features. `Copy`-able plain
+  data.
+- [`HannWindow`] — 480-sample **periodic** taps (matches
+  `numpy.hanning(N, sym=False)` / `scipy.signal.windows.hann(N, sym=False)`;
+  using the symmetric form drifts a few dB per bin).
+- [`MelFilterbank`] — triangular filters spanning 125 Hz to 7 500 Hz
+  on the Slaney mel scale used by `librosa`, `tensorflow.signal`,
+  and TFLite's `AudioFrontend` op.
+- [`log_then_quantize`] / [`quantize_scalar`] / [`QuantParams`] —
+  natural log with a 1e-6 floor, then asymmetric per-tensor
+  quantization with the model's `scale` and `zero_point`.
+- [`hz_to_mel`] / [`mel_to_hz`] — Slaney mel-scale conversion
+  helpers, used to lay out the filterbank.
 
 ## What this crate is not
 
-- **No inference.** The MixConv classifier that consumes these
-  features lives in a follow-up. The frontend ships on its own
-  so the next session's choice between TFLite-micro-via-FFI,
-  a custom MixConv interpreter, or a different architecture
-  isn't blocked on DSP work.
+- **No inference.** The classifier lives in
+  [`stackchan-firmware`'s wake-word task](../stackchan-firmware/src/wake_word.rs)
+  and runs the TFLite-micro interpreter from
+  [`esp-tflite-micro-sys`](../esp-tflite-micro-sys).
 - **No spectral subtraction or PCAN gain control.** The
-  `microWakeWord` reference frontend includes both for
-  noise-robust live audio; this crate's outputs are bit-exact
-  against reference numpy implementations of the simpler
-  log-mel pipeline. A follow-up will either port those kernels
-  or train against the simpler features.
+  `microWakeWord` reference frontend includes both for noise-robust
+  live audio; this crate's outputs are bit-exact against reference
+  numpy implementations of the simpler log-mel pipeline. Follow-up
+  either ports those kernels or trains against the simpler features.
 
 ## Verification
 
-23 host tests cover: Hann symmetry + scaling, mel filter edges
-+ partition-of-unity, quantization rounding + saturation +
-floor, streaming window/hop cadence, and a 1 kHz pure-tone
-fixture that asserts the peak energy lands in the expected mel
-band (around index 12 of 40 for the 125–7 500 Hz band).
+Per-module `#[cfg(test)]` blocks cover: Hann symmetry + scaling, mel
+filter edges + partition-of-unity, quantization rounding +
+saturation + floor handling, streaming window/hop cadence, and a
+1 kHz pure-tone fixture that asserts peak energy lands in the
+expected mel band. The tests run on host in `just check` — no
+firmware target, no model required.
 
-[`window::HannWindow`]: src/window.rs
-[`mel::MelFilterbank`]: src/mel.rs
-[`quantize::log_then_quantize`]: src/quantize.rs
-[`frontend::MelFrame`]: src/frontend.rs
-[`microfft`]: https://crates.io/crates/microfft
+## Gotchas
+
+1. **Periodic Hann, not symmetric.** The 480 taps come from
+   `(sym=False)`. Using the symmetric form gives a few-dB drift per
+   bin; the discrepancy is silent and only shows up against
+   reference fixtures.
+2. **`MelFrontend::push_samples` is push-not-pull.** Callers feed
+   arbitrary chunk sizes; the frontend buffers internally and fires
+   the callback zero or more times per call. For a 20 ms
+   `AudioFrame` (320 samples), one call usually produces two
+   frames. Pass `|_| {}` as the callback to discard.
+3. **Int8 quantization is asymmetric.** [`QuantParams::DEFAULT`]
+   carries `microWakeWord`'s shipped parameters; a different model
+   needs `with_quant`. Wrong `(scale, zero_point)` produces silent
+   feature drift, not a runtime error.
+4. **`libm` for log/sqrt/powf.** `core::f32` doesn't expose those
+   on `xtensa-esp32s3-none-elf` (no hardware-FPU intrinsic). The
+   `libm` dep matches `microWakeWord`'s reference choice and keeps
+   outputs bit-exact against it.
+
+## Integration
+
+- Single consumer today: [`stackchan-firmware`'s wake-word
+  task](../stackchan-firmware/src/wake_word.rs). The task subscribes
+  to `AUDIO_FRAME_PUBSUB` (20 ms PCM frames published by the audio
+  task), feeds each frame to [`MelFrontend::push_samples`], and
+  shifts each emitted [`MelFrame`] into the TFLite-micro input
+  tensor's circular buffer.
+- Depends only on [`microfft`](https://crates.io/crates/microfft)
+  (size-512 real FFT) and [`libm`](https://crates.io/crates/libm).
+- **Stability:** Experimental in v0.x. The constants in
+  `frontend.rs` are pinned to the `microWakeWord` reference
+  pipeline; a different model architecture may require parameter
+  changes.
+
+[`MelFrontend`]: src/frontend.rs
+[`MelFrontend::push_samples`]: src/frontend.rs
+[`MelFrontend::with_quant`]: src/frontend.rs
+[`MelFrontend::reset`]: src/frontend.rs
+[`MelFrame`]: src/frontend.rs
+[`HannWindow`]: src/window.rs
+[`MelFilterbank`]: src/mel.rs
+[`log_then_quantize`]: src/quantize.rs
+[`quantize_scalar`]: src/quantize.rs
+[`QuantParams`]: src/quantize.rs
+[`QuantParams::DEFAULT`]: src/quantize.rs
+[`hz_to_mel`]: src/mel.rs
+[`mel_to_hz`]: src/mel.rs

--- a/crates/stackchan-audio-features/README.md
+++ b/crates/stackchan-audio-features/README.md
@@ -11,11 +11,11 @@ status: experimental (v0.x)
 # stackchan-audio-features
 
 `no_std` audio frontend for on-device keyword spotting. Implements
-the streaming feature pipeline `microWakeWord` (and most TFLite-micro
-keyword-spotting models) expect on their input tensor: 16 kHz mono
-`i16` PCM in, quantized log-mel feature frames out, one frame every
-10 ms. Pure Rust, host-testable in isolation against synthetic
-fixtures.
+the streaming feature pipeline that `microWakeWord` (and most
+TFLite-micro keyword-spotting models) expect on their input tensor:
+16 kHz mono `i16` PCM in, quantized log-mel feature frames out, one
+frame every 10 ms. Pure Rust, host-testable in isolation against
+synthetic fixtures.
 
 No inference. The downstream `MixConv` classifier (TFLite-micro via
 [`esp-tflite-micro-sys`](../esp-tflite-micro-sys), or a future

--- a/crates/stackchan-desktop-protocol/README.md
+++ b/crates/stackchan-desktop-protocol/README.md
@@ -1,38 +1,58 @@
+---
+crate: stackchan-desktop-protocol
+role: Wire protocol for Claude Desktop Hardware Buddy BLE bridge
+bus: none
+transport: "newline-delimited UTF-8 JSON over Nordic UART Service"
+no_std: true (with alloc)
+unsafe: forbidden
+status: experimental (v0.x)
+---
+
 # stackchan-desktop-protocol
 
-Wire protocol for the Claude Desktop Hardware Buddy BLE bridge.
+Wire-format crate for the Claude Desktop Hardware Buddy BLE bridge.
+`no_std` + `alloc`. Pure data and parsers — no transport, no I/O.
+The firmware wraps the Nordic UART Service GATT characteristics
+around this crate; host tests exercise the parsers end-to-end with
+fixtures captured from the reference desktop. The complete
+field-by-field spec lives upstream:
+<https://github.com/anthropics/claude-desktop-buddy/blob/main/REFERENCE.md>.
 
-`no_std` + `alloc`. Pure data and parsers — no transport, no I/O. The firmware
-wraps the Nordic UART Service GATT characteristics around this crate; host
-tests exercise the parsers end-to-end with fixtures captured from the
-reference desktop.
+Newline-delimited UTF-8 JSON over the Nordic UART Service
+(`6e400001-b5a3-f393-e0a9-e50e24dcca9e`), one object per line, in
+both directions.
+
+## What's here
+
+| Module | What it does |
+|---|---|
+| `types.rs` | Message types: [`Inbound`], [`Snapshot`], [`Turn`], [`ContentBlock`], [`Prompt`], [`Cmd`], [`Outbound`], [`Decision`], [`Ack`], [`StatusData`], [`BatteryStatus`], [`SysStatus`], [`UserStats`]. Plus [`is_safe_relative_path`] — call on every `Cmd::File.path` before joining onto a writable root. |
+| `parse.rs` | [`parse_inbound`] / [`parse_outbound`]. Strategy: parse each line into a small generic JSON value tree (one alloc), then dispatch on the top-level discriminator (`cmd` → `Cmd`, `evt` → `Turn`, `time` → `TimeSync`, otherwise `Snapshot`). |
+| `build.rs` | [`render_outbound`] — `Outbound` → newline-terminated JSON line. Exhaustive — every field emitted is named in the spec. |
+| `frame.rs` | [`LineFramer`] — accumulates a stream of byte slices (BLE notifications fragment at the MTU boundary) and yields one complete line at a time. |
+| `error.rs` | [`ProtoError`] — typed errors via `thiserror`. Firmware wraps with `defmt::Debug2Format`. |
 
 ## What it speaks
 
-Claude for macOS and Windows can expose session state and permission prompts
-over Bluetooth LE when developer mode is enabled. The wire format is
-newline-delimited UTF-8 JSON, one object per line, over the Nordic UART
-Service (`6e400001-b5a3-f393-e0a9-e50e24dcca9e`). See the [reference
-protocol][ref] for the field-by-field spec.
-
-[ref]: https://github.com/anthropics/claude-desktop-buddy/blob/main/REFERENCE.md
-
 ### Inbound (desktop → device)
 
-- **Heartbeat snapshot** — session counts, recent transcript, token totals,
-  and a pending permission prompt when one is waiting.
-- **Turn event** — a one-shot record of a completed turn (assistant text,
-  tool calls).
-- **Time sync** — epoch seconds + timezone offset, sent once on connect.
-- **Commands** — `owner`, `name`, `status`, `unpair`, and the folder-push
+- **Snapshot** — session counts, recent transcript, token totals,
+  battery / heap / uptime, and a pending [`Prompt`] when a
+  permission request is waiting. Sent on change and at least every
+  ~10 s as a keepalive.
+- **Turn** — one-shot record of a completed assistant turn (`evt`
+  envelope; carries the raw content array — text + tool calls).
+- **TimeSync** — `{"time":[epoch_secs, tz_offset_secs]}`; sent once
+  per connect.
+- **Cmd** — `owner`, `name`, `status`, `unpair`, and the folder-push
   sequence (`char_begin`, `file`, `chunk`, `file_end`, `char_end`).
 
 ### Outbound (device → desktop)
 
-- **Permission decision** — `{"cmd":"permission","id":"...","decision":"once"|"deny"}`.
-- **Ack** — `{"ack":"<cmd>","ok":<bool>,"n":<u32>,"error":"..."}`.
-- **Status ack** — same shape with a `data` payload (name, sec, battery,
-  uptime, heap, counters).
+- **Permission** — `{"cmd":"permission","id":"…","decision":"once"|"deny"}`.
+- **Ack** — `{"ack":"<cmd>","ok":<bool>,"n":<u32>,"error":"…"}`.
+- **Status ack** — same shape with a [`StatusData`] payload (name,
+  sec, battery, uptime, heap, counters).
 
 ## API
 
@@ -47,26 +67,69 @@ let reply = render_outbound(&Outbound::Permission {
     id: "req_abc".into(),
     decision: Decision::Once,
 });
-assert_eq!(reply.as_str(), r#"{"cmd":"permission","id":"req_abc","decision":"once"}"#);
+assert!(reply.starts_with(r#"{"cmd":"permission","id":"req_abc","decision":"once"}"#));
 ```
-
-[`LineFramer`] accumulates a stream of byte slices (BLE notifications fragment
-at the MTU boundary) and yields one complete line at a time.
-
-`is_safe_relative_path(&str) -> bool` rejects empty input, absolute paths,
-`..` / `.` segments, leading `~`, embedded NUL, backslash separators, and
-Windows drive prefixes. Call it on every `Cmd::File.path` before joining it
-onto a writable root — the desktop sends whatever filenames appeared in the
-dropped folder.
 
 ## Hand-rolled JSON
 
-Same rationale as [`stackchan_net::bare_json`]: avoid `serde` / `serde_json` so
-the firmware compiles cleanly on `xtensa-esp32s3-none-elf` without pulling
-`serde/std`. Unknown keys in inbound messages are **skipped**, not rejected —
-the desktop is the protocol's authority and can add fields without bricking
-firmware that pre-dates them. Outbound builders are exhaustive (every field
-emitted is named in the spec).
+Same rationale as [`stackchan_net::bare_json`](../stackchan-net/src/bare_json.rs):
+avoid `serde` / `serde_json` so the firmware compiles cleanly on
+`xtensa-esp32s3-none-elf` without pulling `serde/std`. Unknown keys
+in inbound messages are **skipped**, not rejected — the desktop is
+the protocol's authority and can add fields without bricking firmware
+that pre-dates them. Outbound builders are exhaustive.
 
-[`LineFramer`]: ./src/frame.rs
-[`stackchan_net::bare_json`]: ../stackchan-net/src/bare_json.rs
+## Gotchas
+
+1. **Always validate paths.** [`is_safe_relative_path`] rejects
+   empty input, absolute paths, `..` / `.` segments, leading `~`,
+   embedded NUL, backslash separators, and Windows drive prefixes.
+   Call it on every `Cmd::File.path` before joining onto a writable
+   root — the desktop sends whatever filenames appeared in the
+   dropped folder.
+2. **BLE notifications fragment at the MTU.** [`LineFramer::push`]
+   accumulates partial chunks and yields complete lines into a
+   caller-owned `Vec<Vec<u8>>`. Per-connection state; reset on
+   disconnect via [`LineFramer::reset`].
+3. **Unknown keys are intentional.** Don't add strict
+   "extra-key-rejected" checks to the parser; future desktop
+   versions add fields and the firmware must keep parsing.
+4. **`alloc` is unconditional.** The parser alloc's a small JSON
+   tree per line. The firmware target has PSRAM; host tests run
+   trivially. Don't try to make this `no_alloc`.
+
+## Integration
+
+- Consumed by [`stackchan-firmware`'s BLE
+  desktop session](../stackchan-firmware/src/ble/desktop.rs) and
+  the four `desktop_*` consumer tasks (render, control, permission,
+  time).
+- The reference upstream
+  [REFERENCE.md](https://github.com/anthropics/claude-desktop-buddy/blob/main/REFERENCE.md)
+  is the source of truth for fields; this crate tracks it with
+  per-message fixtures committed alongside the parser.
+- **Stability:** Experimental in v0.x. Tracks the upstream
+  reference protocol; field additions land as additive type
+  changes.
+
+[`Inbound`]: src/types.rs
+[`Snapshot`]: src/types.rs
+[`Turn`]: src/types.rs
+[`ContentBlock`]: src/types.rs
+[`Prompt`]: src/types.rs
+[`Cmd`]: src/types.rs
+[`Outbound`]: src/types.rs
+[`Decision`]: src/types.rs
+[`Ack`]: src/types.rs
+[`StatusData`]: src/types.rs
+[`BatteryStatus`]: src/types.rs
+[`SysStatus`]: src/types.rs
+[`UserStats`]: src/types.rs
+[`is_safe_relative_path`]: src/types.rs
+[`parse_inbound`]: src/parse.rs
+[`parse_outbound`]: src/parse.rs
+[`render_outbound`]: src/build.rs
+[`LineFramer`]: src/frame.rs
+[`LineFramer::push`]: src/frame.rs
+[`LineFramer::reset`]: src/frame.rs
+[`ProtoError`]: src/error.rs

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -1,7 +1,7 @@
 ---
 crate: stackchan-firmware
 role: Binary firmware for M5Stack CoreS3 Stack-chan
-bus: many (I²C main bus, UART1, SPI2, RMT, I2S, USB-Serial-JTAG)
+bus: many (I²C main bus, UART1, SPI2, RMT, I²S, USB-Serial-JTAG, LCD_CAM)
 transport: "esp-hal + embassy + esp-rtos"
 no_std: true
 alloc: true (PSRAM heap via esp-alloc)
@@ -12,176 +12,300 @@ target: ESP32-S3 (Xtensa, Rust `esp` toolchain)
 
 # stackchan-firmware
 
-Binary crate. `no_std` + `alloc`, embassy executor on esp-rtos, runs on
-the M5Stack CoreS3 Stack-chan. Boots the hardware, wires up every
-driver, spawns the embassy task set, and runs the `stackchan-core`
-modifier pipeline at ~30 FPS.
+Binary crate. `no_std` + `alloc`, embassy executor on esp-rtos, runs
+on the M5Stack CoreS3 Stack-chan. Boots the hardware, wires up every
+driver in the workspace, spawns the embassy task set, and runs the
+[`stackchan-core`](../stackchan-core) modifier + skill pipeline at
+~30 FPS.
 
-## Key Files
+## Layout
 
-- `src/main.rs` — binary entry: heap init, esp-rtos boot, board init, task spawn, heartbeat loop
-- `src/lib.rs` — shared library surface (modules the main binary + `examples/*.rs` both use)
-- `src/board.rs` — `BoardIo`, `SharedI2c(Bus)`, `HeadDriverImpl`. One-shot hardware bring-up: AXP2101 → AW9523 → SPI2 ILI9342C via mipidsi → SCServo UART
-- `src/framebuffer.rs` — PSRAM-backed 320×240 RGB565 double-buffer + dirty-check blit
-- `src/clock.rs` — `HalClock` wraps `embassy_time::Instant` to implement `stackchan_core::Clock`
-- `src/head.rs` — embassy task: `stackchan_core::Pose` → SCServo commands
-- `src/imu.rs` — BMI270 task publishing accel/gyro samples on `IMU_SIGNAL`
-- `src/touch.rs` / `src/ir.rs` / `src/ambient.rs` / `src/button.rs` / `src/leds.rs` / `src/wallclock.rs` / `src/power.rs` — per-peripheral tasks
-- `src/ble/` — BLE peripheral. `mod.rs` re-exports the task entry point; `server.rs` declares the GATT server (Device Information, Battery, Stack-chan emotion, Wi-Fi provisioning, audio control, avatar control, BluFi, Nordic UART Service) via the `trouble-host` macros and runs the advertise / accept / serve loop; `task.rs` pins the controller type for `embassy_executor::task` spawn; `bonds.rs` persists pairing keys to SD; `desktop.rs` holds the per-connection line framer plus the `DESKTOP_INBOUND` / `DESKTOP_OUTBOUND` channels the Claude Desktop Hardware Buddy plumbing fans through
-- `src/audio.rs` — I²S0 + codec bring-up, then RX RMS loop (publishing on `AUDIO_RMS_SIGNAL`) + TX feeder (silence between trigger-driven clips) running concurrently via `embassy_futures::join`. Exposes `AUDIO_TX_PLAYING` so the render loop can gate `audio_rms` against speaker self-trigger
-- `src/camera.rs` — `LCD_CAM` + DMA bring-up + always-on capture loop. Each frame is published on `CAMERA_FRAME_SIGNAL` for the LCD preview AND fed through `tracker::Tracker::step`, with the result on `CAMERA_TRACKING_SIGNAL`. `CAMERA_MODE_SIGNAL` is now display-only (preview vs avatar)
-- `examples/bench.rs` — calibration bench, flashed via `just bench`
-- `examples/{aw88298,es7210,imu,mag,leds,ambient,touch,ir}_bench.rs` — per-driver control-path benches (chip-ID probe + init + heartbeat; the streaming I²S path runs only inside `src/audio.rs` in the main firmware)
+`src/main.rs` is the binary entry — heap init, esp-rtos boot, board
+init, modifier registration, task spawn, heartbeat loop.
+`src/lib.rs` re-exports the per-module surfaces so `examples/*.rs`
+benches can share helpers.
 
-## Boot Sequence
+| Module | What it does |
+|---|---|
+| `board.rs`         | One-shot hardware bring-up: AXP2101 → AW9523 → SPI2 ILI9342C via `mipidsi` → SCServo on UART1. Hands back `BoardIo`, `SharedI2c(Bus)`, `HeadDriverImpl`. |
+| `framebuffer.rs`   | PSRAM-backed 320×240 RGB565 double-buffer + dirty-check blit. |
+| `clock.rs`         | `HalClock` adapter — `embassy_time::Instant` → `stackchan_core::Clock`. |
+| `head.rs`          | Embassy task: drains `Pose` signals → SCServo commands. |
+| `imu.rs`           | BMI270 task publishing accel/gyro samples on `IMU_SIGNAL`. |
+| `touch.rs`         | FT6336U touch task. |
+| `body_touch.rs`    | Si12T 3-zone back-of-head capacitive touch, polled at 50 ms. |
+| `ir.rs`            | NEC IR decoder on the RMT peripheral. |
+| `ambient.rs`       | LTR-553 ambient-light + proximity task. |
+| `button.rs`        | AXP2101 power-key edge detector. |
+| `leds.rs`          | PY32 WS2812 LED-ring task. |
+| `power.rs`         | AXP2101 battery / charge / USB-VBUS sampler. |
+| `wallclock.rs`     | Boot-time BM8563 RTC read so the first defmt log line carries an absolute wall time. Per-task RTC consumers (chime, SNTP, desktop-time) own their own reads. |
+| `audio.rs`         | I²S0 + AW88298 / ES7210 bring-up. RX RMS loop publishing on `AUDIO_RMS_SIGNAL` and the 20 ms `AUDIO_FRAME_PUBSUB`; TX feeder draining the queued `Box<dyn AudioSource>`s from the speech router. `AUDIO_TX_PLAYING` gates RMS against speaker self-trigger. |
+| `audio_debug.rs`   | UDP tee for `AUDIO_FRAME_PUBSUB` — see [docs/audio-debug.md](../../docs/audio-debug.md). Opt-in via `behavior.audio_debug_udp_target`. |
+| `camera.rs`        | `LCD_CAM` + DMA capture loop. Each frame publishes on `CAMERA_FRAME_SIGNAL` (LCD preview) and feeds `tracker::Tracker::step`; result on `CAMERA_TRACKING_SIGNAL`. |
+| `wake_word.rs`     | On-device wake-word inference, opt-in via `behavior.wake_word_enabled` + presence of `/sd/WAKE_WORD.tflite`. Subscribes to `AUDIO_FRAME_PUBSUB`, runs the streaming mel frontend from [`stackchan-audio-features`](../stackchan-audio-features), and ticks a TFLite-micro interpreter via [`esp-tflite-micro-sys`](../esp-tflite-micro-sys). |
+| `agent_sidecar.rs` | Push-to-talk + sidecar HTTP agent client. PTT triggered by `POST /listen` (or MCP `start_listen`); captures PCM, POSTs to `behavior.agent_sidecar_url`, surfaces the reply through the existing `RemoteCommand` channel. |
+| `tracking_trace.rs`| `defmt` event catalogue for the `tracking-trace` Cargo feature. |
+| `chime.rs`         | Hourly chime task — top-of-hour chirp. Opt-in via `behavior.hourly_chime_enabled`. |
+| `reminders.rs`     | Fixed-capacity reminder/timer scheduler; dispatches due entries through `REMOTE_COMMAND_QUEUE`. |
+| `toast.rs`         | On-screen toast band; opt-in via `behavior.toast_overlay_enabled`. `push_info`/`push_warn`/`push_error`/`push_toast` from any task. |
+| `event_log.rs`     | Bounded RAM ring of operator-visible events; surfaced via `GET /events`. |
+| `runtime_store.rs` | `/sd/RUNTIME.RON` writer for fast-changing operator state (palette, mood, face geometry, head offsets) so reboots preserve UI tweaks without churning the boot config. |
+| `crash.rs`         | RTC-fast-RAM crash latch + boot-time copy to `/sd/CRASH.LOG`. Surfaces via `GET /crash`. |
+| `watchdog.rs`      | Per-channel heartbeat watchdog; warns when a producer task goes silent. |
+| `sleep.rs`         | Operator-commanded sleep mode (distinct from autonomous `Dormancy`). |
+| `ota.rs`           | OTA path: parses + verifies the SCFW envelope (signature in [`stackchan-net::ota`](../stackchan-net/src/ota.rs)) and stream-writes via `esp-hal-ota`. |
+| `storage.rs`       | SD-card `/sd/STACKCHAN.RON` reader + atomic writer (`PUT /settings`). Falls back to `Config::default` so the avatar still boots offline-first. |
+| `sd_spi.rs`        | `SdSpiDevice` adapter for the shared SPI2 bus — handles the LCD-DC / SD-MISO dual-role on GPIO35 (M5GFX-style OE flip per CS edge). |
+| `desktop_render.rs` | Translates Claude Desktop `Snapshot` / `Tts` / `Toast` messages into avatar affect, toast bands, and TTS chunks. |
+| `desktop_control.rs`| Handles `cmd:`-tagged desktop messages (status / owner / name / unpair / folder push / turn events). |
+| `desktop_time.rs`  | Writes the desktop's `{"time":[epoch_secs, tz_offset_secs]}` message into the BM8563 RTC. |
+| `desktop_permission.rs` | Permission-decision UX: snapshot prompts + back-of-head tap acks; replies on `DESKTOP_OUTBOUND`. |
+| `ble/`             | BLE peripheral. `mod.rs` exports `ble_task`; `server.rs` declares the GATT services via `trouble-host` macros; `task.rs` pins the controller type for embassy spawn; `bonds.rs` persists pairing keys to SD; `desktop.rs` holds the per-connection NUS line framer + the `DESKTOP_INBOUND` / `DESKTOP_OUTBOUND` channels for the Hardware Buddy plumbing. |
+| `net/`             | Wi-Fi + LAN services. `stack.rs` runs the embassy-net runner; `wifi.rs` handles STA connect; `http.rs` is the hand-rolled HTTP/1.1 server (multi-worker, queues `RemoteCommand`s into `REMOTE_COMMAND_QUEUE`); `mdns.rs` advertises `_stackchan._tcp.local.` and publishes live `yaw=` / `pitch=` TXT; `mdns_follower.rs` consumes a configured leader's TXT for mimic-stack follow; `websocket.rs` implements `GET /state/ws`; `snapshot.rs` rebuilds the read-only avatar snapshot for the HTTP `/state` route; `respond.rs` is the HTTP response builder; `sntp.rs` writes the synced epoch into the RTC; `esp_now.rs` runs the optional ESP-NOW peer-to-peer transport. |
+
+## Boot sequence
 
 ```mermaid
 flowchart TB
     Start[Reset vector]
-    Start --> Hal[esp-hal init<br/><i>clocks, timers</i>]
-    Hal --> Heap[esp-alloc:<br/><i>PSRAM heap + internal SRAM</i>]
+    Start --> Hal[esp-hal init clocks + timers]
+    Hal --> Heap[esp-alloc PSRAM heap + internal SRAM]
     Heap --> Rtos[esp-rtos embassy executor]
-    Rtos --> Pmic[AXP2101::init_cores3<br/><i>ALDO/BLDO rails, power-key, BATFET, ADC</i>]
-    Pmic --> Exp[aw9523::init_cores3<br/><i>LCD reset pulse, backlight-boost</i>]
-    Exp --> Lcd[SPI2 + mipidsi ILI9342C<br/><i>RGB565, 320×240</i>]
-    Lcd --> Servo[SCServo on UART1<br/><i>head pan/tilt</i>]
-    Servo --> Py[PY32 co-processor<br/><i>servo-power, WS2812 ring</i>]
-    Py --> Spawn[Spawn tasks]
-    Spawn --> Render[render_task<br/><i>30 FPS Avatar::draw</i>]
-    Spawn --> Head[head_task<br/><i>Pose → SCServo</i>]
-    Spawn --> Imu[imu_task]
-    Spawn --> Touch[touch_task]
-    Spawn --> Ir[ir_task]
-    Spawn --> Ambient[ambient_task]
-    Spawn --> Button[button_task]
-    Spawn --> Led[led_task]
-    Spawn --> Clock[wallclock_task]
-    Spawn --> Main[main heartbeat loop]
+    Rtos --> Crash[crash::on_boot — copy RTC latch to /sd/CRASH.LOG]
+    Crash --> Pmic[AXP2101::init_cores3 ALDO/BLDO + power-key + ADC]
+    Pmic --> Exp[aw9523::init_cores3 LCD reset + backlight boost]
+    Exp --> Lcd[SPI2 + mipidsi ILI9342C 320×240 RGB565]
+    Lcd --> Servo[SCServo UART1 head pan+tilt]
+    Servo --> Py[PY32 servo-power + WS2812 ring]
+    Py --> Sd[SD mount → STACKCHAN.RON, WAKE_WORD.tflite, RUNTIME.RON]
+    Sd --> Spawn[Spawn embassy tasks]
+    Spawn --> Net[wifi → sntp → http workers → mdns → esp_now → ble]
+    Spawn --> Sense[render, head, touch, body_touch, imu, ambient, button, leds, power, ir, watchdog]
+    Spawn --> AudioCam[audio, camera, audio_debug, wake_word, agent_sidecar]
+    Spawn --> Affordances[chime, reminders, desktop_time, desktop_render, desktop_control, desktop_permission]
+    Spawn --> Main[main heartbeat loop — feeds watchdog, drives sleep state]
 ```
 
-## Modifier Stack
+The avatar boots fully and animates with no SD card and no Wi-Fi; the
+network services park themselves until link-up, and the avatar tasks
+spawn first so face + motor stay responsive throughout.
 
-Main spawns a render task that runs this stack per tick:
+## Modifier + skill registration
 
-```
-EmotionFromTouch → IntentFromBodyTouch → EmotionFromRemote → EmotionFromIntent →
-EmotionFromVoice → IntentFromLoud → EmotionFromAmbient → EmotionFromBattery →
-AttentionFromTracking → DormancyFromActivity → EmotionCycle → StyleFromEmotion →
-StyleFromIntent → GazeFromAttention → MicrosaccadeFromAttention → Blink → Breath →
-IdleDrift → IdleMicroExpression → BatteryOverlayFromPerception → IdleHeadDrift →
-HeadFromEmotion → HeadFromAttention → LostTargetSearch → HeadFromIntent → MouthFromAudio
-```
+The render task constructs a [`Director`] and registers the canonical
+modifier stack plus three skills. Phase ordering
+(`Affect → Expression → Decoration → Motion → Audio`) is enforced by
+the Director's sort regardless of registration order; the firmware
+list is grouped by phase for readability. The source of truth is the
+sequence of `director.add_modifier(...)` / `add_skill(...)` calls in
+`src/main.rs` — `git grep "add_modifier\|add_skill" src/main.rs`
+lists the current registry. New modifiers / skills land via that
+list rather than via Director edits.
 
-Inputs arrive through embassy `Signal` channels from the per-peripheral
-tasks; the modifiers read those signals and mutate the `Avatar` each
-frame.
+Inputs arrive through embassy `Signal` / `PubSubChannel` channels
+from the per-peripheral tasks; the render task drains the latest
+value from each signal into `entity.perception` / `entity.input`,
+calls [`Director::run`], then dispatches the post-frame sinks (LCD
+blit, head pose, LED frame, audio queue).
 
 ## Network surface
 
-Once Wi-Fi connects (SSID from `/sd/STACKCHAN.RON`), the firmware
-runs three networked services on the LAN:
+Once Wi-Fi connects (SSID + PSK from `/sd/STACKCHAN.RON`), the
+firmware runs these services on the LAN:
 
-- **HTTP** on port 80 — operator dashboard at `GET /`, live state +
-  control plane on `/state`, `/state/stream`, `/emotion`, `/look-at`,
-  `/reset`, `/speak`, `/settings`. Write routes (`PUT`, `POST`) are
-  gated on `auth.token` from the boot config — empty token (default)
-  leaves the LAN open; non-empty token requires
-  `Authorization: Bearer <token>`. `POST /speak` queues a baked
-  phrase or chirp on the AW88298 TX path. See
-  [docs/http.md](../../docs/http.md) for the full route table, body
-  shapes, error codes, and the auth section with `curl` examples.
+- **HTTP** on port 80 — operator dashboard at `GET /` (TS + Solid
+  bundle from `../../web`, embedded gzipped at compile time), live
+  state on `/state` + `/state/stream` (SSE) + `/state/ws`
+  (WebSocket), control plane on `/emotion`, `/look-at`, `/reset`,
+  `/speak`, `/settings`, `/dance`, `/motion`, `/face-geometry`,
+  `/listen`, `/toast`, `/mcp`, `/health`, `/events`, `/crash`,
+  `/ota`. Write routes (`PUT`, `POST`) are gated on `auth.token`
+  from the boot config — empty token (default) leaves the LAN open;
+  non-empty token requires `Authorization: Bearer <token>`. Full
+  route table, body shapes, error codes in
+  [docs/http.md](../../docs/http.md).
 - **mDNS** — advertises `<hostname>.local` (A) plus the DNS-SD
   service `_stackchan._tcp.local.` (PTR / SRV / TXT) from
-  `mdns.hostname` in the boot config (default `stackchan`). The TXT
-  record carries `kai=1` as a variant marker; a generic Bonjour
-  browser still lists the device alongside upstream stackchan units.
-  TXT also publishes live `yaw=<deg>` / `pitch=<deg>` (one decimal,
-  refreshed at most every 100 ms with a 1 s heartbeat) so a follower
+  `mdns.hostname`. The TXT record carries `kai=1` as a variant
+  marker plus live `yaw=<deg>` / `pitch=<deg>` (one decimal,
+  throttled to at most 100 ms with a 1 s heartbeat) so a follower
   in a mimic stack can lift current pose off mDNS without an HTTP
   round-trip.
-- **SNTP** — on link-up, queries the SNTP servers from
-  `time.sntp_servers` and writes the result into the BM8563 RTC.
+- **mDNS follower** — opt-in via `behavior.follower_leader_hostname`.
+  Subscribes to mDNS announcements from a named leader and mirrors
+  their commanded yaw / pitch into the local motor.
+- **SNTP** — on link-up, queries `time.sntp_servers` and writes the
+  result into the BM8563 RTC.
+- **ESP-NOW** — opt-in via `esp_now.enabled`. Frame envelope shared
+  with HTTP (see [`stackchan-net::esp_now`](../stackchan-net/src/esp_now.rs)).
+- **Sidecar agent client** — opt-in via `behavior.agent_sidecar_url`.
+  POST-to-talk: on `POST /listen` the firmware captures PCM, POSTs
+  to the configured sidecar, and surfaces the reply through
+  `REMOTE_COMMAND_QUEUE`. See [docs/voice.md](../../docs/voice.md).
 
-The boot config schema (Wi-Fi credentials, mDNS hostname, SNTP
-servers) lives in [`stackchan-net`](../stackchan-net/README.md) and
-round-trips between the SD-card RON file and the HTTP `/settings`
-JSON.
+The boot config schema lives in
+[`stackchan-net`](../stackchan-net) and round-trips between the
+SD-card RON file and the HTTP `/settings` JSON.
 
-In parallel, the device advertises a BLE peripheral named
-`Claude stk-XXXXXX` (last three MAC bytes) so a phone or laptop on
-the same physical radio can read state and drive the firmware
-without joining the LAN. The `Claude ` prefix is required for
-Claude Desktop's Hardware Buddy picker to filter the device in; the
-mDNS hostname is configured separately and unaffected. Services exposed: Device Information (`0x180A` —
-manufacturer / model / firmware revision), Battery (`0x180F`), a
-Stack-chan custom service for emotion read+notify, a Wi-Fi
-provisioning service for SSID + PSK writes, an audio service
-(`8a1c0020-...`) for volume + mute read+write+notify, an avatar
-control service (`8a1c0030-...`) for emotion / look-at / reset /
-speak writes, and a view service (`8a1c0040-...`) with the LCD
-camera-preview / avatar toggle and a capture trigger (writes the
-latest QVGA RGB565 frame to `/sd/CAPTURE.565`). Control writes
-require an authenticated bond (passkey-confirmed pairing). The
+## BLE peripheral
+
+In parallel with Wi-Fi, the device advertises a BLE peripheral named
+`Claude stk-XXXXXX` (last three Wi-Fi MAC bytes). The `Claude `
+prefix is required for Claude Desktop's Hardware Buddy picker to
+filter the device in; the mDNS hostname (`stackchan-XXXXXX` by
+default) is configured separately.
+
+Services exposed:
+
+- **Device Information** (`0x180A`) — manufacturer / model /
+  firmware revision.
+- **Battery** (`0x180F`).
+- **Stack-chan custom service** — emotion read + notify.
+- **Wi-Fi provisioning** — SSID + PSK writes for first-boot
+  bootstrapping, plus BluFi support for the official Espressif
+  provisioning apps.
+- **Audio** (`8a1c0020-…`) — volume + mute read/write/notify.
+- **Avatar control** (`8a1c0030-…`) — emotion / look-at / reset /
+  speak writes.
+- **View** (`8a1c0040-…`) — LCD camera-preview / avatar toggle and
+  a capture trigger (writes the latest QVGA RGB565 frame to
+  `/sd/CAPTURE.565`).
+- **Nordic UART Service (NUS)** — newline-delimited JSON for the
+  Claude Desktop Hardware Buddy plumbing. The per-connection
+  `DesktopSession` line-frames incoming ATT writes and publishes
+  `Inbound` messages on `DESKTOP_INBOUND` (a `PubSubChannel` with up
+  to four subscribers — `desktop_render`, `desktop_control`,
+  `desktop_permission`, `desktop_time`). Outbound replies come back
+  through `DESKTOP_OUTBOUND` and render on the NUS TX
+  characteristic.
+
+Control writes require an authenticated bond (passkey-confirmed
+pairing); bonds persist across reboots via `/sd/BONDS.BIN`. The
 notify task diffs the avatar snapshot every tick so subscribed
-centrals see HTTP-side changes without explicit polling. Wi-Fi and
-BLE share the radio via `esp-radio`'s coex scheduler; expect a
-small Wi-Fi airtime tax when a BLE central is connected.
+centrals see HTTP-side changes without polling. Wi-Fi and BLE share
+the radio via `esp-radio`'s coex scheduler; expect a small Wi-Fi
+airtime tax when a BLE central is connected.
 
-## I²C Bus Sharing
+## I²C bus sharing
 
-All I²C peripherals share one `SharedI2cBus` (`Mutex<NoopRawMutex, I2c<'static, Async>>`)
-and talk to it through `I2cDevice` handles. Addresses on the bus:
+All I²C peripherals share one `SharedI2cBus` (`Mutex<NoopRawMutex,
+I2c<'static, Async>>`) and talk to it through `I2cDevice` handles.
+Addresses on the bus:
 
-| Address | Chip                |
-|---------|---------------------|
-| `0x10/11` | BMM150 magnetometer |
-| `0x23`  | LTR-553 ambient / prox |
-| `0x34`  | AXP2101 PMIC         |
-| `0x36`  | AW88298 amp (I²S TX streaming live; speaker output) |
-| `0x38`  | FT6336U touch        |
-| `0x40`  | ES7210 ADC (control-path only; I²S pending)  |
-| `0x51`  | BM8563 RTC           |
-| `0x58`  | AW9523 I/O expander  |
-| `0x68/69` | BMI270 IMU         |
-| `0x6F`  | PY32 co-processor    |
+| Address | Chip |
+|---|---|
+| `0x10/11` | BMM150 magnetometer (bench-only on this unit) |
+| `0x23`    | LTR-553 ambient / proximity |
+| `0x34`    | AXP2101 PMIC |
+| `0x36`    | AW88298 amp (control path; I²S0 streams audio) |
+| `0x38`    | FT6336U touch |
+| `0x40`    | ES7210 ADC (control path; I²S0 streams audio) |
+| `0x51`    | BM8563 RTC |
+| `0x58`    | AW9523 I/O expander |
+| `0x68`    | Si12T 3-zone body touch (probe-time; driver address is `0x50`) |
+| `0x69`    | BMI270 IMU (also responds at `0x68`; bench arbitrates) |
+| `0x6F`    | PY32 co-processor |
 
-## Gotchas
-
-1. **`unsafe` is allowed per-module, reason-tagged.** The firmware crate's `#![deny(unsafe_code)]` has per-module exceptions for the app-descriptor LTO anchor and any register-map pointer work. Each exception carries a comment explaining why
-2. **Panic handler halts; defmt emits the trace over RTT first.** `--catch-hardfault` on the probe-rs side decodes it. For dev, `espflash monitor --log-format defmt` also picks it up
-3. **Render path is dirty-checked.** `framebuffer` only blits when the `Avatar` state changes from the previous frame. Skipping this costs ~20 ms per frame in SPI traffic
-4. **PSRAM is the framebuffer's home.** Internal SRAM is reserved for ISR / real-time paths. The framebuffer at 320×240×2 bytes = 153 KB wouldn't fit in SRAM anyway
-5. **Many tasks share `SharedI2c`.** Touch / IMU / ambient / power / button / LED tasks all hold `I2cDevice` handles onto the same I²C0 bus; the `embassy-embedded-hal` mutex serialises access. Running each polling task at ≤50 Hz keeps contention negligible for the 30 FPS render task
-6. **`panic!` IS the error-handling layer.** Firmware `main` can't bubble init failures to a caller, so init errors panic. Library code elsewhere returns typed errors; this rule only applies at the `#[no_main]` boundary
-7. **Log timestamps come from embassy-time.** `defmt::timestamp!` captures `embassy_time::Instant::now().as_millis()`, which starts from esp-rtos boot. No wall-clock alignment unless `wallclock_task` sets the RTC
-
-## Build + Flash
+## Build + flash
 
 ```bash
 source ~/export-esp.sh       # adds the esp Xtensa toolchain to PATH
+just check-firmware          # cargo +esp check
+just clippy-firmware         # cargo +esp clippy --release -- -D warnings (CI parity)
 just build-firmware          # cargo +esp build --release
 just fmr                     # flash + monitor in one go
-just fmr-trace               # flash + monitor with `tracking-trace` feature on
-just bench                   # flash the calibration-bench example
-just mag-bench               # magnetometer bench
-just leds-bench              # WS2812 LED ring bench
-just aw88298-bench           # speaker-amp control-path bench
-just es7210-bench            # mic-ADC control-path bench
+just reattach                # attach to a running device without resetting
+just PORT=/dev/ttyACM0 fmr   # override default port
 ```
 
-See the [justfile](../../justfile) for the full recipe set. Default
-port is `/dev/ttyACM1`; override with `just PORT=/dev/ttyACM0 flash`.
+Per-bench recipes flash a single `examples/*_bench.rs` to exercise
+one driver in isolation: `just bench` (servo calibration), `just
+mag-bench`, `just leds-bench`, `just aw88298-bench`, `just
+es7210-bench`, `just audio-bench`, `just tilt-extremes`, `just
+tilt-freewheel`, plus `face-bench`, `i2c-probe`, `imu-bench`,
+`ir-bench`, `si12t-bench`, `touch-bench`, `tracker-bench`. List
+all: `just`.
+
+`just fmr` runs an interactive monitor (espflash). When invoked from
+a non-TTY shell (any agent-spawned bash), launch inside a tmux
+session — see [CLAUDE.md](../../CLAUDE.md#flashing-from-an-agent--non-tty-shell)
+for the recipe.
 
 ### Cargo features
 
 - **`tracking-trace`** — emits structured `defmt` events from the
-  camera-tracking pipeline (attention + engagement transitions, lock-fire
-  latency, observation cadence). Off by default so production builds carry
-  no runtime cost. Filter the live stream with `grep trk:`. See
-  `src/tracking_trace.rs` for the full event catalog.
+  camera-tracking pipeline (attention + engagement transitions,
+  lock-fire latency, observation cadence). Off by default. Filter
+  the live stream with `grep trk:`. Catalog in `src/tracking_trace.rs`.
+
+## Gotchas
+
+1. **`unsafe` is allowed per-module, reason-tagged.** The crate's
+   `#![deny(unsafe_code)]` has per-module exceptions for the
+   app-descriptor LTO anchor and register-map pointer work. Each
+   exception carries a comment explaining why.
+2. **Render path is dirty-checked.** `framebuffer` only blits when the
+   `Entity::draw` pixels change from the previous frame.
+   `Face::frame_eq` excludes non-pixel-affecting fields; new fields
+   default to *excluded* unless they affect drawing.
+3. **PSRAM holds the framebuffer.** Internal SRAM is reserved for
+   ISR / real-time paths. 320×240×2 bytes = 153 KB wouldn't fit in
+   SRAM regardless.
+4. **Many tasks share `SharedI2cBus`.** Touch / IMU / ambient / power
+   / button / LED / body-touch / RTC tasks all hold `I2cDevice`
+   handles onto the same I²C0 bus; the `embassy-embedded-hal` mutex
+   serialises access. Polling tasks run at ≤50 Hz so contention stays
+   negligible for the 30 FPS render task.
+5. **`panic!` is the error layer at `main`.** Firmware `main` can't
+   bubble init failures to a caller, so init errors panic. Module
+   code returns typed errors (see [docs/errors.md](../../docs/errors.md));
+   the panic rule only applies at the `#[no_main]` boundary. The
+   `crash` module catches the panic message into RTC fast RAM and
+   persists it to `/sd/CRASH.LOG` on the next boot.
+6. **Log timestamps come from embassy-time.** `defmt::timestamp!`
+   captures `embassy_time::Instant::now().as_millis()`, which starts
+   from esp-rtos boot. No wall-clock alignment unless `wallclock_task`
+   has set the RTC.
+7. **GPIO35 dual-role.** Same pin serves LCD DC and SD MISO; the
+   `sd_spi` adapter flips the OE bit per CS edge (M5GFX-style).
+   Don't expose GPIO35 to a generic embedded-hal SPI device unless
+   it goes through `SdSpiDevice`.
+8. **Watchdog beats are advisory.** A silent producer task surfaces
+   as a `defmt::warn!`, not a hardware reset. Hardware reset is the
+   ESP32-S3's task watchdog, separately configured by esp-rtos.
 
 ## Integration
 
-- **Consumes `stackchan-core`** for every domain type (`Avatar`, `Modifier`, `Pose`, `Clock`, `HeadDriver`, `LedFrame`)
-- **Consumes every driver crate in the workspace** — axp2101, aw9523, aw88298, bm8563, bmi270, es7210, ft6336u, gc0308, ir-nec, ltr553, py32, scservo, si12t. ES7210 streams RX over I²S into the RMS loop in `src/audio.rs`; AW88298 streams TX (digital silence between trigger-driven clips). Si12T 3-zone body-touch publishes via `src/body_touch.rs`. gc0308 streams continuously into `src/camera.rs` and the `tracker` crate runs block-grid motion analysis on every frame, publishing `TrackingObservation` for the engine. bmm150 is bench-only (`examples/mag_bench.rs`) until a real consumer modifier is built.
-- **HIL via probe-rs + defmt-test** (planned) — CI runs host tests today; on-device integration tests run on a flash-and-capture rig
+- **Consumes [`stackchan-core`](../stackchan-core)** for every
+  domain type (`Entity`, `Director`, `Modifier`, `Skill`, `Pose`,
+  `Clock`, `HeadDriver`, `LedFrame`).
+- **Consumes every driver crate in the workspace** — `axp2101`,
+  `aw9523`, `aw88298`, `bm8563`, `bmi270`, `es7210`, `ft6336u`,
+  `gc0308`, `ir-nec`, `ltr553`, `py32`, `scservo`, `si12t`. ES7210
+  streams RX over I²S0 into the audio task; AW88298 streams TX
+  (silence between queued sources). `gc0308` streams continuously
+  into `camera_task`, where `tracker` runs block-grid motion analysis
+  on every frame and publishes `TrackingObservation` for the engine.
+  `bmm150` is bench-only on this unit (`examples/mag_bench.rs`).
+- **Consumes [`stackchan-net`](../stackchan-net)** for every wire
+  format (boot config, HTTP body parsers, MCP, BLE characteristic
+  codecs, BluFi, ESP-NOW, OTA header, crash latch, mDNS pose TXT,
+  dance JSON).
+- **Consumes [`stackchan-tts`](../stackchan-tts)** for the
+  `SpeechBackend` trait and the `BakedBackend` (sine SFX + verbal
+  phrase PCM).
+- **Consumes [`stackchan-audio-features`](../stackchan-audio-features)**
+  for the wake-word frontend mel spectrogram.
+- **Consumes [`stackchan-desktop-protocol`](../stackchan-desktop-protocol)**
+  for the Hardware Buddy NUS message parsing + rendering.
+- **Consumes [`esp-tflite-micro-sys`](../esp-tflite-micro-sys)** for
+  the wake-word TFLite-micro interpreter.
+- **Consumes [`tracker`](../tracker)** for the block-grid motion
+  tracker on the camera path.
+- **Stability:** Experimental in v0.x. Module structure and the
+  task spawn shape are settled; individual feature flags + behavior
+  defaults continue to evolve.
+
+[`Director`]: ../stackchan-core/src/director.rs
+[`Director::run`]: ../stackchan-core/src/director.rs

--- a/crates/stackchan-firmware/README.md
+++ b/crates/stackchan-firmware/README.md
@@ -174,9 +174,12 @@ Services exposed:
 - **Nordic UART Service (NUS)** — newline-delimited JSON for the
   Claude Desktop Hardware Buddy plumbing. The per-connection
   `DesktopSession` line-frames incoming ATT writes and publishes
-  `Inbound` messages on `DESKTOP_INBOUND` (a `PubSubChannel` with up
-  to four subscribers — `desktop_render`, `desktop_control`,
-  `desktop_permission`, `desktop_time`). Outbound replies come back
+  `Inbound` messages on `DESKTOP_INBOUND` (a `PubSubChannel` with
+  three subscribers today — `desktop_render`, `desktop_control`,
+  `desktop_permission`). `desktop_control` parses any `TimeSync`
+  message and forwards the epoch to `desktop_time` via a separate
+  `DESKTOP_RTC_WRITE_REQUEST` signal so the RTC writer holds its
+  own `I2cDevice` handle on the BM8563. Outbound replies come back
   through `DESKTOP_OUTBOUND` and render on the NUS TX
   characteristic.
 

--- a/crates/stackchan-sim/README.md
+++ b/crates/stackchan-sim/README.md
@@ -1,78 +1,162 @@
 ---
 crate: stackchan-sim
-role: Headless simulator for stackchan-core
+role: Headless host simulator for stackchan-core
 bus: none
 transport: "Vec<Rgb565> framebuffer + FakeClock"
-no_std: false (host-only, uses alloc)
+no_std: false (host-only, uses alloc freely)
 unsafe: forbidden
-status: stable
+status: experimental (v0.x)
 ---
 
 # stackchan-sim
 
-Host-side simulator for `stackchan-core`. Runs the full domain model —
-modifier pipeline, `Avatar::draw`, `HeadDriver` — on the dev machine
-with a deterministic clock and a `Vec<Rgb565>`-backed framebuffer, so
-most of the firmware's behaviour is testable without flashing hardware.
+Host-side simulator for [`stackchan-core`](../stackchan-core). Runs the
+full modifier + skill pipeline against a deterministic clock and an
+in-memory framebuffer, so most of the firmware's behaviour is
+exercised in `cargo test` on the dev machine — no hardware, no
+flashing, no embedded toolchain. The crate is `publish = false`; it
+exists to back the integration tests in `tests/` and the optional
+`viz` host visualiser.
 
-## Key Files
+## What's here
 
-- `src/lib.rs` — `FakeClock`, `Framebuffer`, `RecordingHead`, `TrackingScenario`
-- `tests/idle_head_drift.rs` — golden test for the head-drift trajectory: drive a clock forward in controlled steps, assert that the captured `(Instant, Pose)` sequence respects the per-axis glance amplitude AND that the head spends most of its time at rest
-- `tests/leds.rs` — LED-ring rendering regression tests
-- `tests/render_snapshot.rs` — one-minute full-stack cadence test that renders `Avatar::draw` into the framebuffer and compares pixel hashes
-- `tests/tracking_handoff.rs` + per-modifier `tests/{attention,gaze,head,microsaccade,lost_target}_*.rs` — face-tracking modifier coverage driven by `TrackingScenario` through the full Director
+- [`FakeClock`] — deterministic [`Clock`] backed by a `Cell<Instant>`.
+  `advance(delta_ms)` and `set(instant)` are the only ways time
+  moves. `now()` is `&self` (so [`Director::run`] can call it
+  without `&mut`).
+- [`Framebuffer`] — `width × height` `Vec<Rgb565>` that implements
+  `embedded_graphics::DrawTarget<Color = Rgb565>` with `Infallible`
+  errors. Pixels outside the buffer are silently clipped, matching
+  `embedded-graphics`'s own clip behaviour. `pixel(x, y) → Option<Rgb565>`
+  for read-back.
+- [`RecordingHead`] — [`HeadDriver`] impl that pushes every
+  `(Instant, Pose)` call into a `Vec`, so motion-modifier tests
+  can assert on the full trajectory rather than a single sample.
+- [`TrackingScenario`] — replayable sequence of [`TrackingObservation`]
+  values built from `silent` / `tracking` / `with_face` / `holding` /
+  `returning` blocks. Iterates `(Instant, Option<TrackingObservation>)`
+  per tick at the configured cadence (default 33 ms ≈ 30 FPS), ready
+  to write into `entity.perception.tracking` before each
+  `Director::run`.
+- [`block_on`] — minimal future executor for synchronously driving
+  an always-`Ready` `HeadDriver::set_pose`. Spins on `Pending` so
+  misuse surfaces immediately; the intended caller is
+  [`RecordingHead`].
 
-## Architecture
+## Tick model
 
 ```mermaid
 flowchart LR
-    subgraph "Test / bench"
-        T[Test case]
-    end
-    subgraph "stackchan-sim"
-        FC[FakeClock<br/><i>tests.advance(dt)</i>]
-        FB[Framebuffer<br/><i>Vec&lt;Rgb565&gt;</i>]
-        RH[RecordingHead<br/><i>Vec&lt;(Instant, Pose)&gt;</i>]
-    end
-    subgraph "stackchan-core"
-        A[Avatar]
-        Mods[Modifier stack]
-        Draw[Avatar::draw]
-    end
-
-    T -->|advance| FC
-    FC --> Mods
-    Mods --> A
-    A --> Draw
-    Draw -->|pixels| FB
-    A --> RH
+    T[Test case] -->|advance| FC[FakeClock]
+    T -->|build| TS[TrackingScenario]
+    TS -->|iter| Obs[entity.perception.tracking]
+    FC -->|now| Dir[Director::run]
+    Dir --> Mods[Modifier stack]
+    Mods --> Ent[(Entity)]
+    Dir --> Sk[Skill predicates]
+    Sk --> Ent
+    Ent -->|draw| FB[Framebuffer]
+    Ent -->|head_pose| RH[RecordingHead]
     FB --> T
     RH --> T
 ```
 
-## What It Provides
+The simulator never owns the modifier registry — tests construct
+their own [`Director`], register the modifiers + skills under test,
+and drive the loop themselves. That matches the firmware's render
+task shape and keeps each test scoped to the contract it pins.
 
-- **`FakeClock`** — deterministic `Clock` impl backed by a `Cell<Instant>`. `advance(delta_ms)` and `set(instant)` are the only ways time moves. `now()` is re-entrant safe (takes `&self` via `Cell`)
-- **`Framebuffer`** — `width × height` `Vec<Rgb565>` that implements `embedded_graphics::DrawTarget<Color = Rgb565>` with `Infallible` errors. Out-of-bounds pixels are silently clipped (matches how `embedded-graphics` clips to `OriginDimensions`). `pixel(x, y) → Option<Rgb565>` for read-back
-- **`RecordingHead`** — `HeadDriver` impl that pushes every `(Instant, Pose)` call into a `Vec`, so motion-modifier tests can assert on the full trajectory
-- **`TrackingScenario`** — replayable sequence of `TrackingObservation` values built from `silent` / `tracking` / `tracking_with_face` / `holding` / `returning` blocks. Iterates `(Instant, Option<TrackingObservation>)` per tick at the configured cadence (default 33 ms ≈ 30 FPS), ready for tests to write into `entity.perception.tracking` before each `Director::run`
+## Integration tests
 
-## Test Patterns
+`tests/*.rs` is the bulk of the crate. Each file is one or more
+`#[test]` cases driven through [`Director::run`]:
 
-- **Golden pixel snapshots.** Render a frame, hash the pixel buffer, compare to a stored digest. Catches regressions in `Avatar::draw` or any upstream modifier that changes displayed output
-- **Golden trajectory.** Advance the clock in documented steps, assert on the `(Instant, Pose)` sequence `RecordingHead` captured. Catches timing drifts in motion modifiers
-- **Full-stack cadence.** Run the complete firmware modifier pipeline for one minute of simulated time, sample the framebuffer periodically, confirm the face looks right at known timestamps (emotion cycle boundaries, blink instants, etc.)
+| File | What it pins |
+|---|---|
+| `attention_from_tracking.rs` | `AttentionFromTracking` priorities + the tracking-doesn't-stomp-Listening invariant |
+| `ble_remote_command.rs`      | BLE characteristic payloads decode (via [`stackchan-net`](../stackchan-net)) → `RemoteCommand` → entity transitions match the HTTP path |
+| `body_gesture.rs`            | `IntentFromBodyTouch` Press / Swipe / Release state machine off [`Si12T`-shaped](../si12t) perception |
+| `dance.rs`                   | `POST /dance` JSON → `DanceScript` → `DancePlayer` → frame-by-frame motor pose |
+| `dormancy_head_drift.rs`     | `DormancyFromActivity` gates `IdleHeadDrift` so dormancy actually stills the servo |
+| `face_geometry.rs`           | `POST /face-geometry` JSON → [`FaceGeometry`] preset → `Face::set_geometry` applies |
+| `gaze_from_attention.rs`     | `GazeFromAttention` saccade trajectory |
+| `head_from_attention.rs`     | `HeadFromAttention` pose handoff from cognition to motor |
+| `idle_head_drift.rs`         | Per-axis glance amplitude + rest-time distribution under `IdleHeadDrift` |
+| `intent_from_loud.rs`        | Loud-noise startle: `Intent::Startled` + `Emotion::Surprised` + `ChirpKind::Startle` + head recoil + LED override fire together |
+| `leds.rs`                    | `render_leds` colour buffer regression |
+| `listening.rs`               | `Listening` skill + `HeadFromAttention` handoff under audio RMS |
+| `lost_target_search.rs`      | `LostTargetSearch` saccade after a tracked target disappears |
+| `microsaccade_from_attention.rs` | `MicrosaccadeFromAttention` cadence + amplitude |
+| `mood_style_chain.rs`        | `StyleFromMood` actually modulates `blink_rate_scale` / `breath_depth_scale` on top of `StyleFromEmotion` |
+| `petting.rs`                 | `IntentFromBodyTouch` (modifier) and `Petting` (skill) compose without conflict on the same body-touch input |
+| `remote_command.rs`          | HTTP-plane `RemoteCommand` variants → motor pose, decorator, emotion outcomes |
+| `render_snapshot.rs`         | `Entity::draw` into a 320×240 framebuffer, asserts on hand-picked pixels (eye centres, mouth line, corner) |
+| `tracking_handoff.rs`        | Full tracking arc: `AttentionFromTracking` + `GazeFromAttention` + `MicrosaccadeFromAttention` + `HeadFromAttention` + `LostTargetSearch` composed with the standard background stack |
+
+In-module `#[cfg(test)]` blocks inside `lib.rs` cover the simulator's
+own utilities (`Framebuffer` out-of-bounds clipping, `RecordingHead::clear`,
+`TrackingScenario::tick_ms`) plus a handful of cross-cutting Director
+tests (60 s composition stability, distinct-seed `IdleDrift`
+divergence, blink frequency over one minute, `StyleFromEmotion → Blink`
+single-tick propagation, voice-loop `Listen → Think → Reply` clearing
+thinking, emotion-driven decorator lifecycle).
+
+## Host visualiser
+
+Optional `viz` binary, behind the `viz` Cargo feature:
+
+```bash
+cargo run -p stackchan-sim --bin viz --features viz
+```
+
+Opens an `eframe` (egui + winit) window and runs the firmware-side
+modifier stack at 30 FPS so behaviour changes iterate in sub-second
+cycles instead of the ~30 s build → flash → boot loop. Behind a feature
+flag so the default lib build (and CI host tests) stay free of the
+windowing dep tree.
 
 ## Gotchas
 
-1. **No `no_std` here.** The sim lives on the host; it uses `alloc` freely for the pixel buffer and pose trajectory. Don't import from this crate into firmware code
-2. **FakeClock is not monotonic-enforcing.** `set()` trusts the caller; a test can intentionally go backward to exercise a pathological path. In-test assertions need to know what they're asserting
-3. **Framebuffer clipping is silent.** Pixels written outside `width × height` don't error — they disappear. Match the framebuffer size to the firmware's (320×240 for CoreS3)
-4. **Pixel-golden tests are sensitive to embedded-graphics upgrades.** Any sub-pixel rendering change in the upstream crate invalidates the stored hashes. Update deliberately when bumping the dep
-5. **`RecordingHead` has unbounded memory.** Long-running tests will accumulate millions of `(Instant, Pose)` entries — use `clear()` between phases, or cap simulated duration
+1. **`FakeClock` is not monotonic-enforcing.** `set()` trusts the
+   caller; a test can intentionally go backward to exercise a
+   pathological path. Assertions need to know what they're
+   asserting.
+2. **`Framebuffer` clipping is silent.** Pixels written outside
+   `width × height` don't error — they disappear. Size the buffer
+   to match the firmware's 320×240 when running render snapshots.
+3. **`RecordingHead` is unbounded.** Long-running tests accumulate
+   `(Instant, Pose)` entries indefinitely; call `clear()` between
+   phases, or cap the simulated duration.
+4. **`TrackingScenario` block durations floor to `tick_ms`.** A
+   `duration_ms` block produces `floor(duration_ms / tick_ms)` ticks
+   at `0, tick_ms, …, (count-1)*tick_ms`. Use
+   [`TrackingScenario::duration_for_ticks`] to size a block to
+   produce exactly `N` ticks without redoing the math by hand.
+5. **`block_on` does not yield.** It spins on `Pending`, which is the
+   point — the intended callers (`RecordingHead::set_pose`) return
+   immediately-`Ready` futures and a `Pending` means real I/O leaked
+   into the test path.
 
 ## Integration
 
-- **Runs on every `cargo test`** as part of the host-side default-members. No hardware required
-- **Paired with `stackchan-core`** — the sim consumes the same `Avatar` / `Modifier` / `Clock` / `HeadDriver` types the firmware does. Any behaviour change in core surfaces here first
+- Depends on [`stackchan-core`](../stackchan-core) for the engine
+  types and [`stackchan-net`](../stackchan-net) (dev-only) for the
+  BLE / dance / face-geometry wire-format round trips.
+- The full sim suite runs as part of `just check` (and on every
+  CI host job); no hardware required.
+- **Stability:** Experimental in v0.x. The `FakeClock` / `Framebuffer`
+  / `RecordingHead` shapes are settled; `TrackingScenario`'s builder
+  API is still evolving alongside the tracker.
+
+[`FakeClock`]: src/lib.rs
+[`Framebuffer`]: src/lib.rs
+[`RecordingHead`]: src/lib.rs
+[`TrackingScenario`]: src/lib.rs
+[`TrackingScenario::duration_for_ticks`]: src/lib.rs
+[`block_on`]: src/lib.rs
+[`Clock`]: ../stackchan-core/src/clock.rs
+[`HeadDriver`]: ../stackchan-core/src/head.rs
+[`TrackingObservation`]: ../stackchan-core/src/perception.rs
+[`Director`]: ../stackchan-core/src/director.rs
+[`Director::run`]: ../stackchan-core/src/director.rs
+[`FaceGeometry`]: ../stackchan-core/src/face.rs

--- a/crates/stackchan-tts/README.md
+++ b/crates/stackchan-tts/README.md
@@ -1,18 +1,171 @@
+---
+crate: stackchan-tts
+role: Speech synthesis backends + audio-source abstractions
+bus: none
+transport: "Box<dyn AudioSource> queue + SpeechBackend dispatch"
+no_std: true (with unconditional alloc)
+unsafe: forbidden
+status: experimental (v0.x)
+---
+
 # stackchan-tts
 
-Speech synthesis abstractions for the Stack-chan.
+Speech synthesis layer for the Stack-chan firmware. Defines the trait
+surfaces the audio task runs against, plus the in-tree backends. Domain
+types ([`Utterance`], [`PhraseId`], [`Locale`], [`SpeechContent`],
+[`SpeechStyle`], [`Priority`], [`ContentRef`]) live in
+[`stackchan-core::voice`](../stackchan-core/src/voice.rs); this crate
+turns them into audible PCM.
 
-Defines the trait surfaces the firmware speech path runs against:
+`no_std` with unconditional `alloc` — `Box<dyn AudioSource>` is the
+queue element type the firmware audio router pulls from.
 
-- [`AudioSource`] — pull-based PCM stream (sine cycle, baked clip, network chunk).
-- [`SpeechBackend`] — turns an [`Utterance`] into an `AudioSource`.
-- [`LipSync`] — envelope + optional viseme tag, published alongside playback.
+## What's here
 
-Domain types (`Utterance`, `PhraseId`, `Locale`, `SpeechContent`, `SpeechStyle`, `Priority`, `ContentRef`) live in `stackchan-core::voice`; this crate is the implementation layer.
+- [`AudioSource`] — pull-based 16-bit mono PCM stream at the audio
+  task's configured sample rate (16 kHz on the CoreS3). `fill(buf) →
+  usize` writes into a caller-owned buffer; `0` means exhausted.
+  Optional [`AudioSource::lip_sync`] hint (envelope + viseme) lets a
+  backend ship pre-computed lipsync alongside the audio.
+- [`SpeechBackend`] — resolves an [`Utterance`] into an
+  [`AudioSource`]. The firmware speech router pattern-matches on
+  [`SpeechContent`] and forwards to the first backend whose
+  [`SpeechBackend::can_handle`] returns `true`.
+- [`BakedBackend`] — in-tree backend for [`SpeechContent::Phrase`]
+  catalog entries. Renders non-verbal SFX from compile-time sine-cycle
+  tables, and verbal phrases from `include_bytes!`-embedded raw PCM
+  under `assets/<locale>/<phrase>.pcm`.
+- [`VoiceVoxBackend`] — wire-format + WAV-parsing scaffolding for
+  self-hosted [`VoiceVox`] (and API-compatible engines like
+  [`AivisSpeech`]). [`SpeechBackend::render`] is currently
+  [`RenderError::BackendUnavailable`] until the async HTTP fetcher
+  task lands on the firmware side; the URL builders and WAV parser
+  are host-testable today.
+- [`LipSync`] + [`Viseme`] re-exports from `stackchan-core::lipsync`
+  so backends and the firmware audio task share one envelope shape.
 
-`no_std` with unconditional `alloc` — `Box<dyn AudioSource>` is the queue element type.
+## Dispatch
+
+```mermaid
+flowchart LR
+    M[Modifier emits Utterance] --> R[Speech router]
+    R -->|content?| B1[BakedBackend.can_handle]
+    R -->|content?| B2[VoiceVoxBackend.can_handle]
+    B1 -- true --> Src[Box<dyn AudioSource>]
+    B2 -- true --> Src
+    Src --> Q[Audio TX queue]
+    Q --> I2S[I²S TX → AW88298]
+```
+
+Backends are checked in registration order; the first `true` wins.
+The audio task pulls one source at a time, draining via `fill()` into
+the DMA buffer until the source returns `0`, then dropping it and
+advancing to the next queued source.
+
+## Baked catalogue
+
+`BakedBackend` ships two flavours:
+
+**Non-verbal SFX** — single-cycle sine tables (`SINE_1KHZ`,
+`SINE_2KHZ`, `SINE_4KHZ`, `SILENCE_8`) looped N times via
+[`SineTableSource`] and composed into multi-segment patterns by
+[`SineSequence`]. Used for chirps and short notification tones — keeps
+the firmware crate free of `libm`. Tables live in `baked.rs`; the
+backend renders them from a [`PhraseId`] variant match.
+
+**Verbal phrases** — raw 16 kHz / 16-bit / mono PCM committed under
+`assets/<locale>/<phrase_id>.pcm`. The source-of-truth text is in
+[`assets/manifest.toml`](assets/manifest.toml); `just bake-tts` regenerates
+the `.pcm` files via Piper. To add a phrase: add a [`PhraseId`]
+variant, add a `render` arm to `BakedBackend`, add a `[<phrase_id>]`
+entry to the manifest with text per locale, run `just bake-tts`,
+commit the generated `.pcm`s.
+
+## VoiceVox
+
+`VoiceVoxBackend` targets self-hosted [`VoiceVox`] and any
+API-compatible engine. The protocol is two HTTP round-trips —
+`POST /audio_query?speaker=<id>&text=<utf8>` returns a JSON prosody
+description; `POST /synthesis?speaker=<id>` with that JSON as the body
+returns a WAV file. This module ships:
+
+- [`audio_query_path`] / [`synthesis_path`] — URL builders (paths +
+  query strings). Caller wraps in a full URL.
+- [`VoiceVoxConfig`] — `host` + `port` + `speaker_id` settings.
+  Defaults: port `50_021`, speaker `1` (Zundamon "ノーマル").
+- [`parse_wav`] / [`WavHeader`] / [`WavError`] — RIFF-chunk WAV
+  parser that locates the PCM payload inside a synthesis response.
+- [`BufferedSource`] — [`AudioSource`] that wraps a `Vec<i16>` of
+  decoded samples, suitable for handing back from a future async
+  fetcher task.
+
+The async fetcher itself lives in the firmware crate and isn't
+shipped yet, so [`VoiceVoxBackend::render`] returns
+[`RenderError::BackendUnavailable`]. The URL builders + WAV parser
+are exercised by host tests today.
+
+## Gotchas
+
+1. **No `libm` in baked SFX.** Sine cycles are pre-baked at compile
+   time so the firmware crate doesn't pull `libm`. A future backend
+   that needs trig at runtime should depend on `libm` explicitly.
+2. **Sample format is fixed.** 16-bit signed mono at 16 kHz, baked
+   into [`AudioSource::fill`]'s `&mut [i16]` signature. Backends that
+   want other rates / channel counts must resample at the boundary.
+3. **`SpeechBackend::render` is sync; HTTP is async.** Backends that
+   need network I/O (`VoiceVoxBackend`) split the work between an
+   async firmware-side fetcher task and a sync `render` that returns
+   a [`BufferedSource`] over the already-fetched samples.
+4. **`can_handle` must be cheap.** It runs on every utterance to
+   gate dispatch. Backends that need expensive state (cache lookups,
+   handle validation) do that inside `render`, not `can_handle`.
+5. **PCM assets are large.** Each verbal phrase costs `bytes-per-sec
+   * duration` of flash; the firmware's flash budget is the limit, not
+   PSRAM. Profile with `cargo size` when adding long phrases.
+
+## Integration
+
+- Depends only on [`stackchan-core`](../stackchan-core) for the
+  domain types.
+- The firmware speech router lives in [`stackchan-firmware`'s audio
+  task](../stackchan-firmware/src/audio.rs); modifiers in
+  `stackchan-core` publish [`Utterance`]s via
+  [`Voice::utterance_request`] and the router drains them through
+  the registered backends.
+- **Stability:** Experimental in v0.x. The trait shapes
+  ([`AudioSource`], [`SpeechBackend`]) are settled; the
+  [`VoiceVoxBackend`] surface will move as the async fetcher lands.
 
 [`AudioSource`]: src/source.rs
+[`AudioSource::fill`]: src/source.rs
+[`AudioSource::lip_sync`]: src/source.rs
 [`SpeechBackend`]: src/backend.rs
-[`LipSync`]: src/lipsync.rs
+[`SpeechBackend::can_handle`]: src/backend.rs
+[`SpeechBackend::render`]: src/backend.rs
+[`RenderError`]: src/backend.rs
+[`RenderError::BackendUnavailable`]: src/backend.rs
+[`BakedBackend`]: src/baked.rs
+[`SineTableSource`]: src/baked.rs
+[`SineSequence`]: src/baked.rs
+[`VoiceVoxBackend`]: src/voicevox.rs
+[`VoiceVoxBackend::render`]: src/voicevox.rs
+[`VoiceVoxConfig`]: src/voicevox.rs
+[`audio_query_path`]: src/voicevox.rs
+[`synthesis_path`]: src/voicevox.rs
+[`parse_wav`]: src/voicevox.rs
+[`WavHeader`]: src/voicevox.rs
+[`WavError`]: src/voicevox.rs
+[`BufferedSource`]: src/voicevox.rs
 [`Utterance`]: ../stackchan-core/src/voice.rs
+[`PhraseId`]: ../stackchan-core/src/voice.rs
+[`Locale`]: ../stackchan-core/src/voice.rs
+[`SpeechContent`]: ../stackchan-core/src/voice.rs
+[`SpeechContent::Phrase`]: ../stackchan-core/src/voice.rs
+[`SpeechStyle`]: ../stackchan-core/src/voice.rs
+[`Priority`]: ../stackchan-core/src/voice.rs
+[`ContentRef`]: ../stackchan-core/src/voice.rs
+[`Voice::utterance_request`]: ../stackchan-core/src/voice.rs
+[`LipSync`]: ../stackchan-core/src/lipsync.rs
+[`Viseme`]: ../stackchan-core/src/lipsync.rs
+[`VoiceVox`]: https://voicevox.hiroshiba.jp/
+[`AivisSpeech`]: https://github.com/Aivis-Project/AivisSpeech-Engine

--- a/crates/tracker/README.md
+++ b/crates/tracker/README.md
@@ -1,6 +1,6 @@
 ---
 crate: tracker
-role: Block-grid motion tracker (RGB565 → head Pose)
+role: Block-grid motion tracker + Viola–Jones face cascade (RGB565 → Pose)
 bus: none (pure algorithm)
 transport: in-memory frame slices
 no_std: true
@@ -10,50 +10,87 @@ status: experimental (v0.x)
 
 # tracker
 
-`no_std` block-grid motion tracker for the Stack-chan camera. Consumes
-raw RGB565 QVGA frames, computes inter-frame motion via per-block luma
-deltas, and emits a target `stackchan_core::Pose` for the head servos.
-Pure algorithm — no I/O, no allocation, host-testable from canned
-fixture frames.
+`no_std` camera-side analysis for the Stack-chan. Two layers, both
+allocation-free and host-testable from synthesised fixtures:
 
-## Key Files
+- **Block-grid motion tracker** ([`Tracker`]) — consumes raw RGB565
+  QVGA frames, computes inter-frame motion via per-block luma
+  deltas, and emits a target [`Pose`] for the head servos. Pure
+  algorithm; the firmware ties it into the gc0308 + `LCD_CAM` DMA
+  loop.
+- **Pure-Rust Viola–Jones cascade** ([`cascade`]) — integer-arithmetic
+  face detector. Cascade weights are baked into the crate as
+  [`FRONTAL_FACE`], pre-converted from OpenCV's
+  `haarcascade_frontalface_default.xml` by `xtask-cascade-convert`.
+  Used by the firmware to confirm "is there actually a face here?"
+  on top of the motion centroid.
 
-- `src/lib.rs` — `TrackerConfig`, `Tracker`, `Outcome`, `Motion`,
-  control-law (P-gain + dead zone + per-step slew + idle-timeout
-  return-to-centre), inline unit tests on synthesised frames
-- `src/luma.rs` — RGB565 → 8-bit luma approximation
-  (`(R8 + 2·G8 + B8) >> 2`), `fill_block_luma` reduction over a
-  configurable `blocks_x` × `blocks_y` grid (≤ 16 × 16)
+## Layout
 
-## Algorithm
+| Module | What it does |
+|---|---|
+| `lib.rs`          | `TrackerConfig`, `Tracker`, `Outcome`, `Motion`, `TargetCandidate`, plus the control law (P-gain + dead zone + per-step slew + idle-timeout return-to-centre + optional EMA on the published target) |
+| `luma.rs`         | RGB565 → 8-bit luma via shifts-only Rec. 601 approximation (`(R8 + 2·G8 + B8) >> 2`); `fill_block_luma` reduction over a configurable `blocks_x` × `blocks_y` grid (≤ 16 × 16) |
+| `cascade.rs`      | Viola–Jones scorer: `Rect`, `Feature`, `Stump`, `Stage`, `Cascade`, `IntegralView`, `CascadeScratch`, `FaceDetection`, `Cascade::evaluate`, `Cascade::scan`, `scan_around_centroid` |
+| `cascade_data.rs` | Bake of `FRONTAL_FACE` — the cascade itself as `const` data |
+| `data/`           | Source XML for the cascade (kept in-tree so the bake is reproducible) |
 
-For each step:
+## Motion pipeline
 
-1. **Per-block mean luma.** Reduce the frame into a small grid (default
-   8 × 6 → 40 × 40 pixel cells over QVGA). Luma uses a fast
-   shifts-only Rec. 601 approximation.
+For each `Tracker::step(frame, dt_ms)`:
+
+1. **Per-block mean luma.** Reduce the frame into a small grid
+   (default 8 × 6 → 40 × 40 pixel cells over QVGA).
 2. **Per-block delta vs. previous frame.** A block whose normalised
    delta exceeds `block_threshold` "fires".
 3. **Centroid of fired cells.** Mapped to `[-1, 1]` per axis.
 4. **Reject global events.** If too many cells fire (default > 70%),
    the frame is treated as a lighting flip and the pose held.
-5. **Dead zone + P-gain + slew clamp.** Centroid is converted to a pan
-   / tilt delta via the configured camera FOV; small offsets pass
-   through the dead zone untouched, the rest are scaled by `p_gain`
-   and clamped to `±max_step_deg`. Result feeds the internal
-   accumulator pose.
-6. **Idle timeout.** After `idle_timeout_ms` of no motion the target
-   pose slews back toward `Pose::NEUTRAL` at `idle_step_deg` per step.
+5. **Dead zone + P-gain + slew clamp.** Centroid → pan/tilt delta via
+   the configured camera FOV; small offsets pass through the dead
+   zone untouched, the rest scale by `p_gain` and clamp to
+   `±max_step_deg`. Result feeds the internal accumulator pose.
+6. **Idle timeout.** After `idle_timeout_ms` of no motion, the
+   target slews back toward [`Pose::NEUTRAL`] at `idle_step_deg`
+   per step.
 7. **`Pose::clamped`.** Final assignment routes through the
-   stackchan-core safe-range clamp (asymmetric tilt — see
+   `stackchan-core` safe-range clamp (asymmetric tilt — see
    `stackchan_core::head`).
 8. **Optional EMA on the published target.** A single-pole
-   `target_smoothing_alpha` on `TrackerConfig` blends the accumulator
-   into the value emitted in `Outcome.target` and surfaced via
-   `Tracker::target_pose()`. Default `1.0` is a no-op; lower values
-   add inertia on top of the per-step P-gain.
+   `target_smoothing_alpha` on [`TrackerConfig`] blends the
+   accumulator into the value emitted in `Outcome.target` and
+   surfaced via [`Tracker::target_pose`]. Default `1.0` is a no-op;
+   lower values add inertia on top of the per-step P-gain.
 
-## Sign Conventions
+`Outcome` carries the current motion class ([`Motion::Tracking`] /
+[`Motion::Holding`] / [`Motion::Returning`] / [`Motion::Idle`]),
+the fired-cell count, and a [`heapless::Vec<TargetCandidate,
+MAX_CANDIDATES>`] of secondary attention candidates ranked by
+salience.
+
+## Face cascade
+
+```mermaid
+flowchart LR
+    ROI[RGB565 ROI bytes] --> Luma[luma_from_rgb565_frame]
+    Luma --> II[IntegralView::from_luma]
+    II --> Scan[Cascade::scan / scan_around_centroid]
+    Scan --> Det[FaceDetection]
+```
+
+Cascade evaluation uses OpenCV's variance-normalisation convention
+(`threshold × variance_norm × window_area`,
+`variance_norm = sqrt(sumSqs · area − sum²)`), so the converter pipes
+weights through verbatim without rescaling. Scales sweep in Q16.16
+fixed-point — defaults in `SCAN_MIN_SCALE_Q16` /
+`SCAN_MAX_SCALE_Q16` / `SCAN_SCALE_STEP_Q16` / `SCAN_PIXEL_STEP`.
+
+[`Cascade::scan`] sweeps a full ROI; [`scan_around_centroid`] is the
+hot path used by the firmware — it scans a small window around the
+motion tracker's centroid so face confirmation runs every frame
+inside the existing tracking budget.
+
+## Sign conventions
 
 Inherited from `stackchan_core::head`:
 
@@ -63,31 +100,67 @@ Inherited from `stackchan_core::head`:
   it to level.
 - Centroid `nx > 0` ⇒ motion right of frame centre ⇒ pan delta `> 0`.
 - Centroid `ny > 0` ⇒ motion below frame centre ⇒ tilt delta `< 0`
-  (head nods down) — clamped to 0 in practice.
+  (head nods down — clamped to 0 in practice).
 
-## Coupling
+Frames are assumed column-major byte-pairs in big-endian RGB565
+(`LCD_CAM`'s default). Mirrored cameras correct via
+[`TrackerConfig::flip_x`] / [`TrackerConfig::flip_y`].
 
-- Depends on `stackchan-core` *only* for `Pose` and the safe-range
-  constants. No firmware deps; runs unchanged on host.
-- The firmware's `examples/tracker_bench.rs` exercises this crate
-  end-to-end against the live GC0308 + LCD\_CAM camera task and logs
-  proposed poses without driving any servo.
+## Gotchas
 
-## Tuning
+1. **Motion detection localises to the midpoint, not the new
+   position.** Fast left-to-right travel fires blocks at both ends,
+   biasing the centroid toward the centre. For typical Stack-chan
+   use (people entering frame, slow scene change) this works well;
+   running-mean background subtraction is the upgrade path.
+2. **Default grid is coarse.** 8 × 6 over QVGA puts angular
+   resolution at ~7° per cell on a 62° H FOV — fine enough for slow
+   head tracking, coarse for precise saccades.
+3. **Cascade requires the variance-normalised threshold form.** A
+   converter that emitted raw thresholds (no `variance_norm`
+   multiplier) would silently halve / double detection counts. The
+   `xtask-cascade-convert` bake is the source of truth.
+4. **`Tracker::step` allocates nothing.** Outputs ride in fixed
+   `heapless::Vec<…, MAX_CANDIDATES>` slots and on-stack
+   `CascadeScratch`. Don't add `Box<…>` types to the public
+   surface.
+5. **`libm` is the only float-math dep.** Cascade variance-norm needs
+   `sqrt`; everything else stays integer. New code that wants `cos`
+   / `exp` etc. should grow a wrapper rather than reaching for it
+   ad-hoc.
 
-Defaults live in `TrackerConfig::DEFAULT` and are tuned for QVGA
-GC0308 + Stack-chan SCServo head on a CoreS3. Edit per axis as
-needed; the bench logs centroid + fired-cell counts every step so
-empirical tuning is straightforward.
+## Integration
 
-## Limitations
+- Depends on [`stackchan-core`](../stackchan-core) only for `Pose`
+  and the safe-range constants.
+- The firmware's [`camera_task`](../stackchan-firmware/src/camera.rs)
+  calls `Tracker::step` per captured frame and publishes the
+  `Outcome`-derived `TrackingObservation` on `CAMERA_TRACKING_SIGNAL`.
+- `examples/tracker_bench.rs` in the firmware crate (run via
+  `just tracker-bench`) drives the tracker end-to-end against the
+  live GC0308 + `LCD_CAM` camera task and logs proposed poses
+  without driving any servo, for empirical tuning.
+- Default `TrackerConfig::DEFAULT` is tuned for QVGA GC0308 +
+  Stack-chan SCServo head on a CoreS3.
+- **Stability:** Experimental in v0.x. The motion-pipeline shape is
+  settled; cascade scoring is recent and may move as more models are
+  added.
 
-- Frame-difference detection localises to the **midpoint** of motion,
-  not the new position — fast left-to-right travel of an object will
-  fire blocks at *both* ends, biasing the centroid toward the centre.
-  For Stack-chan use (people entering frame, slow scene-rate change)
-  this works well; longer-term, a running-mean background subtraction
-  would track moving objects more accurately.
-- 8 × 6 grid resolution puts angular resolution at ~7° per cell on a
-  62° H FOV — fine enough for slow head tracking, coarse for precise
-  saccades.
+[`Tracker`]: src/lib.rs
+[`Tracker::step`]: src/lib.rs
+[`Tracker::target_pose`]: src/lib.rs
+[`TrackerConfig`]: src/lib.rs
+[`TrackerConfig::flip_x`]: src/lib.rs
+[`TrackerConfig::flip_y`]: src/lib.rs
+[`Outcome`]: src/lib.rs
+[`Motion`]: src/lib.rs
+[`Motion::Tracking`]: src/lib.rs
+[`Motion::Holding`]: src/lib.rs
+[`Motion::Returning`]: src/lib.rs
+[`Motion::Idle`]: src/lib.rs
+[`cascade`]: src/cascade.rs
+[`Cascade::scan`]: src/cascade.rs
+[`scan_around_centroid`]: src/cascade.rs
+[`FRONTAL_FACE`]: src/cascade_data.rs
+[`Pose`]: ../stackchan-core/src/head.rs
+[`Pose::NEUTRAL`]: ../stackchan-core/src/head.rs

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,15 +27,18 @@ driver crates.
 
 ```
 crates/
-├── stackchan-core      # no_std engine (Entity, Director, Modifier, Skill, Phase, Clock)
-├── stackchan-sim       # host simulator (FakeClock, Framebuffer, viz binary)
-├── stackchan-net       # no_std wire formats: RON config, HTTP parsers, validators
-├── stackchan-tts       # no_std + alloc speech surface: SpeechBackend trait + BakedBackend
-├── stackchan-firmware  # CoreS3 firmware binary (embassy + esp-rtos)
-├── tracker             # block-grid motion tracker for the camera path
-└── driver crates       # axp2101, aw9523, aw88298, bm8563, bmi270, bmm150,
-                        # es7210, ft6336u, gc0308, ir-nec, ltr553, py32,
-                        # scservo, si12t
+├── stackchan-core              # no_std engine (Entity, Director, Modifier, Skill, Phase, Clock)
+├── stackchan-sim               # host simulator (FakeClock, Framebuffer, viz binary)
+├── stackchan-net               # no_std wire formats: RON config, HTTP parsers, MCP, BLE codecs, OTA, …
+├── stackchan-tts               # no_std + alloc speech surface: SpeechBackend trait + BakedBackend + VoiceVox
+├── stackchan-audio-features    # no_std streaming log-mel frontend for on-device keyword spotting
+├── stackchan-desktop-protocol  # no_std + alloc Claude Desktop Hardware Buddy NUS protocol
+├── stackchan-firmware          # CoreS3 firmware binary (embassy + esp-rtos)
+├── esp-tflite-micro-sys        # FFI bindings for TFLite-micro + esp-nn (vendored C/C++)
+├── tracker                     # block-grid motion tracker + Viola–Jones face cascade
+└── driver crates               # axp2101, aw9523, aw88298, bm8563, bmi270, bmm150,
+                                # es7210, ft6336u, gc0308, ir-nec, ltr553, py32,
+                                # scservo, si12t
 ```
 
 See [STABILITY.md](https://github.com/andymai/stackchan-kai/blob/main/STABILITY.md)


### PR DESCRIPTION
## Summary

Picks up the [#499](https://github.com/andymai/stackchan-kai/pull/499) thread for the remaining host-built crates whose READMEs had drifted from `src/`. Each README was re-derived against the current source — public surface, module structure, gotchas, and integration cross-links. Same frontmatter shape and section structure as #499 for consistency across the workspace.

- **`stackchan-sim`**: drops the stale `Avatar::draw` references (now `Entity::draw`), expands the test table to cover the full `tests/*.rs` set, documents the `TrackingScenario` builder + `block_on` helper, calls out the `viz` Cargo feature.
- **`stackchan-tts`**: documents the `VoiceVoxBackend` URL builders + WAV parser + `BufferedSource`, the `assets/manifest.toml` + `just bake-tts` flow, and clarifies that `VoiceVoxBackend::render` is parked on `BackendUnavailable` pending the async fetcher.
- **`stackchan-firmware`**: refreshes the module table for the desktop / sidecar / wake-word / chime / reminders / OTA / crash / runtime-store surfaces, expands the network section for sidecar / mDNS-follower / ESP-NOW / SNTP, documents the Hardware Buddy NUS service and the four `desktop_*` consumer tasks, corrects the BLE bond store path (`/sd/BONDS.BIN`) and the wallclock module's actual role.
- **`stackchan-audio-features`**: drops the (now-stale) literal test count in favour of a shape description; adds the streaming-pipeline mermaid and links the firmware-side wake-word consumer.
- **`tracker`**: documents the new Viola–Jones face cascade alongside the motion tracker, including the `scan_around_centroid` hot path and the OpenCV variance-norm convention.
- **`stackchan-desktop-protocol`**: enumerates the module surface, names every `Inbound`/`Outbound` type, and pins the four `desktop_*` consumer wiring on the firmware side.
- **`docs/index.md`**: source layout now lists `stackchan-audio-features`, `stackchan-desktop-protocol`, and `esp-tflite-micro-sys` (added since the snippet was last edited).

Prose-doc audit during the pass came back clean — `docs/behavior.md` already covers every current `BehaviorConfig` field including `follower_leader_hostname`; `docs/architecture.md` was just refreshed by #418 and is intentionally simplified rather than stale.

## Test plan

- [x] `just check` (fmt + workspace clippy + host tests + doctests)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features` (the rustdoc gate from `just ci` — verified per memory note that `just check` alone skips it)
- [x] Spot-check every claim in each refreshed README against the current `src/`: module paths, struct / enum / trait names, behavior / config / SD-path strings, file inventory
- [ ] Greptile review (auto)