### PR TITLE
docs(firmware): document best-effort cleanup drops in net layer

### DIFF
--- a/crates/stackchan-firmware/src/net/mdns.rs
+++ b/crates/stackchan-firmware/src/net/mdns.rs
@@ -175,6 +175,11 @@ pub async fn mdns_task(stack: Stack<'static>, hostname: String, leader_hostname:
         // or anything errors out.
         serve_loop(&socket, &hostname, &leader_hostname, our_ip, &mut announcer).await;
 
+        // Best-effort multicast-group leave: serve_loop returned
+        // because the link dropped or the socket errored, so the
+        // group membership is moot. A failure here just means the
+        // stack will reject the next join with `AlreadyExists` until
+        // the link transition forces a teardown.
         let _ = stack.leave_multicast_group(MDNS_MULTICAST);
         socket.close();
         // serve_loop returned (link dropped or socket failure) —

--- a/crates/stackchan-firmware/src/net/wifi.rs
+++ b/crates/stackchan-firmware/src/net/wifi.rs
@@ -207,6 +207,11 @@ async fn run_connect_loop(controller: &mut WifiController<'static>, ssid: &str) 
                             "wifi: reconfig while connected (new ssid={=str})",
                             new_creds.ssid.as_str()
                         );
+                        // Best-effort disconnect before returning the
+                        // new creds: connect_async at the top of the
+                        // outer loop will reset the controller state
+                        // even if this fails, so a stuck disconnect
+                        // shouldn't strand the reconfig request.
                         let _ = controller.disconnect_async().await;
                         WIFI_LINK_WATCH.sender().send(WifiLinkState::Disconnected);
                         return new_creds;


### PR DESCRIPTION
## Summary

- The `let _ = stack.leave_multicast_group(...)` site at the end of `mdns_task`'s reconnect loop was undocumented. Spell out why a failure here is safe to drop (the next outer-loop iteration tears down and re-joins from a clean state anyway).
- The `let _ = controller.disconnect_async().await` site in the wifi-reconfig path was also undocumented. Same idea: `connect_async` at the top of the outer loop resets the controller, so a stuck disconnect won't strand the reconfig request.

Surfaced as part of a wider audit of `let _ =` sites across the firmware crate — the other ~50 sites are either already documented inline (in `head.rs`, `board.rs`, `storage.rs`, `agent_sidecar.rs`, `ble/server.rs`, `runtime_store.rs`) or are heapless-buffer pushes that can't fail in context (`audio.rs`, `event_log.rs`, `toast.rs`, `websocket.rs`). These two were the gaps.

## Test plan

- [x] `just check` — fmt + workspace clippy + host tests + doctests all pass via pre-commit hook
- [x] Diff is comment-only — no behavior change