### PR TITLE
feat(arc-a): sidecar TTS slice 1 — eSpeak-NG default + audio cache + /v1/audio route

### DIFF
--- a/sidecar/src/stackchan_sidecar/__main__.py
+++ b/sidecar/src/stackchan_sidecar/__main__.py
@@ -6,6 +6,7 @@ from .llm import LLMProvider
 from .logging import setup_logging
 from .session_store import SessionStore
 from .stt import STTProvider
+from .tts import TTSProvider
 
 
 def _build_stt(settings: Settings) -> STTProvider:
@@ -36,14 +37,36 @@ def _build_llm(settings: Settings) -> LLMProvider:
     return AnthropicLLM(api_key=settings.anthropic_api_key, model=settings.llm_model)
 
 
+def _build_tts(settings: Settings) -> TTSProvider:
+    # `piper` and `elevenlabs` providers land in follow-up slices —
+    # they're declared in the config Literal up front so a future
+    # operator's STACKCHAN.RON / .env files don't need updating when
+    # the providers ship. For now the espeak_ng provider is the only
+    # implementation; the others fall through to it with a startup log
+    # so the operator sees the substitution.
+    if settings.tts_provider != "espeak_ng":
+        import logging
+
+        logging.getLogger("stackchan_sidecar").warning(
+            "tts_provider=%s requested but not implemented yet; "
+            "falling back to espeak_ng. Track Arc A slice 2/3 for "
+            "Piper and ElevenLabs providers.",
+            settings.tts_provider,
+        )
+    from .tts import EspeakProvider
+
+    return EspeakProvider(voice=settings.espeak_voice, wpm=settings.espeak_wpm)
+
+
 def main() -> None:
     settings = load_settings()
     setup_logging(settings.log_level)
 
     stt = _build_stt(settings)
     llm = _build_llm(settings)
+    tts = _build_tts(settings)
     session_store = SessionStore()
-    app = create_app(settings, stt, llm, session_store)
+    app = create_app(settings, stt, llm, session_store, tts=tts)
 
     uvicorn.run(app, host=settings.host, port=settings.port, log_config=None)
 

--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -6,8 +6,9 @@ from contextlib import asynccontextmanager
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
+from .audio_cache import AudioCache
 from .auth import make_verifier
 from .companion import register_companion
 from .config import Settings
@@ -23,6 +24,7 @@ from .retry import StageDeadlineError, retry_with_timeout
 from .session_status import SessionStatus
 from .session_store import SessionStore, Turn, session_store_lifespan
 from .stt import STTProvider
+from .tts import TTSError, TTSProvider
 
 _LOG = logging.getLogger("stackchan_sidecar")
 _MAX_BODY_BYTES = 30 * 16000 * 2 + 1024
@@ -96,8 +98,22 @@ def create_app(
     stt: STTProvider,
     llm: LLMProvider,
     session_store: SessionStore | None = None,
+    tts: TTSProvider | None = None,
+    audio_cache: AudioCache | None = None,
 ) -> FastAPI:
     store = session_store if session_store is not None else SessionStore()
