### PR TITLE
docs(readme): overhaul — voice section, camera surface, regrouped features

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ carries longer-running, predicate-fired capabilities — skills write
 intent into `mind` and `voice`, modifiers translate that to face and
 motion. Catalogues live in
 [`crates/stackchan-core/src/modifiers/`](./crates/stackchan-core/src/modifiers)
-and [`skills/`](./crates/stackchan-core/src/skills).
+and [`crates/stackchan-core/src/skills/`](./crates/stackchan-core/src/skills).
 
 Because time flows in through a `Clock` trait, the same Director runs
 against a `FakeClock` on the host. `stackchan-sim` drives the modifier

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org/)
 
-`no_std` Rust firmware for the M5Stack CoreS3 Stack-chan — embassy-based, cloud-free, testable on the host.
+`no_std` Rust firmware for the M5Stack CoreS3 Stack-chan — embassy-based, LAN-only, host-testable.
 
 [Stability](./STABILITY.md) · [Changelog](./CHANGELOG.md) · [Justfile](./justfile) · [Handbook](https://andymai.github.io/stackchan-kai/)
 
@@ -25,8 +25,8 @@ just fmr    # flash + monitor over USB-Serial-JTAG
 
 Needs a [CoreS3 Stack-chan kit](https://shop.m5stack.com/products/stackchan-kawaii-co-created-open-source-ai-desktop-robot),
 a USB-C cable, Rust 1.88+, and `dialout` group membership for serial access.
-See the [justfile](./justfile) for the full recipe set (host tests, CI gates,
-sensor bench examples).
+See the [justfile](./justfile) for the full recipe set (host tests, MSRV
+build, sensor bench examples).
 
 ## Why
 
@@ -35,9 +35,9 @@ LLM-agent pipeline written in C++. `stackchan-kai` rebuilds the desk-toy
 surface — animated face, head motion, local sensors, optional sidecar-routed
 voice agent — in `no_std` Rust on top of
 [`esp-hal`](https://github.com/esp-rs/esp-hal) and
-[embassy](https://embassy.dev/). The engine is modeled as data and the render
-path is shared with a host-side simulator, so most of the firmware is testable
-without touching the hardware.
+[embassy](https://embassy.dev/). The engine is modeled as data, the render
+path is shared with a host-side simulator, and the only network egress is
+whatever the operator points the voice path at.
 
 ## The engine
 
@@ -46,95 +46,192 @@ perception, voice, mind, events, input, tick) plus a [`Director`] that
 sorts `Modifier`s by phase and ticks them each frame.
 
 ```rust
-use stackchan_core::{Director, Entity, Instant, modifiers::Blink};
+use stackchan_core::{Director, Entity, Instant};
+use stackchan_core::modifiers::{Blink, EmotionCycle, IdleHeadDrift};
 
 let mut entity = Entity::default();
-let mut blink = Blink::new();
+let mut emotion = EmotionCycle::new();   // Phase::Affect
+let mut blink = Blink::new();            // Phase::Expression
+let mut drift = IdleHeadDrift::new();    // Phase::Motion
+
 let mut director = Director::new();
+director.add_modifier(&mut emotion).expect("registry has room");
 director.add_modifier(&mut blink).expect("registry has room");
+director.add_modifier(&mut drift).expect("registry has room");
 
 for ms in (0..10_000).step_by(33) {
     director.run(&mut entity, Instant::from_millis(ms));
 }
 ```
 
-Each `Modifier` declares a phase (`Affect`, `Expression`, `Motion`,
-`Audio`) and a priority; the Director sorts once and ticks per frame.
-Stock modifiers cover blinking, breathing, idle eye drift, occasional
-head glances, emotion transitions, touch / IR / voice / ambient /
-battery reactions, attention-driven head tilt, and audio-driven mouth
-motion. A parallel
-`Skill` surface carries predicate-fired capabilities. See the
+Each `Modifier` declares a phase (`Perception`, `Cognition`, `Affect`,
+`Speech`, `Expression`, `Decoration`, `Motion`, `Audio`) and a priority;
+the Director sorts once and ticks per frame. A parallel `Skill` surface
+carries longer-running, predicate-fired capabilities — skills write
+intent into `mind` and `voice`, modifiers translate that to face and
+motion. Catalogues live in
+[`crates/stackchan-core/src/modifiers/`](./crates/stackchan-core/src/modifiers)
+and [`skills/`](./crates/stackchan-core/src/skills).
+
+Because time flows in through a `Clock` trait, the same Director runs
+against a `FakeClock` on the host. `stackchan-sim` drives the modifier
+stack through scripted time sequences with pixel-golden assertions
+and an `egui` visualiser (`cargo run -p stackchan-sim --bin viz
+--features viz`) — behaviour iteration takes under a second instead of
+a ~30 s flash cycle. See the
 [architecture overview](https://andymai.github.io/stackchan-kai/architecture)
 and [modifier authoring guide](https://andymai.github.io/stackchan-kai/modifiers)
 for the details.
 
-## Features
+## Voice agent
 
-- **Animated face** — eased transitions across the m5stack-avatar emotion palette, blink / breath / idle-drift at double-buffered 30 FPS
-- **Symbolic overlays** — speech-bubble text and decorator badges (heart, sweat, dizzy, ear, pairing, angry, shy) layered on top of the base face
-- **Battery indicator** — opt-in corner overlay; the percent reading is quantised into segment buckets so per-percent jitter doesn't churn the renderer's dirty-check
-- **Color palette swap** — runtime theme switch through a small set of named presets (default / dark / cute / dog) without disturbing the symbolic-overlay layer's distinctness
-- **Head motion** — Feetech SCServo pan/tilt with a calibration bench (`just bench`) and a runtime zero-point correction surface for day-of mounting drift
-- **9-axis sensing** — BMI270 accel + gyro, BMM150 magnetometer (compensated µT, live bench via `just mag-bench`)
-- **Local inputs** — FT6336U touch, Si12T body-touch strip, LTR-553 ambient + proximity, NEC IR decoder
-- **Timekeeping + peripherals** — BM8563 RTC, PY32 co-processor, WS2812 neck LED ring (`just leds-bench`)
-- **Camera tracking** — GC0308 capture into a block-grid motion tracker, engagement-driven gaze with microsaccades and lost-target search
-- **Voice agent path** — opt-in. Wake word fires from on-device microWakeWord inference (TFLite Micro + ESP-NN, model on SD card) or operator-initiated `POST /listen`; the firmware uploads captured PCM to a sidecar URL of your choice and renders the JSON reply (`text`, `emotion`) on the toast band. STT and LLM live in the sidecar — kai never embeds them. End-to-end setup in [docs/voice.md](./docs/voice.md).
-- **Optional autonomy** — opt-in soliloquy bubbles at random intervals; opt-in top-of-hour chime
-- **Host-side sim** — runs the full modifier stack on the host with pixel-golden tests + an `egui` visualiser (`cargo run -p stackchan-sim --bin viz --features viz`); cuts behaviour iteration from ~30 s build cycles to under a second
-- **Safe by default** — no `unwrap` in library code, typed errors throughout, `unsafe` denied workspace-wide
+Opt-in. Wake word fires from on-device
+[microWakeWord](https://github.com/kahrendt/microWakeWord) inference
+(TFLite Micro + ESP-NN, model on SD card) or from an operator-initiated
+`POST /listen`. The firmware uploads captured PCM (`audio/L16` at
+16 kHz mono) to a sidecar URL of your choice and renders the JSON
+reply (`text`, `emotion`) on the avatar's toast band. STT and LLM live
+in the sidecar — kai never embeds them.
+
+A reference Python sidecar (faster-whisper + Anthropic Claude, Docker
+/ systemd deployable) ships in [`sidecar/`](./sidecar). Setup in
+[docs/voice.md](./docs/voice.md); wire contract in
+[sidecar/README.md](./sidecar/README.md). Without a sidecar URL
+configured the listen path is inactive; everything else runs the same.
 
 ## Networking
 
-`STACKCHAN.RON` on an SD card brings up Wi-Fi station, mDNS, and SNTP-on-link-up,
-and the firmware exposes a LAN-only HTTP control plane:
+`STACKCHAN.RON` on an SD card brings up Wi-Fi station, mDNS, and
+SNTP-on-link-up; the firmware then exposes a LAN-only HTTP control
+plane. Writes carry a bearer token (constant-time compare). Without an
+SD card the firmware boots offline and the desk-toy surface works the
+same.
 
-- `GET /` — operator dashboard, single-page HTML embedded in the binary
-- `GET /state/stream` — live state via Server-Sent Events
-- `POST /emotion`, `/look-at`, `/look-at-point`, `/face-target`, `/reset`, `/speak` — manual override
-- `POST /volume`, `/mute`, `/mood`, `/palette`, `/head/offsets` — runtime control surface
-- `POST /sleep`, `/wake` — sleep mode (eyes shut / head limp / LED dark / audio paused). Wake via the route, MCP tool, any touch, or the side power button.
-- `POST /dance` — JSON keyframe stream sequencing head pose, emotion, decorator, and LED-ring colour through the `DancePlayer` modifier. Schema in [docs/dance.md](./docs/dance.md).
-- `POST /mcp` — JSON-RPC 2.0 endpoint speaking minimal MCP for AI agent integrations (`set_emotion`, `look_at`, `speak`, `set_volume`, `create_reminder` / `list_reminders` / `cancel_reminder`, …)
-- `POST /firmware/update` — ed25519-signed SCFW image upload; auto-flashes the inactive OTA slot and soft-resets. Compiled out unless `STACKCHAN_OTA_PUBLIC_KEY` is set at build time. Always requires a configured bearer token.
+- `GET /` — embedded operator dashboard
+- `GET /state` / `GET /state/stream` — snapshot or live SSE
 - `GET` / `PUT /settings` — persistent config with atomic SD writeback
-- Bearer-token auth on writes; constant-time compare; LAN-scoped (no TLS)
+- `POST /emotion`, `/look-at`, `/look-at-point`, `/face-target`,
+  `/reset`, `/speak`, `/volume`, `/mute`, `/mood`, `/palette`,
+  `/head/offsets`, `/face-geometry` — runtime override + control
+- `POST /sleep` / `/wake` — collapse the avatar (eyes shut, head limp,
+  LED dark, audio paused); wake via route, MCP tool, any touch, or the
+  side power button
+- `POST /listen` — operator-initiated voice capture (mirrors the
+  wake-word path)
+- `POST /camera/mode` + `/camera/capture`, `GET /camera/snapshot` —
+  toggle tracker / capture pipeline, trigger a frame, fetch the last
+  320×240 RGB565 raster from SD
+- `POST /dance` — JSON keyframe stream for the `DancePlayer` modifier
+  ([docs/dance.md](./docs/dance.md))
+- `POST /mcp` — JSON-RPC 2.0 MCP endpoint for AI-agent integrations
+  (`set_emotion`, `look_at`, `speak`, `create_reminder`, …)
+- `POST /firmware/update` — ed25519-signed SCFW image; flashes the
+  inactive OTA slot and soft-resets. Compiled out unless
+  `STACKCHAN_OTA_PUBLIC_KEY` is set at build time.
 
-Discovery and inter-device:
+Full reference: [docs/http.md](./docs/http.md).
 
-- **mDNS** — `<hostname>.local` plus DNS-SD service records (`_stackchan._tcp.local.`)
-  carrying a `kai=1` variant marker so kai-aware clients gate on extension endpoints
-  while a generic Bonjour browser still lists the device alongside upstream stackchan units.
-  TXT also publishes live `yaw=` / `pitch=` (one decimal, ≤100 ms refresh with a 1 s heartbeat)
-  so a follower mimicking head pose tracks the leader without an HTTP round-trip
-- **ESP-NOW** — peer-allowlisted RX driving the same `RemoteCommand` plumbing as HTTP,
-  plus a TX path that broadcasts pose-mirror + heartbeat frames so multiple units can
-  choreograph against each other
-- **BLE peripheral** — Device Information / Battery / emotion / Wi-Fi provisioning /
-  audio / avatar control / camera-view services, advertised as `stackchan-XXXXXX`
-  (last three MAC bytes); shares the radio with Wi-Fi via `esp-radio` coex
+**Discovery + inter-device**
 
-Without an SD card the firmware boots offline and the desk-toy surface works
-the same. See [HTTP control plane](https://andymai.github.io/stackchan-kai/http)
-for the full reference.
+- **mDNS** + DNS-SD (`_stackchan._tcp.local.`) with a `kai=1` variant
+  marker; TXT publishes live `yaw=` / `pitch=` so a follower can mirror
+  pose without an HTTP round-trip
+- **ESP-NOW** — peer-allowlisted RX driving the same `RemoteCommand`
+  plumbing as HTTP, plus pose-mirror + heartbeat TX for multi-unit
+  choreography
+- **BLE peripheral** — Device Information, Battery, emotion, audio,
+  avatar control, and view services; Wi-Fi credentials can be set via
+  a custom provisioning service or via BluFi (Espressif standard);
+  shares the radio with Wi-Fi via `esp-radio` coex
+- **Claude Desktop companion** — Nordic UART Service exposes
+  desktop-side render / permission / control / time tasks for a
+  laptop-attached operator surface
+
+## Features
+
+**Avatar**
+
+- Eased transitions across the m5stack-avatar emotion palette, blink /
+  breath / idle-drift at double-buffered 30 FPS
+- Symbolic overlays — speech-bubble text plus decorator badges (heart,
+  sweat, dizzy, ear, pairing, angry, shy) layered on the base face
+- Battery indicator — opt-in corner overlay, segment-bucketed to keep
+  per-percent jitter out of the renderer's dirty-check
+- Color palette swap — runtime theme presets (default / dark / cute /
+  dog) that don't bleed into the symbolic-overlay layer
+- Face geometry presets — selectable via `POST /face-geometry` and MCP;
+  active selection persists to `/sd/RUNTIME.RON` alongside palette + mood
+  and is restored on boot
+- Idle autonomy — opt-in soliloquy bubbles at random intervals; opt-in
+  top-of-hour chime when an RTC year is known
+
+**Motion**
+
+- Feetech SCServo pan/tilt with a calibration bench (`just bench`) and
+  a runtime zero-point correction surface for day-of mounting drift
+- 3D `lookAtPoint` IK via `POST /look-at-point`, plus attention-driven
+  head tilt and microsaccades from the camera tracker
+- Dance keyframe playback through the `DancePlayer` modifier
+- Sleep mode collapses head pose, eyes, LED, and audio together
+
+**Sensors + inputs**
+
+- BMI270 accel + gyro (live tilt streaming, shake detection)
+- BMM150 magnetometer — compensated µT, live bench via `just mag-bench`
+  (bench-only on this unit; see *Known limitations*)
+- FT6336U capacitive touch, Si12T body-touch strip (back-of-head pads)
+- LTR-553 ambient light + proximity, NEC IR decoder
+- GC0308 camera capture into a block-grid motion tracker driving
+  engagement gaze with microsaccades and lost-target search
+
+**Peripherals**
+
+- BM8563 RTC, PY32 co-processor, WS2812 neck LED ring (`just leds-bench`)
+- AXP2101 PMU with side power-key timing and battery gauge
+
+**Robustness**
+
+- No `unwrap` / `expect` in library code, typed errors throughout
+  ([docs/errors.md](./docs/errors.md))
+- `unsafe` denied workspace-wide; firmware crate allows it only behind
+  per-module annotations for linker symbols and register-map pointers
+- Signed OTA path (ed25519, compiled out by default)
 
 ## Scope
 
-To set expectations, this project deliberately does not:
+This project deliberately does not:
 
-- **Embed LLM, STT, or TTS** — speech intelligence lives in an operator-supplied sidecar; the firmware uploads captured PCM and renders the JSON reply. This keeps the binary `no_std` and under embedded flash budgets regardless of whether a voice path is configured.
-- **Support hardware beyond the CoreS3 Stack-chan kit** — the driver set is written against specific datasheets (BMI270, BMM150, FT6336U, Feetech SCServo, etc.) and tested on one physical unit. Porting to other M5Stack boards or ESP32 variants is out of scope.
-- **Provide a stable public API before v2.x** — all crates are Experimental per [STABILITY.md](./STABILITY.md); minor releases break things. The `stackchan-core` library is usable but its contract is still settling.
-- **Replace general-purpose ESP-IDF or M5Unified firmware** — only the desk-toy surface area (face, motion, sensors, LAN control) is covered. Features outside that surface (e.g., arbitrary GPIO scripting, third-party display drivers) belong in a different project.
-- **Accept unsolicited contributions** — single-maintainer, best-effort response. Bug reports and discussion are welcome; the PR policy is in `AGENTS.md`.
+- **Embed STT, LLM, or TTS** — speech intelligence lives in an
+  operator-supplied sidecar. The firmware embeds wake-word inference
+  (microWakeWord, TFLite Micro) but ships captured PCM upstream for
+  transcription and generation, keeping the binary `no_std` and
+  inside the embedded flash budget.
+- **Support hardware beyond the CoreS3 Stack-chan kit** — the driver
+  set is written against specific datasheets (BMI270, BMM150, FT6336U,
+  Feetech SCServo, …) and tested on one physical unit. Porting to
+  other M5Stack boards or ESP32 variants is out of scope.
+- **Provide a stable public API yet** — all crates are Experimental
+  per [STABILITY.md](./STABILITY.md); minor releases break things. The
+  `stackchan-core` library is usable but its contract is still settling.
+- **Replace general-purpose ESP-IDF or M5Unified firmware** — only the
+  desk-toy surface area (face, motion, sensors, LAN control) is
+  covered. Features outside that surface (arbitrary GPIO scripting,
+  third-party display drivers) belong in a different project.
+- **Accept unsolicited contributions** — single-maintainer, best-effort
+  response. Bug reports and discussion are welcome; the PR policy is
+  in `AGENTS.md`.
 
 ## Known limitations
 
-- Tested on a single CoreS3 unit. The BMM150 magnetometer on this kit is bench-only — chassis-side interference makes the in-enclosure reading unusable; other sensors are exercised regularly.
-- LAN-only HTTP plane, no TLS. The bearer-token gate is a soft check against accidental drive-by writes — not a hardened auth surface for an untrusted network.
-- All public APIs are Experimental until at least v2.x per [STABILITY.md](./STABILITY.md). Minor releases will break things.
-- Single-maintainer project. Issue and PR response is best-effort; nothing is on a cadence.
+- Tested on a single CoreS3 unit. The BMM150 magnetometer on this kit
+  is bench-only — chassis-side interference makes the in-enclosure
+  reading unusable; other sensors are exercised regularly.
+- LAN-only HTTP plane, no TLS. The bearer-token gate is not a hardened
+  auth surface for an untrusted network.
+- All public APIs are Experimental per
+  [STABILITY.md](./STABILITY.md). Minor releases will break things.
+- Single-maintainer project. Issue and PR response is best-effort;
+  nothing is on a cadence.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Promote the voice agent path (microWakeWord + sidecar) to its own section between Engine and Networking; STT/LLM still live in `sidecar/`.
- Regroup Features by surface (Avatar / Motion / Sensors+inputs / Peripherals / Robustness) instead of a flat list, and replace the Blink-only sample with three modifiers across `Affect` / `Expression` / `Motion` so the Director phase-ordering claim is visible in the code.
- Fill in shipped surface the previous README missed: camera HTTP control plane (`/camera/mode`, `/camera/capture`, `/camera/snapshot` returning the last 320×240 RGB565 raster from SD), `GET /state` snapshot alongside the SSE stream, BluFi as the second Wi-Fi provisioning path, the Claude Desktop NUS companion under Discovery + inter-device, and the restored Idle autonomy bullet (soliloquy + top-of-hour chime).
- Tagline: drop "cloud-free" → "embassy-based, LAN-only, host-testable" now that wake-word runs on-device and the sidecar adds a configurable egress. Stability horizon goes from "v2.x" to "Experimental per STABILITY.md".
- Scope section: rewrite the LLM/STT/TTS bullet to be honest — wake-word inference IS embedded, but STT/LLM/TTS still aren't.
- Verbosity pass: drop hollow qualifiers ("soft check against accidental drive-by writes", "To set expectations,"), tighten battery / palette / sim prose.

## Test plan

- [x] `grep` confirms no emoji, no counts ("N modifiers / services / drivers"), no PR-numbers / arc / release-flavored callouts, no AI-tells (carefully / robust / leverages / polished / etc.).
- [x] Rust sample in the engine section compiles against `stackchan-core` v0.37 in a scratch crate (`cargo check` clean).
- [x] All referenced paths exist: `docs/voice.md`, `docs/sidecar.md`, `docs/http.md`, `docs/dance.md`, `docs/errors.md`, `sidecar/README.md`, `STABILITY.md`, `CHANGELOG.md`, `justfile`.
- [x] All HTTP routes mentioned exist in `crates/stackchan-firmware/src/net/http.rs`; format claim for `/camera/snapshot` (RGB565BE, 320×240) verified against the handler's response headers.
- [x] Modifier names + phases in the sample match the actual `pub use` exports and `meta().phase` declarations.
- [ ] Render check on GitHub (centered header + badges still align under the new content).