### PR TITLE
feat(arc-a): per-device persona dispatch via X-Persona-Name

### DIFF
--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -248,12 +248,18 @@ impl defmt::Format for PostError {
 /// `session_id` is the per-device identifier sent as `X-Session-Id`
 /// so the sidecar can scope conversation memory to this physical
 /// unit across requests. Hydrated at boot from `/sd/SESSION.UUID`.
+///
+/// `persona_name` is the operator-configured
+/// `behavior.persona_name`. Empty omits the `X-Persona-Name` header
+/// so the sidecar applies its baked-in default persona — keeps the
+/// wire surface unchanged for installs that don't multiplex personas.
 #[embassy_executor::task]
 pub async fn agent_sidecar_task(
     stack: Stack<'static>,
     sidecar_url: String,
     bearer_token: String,
     session_id: String,
+    persona_name: String,
 ) -> ! {
     if sidecar_url.is_empty() {
         defmt::info!("agent-sidecar: url empty, idle");
@@ -340,6 +346,7 @@ pub async fn agent_sidecar_task(
                 &pcm,
                 &bearer_token,
                 &session_id,
+                &persona_name,
                 &mut rx_buf,
                 &mut tx_buf,
             ),
@@ -492,12 +499,17 @@ const CHUNK_SAMPLES: usize = 512;
 
 /// Single POST round-trip. Opens a fresh socket per request so a
 /// half-closed sidecar doesn't poison subsequent uploads.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct concern (network, endpoint, PCM payload, auth, identity, scratch buffers) that doesn't compose into a natural sub-struct; bundling them would obscure the dispatch shape"
+)]
 async fn post_pcm(
     stack: Stack<'static>,
     endpoint: &SidecarEndpoint,
     pcm: &[i16],
     bearer_token: &str,
     session_id: &str,
+    persona_name: &str,
     rx_buf: &mut [u8; TCP_RX_BYTES],
     tx_buf: &mut [u8; TCP_TX_BYTES],
 ) -> Result<(heapless::String<256>, Option<Emotion>), PostError> {
@@ -541,6 +553,10 @@ async fn post_pcm(
     }
     if !session_id.is_empty() {
         write!(&mut header, "X-Session-Id: {session_id}\r\n")
+            .map_err(|_| PostError::HeaderTooLong)?;
+    }
+    if !persona_name.is_empty() {
+        write!(&mut header, "X-Persona-Name: {persona_name}\r\n")
             .map_err(|_| PostError::HeaderTooLong)?;
     }
     header

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1470,6 +1470,7 @@ async fn main(spawner: Spawner) -> ! {
         net_config.behavior.agent_sidecar_url.clone(),
         net_config.behavior.agent_sidecar_token.clone(),
         session_uuid.clone(),
+        net_config.behavior.persona_name.clone(),
     )) {
         defmt::panic!(
             "spawn(agent_sidecar_task) failed: {}",

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -763,8 +763,8 @@ async fn handle_get_settings_backup(socket: &mut TcpSocket<'_>) -> Result<(), Ht
 /// - `behavior.hourly_chime_enabled` (chime task arg at spawn)
 /// - `behavior.auto_torque_release_ms` (head task reads once at boot)
 /// - `behavior.audio_debug_udp_target` (`audio_debug` task arg at spawn)
-/// - `behavior.agent_sidecar_url` / `agent_sidecar_token` (agent
-///   sidecar task args at spawn)
+/// - `behavior.agent_sidecar_url` / `agent_sidecar_token` /
+///   `persona_name` (agent sidecar task args at spawn)
 /// - `behavior.follower_leader_hostname` (follower task arg at spawn)
 ///
 /// Future work that wants any of these to apply live needs both a
@@ -795,6 +795,7 @@ fn requires_reboot(prev: &stackchan_net::Config, new: &stackchan_net::Config) ->
         || b_prev.agent_sidecar_url != b_new.agent_sidecar_url
         || b_prev.agent_sidecar_token != b_new.agent_sidecar_token
         || b_prev.follower_leader_hostname != b_new.follower_leader_hostname
+        || b_prev.persona_name != b_new.persona_name
     {
         return true;
     }

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -177,6 +177,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        wake_word_arena_kib: {},",
         config.behavior.wake_word_arena_kib
     );
+    push_field(
+        &mut out,
+        "        persona_name",
+        &config.behavior.persona_name,
+    );
     out.push_str("    ),\n");
 
     out.push_str(")\n");
@@ -687,6 +692,7 @@ impl<'a> Parser<'a> {
         let mut wake_word_enabled: Option<bool> = None;
         let mut wake_word_threshold: Option<i8> = None;
         let mut wake_word_arena_kib: Option<u32> = None;
+        let mut persona_name: Option<String> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -781,6 +787,12 @@ impl<'a> Parser<'a> {
                     }
                     wake_word_arena_kib = Some(self.parse_u32()?);
                 }
+                "persona_name" => {
+                    if persona_name.is_some() {
+                        return Err(bare_err("duplicate behavior field", "persona_name"));
+                    }
+                    persona_name = Some(self.parse_string()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -801,6 +813,7 @@ impl<'a> Parser<'a> {
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
             wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
+            persona_name: persona_name.unwrap_or_default(),
         })
     }
 

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -304,6 +304,8 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
         ",\"wake_word_arena_kib\":{}",
         config.behavior.wake_word_arena_kib
     );
+    out.push(',');
+    push_string_field(&mut out, "persona_name", &config.behavior.persona_name);
     out.push_str("}}");
     Ok(out)
 }
@@ -814,6 +816,7 @@ impl<'a> Parser<'a> {
         let mut wake_word_enabled: Option<bool> = None;
         let mut wake_word_threshold: Option<i8> = None;
         let mut wake_word_arena_kib: Option<u32> = None;
+        let mut persona_name: Option<String> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -908,6 +911,12 @@ impl<'a> Parser<'a> {
                     }
                     wake_word_arena_kib = Some(self.parse_u32()?);
                 }
+                "persona_name" => {
+                    if persona_name.is_some() {
+                        return Err(bare_err("duplicate behavior field", "persona_name"));
+                    }
+                    persona_name = Some(self.parse_string()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -928,6 +937,7 @@ impl<'a> Parser<'a> {
             wake_word_enabled: wake_word_enabled.unwrap_or(false),
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
             wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
+            persona_name: persona_name.unwrap_or_default(),
         })
     }
 
@@ -1206,6 +1216,7 @@ mod tests {
                 wake_word_enabled: true,
                 wake_word_threshold: 95,
                 wake_word_arena_kib: 96,
+                persona_name: "desk-buddy".to_string(),
             },
         }
     }
