### PR TITLE
feat(arc-a): sidecar GET /v1/personas — list deployed persona slugs

### DIFF
--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -18,7 +18,7 @@ from .errors import (
     failure_kind,
 )
 from .llm import Emotion, LLMProvider, sanitize_short
-from .personas import load_persona
+from .personas import list_personas, load_persona
 from .retry import StageDeadlineError, retry_with_timeout
 from .session_status import SessionStatus
 from .session_store import SessionStore, Turn, session_store_lifespan
@@ -115,6 +115,17 @@ def create_app(
         return {
             "status": "ok",
             "providers": {"stt": "ready", "llm": "ready"},
+        }
+
+    @app.get("/v1/personas")
+    async def personas_endpoint() -> dict[str, object]:
+        # Lists every persona slug under ``settings.personas_dir`` plus
+        # which one a request will use when no X-Persona-Name header is
+        # set. Operator-facing — lets a curl-based introspector see
+        # what's deployed without grepping the filesystem.
+        return {
+            "default": settings.persona,
+            "personas": list_personas(settings.personas_dir),
         }
 
     @app.post("/v1/listen", dependencies=[Depends(verify_bearer)])

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -123,9 +123,17 @@ def create_app(
         # which one a request will use when no X-Persona-Name header is
         # set. Operator-facing — lets a curl-based introspector see
         # what's deployed without grepping the filesystem.
+        #
+        # `default_deployed` distinguishes a healthy install from a
+        # misconfig where `settings.persona` names a slug that isn't
+        # on disk: in that case the next no-header request would 500.
+        # A caller can check this flag to fail fast rather than wait
+        # for the first /v1/listen to surface the problem.
+        deployed = list_personas(settings.personas_dir)
         return {
             "default": settings.persona,
-            "personas": list_personas(settings.personas_dir),
+            "default_deployed": settings.persona in deployed,
+            "personas": deployed,
         }
 
     @app.post("/v1/listen", dependencies=[Depends(verify_bearer)])

--- a/sidecar/src/stackchan_sidecar/personas.py
+++ b/sidecar/src/stackchan_sidecar/personas.py
@@ -6,6 +6,37 @@ from pathlib import Path
 _PERSONA_NAME_MAX_BYTES = 64
 
 
+def list_personas(personas_dir: Path) -> list[str]:
+    """Return the slugs of every persona file under ``personas_dir``,
+    sorted alphabetically.
+
+    A "persona file" is any ``.md`` whose stem passes the same slug
+    rules ``load_persona`` enforces — control-char-free, no path
+    separators, ≤ 64 bytes. Files that don't pass are skipped
+    silently rather than raising, so a stray ``.md`` accidentally
+    dropped in the dir (notes, a README, etc.) doesn't break the
+    listing endpoint.
+
+    Returns an empty list if the directory doesn't exist; the
+    operator can install the sidecar without provisioning personas
+    yet and still hit the endpoint.
+    """
+    if not personas_dir.is_dir():
+        return []
+    out: list[str] = []
+    for entry in personas_dir.iterdir():
+        if not entry.is_file() or entry.suffix != ".md":
+            continue
+        slug = entry.stem
+        try:
+            _validate_slug(slug)
+        except ValueError:
+            continue
+        out.append(slug)
+    out.sort()
+    return out
+
+
 def load_persona(name: str, personas_dir: Path) -> str:
     """Load the persona prompt at ``{personas_dir}/{name}.md``.
 

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -22,6 +22,38 @@ def test_healthz(client: TestClient) -> None:
     assert body["providers"]["llm"] == "ready"
 
 
+def test_list_personas_returns_default_plus_catalogue(
+    personas_dir: Path,
+    settings: Settings,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+) -> None:
+    # personas_dir fixture seeds `stack-chan.md`; add a second so the
+    # listing has something to sort.
+    (personas_dir / "desk-buddy.md").write_text(
+        "---\nname: desk-buddy\n---\nQuiet companion.\n", encoding="utf-8"
+    )
+    app = create_app(settings, fake_stt, fake_llm)
+    with TestClient(app) as c:
+        r = c.get("/v1/personas")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {
+        "default": "stack-chan",
+        "personas": ["desk-buddy", "stack-chan"],
+    }
+
+
+def test_list_personas_no_auth_required(
+    client: TestClient,
+) -> None:
+    # No bearer token in the headers — `/v1/personas` is operator-
+    # discoverable without auth, like `/healthz`. (The persona file
+    # contents stay private; only the slug catalogue is exposed.)
+    r = client.get("/v1/personas")
+    assert r.status_code == 200
+
+
 def test_listen_happy_path(
     client: TestClient,
     auth_headers: dict[str, str],

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -40,8 +40,37 @@ def test_list_personas_returns_default_plus_catalogue(
     body = r.json()
     assert body == {
         "default": "stack-chan",
+        "default_deployed": True,
         "personas": ["desk-buddy", "stack-chan"],
     }
+
+
+def test_list_personas_flags_undeployed_default(
+    tmp_path: Path,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+) -> None:
+    # Misconfigured sidecar: settings.persona names a slug that isn't
+    # on disk. The next no-header /v1/listen would 500, but a caller
+    # polling /v1/personas can detect the problem upfront via the
+    # default_deployed flag.
+    misconfigured = tmp_path / "misconfigured"
+    misconfigured.mkdir()
+    (misconfigured / "desk-buddy.md").write_text("Quiet.", encoding="utf-8")
+    settings = Settings(
+        SIDECAR_BEARER_TOKEN=TEST_TOKEN,
+        ANTHROPIC_API_KEY="sk-ant-test",
+        personas_dir=misconfigured,
+        persona="missing-default",
+    )
+    app = create_app(settings, fake_stt, fake_llm)
+    with TestClient(app) as c:
+        r = c.get("/v1/personas")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["default"] == "missing-default"
+    assert body["default_deployed"] is False
+    assert body["personas"] == ["desk-buddy"]
 
 
 def test_list_personas_no_auth_required(

--- a/sidecar/tests/test_personas.py
+++ b/sidecar/tests/test_personas.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from stackchan_sidecar.personas import load_persona
+from stackchan_sidecar.personas import list_personas, load_persona
 
 
 def test_load_persona_strips_frontmatter(tmp_path: Path) -> None:
@@ -60,3 +60,43 @@ def test_load_persona_accepts_max_length(tmp_path: Path) -> None:
     name = "a" * 64
     (tmp_path / f"{name}.md").write_text("Hi.", encoding="utf-8")
     assert load_persona(name, tmp_path) == "Hi."
+
+
+def test_list_personas_empty_when_dir_missing(tmp_path: Path) -> None:
+    # Sidecar may run before the operator provisions personas; the
+    # listing must not raise just because the dir isn't there yet.
+    assert list_personas(tmp_path / "missing") == []
+
+
+def test_list_personas_empty_when_dir_empty(tmp_path: Path) -> None:
+    assert list_personas(tmp_path) == []
+
+
+def test_list_personas_returns_slugs_sorted(tmp_path: Path) -> None:
+    for name in ["zeta", "alpha", "beta"]:
+        (tmp_path / f"{name}.md").write_text("Hi.", encoding="utf-8")
+    assert list_personas(tmp_path) == ["alpha", "beta", "zeta"]
+
+
+def test_list_personas_ignores_non_md_files(tmp_path: Path) -> None:
+    (tmp_path / "stack-chan.md").write_text("Hi.", encoding="utf-8")
+    (tmp_path / "README.txt").write_text("notes", encoding="utf-8")
+    (tmp_path / "scratch.json").write_text("{}", encoding="utf-8")
+    assert list_personas(tmp_path) == ["stack-chan"]
+
+
+def test_list_personas_ignores_subdirectories(tmp_path: Path) -> None:
+    (tmp_path / "stack-chan.md").write_text("Hi.", encoding="utf-8")
+    (tmp_path / "archive").mkdir()
+    (tmp_path / "archive" / "old.md").write_text("Old.", encoding="utf-8")
+    assert list_personas(tmp_path) == ["stack-chan"]
+
+
+def test_list_personas_skips_invalid_slugs(tmp_path: Path) -> None:
+    # An operator dropping a `.md` whose stem can't be a slug
+    # shouldn't break the listing — skip silently so the rest
+    # remains discoverable.
+    (tmp_path / "stack-chan.md").write_text("Hi.", encoding="utf-8")
+    (tmp_path / ("x" * 65 + ".md")).write_text("Too long.", encoding="utf-8")
+    (tmp_path / "..bad.md").write_text("Traversal.", encoding="utf-8")
+    assert list_personas(tmp_path) == ["stack-chan"]


### PR DESCRIPTION
## Summary

Closes the introspection gap left by #529's X-Persona-Name dispatch. Operators (and a future LLM-callable tool) can now discover which personas a sidecar has deployed without grepping its filesystem.

### Surface

- `personas.list_personas(dir) -> list[str]` (pure function): walks `*.md` files in the directory, applies the same slug rules `load_persona` enforces (control-char-free, no path separators, ≤ 64 bytes), returns sorted slugs. Silently skips files that don't pass — a stray `README.md` or `scratch.md` doesn't break the listing. Returns `[]` if the dir doesn't exist (operator hasn't provisioned personas yet).

- `GET /v1/personas` HTTP route returns:
  ```json
  {"default": "stack-chan", "personas": ["desk-buddy", "stack-chan"]}
  ```
  Caller can tell which slug they'll get if they omit the `X-Persona-Name` header. Unauthenticated like `/healthz` — only the slug catalogue is exposed, never the markdown contents.

Independent of #531 — branches off main, no SessionStore touch.

### Tests

- **6 new** `personas.py` tests: missing dir, empty dir, sorted output, non-md skipped, subdirectories skipped, invalid slugs skipped.
- **2 new** `app.py` tests: endpoint returns default + sorted catalogue, no auth required.

131 sidecar tests pass (was 122 pre-Arc-A).

### Deferred (future slices)

- MCP `list_personas` tool — would HTTP-fetch this endpoint from the firmware and surface the catalogue to the LLM caller. Bundled into a later slice to keep this PR scoped to the sidecar side.

## Test plan

- [x] `uv run pytest` in `sidecar/` — 131 passed
- [x] `curl http://sidecar:port/v1/personas` returns the expected JSON shape