### PR TITLE
docs(agents): fix dashboard path + drop stale driver count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ translate that into face / motor.
 1. Wire format: parsers + validators in `crates/stackchan-net/src/{config,http_command,http_parse,bare_json}.rs`. Host-testable; unit tests live beside the parser.
 2. Handler: `crates/stackchan-firmware/src/net/http.rs` matches requests by `(method, path)`; each route is a handler function.
 3. Persisted state rides the RON schema (`stackchan_net::config::Config`) through `PUT /settings`'s atomic writeback — no parallel persistence paths.
-4. Operator-driven routes update the dashboard at `crates/stackchan-firmware/src/net/dashboard.html` (embedded via `include_bytes!`).
+4. Operator-driven routes show up in the dashboard: source lives under `web/src/` (Vite + Solid), and the firmware's HTTP responder embeds the built `web/dist/index.html.gz` via `include_bytes!` (see `crates/stackchan-firmware/src/net/respond.rs`). Run `just web-build` after touching `web/src/` — `just check-firmware` chains through it automatically.
 5. `just check-firmware && just clippy-firmware && just build-firmware`, then curl smoke after flashing.
 6. Document the route in `docs/http.md` (the canonical reference).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ translate that into face / motor.
    modifier (`Phase::Motion` for pose, `Phase::Expression` for
    face) that reads `mind.intent` / `mind.attention`.
 
-### Shape 2: driver work (one of the 14 driver crates)
+### Shape 2: driver work (any of the chip-specific driver crates)
 1. Read the crate's README to understand current scope.
 2. Add registers, driver methods, or init steps; keep `embedded-hal-async` boundary clean.
 3. Unit-test what you can on host (packet construction, register encoding).


### PR DESCRIPTION
## Summary

Two small AGENTS.md doc-drift fixes:

1. **Shape 5 step 4** referenced `crates/stackchan-firmware/src/net/dashboard.html` — that file hasn't existed in months. The dashboard moved to a top-level `web/` Vite project, with the firmware embedding `web/dist/index.html.gz` via `include_bytes!` in `crates/stackchan-firmware/src/net/respond.rs:30`. Updated the step to point at the real source layout and mention the `just web-build` chain.

2. **Shape 2 title** said `(one of the 14 driver crates)` — the count is correct today but rots every time a chip lands or leaves the inventory. Drop the number; the actual list lives in `crates/` + the CLAUDE.md inventory (per `feedback_no_count_in_docs` memory).

## Test plan

- [x] `ls crates/stackchan-firmware/src/net/dashboard.html` → ENOENT.
- [x] `grep include_bytes crates/stackchan-firmware/src/net/respond.rs` → confirms the real path is `../../../../web/dist/index.html.gz`.
- [x] `ls crates/` ↔ CLAUDE.md inventory → 14 driver crates today, but stops mattering once the count is gone.