### PR TITLE
refactor(firmware): drop stale modifier-name list from render-task boot log

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -394,10 +394,7 @@ async fn render_task(
     let canvas = Rectangle::new(EgPoint::zero(), Size::new(FB_WIDTH, FB_HEIGHT));
 
     let mut ticker = Ticker::every(Duration::from_millis(FRAME_PERIOD_MS));
-    defmt::info!(
-        "render task: {=u64} ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + EmotionFromIntent + EmotionFromVoice + IntentFromLoud + EmotionFromAmbient + EmotionFromBattery + AttentionFromTracking + DormancyFromActivity + EmotionCycle + StyleFromEmotion + StyleFromIntent + GazeFromAttention + MicrosaccadeFromAttention + Blink + Breath + IdleDrift + IdleMicroExpression + BatteryOverlayFromPerception + IdleHeadDrift + HeadFromEmotion + HeadFromAttention + LostTargetSearch + HeadFromIntent + HeadFromBodyGesture + DancePlayer + MouthFromAudio + Listening[skill] + Petting[skill] + Handling[skill]",
-        FRAME_PERIOD_MS
-    );
+    defmt::info!("render task: {=u64} ms tick", FRAME_PERIOD_MS);
 
     loop {
         let now = clock.now();


### PR DESCRIPTION
## Summary

The `render task:` boot line in `main.rs` hardcoded a 31-name `+`-joined list of modifiers and skills. The list hadn't been updated as new modifiers landed — by the time #508 collapsed the registration calls, the log was missing 11 entries (every Phase::Decoration modifier except `BatteryOverlayFromPerception`, plus `Soliloquy`, `IntentFromBodyTouch`, `RemoteCommand`, `IntentFromLoud`).

Maintaining a parallel list by hand is exactly the kind of drift the bulk-register array in #508 was supposed to eliminate. Drop the manual list; keep the frame-period log so boot-time / heartbeat assertions still have an anchor. The actual roster lives in `main.rs` registration order and is reachable via grep when you need it.

Before:

```
render task: 33 ms tick, EmotionFromTouch + IntentFromBodyTouch + EmotionFromRemote + … + Listening[skill] + Petting[skill] + Handling[skill]
```

After:

```
render task: 33 ms tick
```

## Test plan

- [x] `cargo +esp clippy -- -D warnings` clean from `crates/stackchan-firmware/`.
- [x] Boot-log golden (`tests/golden/boot.txt`) doesn't pin the modifier list — only the `render task:` prefix and the tick value, so this is safe under `just verify-boot`.
- [ ] Hardware smoke via `just fmr`: confirm the boot log now reads `render task: 33 ms tick` followed by the usual idle heartbeat.