@@ -1753,6 +1764,7 @@ mod tests {
                 wake_word_enabled: true,
                 wake_word_threshold: -32,
                 wake_word_arena_kib: 128,
+                persona_name: "desk-buddy".to_string(),
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -401,6 +401,18 @@ pub struct BehaviorConfig {
     /// operator gets feedback from the HTTP write rather than
     /// discovering a parked task on next reboot.
     pub wake_word_arena_kib: u32,
+    /// Persona slug the firmware advertises to the sidecar via
+    /// `X-Persona-Name` on every `POST /v1/listen`. Empty (the
+    /// default) leaves the header off so the sidecar applies its
+    /// baked-in default persona — keeps the wire surface unchanged
+    /// for installs that don't multiplex personas.
+    ///
+    /// When set, must be a short slug (≤ 64 bytes, ASCII control-free,
+    /// no path separators) so it can't inject extra HTTP headers via
+    /// `\r\n` or pivot to arbitrary files on the sidecar's filesystem.
+    /// The sidecar still validates per-request — this is defence in
+    /// depth at the firmware boundary.
+    pub persona_name: String,
 }
 
 impl Default for BehaviorConfig {
@@ -418,6 +430,7 @@ impl Default for BehaviorConfig {
             wake_word_enabled: false,
             wake_word_threshold: 100,
             wake_word_arena_kib: 64,
+            persona_name: String::new(),
         }
     }
 }
