### PR TITLE
chore(hooks): scope pre-commit's .toml match to host-relevant files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,9 +13,15 @@ set -euo pipefail
 
 staged=$(git diff --cached --name-only --diff-filter=ACMR)
 
-# Only run when Rust files (or Cargo.toml / Cargo.lock) are staged.
+# Only run when Rust source or build-affecting config is staged.
+# Matches: any .rs, Cargo.toml/lock at any path depth, clippy.toml at
+# the repo root. Deliberately excludes deny.toml (supply chain only),
+# pyproject.toml (Python), sidecar/config.example.toml, and per-crate
+# rust-toolchain.toml / .cargo/config.toml — none of those affect the
+# host clippy / test outcome, and edits to them used to drag a full
+# host build through the hook for no reason.
 has_rust=false
-if echo "$staged" | grep -qE '(^Cargo\.(toml|lock)$|\.rs$|\.toml$)'; then
+if echo "$staged" | grep -qE '(\.rs$|(^|/)Cargo\.(toml|lock)$|^clippy\.toml$)'; then
     has_rust=true
 fi
 


### PR DESCRIPTION
## Summary

The pre-commit hook ran the full host Rust gate (fmt + clippy + tests + doctests + workspace check, ~30 s on a warm cache) whenever any `*.toml` was staged — including ones that can't affect host compilation:

- `deny.toml` (supply chain config)
- `sidecar/pyproject.toml`, `sidecar/config.example.toml` (Python sidecar)
- `crates/*/rust-toolchain.toml` (firmware-only)
- `crates/*/.cargo/config.toml` (firmware-only)
- `crates/stackchan-tts/assets/manifest.toml` (asset metadata)

Tighten the regex to:

```
(\.rs$|(^|/)Cargo\.(toml|lock)$|^clippy\.toml$)
```

`.rs` at any depth, `Cargo.toml`/`Cargo.lock` at any depth, plus the root-level `clippy.toml` (since it shapes lint output). Everything else `.toml` skips the host gate; CI still runs the appropriate workflow for non-Rust changes via `paths-ignore` in `.github/workflows/ci.yml`.

The deny.toml PR #503 earlier today is the recent example — a 5-line change pulled a full host compile through the hook. With this change a deny.toml-only commit completes in <1 s.

## Test plan

- [x] Regex check against representative paths:
  - `crates/stackchan-firmware/src/main.rs` → match
  - `Cargo.toml`, `crates/aw9523/Cargo.toml`, `Cargo.lock` → match
  - `clippy.toml` → match
  - `deny.toml`, `sidecar/pyproject.toml`, `release-please-config.json`, `crates/*/rust-toolchain.toml`, `crates/*/.cargo/config.toml`, `CLAUDE.md` → no match
- [x] Cargo.lock drift guard below the matcher uses its own anchored regex; unaffected.
- [x] Commit message bypasses the gate (no .rs / Cargo.* staged) — verified locally on this PR's own commit.