### PR TITLE
docs(voice): add Multi-persona section to the reference-sidecar overview

### DIFF
--- a/docs/voice.md
+++ b/docs/voice.md
@@ -83,6 +83,37 @@ stackchan-sidecar` inside `sidecar/` and point the firmware at it.
 The persona prompt is a single editable markdown file at
 `sidecar/personas/stack-chan.md`. Copy it for a different voice.
 
+### Multiple personas on one sidecar
+
+One sidecar can serve several personas — the firmware picks which
+one to use per request via the `X-Persona-Name` header.
+
+1. Drop more persona files into `sidecar/personas/`, one `.md` per
+   voice (`desk-buddy.md`, `wake-only.md`, etc.). Each follows the
+   same frontmatter shape as the bundled `stack-chan.md`.
+2. Set `behavior.persona_name = "desk-buddy"` in the device's
+   `/sd/STACKCHAN.RON` (or via `PUT /settings`). Empty / unset keeps
+   the firmware's wire surface header-free, and the sidecar falls
+   back to its baked-in `settings.persona`.
+3. Confirm with `curl http://sidecar:port/v1/personas` — the
+   response lists every deployed slug plus the configured default
+   and a `default_deployed` flag that tells you upfront whether
+   the install is healthy.
+
+Validation runs at both boundaries: the firmware rejects slugs
+longer than 64 bytes, with control characters, or containing path
+separators / `..`; the sidecar re-checks per request so a curl
+caller bypassing the firmware can't pivot the filesystem lookup.
+Invalid slug → `400`; well-formed but missing file → `404`;
+sidecar's default missing → `500` (operator misconfig, not your
+caller's fault).
+
+Conversation memory is partitioned per `(session_id, persona)`.
+A device that switches personas under the same session_id (a
+firmware reflash, or a future mid-runtime swap) gets a clean
+slate for the new voice — the old voice's history stays
+addressable under its own bucket until TTL expires.
+
 ## Enable the wake word (optional)
 
 Wake-word detection is local-only — microWakeWord v2 streaming

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -91,10 +91,12 @@ one to use per request via the `X-Persona-Name` header.
 1. Drop more persona files into `sidecar/personas/`, one `.md` per
    voice (`desk-buddy.md`, `wake-only.md`, etc.). Each follows the
    same frontmatter shape as the bundled `stack-chan.md`.
-2. Set `behavior.persona_name = "desk-buddy"` in the device's
-   `/sd/STACKCHAN.RON` (or via `PUT /settings`). Empty / unset keeps
-   the firmware's wire surface header-free, and the sidecar falls
-   back to its baked-in `settings.persona`.
+2. Set `persona_name: "desk-buddy"` in the `behavior:` block of the
+   device's `/sd/STACKCHAN.RON` (RON uses `:` between key and value,
+   not `=`). Equivalent JSON for `PUT /settings`:
+   `"persona_name": "desk-buddy"`. Empty / unset keeps the firmware's
+   wire surface header-free, and the sidecar falls back to its
+   baked-in `settings.persona`.
 3. Confirm with `curl http://sidecar:port/v1/personas` — the
    response lists every deployed slug plus the configured default
    and a `default_deployed` flag that tells you upfront whether

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -105,6 +105,41 @@ lines at the start of the file) — the sidecar strips it before sending the
 prompt to the model, so you can keep metadata next to the prompt without
 polluting it.
 
+### Per-request persona dispatch
+
+Multiple personas on one sidecar: the firmware (or any client) can pick which
+one to load per request via the `X-Persona-Name` header. Omitting the header
+falls back to `config.toml`'s `persona`, so single-persona installs work
+without changes.
+
+Failure modes the caller sees on `POST /v1/listen`:
+
+| Caller state | Response |
+|---|---|
+| `X-Persona-Name` is well-formed and the slug is deployed | success |
+| `X-Persona-Name` is well-formed but the slug isn't deployed | `404 persona_missing` |
+| `X-Persona-Name` is malformed (path traversal, controls, > 64 bytes) | `400 persona_name_invalid` |
+| no `X-Persona-Name` and `config.toml`'s `persona` isn't deployed | `500 persona_missing` |
+
+Discover what's available without grepping the filesystem:
+
+```bash
+curl -s http://localhost:8080/v1/personas | jq
+{
+  "default": "stack-chan",
+  "default_deployed": true,
+  "personas": ["desk-buddy", "stack-chan"]
+}
+```
+
+`default_deployed: false` flags a misconfigured install upfront — the next
+no-header request would otherwise 500 on first audio POST.
+
+Conversation memory is partitioned per `(session_id, persona)`. A device
+switching personas under the same session_id gets a clean slate for the
+new voice; the old voice's turns stay addressable under their own bucket
+until the TTL sweep.
+
 ## Provider selection
 
 Pick STT and LLM backends via `config.toml` (or env vars). Each provider has


### PR DESCRIPTION
## Summary

Folds the recently-landed Arc A surface into the public voice-agent guide so a new operator can find the multi-persona workflow alongside the single-persona "edit stack-chan.md" path that was already documented.

Covers four practical questions an operator hits when standing up a multi-persona install:

- **How to deploy a second persona** — drop another `.md` into `sidecar/personas/`.
- **How to point a device at it** — `behavior.persona_name = "desk-buddy"` in `/sd/STACKCHAN.RON` (or via `PUT /settings`); empty falls back to the sidecar's default.
- **How to introspect what's deployed** — `curl /v1/personas` (from #532).
- **What the validation rules and error codes mean** — dual gate at firmware + sidecar, plus the 400 / 404 / 500 distinctions a caller sees.
- **What the session-memory partition implies** — a persona swap won't leak history between voices (from #531).

No code touched.

## Test plan

- [x] Doc-only change — Markdown renders cleanly