@@ -617,6 +630,7 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
         return Err(ConfigError::InvalidWakeWordArenaKib);
     }
     validate_agent_sidecar_token(&config.behavior.agent_sidecar_token)?;
+    validate_persona_name(&config.behavior.persona_name)?;
     Ok(())
 }
 
@@ -693,6 +707,41 @@ fn validate_agent_sidecar_token(token: &str) -> Result<(), ConfigError> {
     }
     if token.chars().any(|c| c.is_ascii_control()) {
         return Err(ConfigError::AgentSidecarTokenInvalidChars);
+    }
+    Ok(())
+}
+
+/// Max length of a persona slug. 64 bytes is well above typical
+/// kebab-case names (`stack-chan`, `desk-buddy`, etc.) and small
+/// enough that an `X-Persona-Name` header stays well under the
+/// firmware's `HEADER_CAPACITY` budget.
+const PERSONA_NAME_MAX_BYTES: usize = 64;
+
+/// Reject persona slugs that would corrupt the HTTP request or
+/// pivot the sidecar's filesystem lookup.
+///
+/// Empty short-circuits — that's the documented "let the sidecar pick
+/// its default" marker. Otherwise the slug must be:
+/// - ASCII-control-free (no embedded `\r\n` to inject headers)
+/// - free of `/`, `\`, and `..` (no traversal into the sidecar's
+///   `personas/` parent)
+/// - within [`PERSONA_NAME_MAX_BYTES`]
+///
+/// The sidecar still re-validates per-request — this is defence in
+/// depth at the firmware config boundary.
+fn validate_persona_name(name: &str) -> Result<(), ConfigError> {
+    if name.is_empty() {
+        return Ok(());
+    }
+    if name.len() > PERSONA_NAME_MAX_BYTES {
+        return Err(ConfigError::PersonaNameTooLong(name.len()));
+    }
+    if name
+        .chars()
+        .any(|c| c.is_ascii_control() || c == '/' || c == '\\')
+        || name.contains("..")
+    {
+        return Err(ConfigError::PersonaNameInvalidChars);
     }
     Ok(())
 }

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -150,6 +150,25 @@ pub enum ConfigError {
     #[error("behavior.agent_sidecar_token contains an ASCII control character")]
     AgentSidecarTokenInvalidChars,
 
+    /// `behavior.persona_name` exceeded the documented 64-byte slug
+    /// cap. The firmware sends this as `X-Persona-Name` on every
+    /// `POST /v1/listen`, so an oversize value would either trip the
+    /// per-request header buffer or surface as a 4xx from the
+    /// sidecar's persona-load step.
+    #[error("behavior.persona_name must be <= 64 bytes; got {0}")]
+    PersonaNameTooLong(usize),
+
+    /// `behavior.persona_name` contained an ASCII control char or a
+    /// path-traversal token (`/`, `\`, `..`). The sidecar uses the
+    /// slug as a filename component under its `personas/` directory,
+    /// so any of those would either inject extra HTTP headers via
+    /// embedded `\r\n` or pivot the lookup outside the persona dir.
+    /// The sidecar revalidates per-request; this gate stops the bad
+    /// value at the firmware boundary so operators see the failure
+    /// on `PUT /settings` instead of after the next push-to-talk.
+    #[error("behavior.persona_name contains an invalid character")]
+    PersonaNameInvalidChars,
+
     /// A disk-loaded `Config` had the redaction sentinel (`"***"`)
     /// in a secret field. The sentinel is meaningful only on the
     /// HTTP `PUT /settings` merge path — on disk there's nothing to

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -73,6 +73,7 @@ Content-Length: <n>
 Connection: close
 Authorization: Bearer sk-sidecar-shared-secret
 X-Session-Id: 7f3c2a1d-9b40-4e8a-93f1-2bc6d4e1a7f0
+X-Persona-Name: desk-buddy
 
 <n bytes of raw little-endian s16 PCM @ 16 kHz mono>
 ```
@@ -92,6 +93,15 @@ care about multi-turn context key memory off this value; sidecars
 that don't can ignore it. Deleting the file rotates the identifier;
 copying it across SD cards preserves it. SD-less boots get a fresh
 ephemeral ID per cold start.
+
+`X-Persona-Name` is sent only when `behavior.persona_name` is set in
+`STACKCHAN.RON`. Empty (the default) omits the header so the sidecar
+applies its baked-in default persona; non-empty asks the sidecar to
+load `personas/{name}.md`. The firmware validates the slug at config
+time (≤ 64 bytes, ASCII control-free, no path separators or `..`)
+and the sidecar re-validates per-request — a `400` is returned if
+the slug is malformed, `404` if it's well-formed but the persona
+file isn't on the sidecar.
 
 ### Response (sidecar → firmware)
 

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -167,53 +167,81 @@ def create_app(
         # persona file to load. Empty / missing header falls back to
         # the sidecar's baked-in `settings.persona` so installs that
         # don't multiplex personas keep working unchanged.
+        #
+        # The header path and the fallback path map load failures
+        # differently:
+        #   - Header path: ValueError → 400 (client sent a bad slug),
+        #                  FileNotFoundError → 404 (client named a
+        #                  persona this sidecar hasn't been deployed
+        #                  with).
+        #   - Fallback path: any failure → 500 (the sidecar's default
+        #                    is misconfigured; the client did nothing
+        #                    wrong).
         requested_persona = request.headers.get("x-persona-name", "").strip()
-        persona_name = requested_persona or settings.persona
-        try:
-            persona = load_persona(persona_name, settings.personas_dir)
-        except ValueError as exc:
-            _LOG.warning(
-                "persona name rejected",
-                extra={
-                    "request_id": request_id,
-                    "session_id": session_id,
-                    "requested_persona": requested_persona,
-                    "reason": str(exc),
-                    "status": 400,
-                },
-            )
-            return _failure(
-                ErrorCode.PERSONA_NAME_INVALID,
-                request_id=request_id,
-                session_id=session_id,
-                status=400,
-                session_status=session_status,
-                extra={"requested_persona": requested_persona},
-            )
-        except FileNotFoundError:
-            # Distinguish per-request misses (header set, file absent —
-            # the operator-provisioned firmware names a persona the
-            # sidecar hasn't been deployed with) from misconfig of the
-            # sidecar's default. 404 vs 500 lets a caller tell.
-            status = 404 if requested_persona else 500
-            _LOG.exception(
-                "persona load failed",
-                extra={
-                    "request_id": request_id,
-                    "session_id": session_id,
-                    "persona": persona_name,
-                    "requested_persona": requested_persona,
-                    "status": status,
-                },
-            )
-            return _failure(
-                ErrorCode.PERSONA_MISSING,
-                request_id=request_id,
-                session_id=session_id,
-                status=status,
-                session_status=session_status,
-                extra={"persona": persona_name},
-            )
+        if requested_persona:
+            try:
+                persona = load_persona(requested_persona, settings.personas_dir)
+            except ValueError as exc:
+                _LOG.warning(
+                    "persona name rejected",
+                    extra={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "requested_persona": requested_persona,
+                        "reason": str(exc),
+                        "status": 400,
+                    },
+                )
+                return _failure(
+                    ErrorCode.PERSONA_NAME_INVALID,
+                    request_id=request_id,
+                    session_id=session_id,
+                    status=400,
+                    session_status=session_status,
+                    extra={"requested_persona": requested_persona},
+                )
+            except FileNotFoundError:
+                _LOG.warning(
+                    "requested persona not deployed",
+                    extra={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "requested_persona": requested_persona,
+                        "status": 404,
+                    },
+                )
+                return _failure(
+                    ErrorCode.PERSONA_MISSING,
+                    request_id=request_id,
+                    session_id=session_id,
+                    status=404,
+                    session_status=session_status,
+                    extra={"persona": requested_persona},
+                )
+        else:
+            try:
+                persona = load_persona(settings.persona, settings.personas_dir)
+            except (ValueError, FileNotFoundError):
+                # Both failure modes here are sidecar-side misconfig
+                # (`settings.persona` empty or pointing at a missing
+                # file). The client didn't supply anything to blame.
+                _LOG.exception(
+                    "default persona load failed",
+                    extra={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "persona": settings.persona,
+                        "status": 500,
+                    },
+                )
+                return _failure(
+                    ErrorCode.PERSONA_MISSING,
+                    request_id=request_id,
+                    session_id=session_id,
+                    status=500,
+                    session_status=session_status,
+                    extra={"persona": settings.persona},
+                )
 
         t_stt0 = time.perf_counter()
         try:

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -163,25 +163,56 @@ def create_app(
         t0 = time.perf_counter()
         deadline = time.monotonic() + settings.total_timeout_seconds
 
+        # `X-Persona-Name` lets a per-device firmware pick which
+        # persona file to load. Empty / missing header falls back to
+        # the sidecar's baked-in `settings.persona` so installs that
+        # don't multiplex personas keep working unchanged.
+        requested_persona = request.headers.get("x-persona-name", "").strip()
+        persona_name = requested_persona or settings.persona
         try:
-            persona = load_persona(settings.persona, settings.personas_dir)
+            persona = load_persona(persona_name, settings.personas_dir)
+        except ValueError as exc:
+            _LOG.warning(
+                "persona name rejected",
+                extra={
+                    "request_id": request_id,
+                    "session_id": session_id,
+                    "requested_persona": requested_persona,
+                    "reason": str(exc),
+                    "status": 400,
+                },
+            )
+            return _failure(
+                ErrorCode.PERSONA_NAME_INVALID,
+                request_id=request_id,
+                session_id=session_id,
+                status=400,
+                session_status=session_status,
+                extra={"requested_persona": requested_persona},
+            )
         except FileNotFoundError:
+            # Distinguish per-request misses (header set, file absent —
+            # the operator-provisioned firmware names a persona the
+            # sidecar hasn't been deployed with) from misconfig of the
+            # sidecar's default. 404 vs 500 lets a caller tell.
+            status = 404 if requested_persona else 500
             _LOG.exception(
                 "persona load failed",
                 extra={
                     "request_id": request_id,
                     "session_id": session_id,
-                    "persona": settings.persona,
-                    "status": 500,
+                    "persona": persona_name,
+                    "requested_persona": requested_persona,
+                    "status": status,
                 },
             )
             return _failure(
                 ErrorCode.PERSONA_MISSING,
                 request_id=request_id,
                 session_id=session_id,
-                status=500,
+                status=status,
                 session_status=session_status,
-                extra={"persona": settings.persona},
+                extra={"persona": persona_name},
             )
 
         t_stt0 = time.perf_counter()

--- a/sidecar/src/stackchan_sidecar/errors.py
+++ b/sidecar/src/stackchan_sidecar/errors.py
@@ -39,6 +39,7 @@ class ErrorCode(StrEnum):
     LLM_FAILED = "llm_failed"
     LLM_PARSE_FAILED = "llm_parse_failed"
     PERSONA_MISSING = "persona_missing"
+    PERSONA_NAME_INVALID = "persona_name_invalid"
     INTERNAL = "internal"
 
 
@@ -87,6 +88,12 @@ _FAILURES: dict[ErrorCode, FailureKind] = {
     ),
     ErrorCode.PERSONA_MISSING: FailureKind(
         ErrorCode.PERSONA_MISSING, Stage.SYSTEM, "persona missing", Emotion.NEUTRAL
+    ),
+    ErrorCode.PERSONA_NAME_INVALID: FailureKind(
+        ErrorCode.PERSONA_NAME_INVALID,
+        Stage.SYSTEM,
+        "invalid persona name",
+        Emotion.NEUTRAL,
     ),
     ErrorCode.INTERNAL: FailureKind(
         ErrorCode.INTERNAL, Stage.SYSTEM, "internal error", Emotion.NEUTRAL

--- a/sidecar/src/stackchan_sidecar/personas.py
+++ b/sidecar/src/stackchan_sidecar/personas.py
@@ -1,12 +1,50 @@
 from pathlib import Path
 
+# Max length of a persona slug. Mirrors the firmware-side
+# PERSONA_NAME_MAX_BYTES in stackchan-net::config so the wire boundary
+# rejects the same set of inputs on both ends.
+_PERSONA_NAME_MAX_BYTES = 64
+
 
 def load_persona(name: str, personas_dir: Path) -> str:
+    """Load the persona prompt at ``{personas_dir}/{name}.md``.
+
+    Raises ``ValueError`` if ``name`` isn't a safe filename component
+    (controls path traversal + HTTP header injection on the
+    firmware-supplied input path), or ``FileNotFoundError`` if the
+    resolved file doesn't exist.
+    """
+    _validate_slug(name)
     path = personas_dir / f"{name}.md"
     if not path.is_file():
         raise FileNotFoundError(f"persona file not found: {path}")
     text = path.read_text(encoding="utf-8")
     return _strip_frontmatter(text).strip()
+
+
+def _validate_slug(name: str) -> None:
+    """Reject persona slugs that could traverse the filesystem or
+    inject HTTP headers (relevant when ``name`` came in from an
+    ``X-Persona-Name`` request header).
+
+    Defence in depth — the firmware-side validator in
+    ``stackchan-net::config::validate_persona_name`` applies the
+    same rules at config time, but the sidecar can't trust an
+    upstream proxy or a curl-based caller to have gone through
+    that gate.
+    """
+    if not name:
+        raise ValueError("persona name must be non-empty")
+    if len(name.encode("utf-8")) > _PERSONA_NAME_MAX_BYTES:
+        raise ValueError(
+            f"persona name exceeds {_PERSONA_NAME_MAX_BYTES} bytes"
+        )
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
+        raise ValueError("persona name contains a control character")
+    if "/" in name or "\\" in name or ".." in name:
+        raise ValueError(
+            "persona name contains a path separator or traversal token"
+        )
 
 
 def _strip_frontmatter(text: str) -> str:

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -225,6 +225,38 @@ def test_listen_invalid_x_persona_name_returns_400(
         assert r.json()["error"]["code"] == "persona_name_invalid"
 
 
+def test_listen_empty_default_persona_returns_500_not_400(
+    tmp_path: Path,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    # Misconfigured sidecar: settings.persona is empty AND the caller
+    # didn't send X-Persona-Name. The client did nothing wrong, so
+    # this must be 500 (server misconfig), not 400 (client error).
+    # The old catch-all `except ValueError` would have collapsed this
+    # into 400; the header-vs-fallback split keeps the two cases
+    # distinct.
+    empty_personas = tmp_path / "no-personas"
+    empty_personas.mkdir()
+    settings = Settings(
+        SIDECAR_BEARER_TOKEN=TEST_TOKEN,
+        ANTHROPIC_API_KEY="sk-ant-test",
+        personas_dir=empty_personas,
+        persona="",
+    )
+    app = create_app(settings, fake_stt, fake_llm)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 500
+    assert r.json()["error"]["code"] == "persona_missing"
+
+
 def test_listen_persona_missing_returns_500(
     tmp_path: Path,
     fake_stt: FakeSTT,

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -132,6 +132,99 @@ def test_listen_strips_embedded_quotes(
     assert '"' not in r.json()["text"]
 
 
+def test_listen_uses_x_persona_name_header_when_set(
+    personas_dir: Path,
+    settings: Settings,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    # `personas_dir` fixture seeds `stack-chan.md`; add a second
+    # persona the firmware can opt into via header.
+    (personas_dir / "desk-buddy.md").write_text(
+        "---\nname: desk-buddy\n---\nYou are a quiet desk companion.\n",
+        encoding="utf-8",
+    )
+    app = create_app(settings, fake_stt, fake_llm)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={
+                **auth_headers,
+                "Content-Type": _AUDIO_CT,
+                "X-Persona-Name": "desk-buddy",
+            },
+        )
+    assert r.status_code == 200
+    # The LLM saw the desk-buddy persona text, not the default
+    # stack-chan one — confirms the header took priority.
+    _, persona, _, _ = fake_llm.calls[0]
+    assert "quiet desk companion" in persona
+
+
+def test_listen_empty_x_persona_name_falls_back_to_default(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_llm: FakeLLM,
+) -> None:
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={
+            **auth_headers,
+            "Content-Type": _AUDIO_CT,
+            "X-Persona-Name": "",
+        },
+    )
+    assert r.status_code == 200
+    _, persona, _, _ = fake_llm.calls[0]
+    # Default `stack-chan.md` was loaded.
+    assert "helpful robot" in persona
+
+
+def test_listen_unknown_x_persona_name_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={
+            **auth_headers,
+            "Content-Type": _AUDIO_CT,
+            "X-Persona-Name": "no-such-persona",
+        },
+    )
+    # Distinct from the sidecar-default-misconfig case (500): the
+    # caller asked for a specific persona that doesn't exist here.
+    assert r.status_code == 404
+    body = r.json()
+    assert body["error"]["code"] == "persona_missing"
+
+
+def test_listen_invalid_x_persona_name_returns_400(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    for bad in ["../etc/passwd", "foo/bar", "foo\\bar"]:
+        r = client.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={
+                **auth_headers,
+                "Content-Type": _AUDIO_CT,
+                "X-Persona-Name": bad,
+            },
+        )
+        assert r.status_code == 400, f"expected 400 for {bad!r}, got {r.status_code}"
+        assert r.json()["error"]["code"] == "persona_name_invalid"
+
+
 def test_listen_persona_missing_returns_500(
     tmp_path: Path,
     fake_stt: FakeSTT,

--- a/sidecar/tests/test_personas.py
+++ b/sidecar/tests/test_personas.py
@@ -27,3 +27,36 @@ def test_load_persona_handles_unterminated_frontmatter(tmp_path: Path) -> None:
     p.write_text("---\nname: weird\nno closing\nstill no closing\n", encoding="utf-8")
     result = load_persona("weird", tmp_path)
     assert result.startswith("---")
+
+
+def test_load_persona_rejects_empty_name(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        load_persona("", tmp_path)
+
+
+def test_load_persona_rejects_path_traversal(tmp_path: Path) -> None:
+    # Real attack surface: an X-Persona-Name header value could
+    # otherwise resolve outside the personas dir and read arbitrary
+    # files on the sidecar host.
+    for bad in ["../etc", "..\\etc", "foo/bar", "foo\\bar", "..foo", "foo..bar"]:
+        with pytest.raises(ValueError):
+            load_persona(bad, tmp_path)
+
+
+def test_load_persona_rejects_control_chars(tmp_path: Path) -> None:
+    # Header values shouldn't reach load_persona with controls (the
+    # HTTP layer rejects them earlier), but defence in depth.
+    for bad in ["foo\r\nX-Inject: yes", "foo\tbar", "foo\x00bar"]:
+        with pytest.raises(ValueError):
+            load_persona(bad, tmp_path)
+
+
+def test_load_persona_rejects_oversize_name(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="exceeds"):
+        load_persona("a" * 65, tmp_path)
+
+
+def test_load_persona_accepts_max_length(tmp_path: Path) -> None:
+    name = "a" * 64
+    (tmp_path / f"{name}.md").write_text("Hi.", encoding="utf-8")
+    assert load_persona(name, tmp_path) == "Hi."


### PR DESCRIPTION
## Summary

First Arc A slice (after the Arc C wrap). Lets a firmware unit pick which sidecar persona to load on every POST without redeploying the sidecar — operator sets `behavior.persona_name` in `STACKCHAN.RON`, the firmware echoes it as `X-Persona-Name` on each `POST /v1/listen`, and the sidecar loads `personas/{name}.md` per-request instead of the baked-in default.

Builds on infrastructure that was already mostly there: the sidecar's `SessionStore`, `load_persona`, and `personas/` directory were already shipped — the missing piece was per-device dispatch.

### Wire surface

**`behavior.persona_name`** (new `String` field, default empty):
- ≤ 64 bytes, ASCII control-free, no `/` / `\` / `..` — `validate_persona_name` in `stackchan-net::config` rejects anything else so the slug can't inject HTTP headers via `\r\n` or pivot the sidecar's filesystem lookup. Mirrors `validate_agent_sidecar_token`'s shape.
- New `ConfigError::PersonaNameTooLong` / `PersonaNameInvalidChars` variants.
- Both `bare.rs` (RON, on-disk) and `bare_json.rs` (JSON, over the wire) round-trip the field; golden fixtures updated.
- Added to `requires_reboot` — `agent_sidecar_task` captures the field at spawn (same pattern as `agent_sidecar_url` / `agent_sidecar_token`).

**Firmware side**:
- `agent_sidecar_task` takes a `persona_name: String` arg; threaded into `post_pcm` which emits `X-Persona-Name: <name>\r\n` when non-empty, alongside the existing `X-Session-Id` line. Empty omits the header (no wire change for installs that don't multiplex personas).

**Sidecar side**:
- `personas.py::load_persona` validates the slug itself — defence in depth so the sidecar can't be exploited by an upstream proxy or a direct curl. Invalid slug → `ValueError`; the existing `FileNotFoundError` shape is preserved for missing files.
- `app.py` reads `X-Persona-Name`, falls back to `settings.persona` when empty, and surfaces three distinct outcomes:

  | Caller state | Sidecar state | Outcome |
  |---|---|---|
  | Header malformed | — | **400** `persona_name_invalid` |
  | Header present, file missing | — | **404** `persona_missing` |
  | Header empty, default missing | misconfigured | **500** `persona_missing` |

- New `ErrorCode::PERSONA_NAME_INVALID` + `FailureKind` entry.

### Tests

- **6 new** in `test_personas.py`: empty / path-traversal / control-chars / oversize rejection, max-length acceptance.
- **4 new** in `test_app.py`: header sets persona, empty header falls back, unknown → 404, invalid → 400.
- All 122 sidecar tests + 16 stackchan-net host tests + firmware clippy green.

### Docs

`docs/sidecar.md` now documents the new header + validation rules alongside `X-Session-Id`.

## Test plan

- [x] `uv run pytest` in `sidecar/` — 122 passed (was 118, +4 new app tests + 6 new persona tests minus 2 reorgs)
- [x] `cargo test -p stackchan-net --all-features` — green
- [x] `cargo +esp clippy -- -D warnings` on `stackchan-firmware` — green
- [x] `just check` passes via pre-commit hook
- [ ] On-device end-to-end: set `behavior.persona_name = "desk-buddy"` on SD, drop a `desk-buddy.md` into the sidecar's `personas/`, fire `POST /listen`, confirm the toast voice changed (blocked on SD card replacement)