### PR TITLE
chore(deny): prune unmatched license allowances

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,18 +19,16 @@ ignore = []
 
 [licenses]
 version = 2
+# Only licenses actually present in the resolved host dep graph. Add
+# entries here when a new dep introduces a license, not pre-emptively;
+# cargo-deny warns on unused allowances and CI surfaces those quickly.
 allow = [
     "MIT",
-    "MIT-0",
     "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
     "BSD-2-Clause",
-    "MPL-2.0",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "ISC",
-    "CC0-1.0",
     "Zlib",
     # `smoltcp` and `managed`, pulled in transitively by embassy-net,
     # ship under the BSD Zero Clause licence.


### PR DESCRIPTION
## Summary

`cargo deny check` warns on five entries in `[licenses].allow` that no resolved host dep ships under: `MIT-0`, `Apache-2.0 WITH LLVM-exception`, `MPL-2.0`, `Unicode-DFS-2016`, `CC0-1.0`. Drop them.

The right policy is to add allowances when a new dep brings a license in, not pre-emptively — CI surfaces unused entries quickly. Added a short policy comment near the list so the next audit pass doesn't reintroduce speculative entries.

## Test plan

- [x] `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok` (no warnings)
- [x] `just check` clean (fmt + clippy + host tests + doctests + workspace check) via pre-commit