### PR TITLE
feat(arc-a): partition SessionStore by (session_id, persona)

### DIFF
--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -178,6 +178,12 @@ def create_app(
         #                    is misconfigured; the client did nothing
         #                    wrong).
         requested_persona = request.headers.get("x-persona-name", "").strip()
+        # `persona_name` is the slug that goes into the SessionStore
+        # key so conversation history is partitioned per-persona.
+        # `persona` (set inside the branches) is the loaded markdown
+        # prompt the LLM sees. Track them both — the slug travels with
+        # the key; the prompt travels with the call.
+        persona_name = requested_persona or settings.persona
         if requested_persona:
             try:
                 persona = load_persona(requested_persona, settings.personas_dir)
@@ -275,7 +281,7 @@ def create_app(
             )
         stt_ms = int((time.perf_counter() - t_stt0) * 1000)
 
-        history = store.get_history(session_id)
+        history = store.get_history(session_id, persona_name)
         t_llm0 = time.perf_counter()
         try:
             reply = await retry_with_timeout(
@@ -326,6 +332,7 @@ def create_app(
 
         store.record(
             session_id,
+            persona_name,
             Turn(user=transcript, assistant=reply.full, emotion=emotion),
         )
 

--- a/sidecar/src/stackchan_sidecar/session_store.py
+++ b/sidecar/src/stackchan_sidecar/session_store.py
@@ -45,7 +45,13 @@ class SessionStore:
         self._entries: dict[tuple[str, str], SessionEntry] = {}
 
     def get_history(self, session_id: str, persona: str) -> list[Turn]:
-        if not session_id:
+        # Both halves of the key must be non-empty for the partition
+        # to be meaningful. Today's app.py callers can't produce an
+        # empty `persona` (load_persona rejects the empty slug before
+        # we get here), but a future internal caller bypassing app.py
+        # would silently merge everything into one bucket; the
+        # explicit guard makes that fail closed.
+        if not session_id or not persona:
             return []
         entry = self._entries.get((session_id, persona))
         if entry is None:
@@ -54,7 +60,7 @@ class SessionStore:
         return list(entry.turns)
 
     def record(self, session_id: str, persona: str, turn: Turn) -> None:
-        if not session_id:
+        if not session_id or not persona:
             return
         key = (session_id, persona)
         entry = self._entries.get(key)

--- a/sidecar/src/stackchan_sidecar/session_store.py
+++ b/sidecar/src/stackchan_sidecar/session_store.py
@@ -29,27 +29,38 @@ class SessionEntry:
 
 
 class SessionStore:
+    """In-memory turn history keyed by ``(session_id, persona)``.
+
+    Persona is part of the key so a device that switches personas
+    mid-deployment doesn't carry context from the old voice into the
+    new one. The same session_id + different persona is treated as
+    two independent conversations; a future tool that swaps persona
+    mid-session gets a clean slate for the new voice while leaving
+    the old voice's history intact for a possible revert.
+    """
+
     def __init__(self, *, max_turns: int = 8, ttl_seconds: float = 600.0) -> None:
         self._max_turns = max_turns
         self._ttl_seconds = ttl_seconds
-        self._entries: dict[str, SessionEntry] = {}
+        self._entries: dict[tuple[str, str], SessionEntry] = {}
 
-    def get_history(self, session_id: str) -> list[Turn]:
+    def get_history(self, session_id: str, persona: str) -> list[Turn]:
         if not session_id:
             return []
-        entry = self._entries.get(session_id)
+        entry = self._entries.get((session_id, persona))
         if entry is None:
             return []
         entry.last_seen = time.monotonic()
         return list(entry.turns)
 
-    def record(self, session_id: str, turn: Turn) -> None:
+    def record(self, session_id: str, persona: str, turn: Turn) -> None:
         if not session_id:
             return
-        entry = self._entries.get(session_id)
+        key = (session_id, persona)
+        entry = self._entries.get(key)
         if entry is None:
             entry = SessionEntry(last_seen=time.monotonic())
-            self._entries[session_id] = entry
+            self._entries[key] = entry
         entry.turns.append(turn)
         while len(entry.turns) > self._max_turns:
             entry.turns.pop(0)
@@ -57,9 +68,9 @@ class SessionStore:
 
     def sweep(self) -> int:
         now = time.monotonic()
-        expired = [sid for sid, e in self._entries.items() if now - e.last_seen > self._ttl_seconds]
-        for sid in expired:
-            del self._entries[sid]
+        expired = [key for key, e in self._entries.items() if now - e.last_seen > self._ttl_seconds]
+        for key in expired:
+            del self._entries[key]
         return len(expired)
 
 

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -323,6 +323,65 @@ def test_listen_no_session_history_for_empty_session_id(
     assert fake_llm.calls[1][3] == []
 
 
+def test_listen_history_does_not_leak_across_personas(
+    personas_dir: Path,
+    settings: Settings,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    # End-to-end through the wire: a device that switches personas
+    # under the same session_id must NOT see the prior persona's
+    # turns. Pins the per-persona partition all the way from the
+    # request handler through the SessionStore.
+    (personas_dir / "desk-buddy.md").write_text(
+        "---\nname: desk-buddy\n---\nYou are a quiet desk companion.\n",
+        encoding="utf-8",
+    )
+    sid = "44444444-4444-4444-8444-444444444444"
+    app = create_app(settings, fake_stt, fake_llm)
+    with TestClient(app) as c:
+        # Two turns under stack-chan to build up history.
+        c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={
+                **auth_headers,
+                "Content-Type": _AUDIO_CT,
+                "X-Session-Id": sid,
+                "X-Persona-Name": "stack-chan",
+            },
+        )
+        c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={
+                **auth_headers,
+                "Content-Type": _AUDIO_CT,
+                "X-Session-Id": sid,
+                "X-Persona-Name": "stack-chan",
+            },
+        )
+        # Switch to desk-buddy on the SAME session.
+        c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={
+                **auth_headers,
+                "Content-Type": _AUDIO_CT,
+                "X-Session-Id": sid,
+                "X-Persona-Name": "desk-buddy",
+            },
+        )
+
+    # First two LLM calls were stack-chan, third was desk-buddy.
+    histories = [call[3] for call in fake_llm.calls]
+    assert len(histories[0]) == 0, "first call: no prior history"
+    assert len(histories[1]) == 1, "second call: one stack-chan turn"
+    assert len(histories[2]) == 0, "persona switch: no inherited history"
+
+
 def test_listen_logs_session_id(
     client: TestClient,
     auth_headers: dict[str, str],

--- a/sidecar/tests/test_session_store.py
+++ b/sidecar/tests/test_session_store.py
@@ -103,6 +103,17 @@ def test_empty_session_id_is_noop() -> None:
     assert store.get_history("", _P) == []
 
 
+def test_empty_persona_is_noop() -> None:
+    # Defence in depth: if an internal caller bypasses app.py's
+    # load_persona validation and passes empty persona, the store
+    # must not collapse it into a partition that mixes voices.
+    store = SessionStore()
+    store.record("sid", "", _turn())
+    assert store.get_history("sid", "") == []
+    # And the empty-persona record didn't pollute any real bucket.
+    assert store.get_history("sid", "stack-chan") == []
+
+
 def test_history_partitioned_per_persona() -> None:
     # Same session_id, two personas: the second voice doesn't inherit
     # the first voice's turns. This is the core invariant of the

--- a/sidecar/tests/test_session_store.py
+++ b/sidecar/tests/test_session_store.py
@@ -10,16 +10,22 @@ def _turn(user: str = "hi", assistant: str = "hello") -> Turn:
     return Turn(user=user, assistant=assistant, emotion=Emotion.HAPPY)
 
 
+# Default persona slug used when the test isn't exercising the
+# per-persona partition. Pulled out as a constant so a future rename
+# (e.g. "default" → "") only changes one line.
+_P = "stack-chan"
+
+
 def test_get_history_empty_when_unknown() -> None:
     store = SessionStore()
-    assert store.get_history("sid-a") == []
+    assert store.get_history("sid-a", _P) == []
 
 
 def test_record_then_get_history() -> None:
     store = SessionStore()
-    store.record("sid-a", _turn("u1", "a1"))
-    store.record("sid-a", _turn("u2", "a2"))
-    history = store.get_history("sid-a")
+    store.record("sid-a", _P, _turn("u1", "a1"))
+    store.record("sid-a", _P, _turn("u2", "a2"))
+    history = store.get_history("sid-a", _P)
     assert len(history) == 2
     assert history[0].user == "u1"
     assert history[1].user == "u2"
@@ -27,27 +33,27 @@ def test_record_then_get_history() -> None:
 
 def test_get_history_is_isolated_per_session() -> None:
     store = SessionStore()
-    store.record("sid-a", _turn("a-only", "a-resp"))
-    store.record("sid-b", _turn("b-only", "b-resp"))
-    history_a = store.get_history("sid-a")
-    history_b = store.get_history("sid-b")
+    store.record("sid-a", _P, _turn("a-only", "a-resp"))
+    store.record("sid-b", _P, _turn("b-only", "b-resp"))
+    history_a = store.get_history("sid-a", _P)
+    history_b = store.get_history("sid-b", _P)
     assert len(history_a) == 1 and history_a[0].user == "a-only"
     assert len(history_b) == 1 and history_b[0].user == "b-only"
 
 
 def test_get_history_returns_copy() -> None:
     store = SessionStore()
-    store.record("sid", _turn("u1", "a1"))
-    history = store.get_history("sid")
+    store.record("sid", _P, _turn("u1", "a1"))
+    history = store.get_history("sid", _P)
     history.append(_turn("forged", "forged"))
-    assert len(store.get_history("sid")) == 1
+    assert len(store.get_history("sid", _P)) == 1
 
 
 def test_max_turns_eviction() -> None:
     store = SessionStore(max_turns=3)
     for i in range(5):
-        store.record("sid", _turn(f"u{i}", f"a{i}"))
-    history = store.get_history("sid")
+        store.record("sid", _P, _turn(f"u{i}", f"a{i}"))
+    history = store.get_history("sid", _P)
     assert len(history) == 3
     assert history[0].user == "u2"
     assert history[-1].user == "u4"
@@ -61,20 +67,20 @@ def test_sweep_evicts_expired(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(time, "monotonic", fake_monotonic)
     store = SessionStore(ttl_seconds=60.0)
-    store.record("sid-old", _turn())
+    store.record("sid-old", _P, _turn())
     now[0] += 120.0
-    store.record("sid-new", _turn())
+    store.record("sid-new", _P, _turn())
     removed = store.sweep()
     assert removed == 1
-    assert store.get_history("sid-old") == []
-    assert len(store.get_history("sid-new")) == 1
+    assert store.get_history("sid-old", _P) == []
+    assert len(store.get_history("sid-new", _P)) == 1
 
 
 def test_sweep_returns_zero_when_nothing_expired(monkeypatch: pytest.MonkeyPatch) -> None:
     now = [1000.0]
     monkeypatch.setattr(time, "monotonic", lambda: now[0])
     store = SessionStore(ttl_seconds=60.0)
-    store.record("sid", _turn())
+    store.record("sid", _P, _turn())
     now[0] += 30.0
     assert store.sweep() == 0
 
@@ -83,15 +89,60 @@ def test_get_history_touches_last_seen(monkeypatch: pytest.MonkeyPatch) -> None:
     now = [1000.0]
     monkeypatch.setattr(time, "monotonic", lambda: now[0])
     store = SessionStore(ttl_seconds=60.0)
-    store.record("sid", _turn())
+    store.record("sid", _P, _turn())
     now[0] += 50.0
-    store.get_history("sid")
+    store.get_history("sid", _P)
     now[0] += 30.0
     assert store.sweep() == 0
-    assert len(store.get_history("sid")) == 1
+    assert len(store.get_history("sid", _P)) == 1
 
 
 def test_empty_session_id_is_noop() -> None:
     store = SessionStore()
-    store.record("", _turn())
-    assert store.get_history("") == []
+    store.record("", _P, _turn())
+    assert store.get_history("", _P) == []
+
+
+def test_history_partitioned_per_persona() -> None:
+    # Same session_id, two personas: the second voice doesn't inherit
+    # the first voice's turns. This is the core invariant of the
+    # per-persona partition.
+    store = SessionStore()
+    store.record("sid", "stack-chan", _turn("hi stack", "hello"))
+    store.record("sid", "desk-buddy", _turn("hi buddy", "yo"))
+    stack_history = store.get_history("sid", "stack-chan")
+    buddy_history = store.get_history("sid", "desk-buddy")
+    assert len(stack_history) == 1 and stack_history[0].user == "hi stack"
+    assert len(buddy_history) == 1 and buddy_history[0].user == "hi buddy"
+
+
+def test_persona_partition_survives_round_trip() -> None:
+    # Switching personas mid-deployment and back returns the original
+    # history — neither bucket overwrites the other.
+    store = SessionStore()
+    store.record("sid", "a", _turn("a1", "ra1"))
+    store.record("sid", "a", _turn("a2", "ra2"))
+    store.record("sid", "b", _turn("b1", "rb1"))
+    store.record("sid", "a", _turn("a3", "ra3"))
+    a_history = store.get_history("sid", "a")
+    b_history = store.get_history("sid", "b")
+    assert [t.user for t in a_history] == ["a1", "a2", "a3"]
+    assert [t.user for t in b_history] == ["b1"]
+
+
+def test_sweep_evicts_per_persona_bucket_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An idle persona on a still-active session times out on its own
+    # clock — the partition's TTL is per-(session, persona), not
+    # per-session. Without this, a chatty persona-A would keep
+    # persona-B's stale history alive forever on the same device.
+    now = [1000.0]
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+    store = SessionStore(ttl_seconds=60.0)
+    store.record("sid", "a", _turn("a-old", "ra"))
+    now[0] += 120.0
+    store.record("sid", "b", _turn("b-fresh", "rb"))
+    assert store.sweep() == 1
+    assert store.get_history("sid", "a") == []
+    assert len(store.get_history("sid", "b")) == 1


### PR DESCRIPTION
## Summary

Stacks on the X-Persona-Name dispatch from #529. Today conversation history is keyed by `session_id` alone, so a device that switches personas under the same session_id (firmware config change + reboot, or a future mid-runtime swap) sees the new voice inherit the old voice's turns. This makes per-persona partitioning the default.

| Concern | Before | After |
|---|---|---|
| `SessionStore._entries` key | `str` | `tuple[str, str]` = `(session_id, persona)` |
| `get_history` / `record` signature | `(session_id, ...)` | `(session_id, persona, ...)` |
| `sweep()` TTL granularity | per-session | per-(session, persona) |
| Same session_id + persona swap → history seen by new voice | **Inherited** | **Empty** |

Both `app.py` call sites pass the slug that drove the persona load — `X-Persona-Name` header value when set, `settings.persona` when the header was empty. Single-persona installs (header omitted, default unchanged) still get one partition keyed by `(session_id, settings.persona)`, so existing behaviour is identical.

## Tests

- 9 existing `test_session_store.py` tests updated to thread the persona arg (mechanical; no behaviour change).
- **3 new** session_store tests: same session + different persona → independent histories, round-trip switching preserves both buckets, per-persona TTL.
- **1 new** app-level wire test (`test_listen_history_does_not_leak_across_personas`) — pins the partition end-to-end through the request handler.

127 sidecar tests pass (was 126, +1 net).

## Test plan

- [x] `uv run pytest` in `sidecar/` — 127 passed
- [x] `mypy` clean (no type changes that affect external callers)
- [ ] On-device end-to-end: set `behavior.persona_name = "A"`, do a turn, change to `"B"`, confirm B doesn't see A's history (blocked on SD card replacement)