### PR TITLE
feat(arc-a): sidecar TTS slice 3 — ElevenLabsProvider

### DIFF
--- a/sidecar/src/stackchan_sidecar/__main__.py
+++ b/sidecar/src/stackchan_sidecar/__main__.py
@@ -50,10 +50,12 @@ def _build_tts(settings: Settings) -> TTSProvider:
             speaker_id=settings.piper_speaker_id,
         )
     if settings.tts_provider == "elevenlabs":
-        import logging
+        from .tts import ElevenLabsProvider
 
-        logging.getLogger("stackchan_sidecar").warning(
-            "tts_provider=elevenlabs requested but not implemented yet; falling back to espeak_ng.",
+        return ElevenLabsProvider(
+            api_key=settings.elevenlabs_api_key,
+            voice_id=settings.elevenlabs_voice_id,
+            model_id=settings.elevenlabs_model_id,
         )
     from .tts import EspeakProvider
 

--- a/sidecar/src/stackchan_sidecar/config.py
+++ b/sidecar/src/stackchan_sidecar/config.py
@@ -53,11 +53,19 @@ class Settings(BaseSettings):
     # Speaker index for multi-speaker piper models; ignored on
     # single-speaker ones.
     piper_speaker_id: int | None = None
+    # ElevenLabs voice + model selectors. Voice id defaults to Rachel
+    # (a public preset); operators with a cloned voice override it.
+    # `eleven_turbo_v2_5` is the latency-optimised model — cheaper and
+    # fast enough for a desk toy; switch to `eleven_multilingual_v2`
+    # for non-English voices.
+    elevenlabs_voice_id: str = "21m00Tcm4TlvDq8ikWAM"
+    elevenlabs_model_id: str = "eleven_turbo_v2_5"
 
     bearer_token: str = Field(default="", alias="SIDECAR_BEARER_TOKEN")
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
     openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
     deepgram_api_key: str = Field(default="", alias="DEEPGRAM_API_KEY")
+    elevenlabs_api_key: str = Field(default="", alias="ELEVENLABS_API_KEY")
 
     firmware_url: str = Field(default="http://stackchan.local", alias="STACKCHAN_FIRMWARE_URL")
     firmware_token: str = Field(default="", alias="STACKCHAN_FIRMWARE_TOKEN")
@@ -95,5 +103,10 @@ def load_settings() -> Settings:
         raise RuntimeError(
             "piper_model_path is required when tts_provider=piper. "
             "Point it at a downloaded .onnx voice model (see docs/voice.md)."
+        )
+    if settings.tts_provider == "elevenlabs" and not settings.elevenlabs_api_key:
+        raise RuntimeError(
+            "ELEVENLABS_API_KEY is required when tts_provider=elevenlabs. "
+            "Set it in .env or the process environment."
         )
     return settings

--- a/sidecar/src/stackchan_sidecar/tts/__init__.py
+++ b/sidecar/src/stackchan_sidecar/tts/__init__.py
@@ -24,12 +24,14 @@ callers catch it and fall back to ``audio_url: null``.
 
 from __future__ import annotations
 
+from .elevenlabs import ElevenLabsProvider
 from .errors import TTSError
 from .espeak import EspeakProvider
 from .piper import PiperProvider
 from .protocol import TTSProvider, TTSResult
 
 __all__ = [
+    "ElevenLabsProvider",
     "EspeakProvider",
     "PiperProvider",
     "TTSError",

--- a/sidecar/src/stackchan_sidecar/tts/elevenlabs.py
+++ b/sidecar/src/stackchan_sidecar/tts/elevenlabs.py
@@ -1,0 +1,101 @@
+"""ElevenLabs TTS provider.
+
+ElevenLabs is the cloud quality opt-in — a paid API call per
+synthesis, but produces voices indistinguishable from human
+recordings. Setup requires:
+
+1. An ``xi-api-key`` from elevenlabs.io.
+2. A voice id (``settings.elevenlabs_voice_id``) — either a built-in
+   like Rachel (``21m00Tcm4TlvDq8ikWAM``) or one cloned by the
+   operator.
+3. The Starter tier or higher; the free tier only emits MP3, and
+   this provider asks for raw PCM at 16 kHz so the firmware audio
+   pipeline doesn't need an MP3 decoder.
+
+If any of those are missing, [`synthesize`] raises [`TTSError`] with
+stage ``"setup"`` (api-key) or ``"synthesize"`` (HTTP 4xx/5xx) so
+the operator gets a clear log rather than a runtime guess about
+the failure.
+
+The endpoint returns raw 16 kHz mono s16 LE PCM directly — no WAV
+header, no transcode, no resample. That's the same wire shape the
+firmware audio cache stores, so we hand it through unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from .errors import TTSError
+from .protocol import PCM_SAMPLE_RATE_HZ, TTSResult
+
+_LOG = logging.getLogger("stackchan_sidecar.tts.elevenlabs")
+
+_ENDPOINT_TEMPLATE = "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+# `eleven_turbo_v2_5` is the latency-optimised model — ~70 % cheaper
+# than the multilingual flagship and fast enough for a desk toy.
+# Operators can swap it for `eleven_multilingual_v2` if they need
+# non-English voices.
+_DEFAULT_MODEL = "eleven_turbo_v2_5"
+_DEFAULT_TIMEOUT_S = 30.0
+
+
+class ElevenLabsProvider:
+    """Provider that POSTs to ElevenLabs' text-to-speech REST endpoint
+    and asks for raw 16 kHz mono s16 LE PCM in the response body."""
+
+    name: str = "elevenlabs"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        voice_id: str,
+        model_id: str = _DEFAULT_MODEL,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._api_key = api_key
+        self._voice_id = voice_id
+        self._model_id = model_id
+        self._timeout_seconds = timeout_seconds
+
+    async def synthesize(self, text: str) -> TTSResult:
+        if not self._api_key:
+            raise TTSError("setup", "elevenlabs_api_key not configured")
+        if not text.strip():
+            raise TTSError("synthesize", "empty text")
+        endpoint = _ENDPOINT_TEMPLATE.format(voice_id=self._voice_id)
+        headers = {
+            "xi-api-key": self._api_key,
+            "Accept": "audio/pcm",
+            "Content-Type": "application/json",
+        }
+        params = {"output_format": f"pcm_{PCM_SAMPLE_RATE_HZ}"}
+        body = {"text": text, "model_id": self._model_id}
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+                response = await client.post(endpoint, headers=headers, params=params, json=body)
+        except httpx.HTTPError as e:
+            raise TTSError("synthesize", f"http error: {e}") from e
+        if response.status_code != 200:
+            raise TTSError(
+                "synthesize",
+                f"elevenlabs returned {response.status_code}: {response.text.strip()[:120]}",
+            )
+        pcm = response.content
+        if not pcm:
+            raise TTSError("synthesize", "elevenlabs produced empty audio")
+        if len(pcm) % 2 != 0:
+            # The response is supposed to be s16, so byte count must
+            # be even. An odd count means the API returned a wrapper
+            # we don't recognise (mp3, ogg) — treat as transcode-stage.
+            raise TTSError("transcode", f"elevenlabs PCM odd-length: {len(pcm)} bytes")
+        _LOG.debug(
+            "elevenlabs synthesized %d bytes (voice=%s, model=%s)",
+            len(pcm),
+            self._voice_id,
+            self._model_id,
+        )
+        return TTSResult(pcm=pcm, provider=self.name, voice=self._voice_id)

--- a/sidecar/tests/test_tts_elevenlabs.py
+++ b/sidecar/tests/test_tts_elevenlabs.py
@@ -1,0 +1,155 @@
+"""Unit tests for the ElevenLabs TTS provider.
+
+These tests never hit the real ElevenLabs API — we monkeypatch the
+`httpx.AsyncClient` constructor in the provider module to a stub
+that returns canned responses. That covers every wrapping concern
+(setup error, auth, non-200, empty body, success) without an API
+key or network call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from stackchan_sidecar.tts import ElevenLabsProvider, TTSError
+
+
+class _FakeAsyncClient:
+    """Stand-in for `httpx.AsyncClient` used in the provider.
+
+    Stores the last call's args + a list of canned responses or
+    exceptions. The provider uses it via `async with` so we need
+    both async context manager and `.post` methods.
+    """
+
+    def __init__(self, response: httpx.Response | Exception, **_kw: Any) -> None:
+        self._response = response
+        self.last_call: dict[str, Any] | None = None
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        self.last_call = {"url": url, **kwargs}
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+def _install_fake(monkeypatch: pytest.MonkeyPatch, fake: _FakeAsyncClient) -> _FakeAsyncClient:
+    """Patch httpx.AsyncClient in the provider module to return `fake`.
+    Returned reference is the same as `fake` for caller convenience.
+    """
+
+    def factory(**_kw: Any) -> _FakeAsyncClient:
+        return fake
+
+    monkeypatch.setattr("stackchan_sidecar.tts.elevenlabs.httpx.AsyncClient", factory)
+    return fake
+
+
+def _mk_response(content: bytes, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        content=content,
+        request=httpx.Request("POST", "https://api.elevenlabs.io/x"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_error_when_api_key_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = ElevenLabsProvider(api_key="", voice_id="any")
+    with pytest.raises(TTSError) as exc_info:
+        await provider.synthesize("hello")
+    assert exc_info.value.stage == "setup"
+
+
+@pytest.mark.asyncio
+async def test_rejects_empty_text() -> None:
+    provider = ElevenLabsProvider(api_key="sk-test", voice_id="any")
+    with pytest.raises(TTSError, match="empty text"):
+        await provider.synthesize("")
+    with pytest.raises(TTSError, match="empty text"):
+        await provider.synthesize("   \n\t")
+
+
+@pytest.mark.asyncio
+async def test_successful_synthesis_returns_raw_pcm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 100 even bytes — matches the s16 "byte count must be even" check.
+    pcm = b"\x10\x00" * 50
+    fake = _install_fake(monkeypatch, _FakeAsyncClient(_mk_response(pcm)))
+    result = await ElevenLabsProvider(
+        api_key="sk-test", voice_id="V1", model_id="eleven_turbo_v2_5"
+    ).synthesize("hello")
+    assert result.provider == "elevenlabs"
+    assert result.voice == "V1"
+    assert result.pcm == pcm
+    # Audit the request: voice id in the URL, output_format param,
+    # api-key header, model id in the body.
+    assert fake.last_call is not None
+    assert "V1" in fake.last_call["url"]
+    assert fake.last_call["params"]["output_format"] == "pcm_16000"
+    assert fake.last_call["headers"]["xi-api-key"] == "sk-test"
+    assert fake.last_call["json"]["model_id"] == "eleven_turbo_v2_5"
+    assert fake.last_call["json"]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_non_200_status_raises_synthesize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake(
+        monkeypatch,
+        _FakeAsyncClient(_mk_response(b'{"detail": "quota exhausted"}', 401)),
+    )
+    with pytest.raises(TTSError) as exc_info:
+        await ElevenLabsProvider(api_key="sk-test", voice_id="V1").synthesize("hi")
+    assert exc_info.value.stage == "synthesize"
+    assert "401" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_httpx_connect_error_raises_synthesize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake(monkeypatch, _FakeAsyncClient(httpx.ConnectError("dns")))
+    with pytest.raises(TTSError) as exc_info:
+        await ElevenLabsProvider(api_key="sk-test", voice_id="V1").synthesize("hi")
+    assert exc_info.value.stage == "synthesize"
+    assert "http error" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_empty_body_raises_synthesize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake(monkeypatch, _FakeAsyncClient(_mk_response(b"")))
+    with pytest.raises(TTSError) as exc_info:
+        await ElevenLabsProvider(api_key="sk-test", voice_id="V1").synthesize("hi")
+    assert exc_info.value.stage == "synthesize"
+    assert "empty" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_odd_length_body_raises_transcode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # s16 → byte count must be even. Odd-length is a clear protocol
+    # mismatch (the API returned a different audio container) and
+    # we want it surfaced as a transcode-stage error so logs point
+    # at the right layer.
+    _install_fake(monkeypatch, _FakeAsyncClient(_mk_response(b"\x00\x01\x02")))
+    with pytest.raises(TTSError) as exc_info:
+        await ElevenLabsProvider(api_key="sk-test", voice_id="V1").synthesize("hi")
+    assert exc_info.value.stage == "transcode"
+    assert "odd-length" in exc_info.value.detail


### PR DESCRIPTION
## Summary

- Add `ElevenLabsProvider` — cloud-quality TTS via the ElevenLabs REST API. Sidecar POSTs to `/v1/text-to-speech/{voice_id}` with `output_format=pcm_16000`, so the response body is already raw 16 kHz mono s16 LE PCM and gets handed to the audio cache unchanged (no resample, no WAV strip).
- Config: add `ELEVENLABS_API_KEY` + `elevenlabs_voice_id` (defaults to Rachel `21m00Tcm4TlvDq8ikWAM`) + `elevenlabs_model_id` (`eleven_turbo_v2_5` — cheap and fast). `load_settings()` refuses to start with `tts_provider=elevenlabs` and no api key.
- Selecting `tts_provider=elevenlabs` now wires `ElevenLabsProvider` end-to-end — Arc A's three-provider lineup (espeak-ng default, piper local-neural, ElevenLabs cloud-neural) is feature-complete on the sidecar side.

Stacked on #536 (slice 2) — base will retarget to `main` automatically when #536 merges.

## Tier note

ElevenLabs free tier returns MP3 only; `pcm_16000` requires Starter ($5/mo) or higher. Operators on the free tier should pick `tts_provider=piper` or `espeak_ng` instead. The 401/402 from the API surfaces as a clear `TTSError` so misconfig is obvious in logs.

## Test plan

- [x] `uv run pytest` — 175 passed, 3 skipped (espeak-ng absent locally)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — clean
- [ ] On-host smoke: set `ELEVENLABS_API_KEY`, `tts_provider=elevenlabs`, POST /v1/listen, verify audio_url returns. Deferred until firmware playback slice lands.