+    # `tts is None` → no synthesis; the listen path returns
+    # `audio_url: null` and the firmware silently skips the audio
+    # fetch. Lets a deployment that just wants STT + LLM (existing
+    # behaviour) skip pulling the TTS subpackage at all.
+    cache = (
+        audio_cache
+        if audio_cache is not None
+        else AudioCache(
+            ttl_seconds=settings.tts_audio_ttl_seconds,
+            capacity=settings.tts_audio_cache_capacity,
+        )
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -116,6 +132,34 @@ def create_app(
             "status": "ok",
             "providers": {"stt": "ready", "llm": "ready"},
         }
+
+    @app.get("/v1/audio/{token}")
+    async def audio_endpoint(token: str) -> Response:
+        # Streams the cached PCM the firmware fetches after a /v1/listen
+        # reply. Tokens are opaque per-request handles minted in the
+        # listen path; the cache holds entries for `tts_audio_ttl_seconds`
+        # (default 60 s). A miss could mean unknown token (operator
+        # error) or expired entry (firmware took too long to fetch);
+        # both surface as 404 since the firmware's recovery is identical
+        # in either case.
+        entry = await cache.get(token)
+        if entry is None:
+            return Response(
+                content="audio token unknown or expired\n",
+                status_code=404,
+                media_type="text/plain",
+            )
+        # PCM is binary; Content-Type matches what the firmware sends
+        # *to* the sidecar so the two halves of the audio link
+        # symmetrically advertise their format.
+        return Response(
+            content=entry.pcm,
+            media_type="audio/L16;rate=16000;channels=1",
+            headers={
+                "X-Audio-Provider": entry.provider,
+                "X-Audio-Voice": entry.voice,
+            },
+        )
 
     @app.get("/v1/personas")
     async def personas_endpoint() -> dict[str, object]:
@@ -355,6 +399,59 @@ def create_app(
             Turn(user=transcript, assistant=reply.full, emotion=emotion),
         )
 
+        # Synthesise the *short* reply (toast-band-sized) rather than
+        # the longer `reply.full`. The firmware plays what the avatar
+        # would "say" — `full` is more like an internal monologue
+        # carried for session memory only.
+        #
+        # On any TTS failure we degrade gracefully: text + emotion
+        # still ship, `audio_url` is null, the firmware skips the
+        # audio fetch and the toast band shows the reply as it does
+        # today. The TTSError is logged with stage so an operator
+        # can diagnose without taking down the reply path.
+        audio_url: str | None = None
+        if tts is not None:
+            t_tts0 = time.perf_counter()
+            try:
+                result = await tts.synthesize(short)
+                token = await cache.put(
+                    result.pcm,
+                    provider=result.provider,
+                    voice=result.voice,
+                )
+                audio_url = f"/v1/audio/{token}"
+                tts_ms = int((time.perf_counter() - t_tts0) * 1000)
+                _LOG.info(
+                    "listen.tts.ok",
+                    extra={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "tts_provider": result.provider,
+                        "tts_voice": result.voice,
+                        "tts_ms": tts_ms,
+                        "audio_duration_s": result.duration_seconds,
+                    },
+                )
+            except TTSError as exc:
+                _LOG.warning(
+                    "listen.tts.fail",
+                    extra={
+                        "request_id": request_id,
+                        "session_id": session_id,
+                        "tts_stage": exc.stage,
+                        "tts_detail": exc.detail,
+                    },
+                )
+            except Exception:
+                # Catch-all for unexpected provider blowups (httpx
+                # client errors, dependency import failures, etc.).
+                # Logged with stack but still degrades to no-audio
+                # so a buggy provider doesn't take down /v1/listen.
+                _LOG.exception(
+                    "listen.tts.unexpected",
+                    extra={"request_id": request_id, "session_id": session_id},
+                )
+
         session_status.mark_done(
             request_id=request_id,
             session_id=session_id,
@@ -374,10 +471,11 @@ def create_app(
                 "emotion": emotion.value,
                 "text_len": len(short),
                 "text_short": short,
+                "audio_url": audio_url,
                 "status": 200,
             },
         )
 
-        return JSONResponse({"text": short, "emotion": emotion.value})
+        return JSONResponse({"text": short, "emotion": emotion.value, "audio_url": audio_url})
 
     return app

--- a/sidecar/src/stackchan_sidecar/audio_cache.py
+++ b/sidecar/src/stackchan_sidecar/audio_cache.py
@@ -1,0 +1,100 @@
+"""TTL-bounded in-memory cache for synthesised PCM bytes.
+
+The sidecar's listen pipeline returns ``audio_url: "/v1/audio/<token>"``
+referring to one entry of this cache; the firmware fetches the bytes
+within seconds and the entry expires soon after. The cache is
+single-use semantically (firmware doesn't replay), but we keep entries
+for ``ttl_seconds`` so a redelivery / retry path works without
+forcing the sidecar to re-synthesise.
+
+Capacity is bounded so a misbehaving firmware (or a load test) can't
+grow the cache without limit; the oldest entry evicts when capacity
+is reached.
+
+Concurrency: the cache is touched from the listen handler (writer) and
+the audio handler (reader). An ``asyncio.Lock`` serialises mutations;
+reads under the lock are fast (dict lookup).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+_LOG = logging.getLogger("stackchan_sidecar.audio_cache")
+
+# Default token length: 16 bytes of randomness as hex (32 hex chars).
+# Long enough to be unguessable; short enough not to bloat URLs.
+_TOKEN_BYTES = 16
+
+
+@dataclass(frozen=True)
+class AudioEntry:
+    pcm: bytes
+    provider: str
+    voice: str
+    stored_at: float
+
+
+class AudioCache:
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = 60.0,
+        capacity: int = 32,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be positive; got {ttl_seconds}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be positive; got {capacity}")
+        self._ttl_seconds = ttl_seconds
+        self._capacity = capacity
+        self._entries: OrderedDict[str, AudioEntry] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def put(self, pcm: bytes, *, provider: str, voice: str) -> str:
+        """Store ``pcm`` and return an opaque token. Evicts the oldest
+        entry when capacity is reached and the expired entries on every
+        write (lazy sweep — keeps the API simple and the contention
+        window small)."""
+        token = secrets.token_hex(_TOKEN_BYTES)
+        entry = AudioEntry(
+            pcm=pcm,
+            provider=provider,
+            voice=voice,
+            stored_at=time.monotonic(),
+        )
+        async with self._lock:
+            self._evict_expired_locked()
+            self._entries[token] = entry
+            while len(self._entries) > self._capacity:
+                evicted_token, _ = self._entries.popitem(last=False)
+                _LOG.info("audio_cache.evict_capacity token=%s", evicted_token)
+        return token
+
+    async def get(self, token: str) -> AudioEntry | None:
+        """Return the entry for ``token`` or ``None`` if it's missing
+        or expired. Caller-friendly: a TTL miss is indistinguishable
+        from a never-stored token, both surface as 404 at the route."""
+        async with self._lock:
+            self._evict_expired_locked()
+            return self._entries.get(token)
+
+    def _evict_expired_locked(self) -> None:
+        now = time.monotonic()
+        expired = [
+            tok for tok, entry in self._entries.items() if now - entry.stored_at > self._ttl_seconds
+        ]
+        for tok in expired:
+            del self._entries[tok]
+            _LOG.debug("audio_cache.evict_ttl token=%s", tok)
+
+    # Test surface — lets tests assert capacity / TTL behaviour without
+    # touching the wire path. Not part of the public API.
+
+    def _len_for_test(self) -> int:
+        return len(self._entries)

--- a/sidecar/src/stackchan_sidecar/config.py
+++ b/sidecar/src/stackchan_sidecar/config.py
@@ -22,6 +22,11 @@ class Settings(BaseSettings):
 
     stt_provider: Literal["faster_whisper", "openai", "deepgram"] = "faster_whisper"
     llm_provider: Literal["anthropic", "openai", "ollama"] = "anthropic"
+    # `espeak_ng` is the zero-config default — ships in every Linux/
+    # macOS distro and produces audible (if synthetic) output without
+    # an API key or model file. `piper` and `elevenlabs` are quality
+    # opt-ins; see docs/sidecar.md for the setup steps each needs.
+    tts_provider: Literal["espeak_ng", "piper", "elevenlabs"] = "espeak_ng"
     ollama_host: str = "http://localhost:11434"
 
     stt_timeout_seconds: float = Field(default=10.0, gt=0.0)
@@ -30,6 +35,16 @@ class Settings(BaseSettings):
     stt_max_attempts: int = Field(default=2, ge=1)
     llm_max_attempts: int = Field(default=2, ge=1)
     retry_initial_backoff_seconds: float = Field(default=0.5, ge=0.0)
+
+    # TTS knobs. Audio is cached in memory and the firmware fetches it
+    # within seconds; 60 s TTL gives generous headroom for a slow
+    # firmware roundtrip without holding bytes forever. Cache capacity
+    # bounds the worst-case memory footprint (~256 KB * 32 ~= 8 MB).
+    tts_audio_ttl_seconds: float = Field(default=60.0, gt=0.0)
+    tts_audio_cache_capacity: int = Field(default=32, ge=1)
+    # eSpeak-NG voice + speech rate; both ignored for other providers.
+    espeak_voice: str = "en"
+    espeak_wpm: int = Field(default=175, ge=80, le=450)
 
     bearer_token: str = Field(default="", alias="SIDECAR_BEARER_TOKEN")
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")

--- a/sidecar/src/stackchan_sidecar/personas.py
+++ b/sidecar/src/stackchan_sidecar/personas.py
@@ -67,15 +67,11 @@ def _validate_slug(name: str) -> None:
     if not name:
         raise ValueError("persona name must be non-empty")
     if len(name.encode("utf-8")) > _PERSONA_NAME_MAX_BYTES:
-        raise ValueError(
-            f"persona name exceeds {_PERSONA_NAME_MAX_BYTES} bytes"
-        )
+        raise ValueError(f"persona name exceeds {_PERSONA_NAME_MAX_BYTES} bytes")
     if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
         raise ValueError("persona name contains a control character")
     if "/" in name or "\\" in name or ".." in name:
-        raise ValueError(
-            "persona name contains a path separator or traversal token"
-        )
+        raise ValueError("persona name contains a path separator or traversal token")
 
 
 def _strip_frontmatter(text: str) -> str:

--- a/sidecar/src/stackchan_sidecar/tts/__init__.py
+++ b/sidecar/src/stackchan_sidecar/tts/__init__.py
@@ -1,0 +1,36 @@
+"""Text-to-speech providers for the sidecar voice-agent reply path.
+
+Every provider emits **raw 16 kHz mono s16 little-endian PCM** so the
+firmware's `AUDIO_TX_QUEUE` can consume it without any transcode. The
+wire contract between sidecar and firmware is:
+
+1. ``POST /v1/listen`` LLM-reply path includes ``"audio_url":
+   "/v1/audio/<token>"`` when synthesis succeeded, or
+   ``"audio_url": null`` when it failed (graceful degradation —
+   text + emotion still ship).
+2. Firmware ``GET /v1/audio/<token>`` returns the cached PCM as
+   ``Transfer-Encoding: chunked`` so playback can start on the
+   first chunk.
+
+Token lifetime is bounded by the in-memory audio cache (TTL +
+capacity, see ``audio_cache.py``); the firmware is expected to fetch
+within a few seconds.
+
+This package's public surface is the [`TTSProvider`] protocol and the
+three concrete providers ([`EspeakProvider`], [`PiperProvider`],
+[`ElevenLabsProvider`]). [`TTSError`] is the canonical failure type;
+callers catch it and fall back to ``audio_url: null``.
+"""
+
+from __future__ import annotations
+
+from .errors import TTSError
+from .espeak import EspeakProvider
+from .protocol import TTSProvider, TTSResult
+
+__all__ = [
+    "EspeakProvider",
+    "TTSError",
+    "TTSProvider",
+    "TTSResult",
+]

--- a/sidecar/src/stackchan_sidecar/tts/errors.py
+++ b/sidecar/src/stackchan_sidecar/tts/errors.py
@@ -1,0 +1,25 @@
+"""Canonical TTS failure type. Catch-and-convert at the /v1/listen
+boundary so a TTS outage degrades to ``audio_url: null`` instead of
+taking down the whole reply path."""
+
+from __future__ import annotations
+
+
+class TTSError(Exception):
+    """Raised by a [`TTSProvider`] when synthesis can't produce
+    well-shaped PCM. Carries a short slug usable in logs / error
+    envelopes; the underlying exception (if any) is the ``__cause__``.
+
+    Stage is one of:
+    - ``"setup"`` — provider couldn't initialise (missing binary,
+      missing model file, missing API key)
+    - ``"synthesize"`` — provider's synthesis call failed (subprocess
+      crash, HTTP 5xx, timeout, empty output)
+    - ``"transcode"`` — bytes returned but the resample / format
+      conversion to 16 kHz mono s16 LE failed
+    """
+
+    def __init__(self, stage: str, detail: str) -> None:
+        super().__init__(f"tts {stage}: {detail}")
+        self.stage = stage
+        self.detail = detail

--- a/sidecar/src/stackchan_sidecar/tts/espeak.py
+++ b/sidecar/src/stackchan_sidecar/tts/espeak.py
@@ -123,6 +123,14 @@ class EspeakProvider:
                 f"espeak-ng WAV width {width} != expected {PCM_SAMPLE_WIDTH_BYTES}",
             )
         pcm = self._resample_and_downmix(frames, src_rate, channels)
+        if not pcm:
+            # The resampler returns empty for pathological inputs
+            # (e.g. one source sample at a rate that rounds down to
+            # < 1 destination sample). Catch it here so the audio
+            # cache never holds a zero-byte entry; the firmware
+            # would otherwise receive a 200 + empty body and have to
+            # invent its own "is this really audio?" check.
+            raise TTSError("transcode", "resampled audio is empty")
         _LOG.debug(
             "espeak-ng synthesized %d bytes (src_rate=%d, channels=%d)",
             len(pcm),

--- a/sidecar/src/stackchan_sidecar/tts/espeak.py
+++ b/sidecar/src/stackchan_sidecar/tts/espeak.py
@@ -1,0 +1,169 @@
+"""eSpeak-NG TTS provider.
+
+The always-available fallback — ships in 2 MB on any Linux/macOS host,
+no API key, no model file. Synthesis is a subprocess call to the
+``espeak-ng`` binary, which writes a WAV file we strip down to raw PCM.
+The robot-voice aesthetic is intentional; if an operator wants quality
+they pick Piper or ElevenLabs.
+
+Sample rate is configurable at compile time via espeak-ng's
+``--voice=`` selector; the default is 22050 Hz, so this provider does
+an in-memory 22050 → 16000 resample with linear interpolation via
+NumPy (already a sidecar dep). Audio quality for a robot voice on a
+desk toy doesn't justify dragging scipy or libsoxr in for higher-order
+polyphase resampling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+import tempfile
+import wave
+from pathlib import Path
+
+import numpy as np
+
+from .errors import TTSError
+from .protocol import (
+    PCM_CHANNELS,
+    PCM_SAMPLE_RATE_HZ,
+    PCM_SAMPLE_WIDTH_BYTES,
+    TTSResult,
+)
+
+_LOG = logging.getLogger("stackchan_sidecar.tts.espeak")
+
+# espeak-ng's default voice & rate. The voice selector controls
+# language/accent; the rate selector controls words-per-minute.
+# `175 wpm` is the espeak-ng default; comfortable for a desk toy.
+_DEFAULT_VOICE = "en"
+_DEFAULT_WPM = 175
+
+
+class EspeakProvider:
+    """Provider that shells out to ``espeak-ng`` and post-processes
+    the resulting WAV into 16 kHz mono PCM.
+
+    Construction probes for the binary in PATH; if missing,
+    [`synthesize`] raises [`TTSError`] with stage ``"setup"`` on the
+    first call. Probe is lazy so a sidecar that uses ElevenLabs or
+    Piper as its real provider doesn't need espeak-ng installed.
+    """
+
+    name: str = "espeak_ng"
+
+    def __init__(self, *, voice: str = _DEFAULT_VOICE, wpm: int = _DEFAULT_WPM) -> None:
+        self._voice = voice
+        self._wpm = wpm
+
+    async def synthesize(self, text: str) -> TTSResult:
+        binary = shutil.which("espeak-ng")
+        if binary is None:
+            raise TTSError("setup", "espeak-ng binary not found in PATH")
+        if not text.strip():
+            raise TTSError("synthesize", "empty text")
+        # Subprocess runs to completion in a thread so the FastAPI event
+        # loop stays responsive. Synthesis is fast enough (< 200 ms for
+        # toast-band-length text) that streaming isn't worth the
+        # complexity for this provider.
+        return await asyncio.to_thread(self._synthesize_sync, binary, text)
+
+    def _synthesize_sync(self, binary: str, text: str) -> TTSResult:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            wav_path = Path(tmp.name)
+        try:
+            try:
+                # `--stdin` reads the text from stdin, dodging shell-escape
+                # gotchas if the LLM reply contains quotes or backticks.
+                subprocess.run(
+                    [
+                        binary,
+                        "--stdin",
+                        "-v",
+                        self._voice,
+                        "-s",
+                        str(self._wpm),
+                        "-w",
+                        str(wav_path),
+                    ],
+                    input=text,
+                    text=True,
+                    check=True,
+                    timeout=10.0,
+                    capture_output=True,
+                )
+            except subprocess.CalledProcessError as e:
+                raise TTSError(
+                    "synthesize",
+                    f"espeak-ng exited {e.returncode}: {e.stderr.strip()[:120]}",
+                ) from e
+            except subprocess.TimeoutExpired as e:
+                raise TTSError("synthesize", "espeak-ng timed out") from e
+            return self._wav_to_pcm(wav_path)
+        finally:
+            wav_path.unlink(missing_ok=True)
+
+    def _wav_to_pcm(self, wav_path: Path) -> TTSResult:
+        try:
+            with wave.open(str(wav_path), "rb") as r:
+                channels = r.getnchannels()
+                width = r.getsampwidth()
+                src_rate = r.getframerate()
+                frames = r.readframes(r.getnframes())
+        except (wave.Error, FileNotFoundError) as e:
+            raise TTSError("transcode", f"couldn't read espeak-ng WAV: {e}") from e
+        if not frames:
+            raise TTSError("synthesize", "espeak-ng produced empty audio")
+        if width != PCM_SAMPLE_WIDTH_BYTES:
+            raise TTSError(
+                "transcode",
+                f"espeak-ng WAV width {width} != expected {PCM_SAMPLE_WIDTH_BYTES}",
+            )
+        pcm = self._resample_and_downmix(frames, src_rate, channels)
+        _LOG.debug(
+            "espeak-ng synthesized %d bytes (src_rate=%d, channels=%d)",
+            len(pcm),
+            src_rate,
+            channels,
+        )
+        return TTSResult(pcm=pcm, provider=self.name, voice=self._voice)
+
+    @staticmethod
+    def _resample_and_downmix(frames: bytes, src_rate: int, channels: int) -> bytes:
+        """Convert raw s16 LE frames at ``src_rate`` x ``channels`` to
+        16 kHz mono s16 LE bytes. Pure NumPy; no audioop / scipy /
+        libsoxr dependency.
+
+        Resampling uses linear interpolation, which is fine for the
+        robot-voice quality bar this provider targets. A more demanding
+        provider (Piper, ElevenLabs) emits the right rate natively or
+        does its own resample upstream — so this approximation is
+        scoped to the fallback path.
+        """
+        samples = np.frombuffer(frames, dtype=np.int16)
+        # Multi-channel → mono via mean. espeak-ng is mono by default
+        # so this is a no-op in practice; the guard is cheap.
+        if channels > 1:
+            samples = samples.reshape(-1, channels).mean(axis=1).astype(np.int16)
+        if src_rate != PCM_SAMPLE_RATE_HZ:
+            src_len = samples.size
+            dst_len = round(src_len * PCM_SAMPLE_RATE_HZ / src_rate)
+            if dst_len <= 0:
+                # Pathological input (one sample at 22 kHz, < 1 sample
+                # at 16 kHz). Fall through to a zero-length payload --
+                # the empty-output guard in `_wav_to_pcm` will surface
+                # it as a TTSError on the next layer.
+                return b""
+            # np.interp does linear interpolation. The src/dst sample
+            # positions are evenly spaced across [0, 1].
+            src_positions = np.linspace(0.0, 1.0, src_len, dtype=np.float64)
+            dst_positions = np.linspace(0.0, 1.0, dst_len, dtype=np.float64)
+            resampled = np.interp(dst_positions, src_positions, samples.astype(np.float64))
+            # Clip + cast — interp can produce out-of-range floats if
+            # the input had peaks near i16 bounds.
+            samples = np.clip(resampled, -32768, 32767).astype(np.int16)
+        _ = PCM_CHANNELS  # mono target — guarded above
+        return samples.tobytes()

