### PR TITLE
fix(sidecar): surface firmware-cmd failures instead of dropping them

### DIFF
--- a/sidecar/web/src/actions.ts
+++ b/sidecar/web/src/actions.ts
@@ -2,13 +2,15 @@
 // holds the firmware bearer token; the sidecar injects it before the
 // proxied POST.
 
-async function firmwareCmd(name: string, body: unknown): Promise<Response> {
+async function firmwareCmd(name: string, body: unknown): Promise<void> {
   const r = await fetch(`/v1/firmware-cmd/${name}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body ?? {}),
   });
-  return r;
+  if (!r.ok) {
+    throw new Error(`firmware-cmd ${name} failed: ${r.status} ${r.statusText}`);
+  }
 }
 
 const DEFAULT_LISTEN_MS = 5000;

--- a/sidecar/web/src/main.ts
+++ b/sidecar/web/src/main.ts
@@ -58,7 +58,9 @@ for (const { id, label } of EMOTION_CHIPS) {
   btn.setAttribute("aria-label", `Set emotion ${label}`);
   btn.setAttribute("aria-pressed", "false");
   btn.addEventListener("click", () => {
-    void setEmotion(id);
+    setEmotion(id).catch((err: unknown) => {
+      console.error("setEmotion failed", err);
+    });
   });
   chipsEl.appendChild(btn);
   chipButtons.set(id, btn);
@@ -73,6 +75,8 @@ pttEl.addEventListener("click", async () => {
   pttEl.disabled = true;
   try {
     await startListen();
+  } catch (err) {
+    console.error("startListen failed", err);
   } finally {
     pttBusy = false;
     pttEl.classList.remove("is-loading");


### PR DESCRIPTION
## Summary

`firmwareCmd` in `sidecar/web/src/actions.ts` returned the raw `Response` and never inspected `response.ok`, so 4xx/5xx errors from the firmware command relay disappeared silently — a user clicked an emotion chip, the fetch 500'd, and nothing surfaced anywhere. Same for the PTT button.

- `firmwareCmd` now throws on non-2xx with the status code + status text.
- The two call sites in `main.ts` catch and `console.error` so the failure shows up in DevTools instead of vanishing.
- The PTT button still drops `is-loading` via the existing `finally`, so the UI recovers either way.
- `firmwareCmd`'s return type drops from `Promise<Response>` to `Promise<void>` — no caller reads the body, and the tighter return type matches what the function actually contracts now.

This is the smallest fix that takes the symptom from "silent" to "observable in DevTools" without inventing a toast/banner UI surface that doesn't exist yet. A richer in-page error UX is a separate scope.

## Test plan

- [x] `npm run build` clean (tsc --noEmit + vite build) inside `sidecar/web/`.
- [x] Diff is two files / 9 insertions / 3 deletions — no unrelated edits.
- [ ] On-device smoke: click an emotion chip while the firmware bearer is wrong → DevTools console shows `setEmotion failed Error: firmware-cmd emotion failed: 401 Unauthorized`. Click PTT → analogous `startListen failed` log.