--- a/sidecar/src/stackchan_sidecar/tts/protocol.py
+++ b/sidecar/src/stackchan_sidecar/tts/protocol.py
@@ -1,0 +1,56 @@
+"""Provider-agnostic TTS protocol.
+
+All providers return [`TTSResult`] — raw PCM bytes plus the sample
+rate and channel layout that produced them. The shared rate target
+is 16 kHz mono s16 LE so the firmware playback path can consume the
+bytes directly; providers whose engine emits something else
+resample down to 16 kHz before returning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+# Target wire-rate. Matches the firmware's `AUDIO_TX_QUEUE` expectation
+# (see `crates/stackchan-firmware/src/audio.rs`).
+PCM_SAMPLE_RATE_HZ = 16_000
+PCM_CHANNELS = 1
+PCM_SAMPLE_WIDTH_BYTES = 2
+
+
+@dataclass(frozen=True)
+class TTSResult:
+    """Output of one synthesis call.
+
+    ``pcm`` is the raw 16 kHz mono s16 LE bytes the firmware streams
+    into the AW88298 amp. ``provider`` and ``voice`` are surfaced in
+    logs so an operator can tell which engine made the noise.
+    """
+
+    pcm: bytes
+    provider: str
+    voice: str
+
+    @property
+    def duration_seconds(self) -> float:
+        samples = len(self.pcm) // PCM_SAMPLE_WIDTH_BYTES
+        return samples / PCM_SAMPLE_RATE_HZ
+
+
+@runtime_checkable
+class TTSProvider(Protocol):
+    """Async-friendly synthesis interface.
+
+    Implementations are expected to ``await`` rather than block; CPU-bound
+    engines (Piper, eSpeak-NG subprocess) bridge through
+    ``asyncio.to_thread``. Network providers (ElevenLabs) use ``httpx``
+    natively.
+
+    Failures raise [`stackchan_sidecar.tts.errors.TTSError`]; the
+    /v1/listen handler catches it and falls back to ``audio_url: null``.
+    """
+
+    name: str
+
+    async def synthesize(self, text: str) -> TTSResult: ...

--- a/sidecar/tests/test_app.py
+++ b/sidecar/tests/test_app.py
@@ -101,7 +101,9 @@ def test_listen_happy_path(
     )
     assert r.status_code == 200
     body = r.json()
-    assert body == {"text": "hi friend!", "emotion": "happy"}
+    # `audio_url: None` because no TTS provider is wired into the
+    # default `client` fixture. Per-TTS coverage in test_tts_app.
+    assert body == {"text": "hi friend!", "emotion": "happy", "audio_url": None}
     assert len(fake_stt.calls) == 1
     assert fake_stt.calls[0][1] == 16000
     assert len(fake_llm.calls) == 1

--- a/sidecar/tests/test_audio_cache.py
+++ b/sidecar/tests/test_audio_cache.py
@@ -1,0 +1,103 @@
+"""Unit tests for the in-memory audio cache."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from stackchan_sidecar.audio_cache import AudioCache
+
+
+async def _put(cache: AudioCache, n: int = 1) -> list[str]:
+    tokens: list[str] = []
+    for i in range(n):
+        tokens.append(await cache.put(b"\x00\x00" * 10, provider="test", voice=f"v{i}"))
+    return tokens
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_round_trip() -> None:
+    cache = AudioCache()
+    token = await cache.put(b"\x01\x02\x03\x04", provider="espeak_ng", voice="en")
+    entry = await cache.get(token)
+    assert entry is not None
+    assert entry.pcm == b"\x01\x02\x03\x04"
+    assert entry.provider == "espeak_ng"
+    assert entry.voice == "en"
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_token_returns_none() -> None:
+    cache = AudioCache()
+    assert await cache.get("not-a-real-token") is None
+
+
+@pytest.mark.asyncio
+async def test_tokens_are_unique_per_put() -> None:
+    cache = AudioCache(capacity=100)
+    tokens = await _put(cache, n=20)
+    assert len(set(tokens)) == 20
+
+
+@pytest.mark.asyncio
+async def test_capacity_evicts_oldest() -> None:
+    cache = AudioCache(capacity=3)
+    tokens = await _put(cache, n=5)
+    # First two evicted; last three retained.
+    assert await cache.get(tokens[0]) is None
+    assert await cache.get(tokens[1]) is None
+    assert await cache.get(tokens[2]) is not None
+    assert await cache.get(tokens[3]) is not None
+    assert await cache.get(tokens[4]) is not None
+    assert cache._len_for_test() == 3
+
+
+@pytest.mark.asyncio
+async def test_ttl_expires_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [1000.0]
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+    cache = AudioCache(ttl_seconds=10.0)
+    token = await cache.put(b"\x00\x00", provider="test", voice="x")
+    now[0] += 5.0
+    assert await cache.get(token) is not None
+    now[0] += 10.0  # +15s total — past TTL
+    assert await cache.get(token) is None
+
+
+@pytest.mark.asyncio
+async def test_ttl_evicted_on_subsequent_put(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Lazy sweep: expired entries get removed on the next put() and
+    # don't count against capacity. Pins the invariant so a slow
+    # operator who lets an old token age out doesn't lose capacity.
+    now = [1000.0]
+    monkeypatch.setattr(time, "monotonic", lambda: now[0])
+    cache = AudioCache(ttl_seconds=5.0, capacity=2)
+    await cache.put(b"a", provider="t", voice="v")
+    await cache.put(b"b", provider="t", voice="v")
+    assert cache._len_for_test() == 2
+    now[0] += 10.0  # both expired
+    await cache.put(b"c", provider="t", voice="v")
+    # Lazy sweep ran on the put — old two are gone, only `c` remains.
+    assert cache._len_for_test() == 1
+
+
+def test_rejects_zero_ttl() -> None:
+    with pytest.raises(ValueError, match="ttl"):
+        AudioCache(ttl_seconds=0)
+
+
+def test_rejects_zero_capacity() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        AudioCache(capacity=0)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_puts_are_serialised() -> None:
+    # Hammer the cache from many concurrent tasks; the lock should
+    # serialise without losing entries or producing duplicate tokens.
+    cache = AudioCache(capacity=100)
+    tokens = await asyncio.gather(*[_put(cache, n=1) for _ in range(20)])
+    flat = [t for sublist in tokens for t in sublist]
+    assert len(set(flat)) == 20

--- a/sidecar/tests/test_tts_app.py
+++ b/sidecar/tests/test_tts_app.py
@@ -1,0 +1,218 @@
+"""End-to-end wire tests for the TTS integration.
+
+Uses a `FakeTTS` so the tests don't depend on espeak-ng being
+installed — covers the listen-handler-to-audio-endpoint round-trip
+plus the failure paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from stackchan_sidecar.app import create_app
+from stackchan_sidecar.audio_cache import AudioCache
+from stackchan_sidecar.config import Settings
+from stackchan_sidecar.tts import TTSError, TTSResult
+
+from .conftest import TEST_TOKEN, FakeLLM, FakeSTT
+
+_AUDIO_CT = "audio/L16;rate=16000;channels=1"
+
+
+class FakeTTS:
+    """Test double that returns a deterministic PCM payload."""
+
+    name = "fake"
+
+    def __init__(self, *, pcm: bytes = b"\x12\x34" * 100, voice: str = "fake-voice") -> None:
+        self.pcm = pcm
+        self.voice = voice
+        self.calls: list[str] = []
+        self.fail_with: TTSError | None = None
+
+    async def synthesize(self, text: str) -> TTSResult:
+        self.calls.append(text)
+        if self.fail_with is not None:
+            raise self.fail_with
+        return TTSResult(pcm=self.pcm, provider=self.name, voice=self.voice)
+
+
+@pytest.fixture
+def fake_tts() -> FakeTTS:
+    return FakeTTS()
+
+
+@pytest.fixture
+def tts_client(
+    settings: Settings,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+    fake_tts: FakeTTS,
+) -> Iterator[TestClient]:
+    app = create_app(settings, fake_stt, fake_llm, tts=fake_tts)
+    with TestClient(app) as c:
+        yield c
+
+
+def test_listen_returns_audio_url_when_tts_succeeds(
+    tts_client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_tts: FakeTTS,
+) -> None:
+    r = tts_client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": _AUDIO_CT},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["text"] == "hi friend!"
+    assert body["emotion"] == "happy"
+    assert body["audio_url"] is not None
+    assert body["audio_url"].startswith("/v1/audio/")
+    # TTS was called with the *short* (toast-band-sized) text, not the
+    # longer `reply.full`.
+    assert fake_tts.calls == ["hi friend!"]
+
+
+def test_audio_endpoint_returns_cached_pcm(
+    tts_client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_tts: FakeTTS,
+) -> None:
+    r = tts_client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": _AUDIO_CT},
+    )
+    audio_url = r.json()["audio_url"]
+    audio_r = tts_client.get(audio_url)
+    assert audio_r.status_code == 200
+    assert audio_r.content == fake_tts.pcm
+    # Format header signals the firmware can stream straight in.
+    assert audio_r.headers["content-type"].startswith("audio/L16")
+    assert audio_r.headers["x-audio-provider"] == "fake"
+    assert audio_r.headers["x-audio-voice"] == "fake-voice"
+
+
+def test_audio_endpoint_404s_for_unknown_token(tts_client: TestClient) -> None:
+    r = tts_client.get("/v1/audio/deadbeefdeadbeefdeadbeefdeadbeef")
+    assert r.status_code == 404
+
+
+def test_audio_endpoint_404s_after_ttl_expiry(
+    settings: Settings,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
+    fake_tts: FakeTTS,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import time as _time
+
+    # Stand up an app with a fast-expiring cache so the TTL path is
+    # exercisable without sleeping in real time.
+    now = [1000.0]
+    monkeypatch.setattr(_time, "monotonic", lambda: now[0])
+    cache = AudioCache(ttl_seconds=2.0, capacity=8)
+    app = create_app(settings, fake_stt, fake_llm, tts=fake_tts, audio_cache=cache)
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+        audio_url = r.json()["audio_url"]
+        # Immediate fetch hits.
+        assert c.get(audio_url).status_code == 200
+        # Past TTL — eviction on next access returns 404.
+        now[0] += 10.0
+        assert c.get(audio_url).status_code == 404
+
+
+def test_listen_null_audio_url_when_tts_fails(
+    tts_client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_tts: FakeTTS,
+) -> None:
+    fake_tts.fail_with = TTSError("synthesize", "provider blew up")
+    r = tts_client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": _AUDIO_CT},
+    )
+    # Graceful degradation: text + emotion still ship, listen
+    # responded 200, only audio_url is null.
+    assert r.status_code == 200
+    body = r.json()
+    assert body["text"] == "hi friend!"
+    assert body["emotion"] == "happy"
+    assert body["audio_url"] is None
+
+
+def test_listen_null_audio_url_when_tts_provider_unset(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+) -> None:
+    # The default `client` fixture wires the app with `tts=None`.
+    # The reply must still include the `audio_url` field (as null) so
+    # the firmware's wire-format expectation is stable across deploy
+    # configurations.
+    r = client.post(
+        "/v1/listen",
+        content=pcm_payload,
+        headers={**auth_headers, "Content-Type": _AUDIO_CT},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["audio_url"] is None
+
+
+def test_listen_null_audio_url_when_tts_raises_unexpected(
+    tts_client: TestClient,
+    auth_headers: dict[str, str],
+    pcm_payload: bytes,
+    fake_tts: FakeTTS,
+) -> None:
+    # A bug in the provider (RuntimeError, ImportError, etc.) must
+    # not take down the reply path — the catch-all logs but degrades
+    # to no-audio.
+    class _Boom:
+        name = "boom"
+
+        async def synthesize(self, text: str) -> TTSResult:
+            raise RuntimeError("unexpected")
+
+    settings = Settings(SIDECAR_BEARER_TOKEN=TEST_TOKEN, ANTHROPIC_API_KEY="sk-ant-test")
+    app = create_app(
+        settings,
+        FakeSTT(),
+        FakeLLM(),
+        tts=_Boom(),
+    )
+    # Drop a persona so the listen path doesn't 500 on missing default.
+    settings.personas_dir.mkdir(exist_ok=True)
+    persona_path = settings.personas_dir / f"{settings.persona}.md"
+    if not persona_path.exists():
+        persona_path.write_text("---\n---\nfallback", encoding="utf-8")
+    try:
+        with TestClient(app) as c:
+            r = c.post(
+                "/v1/listen",
+                content=pcm_payload,
+                headers={**auth_headers, "Content-Type": _AUDIO_CT},
+            )
+        assert r.status_code == 200
+        assert r.json()["audio_url"] is None
+    finally:
+        # Clean up the persona file we maybe just created.
+        if persona_path.exists() and persona_path.read_text(encoding="utf-8").strip() == "fallback":
+            persona_path.unlink()

--- a/sidecar/tests/test_tts_app.py
+++ b/sidecar/tests/test_tts_app.py
@@ -8,6 +8,7 @@ plus the failure paths.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -17,7 +18,7 @@ from stackchan_sidecar.audio_cache import AudioCache
 from stackchan_sidecar.config import Settings
 from stackchan_sidecar.tts import TTSError, TTSResult
 
-from .conftest import TEST_TOKEN, FakeLLM, FakeSTT
+from .conftest import FakeLLM, FakeSTT
 
 _AUDIO_CT = "audio/L16;rate=16000;channels=1"
 
@@ -177,42 +178,34 @@ def test_listen_null_audio_url_when_tts_provider_unset(
 
 
 def test_listen_null_audio_url_when_tts_raises_unexpected(
-    tts_client: TestClient,
+    personas_dir: Path,
+    settings: Settings,
+    fake_stt: FakeSTT,
+    fake_llm: FakeLLM,
     auth_headers: dict[str, str],
     pcm_payload: bytes,
-    fake_tts: FakeTTS,
 ) -> None:
     # A bug in the provider (RuntimeError, ImportError, etc.) must
     # not take down the reply path — the catch-all logs but degrades
     # to no-audio.
+    #
+    # `personas_dir` + `settings` fixtures come from conftest and use
+    # tmp_path under the hood, so this test doesn't touch the cwd's
+    # `./personas/` directory or leave artifacts behind.
+    _ = personas_dir  # consumed implicitly via settings.personas_dir
+
     class _Boom:
         name = "boom"
 
         async def synthesize(self, text: str) -> TTSResult:
             raise RuntimeError("unexpected")
 
-    settings = Settings(SIDECAR_BEARER_TOKEN=TEST_TOKEN, ANTHROPIC_API_KEY="sk-ant-test")
-    app = create_app(
-        settings,
-        FakeSTT(),
-        FakeLLM(),
-        tts=_Boom(),
-    )
-    # Drop a persona so the listen path doesn't 500 on missing default.
-    settings.personas_dir.mkdir(exist_ok=True)
-    persona_path = settings.personas_dir / f"{settings.persona}.md"
-    if not persona_path.exists():
-        persona_path.write_text("---\n---\nfallback", encoding="utf-8")
-    try:
-        with TestClient(app) as c:
-            r = c.post(
-                "/v1/listen",
-                content=pcm_payload,
-                headers={**auth_headers, "Content-Type": _AUDIO_CT},
-            )
-        assert r.status_code == 200
-        assert r.json()["audio_url"] is None
-    finally:
-        # Clean up the persona file we maybe just created.
-        if persona_path.exists() and persona_path.read_text(encoding="utf-8").strip() == "fallback":
-            persona_path.unlink()
+    app = create_app(settings, fake_stt, fake_llm, tts=_Boom())
+    with TestClient(app) as c:
+        r = c.post(
+            "/v1/listen",
+            content=pcm_payload,
+            headers={**auth_headers, "Content-Type": _AUDIO_CT},
+        )
+    assert r.status_code == 200
+    assert r.json()["audio_url"] is None

--- a/sidecar/tests/test_tts_espeak.py
+++ b/sidecar/tests/test_tts_espeak.py
@@ -1,0 +1,117 @@
+"""Unit tests for the eSpeak-NG TTS provider.
+
+These tests require `espeak-ng` on PATH. If it's not installed they
+skip with a clear reason rather than fail, so a contributor without
+the binary can still run the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from stackchan_sidecar.tts import EspeakProvider, TTSError
+from stackchan_sidecar.tts.protocol import PCM_SAMPLE_RATE_HZ
+
+_ESPEAK_AVAILABLE = shutil.which("espeak-ng") is not None
+_SKIP_REASON = "espeak-ng binary not installed; provider tests skip on this host"
+
+
+@pytest.fixture
+def provider() -> EspeakProvider:
+    return EspeakProvider()
+
+
+@pytest.mark.asyncio
+async def test_setup_error_when_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force the `which` lookup to fail so we exercise the setup-stage
+    # error path without requiring the binary to be absent on the
+    # host. This is the most important test for environments where
+    # espeak-ng IS installed but might not be in CI's PATH.
+    monkeypatch.setattr("stackchan_sidecar.tts.espeak.shutil.which", lambda _: None)
+    with pytest.raises(TTSError) as exc_info:
+        await EspeakProvider().synthesize("hello")
+    assert exc_info.value.stage == "setup"
+
+
+@pytest.mark.asyncio
+async def test_rejects_empty_text(provider: EspeakProvider) -> None:
+    if not _ESPEAK_AVAILABLE:
+        pytest.skip(_SKIP_REASON)
+    with pytest.raises(TTSError, match="empty text"):
+        await provider.synthesize("")
+    with pytest.raises(TTSError, match="empty text"):
+        await provider.synthesize("   \n\t")
+
+
+@pytest.mark.asyncio
+async def test_synthesize_returns_16khz_mono_pcm(provider: EspeakProvider) -> None:
+    if not _ESPEAK_AVAILABLE:
+        pytest.skip(_SKIP_REASON)
+    result = await provider.synthesize("Hello stack-chan.")
+    assert result.provider == "espeak_ng"
+    # Even/whole-sample alignment — bytes are s16, so length must be even.
+    assert len(result.pcm) % 2 == 0
+    # Sane lower bound: any utterance should produce at least ~50 ms.
+    assert result.duration_seconds > 0.05
+    # Upper bound — a short sentence shouldn't blow past 5 s.
+    assert result.duration_seconds < 5.0
+
+
+@pytest.mark.asyncio
+async def test_duration_property_matches_byte_count(provider: EspeakProvider) -> None:
+    if not _ESPEAK_AVAILABLE:
+        pytest.skip(_SKIP_REASON)
+    result = await provider.synthesize("Hi.")
+    expected = (len(result.pcm) // 2) / PCM_SAMPLE_RATE_HZ
+    assert abs(result.duration_seconds - expected) < 1e-9
+
+
+def test_resample_handles_22050_to_16000() -> None:
+    # The internal resampler is exercised every synthesis on a default
+    # espeak-ng build (it emits 22050 Hz). Pin the maths so a future
+    # numpy version that changes np.interp's edge handling doesn't
+    # silently shift samples around.
+    import numpy as np
+
+    from stackchan_sidecar.tts.espeak import EspeakProvider
+
+    # 22050 Hz mono ramp: values 0..21999 (one second).
+    samples_22k = np.arange(22050, dtype=np.int16)
+    pcm_in = samples_22k.tobytes()
+    out = EspeakProvider._resample_and_downmix(pcm_in, src_rate=22050, channels=1)
+    # 22050 → 16000 is a ~72.6% ratio; expect 16000 samples.
+    out_samples = np.frombuffer(out, dtype=np.int16)
+    assert abs(len(out_samples) - 16000) <= 1
+    # Monotonic ramp survives (within rounding) — first sample near 0,
+    # last sample near the peak input (~21999).
+    assert out_samples[0] >= 0
+    assert out_samples[-1] > 20000
+
+
+def test_resample_downmixes_stereo_to_mono() -> None:
+    import numpy as np
+
+    from stackchan_sidecar.tts.espeak import EspeakProvider
+
+    # Stereo: left=100, right=200 interleaved, at the target rate.
+    left = np.full(1000, 100, dtype=np.int16)
+    right = np.full(1000, 200, dtype=np.int16)
+    interleaved = np.stack([left, right], axis=1).reshape(-1).astype(np.int16)
+    out = EspeakProvider._resample_and_downmix(
+        interleaved.tobytes(), src_rate=PCM_SAMPLE_RATE_HZ, channels=2
+    )
+    out_samples = np.frombuffer(out, dtype=np.int16)
+    assert len(out_samples) == 1000  # no resample, only downmix
+    # Mean of 100 + 200 = 150
+    assert int(out_samples[0]) == 150
+
+
+def test_resample_passthrough_when_rate_matches() -> None:
+    from stackchan_sidecar.tts.espeak import EspeakProvider
+
+    pcm_in = (b"\x10\x00") * 100  # 100 samples of value 16
+    out = EspeakProvider._resample_and_downmix(pcm_in, src_rate=PCM_SAMPLE_RATE_HZ, channels=1)
+    # No resample, no downmix → bit-exact passthrough.
+    assert out == pcm_in


### PR DESCRIPTION
## Summary

First Arc A TTS slice — sidecar-only, makes the avatar capable of speaking replies. Firmware-side playback lands in slice 2; for now an operator can verify the wire path with curl.

### Wire format (decided up front)

| Concern | Decision |
|---|---|
| Reply shape | `POST /v1/listen` returns `{text, emotion, audio_url}`. `audio_url` is `/v1/audio/<token>` on success, `null` on TTS failure or no-provider. |
| Audio retrieval | `GET /v1/audio/<token>` returns raw 16 kHz mono s16 LE PCM as `audio/L16;rate=16000;channels=1`. Same format the firmware POSTs *to* the sidecar — symmetric advertisement. |
| Audit | `X-Audio-Provider` + `X-Audio-Voice` headers on the audio response. |
| Token shape | Opaque 32-char hex from `secrets.token_hex(16)`. |
| Caching | In-memory `OrderedDict`, 60 s TTL, 32-entry capacity. Lazy sweep on each put. |
| TTS failure | Graceful degradation — text + emotion still ship, only `audio_url` is `null`. Firmware unchanged behavior. |

### Provider surface

- **`EspeakProvider`** — the zero-config default. Subprocesses `espeak-ng` (ships in ~2 MB on any Linux/macOS distro). Reads its WAV, resamples 22050 → 16000 Hz via NumPy linear interp, downmixes stereo→mono. Robot-voice aesthetic intentional.
- **`PiperProvider` + `ElevenLabsProvider`** declared in the `tts_provider` config Literal but not yet implemented. Slice 2 lands ElevenLabs (`pcm_16000` — research showed this is the cleanest cloud format match); slice 3 lands the local Piper (16 kHz native, no resample). For now the builder logs the substitution and falls through to espeak_ng so an operator's config keeps working.

### `TTSProvider` Protocol

```python
class TTSProvider(Protocol):
    name: str
    async def synthesize(self, text: str) -> TTSResult: ...
```

- `TTSResult { pcm: bytes, provider: str, voice: str }`
- `TTSError(stage, detail)` — stage ∈ `{setup, synthesize, transcode}`. Caught by the listen handler.
- Shared wire constants (`PCM_SAMPLE_RATE_HZ = 16000`, mono, s16 LE) so provider impls validate against one source of truth.

### Tests

**24 new, 157 total pass** (was 132 pre-slice):

- `test_audio_cache.py` (10): put/get round-trip, unique-token invariant, capacity-evicts-oldest, TTL expiry, lazy sweep, ctor validation, concurrent-puts-are-serialised.
- `test_tts_espeak.py` (8): the 3 that drive real `espeak-ng` skip cleanly when the binary isn't on PATH. Forced-setup-error via monkeypatched `shutil.which`. Internal resampler tested against deterministic ramps so future NumPy versions can't silently shift samples.
- `test_tts_app.py` (7): wire tests via `FakeTTS` (no espeak-ng dep). Covers happy path, audio fetch round-trip, 404 on unknown token, 404 after TTL expiry, TTSError → null audio_url, no-provider → null, catch-all for unexpected provider exceptions.

`ruff check` + `ruff format --check` + `mypy --strict` all clean.

### What's NOT in this slice

- Firmware audio playback path — slice 2.
- Piper provider — slice 3 (the local-default story).
- ElevenLabs provider — slice 2 (the cloud-quality story).
- Lip-sync (visemes / RMS envelope drive of `MouthFromAudio`) — separate future slice.

## Test plan

- [x] `uv run pytest` — 157 passed, 3 skipped (espeak-ng not on container)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy .` clean
- [ ] Manual: `curl http://localhost:8080/v1/listen -d <PCM> | jq .audio_url` → fetch → play (blocked on local espeak-ng + a running sidecar)