### PR TITLE
feat(kws-trainer): kws-build-dataset CLI

### DIFF
--- a/tools/kws-trainer/README.md
+++ b/tools/kws-trainer/README.md
@@ -5,9 +5,13 @@ stackchan-kai device. Eventually closes the loop: record samples →
 build dataset → train a `microWakeWord` model → drop the `.tflite`
 on the device's SD card → reboot.
 
-This package starts that loop. Slice 1 ships only the recorder
-(`kws-record`); dataset builder and training wrapper land in
-follow-ups.
+This package walks the loop one step at a time:
+
+- `kws-record` — capture a fixed-duration WAV from a running device.
+- `kws-build-dataset` — turn a directory of labelled WAVs into a
+  deterministic train/val/test manifest the trainer can consume.
+
+The training wrapper (`kws-train`) and eval tool land in follow-ups.
 
 ## Setup
 
@@ -49,10 +53,33 @@ run `kws-record` to capture WAVs:
 The WAV format is 16 kHz mono s16 LE — the same shape
 `microwakeword`'s training pipeline ingests directly.
 
+## Building a dataset manifest
+
+After collecting recordings (the recorder names files
+`positive-001.wav`, `negative-042.wav`, etc.), turn them into a
+deterministic train/val/test split:
+
+```bash
+uv run kws-build-dataset --input samples/ --output manifest.json
+```
+
+The output manifest is a JSON file with each split's recordings
+listed as `(path, label, duration_seconds)` triples, plus a
+per-split label-count summary. Same `--seed` + same input directory
+gives a bit-stable manifest — re-run after adding more samples and
+the previously-classified files stay in their original split.
+
+Operator-facing knobs:
+
+- `--val-fraction` / `--test-fraction` (defaults 0.15 each) —
+  per-label stratified hold-out, so a small `silence` bucket isn't
+  crowded out of validation by a much larger `negative` bucket.
+- `--strict` — exit non-zero if any WAV is rejected (wrong sample
+  rate, stereo, < 0.5 s). Useful in CI; default behaviour logs and
+  continues so a single bad file doesn't stop manifest generation.
+
 ## What's next
 
-- `kws-build-dataset` — directory of WAVs → microWakeWord training
-  dataset shape (positive / negative / silence buckets).
 - `kws-train` — wrap `microwakeword`'s training pipeline, emit a
   ready-to-flash `.tflite`.
 - `kws-eval` — run a `.tflite` against a WAV, report detection

--- a/tools/kws-trainer/pyproject.toml
+++ b/tools/kws-trainer/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 
 [project.scripts]
 kws-record = "kws_trainer.cli.record:main"
+kws-build-dataset = "kws_trainer.cli.build_dataset:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/kws-trainer/src/kws_trainer/cli/build_dataset.py
+++ b/tools/kws-trainer/src/kws_trainer/cli/build_dataset.py
@@ -1,0 +1,151 @@
+"""``kws-build-dataset`` CLI — turn a directory of labelled WAVs into
+a train/val/test split manifest.
+
+Operator workflow:
+
+1. Capture ~50 ``positive-*.wav`` and ~200 ``negative-*.wav``
+   recordings via ``kws-record`` (or copy in equivalents from
+   another source).
+2. Drop them all into one directory (nesting is fine —
+   subdirectories are walked).
+3. Run::
+
+       uv run kws-build-dataset --input samples/ --output manifest.json
+
+4. Inspect the manifest summary; re-record any classes that are
+   under-represented and re-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from kws_trainer.dataset import (
+    scan_directory,
+    split_recordings,
+    summarize_splits,
+    write_manifest,
+)
+
+_LOG = logging.getLogger("kws_trainer.cli.build_dataset")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="kws-build-dataset",
+        description=(
+            "Walk a directory of labelled WAVs and emit a deterministic "
+            "train/val/test split manifest."
+        ),
+    )
+    p.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Directory containing labelled WAVs. Files must be named "
+        "`<label>-<NNN>.wav` where `<label>` is one of "
+        "{positive, negative, noise, silence}. Subdirectories are walked.",
+    )
+    p.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Manifest JSON to write. Sample paths are recorded relative "
+        "to --input so the manifest can move alongside the directory.",
+    )
+    p.add_argument(
+        "--val-fraction",
+        type=float,
+        default=0.15,
+        help="Fraction of each label's samples to hold out for validation (default: 0.15).",
+    )
+    p.add_argument(
+        "--test-fraction",
+        type=float,
+        default=0.15,
+        help="Fraction of each label's samples to hold out for test (default: 0.15).",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for the deterministic split shuffle (default: 42). "
+        "Same seed + same input directory → bit-stable manifest.",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 2 if any input WAV is rejected (wrong shape, "
+        "bad name, too short). Default: log + continue.",
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Log per-file scan decisions at INFO level.",
+    )
+    return p
+
+
+def _configure_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.INFO if verbose else logging.WARNING,
+        format="%(message)s",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _configure_logging(args.verbose)
+    input_dir: Path = args.input
+    if not input_dir.is_dir():
+        print(f"error: --input {input_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    scan = scan_directory(input_dir)
+    if not scan.recordings:
+        print(
+            f"error: no usable WAVs found under {input_dir}",
+            file=sys.stderr,
+        )
+        if scan.invalid:
+            print(
+                f"  ({len(scan.invalid)} files rejected — re-run with --verbose for details)",
+                file=sys.stderr,
+            )
+        return 2
+
+    for invalid in scan.invalid:
+        _LOG.info("skip %s: %s", invalid.path, invalid.reason)
+    if scan.invalid and args.strict:
+        print(
+            f"error: {len(scan.invalid)} files rejected in strict mode",
+            file=sys.stderr,
+        )
+        return 2
+
+    splits = split_recordings(
+        scan.recordings,
+        val_fraction=args.val_fraction,
+        test_fraction=args.test_fraction,
+        seed=args.seed,
+    )
+    write_manifest(splits, args.output, base=input_dir, split_seed=args.seed)
+
+    summary = summarize_splits(splits)
+    print(f"manifest: {args.output}")
+    for split_name in ("train", "val", "test"):
+        counts = summary[split_name]
+        items = ", ".join(f"{lbl}={n}" for lbl, n in sorted(counts.items())) or "(empty)"
+        print(f"  {split_name}: {items}")
+    if scan.invalid:
+        print(f"rejected: {len(scan.invalid)} files (use --verbose to see why)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/kws-trainer/src/kws_trainer/dataset.py
+++ b/tools/kws-trainer/src/kws_trainer/dataset.py
@@ -1,0 +1,314 @@
+"""Dataset assembly: directory of WAVs → labelled train/val/test split.
+
+The recorder (`kws_trainer.recorder`) writes WAVs named with a
+label prefix — ``positive-001.wav``, ``negative-042.wav``,
+``silence-007.wav``. This module turns a directory of those WAVs
+into a deterministic train/val/test split with a JSON manifest
+the trainer can consume.
+
+Labels are derived from the filename prefix only — no audio
+classification. That's deliberate: operators curate the recordings
+during capture (one PTT = one labelled clip), and a downstream tool
+"auto-detecting" the wake phrase would risk leaking the training
+target into the labelling.
+
+Wire shape (input WAVs):
+- 16 kHz mono s16 LE — matches `kws_trainer.recorder.SAMPLE_RATE_HZ`.
+- Sample width must be 2 bytes; channels 1; frame rate 16000.
+- Files violating the shape are surfaced in
+  [`scan_directory`]'s `invalid` list rather than silently dropped.
+
+Manifest layout (output JSON):
+
+.. code-block:: json
+
+    {
+      "schema_version": 1,
+      "split_seed": 42,
+      "splits": {
+        "train": [
+          {"path": "positive-001.wav", "label": "positive",
+           "duration_seconds": 5.0}
+        ],
+        "val": [...],
+        "test": [...]
+      },
+      "summary": {"train": {"positive": 35, "negative": 140},
+                  "val": {...}, "test": {...}}
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+import wave
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .recorder import CHANNELS, SAMPLE_RATE_HZ, SAMPLE_WIDTH_BYTES
+
+_LOG = logging.getLogger("kws_trainer.dataset")
+
+Label = Literal["positive", "negative", "silence"]
+
+_LABEL_PREFIXES: dict[str, Label] = {
+    "positive": "positive",
+    "negative": "negative",
+    "silence": "silence",
+    # `noise-` is an alias for `negative-` — some operators prefer
+    # the more specific term when recording ambient backgrounds.
+    "noise": "negative",
+}
+
+# Minimum WAV duration to count as a usable training sample. Anything
+# shorter is almost certainly an aborted recording (op cancelled
+# before the trigger window finished); microWakeWord's training
+# pipeline doesn't fail on these, but they bias the loss and aren't
+# worth carrying.
+_MIN_DURATION_SECONDS = 0.5
+
+
+@dataclass
+class Recording:
+    """One labelled training sample on disk."""
+
+    path: Path
+    label: Label
+    duration_seconds: float
+
+    def to_manifest_entry(self, base: Path) -> dict[str, object]:
+        """Convert to the dict shape persisted in the manifest JSON.
+        Stores the path relative to ``base`` so the manifest stays
+        portable across hosts."""
+        try:
+            rel = self.path.relative_to(base)
+        except ValueError:
+            # Path isn't under base — keep it absolute. Operators who
+            # mix sources will see the full path in the manifest.
+            rel = self.path
+        return {
+            "path": str(rel),
+            "label": self.label,
+            "duration_seconds": round(self.duration_seconds, 3),
+        }
+
+
+@dataclass
+class InvalidRecording:
+    """A WAV that scanned but was rejected (wrong shape, bad name,
+    too short). Surfaced so operators can fix the input rather than
+    quietly dropping samples."""
+
+    path: Path
+    reason: str
+
+
+@dataclass
+class ScanResult:
+    """Aggregate output of [`scan_directory`]."""
+
+    recordings: list[Recording]
+    invalid: list[InvalidRecording]
+
+    @property
+    def label_counts(self) -> dict[Label, int]:
+        counts: Counter[Label] = Counter()
+        for r in self.recordings:
+            counts[r.label] += 1
+        return dict(counts)
+
+
+@dataclass
+class Splits:
+    """Deterministic train/val/test split of recordings."""
+
+    train: list[Recording]
+    val: list[Recording]
+    test: list[Recording]
+
+    @property
+    def all_recordings(self) -> Iterable[Recording]:
+        yield from self.train
+        yield from self.val
+        yield from self.test
+
+
+def label_from_filename(path: Path) -> Label | None:
+    """Derive the [`Label`] from ``path``'s stem prefix
+    (``positive-001`` → ``"positive"``). Returns ``None`` on any
+    unknown prefix so callers can surface it in [`InvalidRecording`]
+    rather than crashing.
+    """
+    stem = path.stem
+    head, _, _ = stem.partition("-")
+    if not head:
+        return None
+    return _LABEL_PREFIXES.get(head.lower())
+
+
+def inspect_wav(path: Path) -> tuple[float, str | None]:
+    """Open ``path`` and return ``(duration_seconds, reason_or_none)``.
+
+    ``reason_or_none`` is ``None`` on a well-shaped WAV; otherwise a
+    short string describing the violation. The duration is best-effort
+    in the error path — `0.0` when the file couldn't be opened at all.
+    """
+    try:
+        with wave.open(str(path), "rb") as w:
+            channels = w.getnchannels()
+            width = w.getsampwidth()
+            rate = w.getframerate()
+            n_frames = w.getnframes()
+    except (wave.Error, FileNotFoundError, OSError) as e:
+        return 0.0, f"unreadable WAV: {e}"
+    duration = n_frames / rate if rate else 0.0
+    if channels != CHANNELS:
+        return duration, f"channels={channels} != expected {CHANNELS}"
+    if width != SAMPLE_WIDTH_BYTES:
+        return duration, f"sample_width={width} != expected {SAMPLE_WIDTH_BYTES}"
+    if rate != SAMPLE_RATE_HZ:
+        return duration, f"sample_rate={rate} != expected {SAMPLE_RATE_HZ}"
+    if duration < _MIN_DURATION_SECONDS:
+        return duration, f"too short: {duration:.2f}s < {_MIN_DURATION_SECONDS}s"
+    return duration, None
+
+
+def scan_directory(root: Path, *, pattern: str = "*.wav") -> ScanResult:
+    """Walk ``root`` for files matching ``pattern``, classify by
+    filename prefix, validate WAV shape, and return the partition.
+
+    Iterates with `Path.rglob` so nested operator layouts
+    (``samples/2026-05-20/positive-001.wav``) are picked up.
+    """
+    recordings: list[Recording] = []
+    invalid: list[InvalidRecording] = []
+    for path in sorted(root.rglob(pattern)):
+        if not path.is_file():
+            continue
+        label = label_from_filename(path)
+        if label is None:
+            invalid.append(
+                InvalidRecording(path=path, reason=f"unknown label prefix in {path.name}")
+            )
+            continue
+        duration, reason = inspect_wav(path)
+        if reason is not None:
+            invalid.append(InvalidRecording(path=path, reason=reason))
+            continue
+        recordings.append(Recording(path=path, label=label, duration_seconds=duration))
+    return ScanResult(recordings=recordings, invalid=invalid)
+
+
+def split_recordings(
+    recordings: Sequence[Recording],
+    *,
+    val_fraction: float = 0.15,
+    test_fraction: float = 0.15,
+    seed: int = 42,
+) -> Splits:
+    """Deterministic train/val/test split, stratified per label.
+
+    The split is independent per label so a small ``silence`` bucket
+    isn't accidentally crowded out of the validation set by the much
+    larger ``negative`` bucket. ``seed`` controls the shuffle so
+    re-runs against the same input directory are bit-stable.
+    """
+    if not 0.0 <= val_fraction < 1.0:
+        raise ValueError(f"val_fraction must be in [0, 1): {val_fraction}")
+    if not 0.0 <= test_fraction < 1.0:
+        raise ValueError(f"test_fraction must be in [0, 1): {test_fraction}")
+    if val_fraction + test_fraction >= 1.0:
+        raise ValueError(
+            f"val + test fractions ({val_fraction + test_fraction}) leave no train data"
+        )
+
+    by_label: defaultdict[Label, list[Recording]] = defaultdict(list)
+    for r in recordings:
+        by_label[r.label].append(r)
+
+    rng = random.Random(seed)
+    train: list[Recording] = []
+    val: list[Recording] = []
+    test: list[Recording] = []
+    for label in sorted(by_label.keys()):
+        bucket = list(by_label[label])
+        rng.shuffle(bucket)
+        n_total = len(bucket)
+        n_test = round(n_total * test_fraction)
+        n_val = round(n_total * val_fraction)
+        # Take from the front so the same seed + dataset always
+        # produces the same partition assignment per file.
+        test.extend(bucket[:n_test])
+        val.extend(bucket[n_test : n_test + n_val])
+        train.extend(bucket[n_test + n_val :])
+    return Splits(train=train, val=val, test=test)
+
+
+def summarize_splits(splits: Splits) -> dict[str, dict[Label, int]]:
+    """Build the manifest's ``summary`` section: per-split label
+    counts. Empty buckets are omitted so operators can spot a missing
+    label at a glance."""
+    out: dict[str, dict[Label, int]] = {}
+    for name, bucket in (
+        ("train", splits.train),
+        ("val", splits.val),
+        ("test", splits.test),
+    ):
+        counts: Counter[Label] = Counter()
+        for r in bucket:
+            counts[r.label] += 1
+        out[name] = dict(counts)
+    return out
+
+
+def write_manifest(
+    splits: Splits,
+    output_path: Path,
+    *,
+    base: Path,
+    split_seed: int,
+) -> None:
+    """Persist ``splits`` to ``output_path`` as JSON.
+
+    ``base`` is the WAV-input root; paths in the manifest are
+    rendered relative to it so the manifest can move alongside the
+    sample directory across hosts.
+    """
+    manifest: dict[str, object] = {
+        "schema_version": 1,
+        "split_seed": split_seed,
+        "splits": {
+            "train": [r.to_manifest_entry(base) for r in splits.train],
+            "val": [r.to_manifest_entry(base) for r in splits.val],
+            "test": [r.to_manifest_entry(base) for r in splits.test],
+        },
+        "summary": summarize_splits(splits),
+    }
+    output_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    _LOG.info(
+        "wrote manifest %s (train=%d val=%d test=%d)",
+        output_path,
+        len(splits.train),
+        len(splits.val),
+        len(splits.test),
+    )
+
+
+__all__ = [
+    "InvalidRecording",
+    "Label",
+    "Recording",
+    "ScanResult",
+    "Splits",
+    "inspect_wav",
+    "label_from_filename",
+    "scan_directory",
+    "split_recordings",
+    "summarize_splits",
+    "write_manifest",
+]

--- a/tools/kws-trainer/tests/test_dataset.py
+++ b/tools/kws-trainer/tests/test_dataset.py
@@ -1,0 +1,234 @@
+"""Tests for the dataset assembly module.
+
+Synthesise small WAVs in tmp_path rather than depending on captured
+recordings — keeps the suite self-contained and fast.
+"""
+
+from __future__ import annotations
+
+import json
+import wave
+from pathlib import Path
+
+import pytest
+
+from kws_trainer.dataset import (
+    InvalidRecording,
+    Recording,
+    inspect_wav,
+    label_from_filename,
+    scan_directory,
+    split_recordings,
+    summarize_splits,
+    write_manifest,
+)
+from kws_trainer.recorder import SAMPLE_RATE_HZ
+
+
+def _write_wav(path: Path, duration_seconds: float, *, rate: int = SAMPLE_RATE_HZ) -> None:
+    """Synthesise a silent mono s16 WAV of the requested duration."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n_samples = round(duration_seconds * rate)
+    pcm = b"\x00\x00" * n_samples
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(pcm)
+
+
+def _write_stereo_wav(path: Path, duration_seconds: float) -> None:
+    n_samples = round(duration_seconds * SAMPLE_RATE_HZ)
+    # Interleaved L/R s16 silence.
+    pcm = b"\x00\x00\x00\x00" * n_samples
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(2)
+        w.setsampwidth(2)
+        w.setframerate(SAMPLE_RATE_HZ)
+        w.writeframes(pcm)
+
+
+def test_label_from_filename_recognises_canonical_prefixes(tmp_path: Path) -> None:
+    assert label_from_filename(tmp_path / "positive-001.wav") == "positive"
+    assert label_from_filename(tmp_path / "negative-042.wav") == "negative"
+    assert label_from_filename(tmp_path / "silence-007.wav") == "silence"
+
+
+def test_label_from_filename_noise_alias_maps_to_negative(tmp_path: Path) -> None:
+    # `noise-` and `negative-` should both classify as negative so
+    # operators using either convention land in the same bucket.
+    assert label_from_filename(tmp_path / "noise-005.wav") == "negative"
+
+
+def test_label_from_filename_is_case_insensitive(tmp_path: Path) -> None:
+    assert label_from_filename(tmp_path / "Positive-001.wav") == "positive"
+    assert label_from_filename(tmp_path / "NEGATIVE-042.wav") == "negative"
+
+
+def test_label_from_filename_rejects_unknown_prefix(tmp_path: Path) -> None:
+    assert label_from_filename(tmp_path / "random-001.wav") is None
+    assert label_from_filename(tmp_path / "no_dash.wav") is None
+
+
+def test_inspect_wav_accepts_well_shaped_audio(tmp_path: Path) -> None:
+    wav = tmp_path / "positive-001.wav"
+    _write_wav(wav, duration_seconds=2.0)
+    duration, reason = inspect_wav(wav)
+    assert reason is None
+    assert abs(duration - 2.0) < 0.01
+
+
+def test_inspect_wav_rejects_wrong_sample_rate(tmp_path: Path) -> None:
+    wav = tmp_path / "positive-001.wav"
+    _write_wav(wav, duration_seconds=2.0, rate=22050)
+    _duration, reason = inspect_wav(wav)
+    assert reason is not None
+    assert "sample_rate" in reason
+
+
+def test_inspect_wav_rejects_stereo(tmp_path: Path) -> None:
+    wav = tmp_path / "positive-001.wav"
+    _write_stereo_wav(wav, duration_seconds=2.0)
+    _duration, reason = inspect_wav(wav)
+    assert reason is not None
+    assert "channels" in reason
+
+
+def test_inspect_wav_rejects_too_short(tmp_path: Path) -> None:
+    wav = tmp_path / "positive-001.wav"
+    _write_wav(wav, duration_seconds=0.1)
+    duration, reason = inspect_wav(wav)
+    assert reason is not None
+    assert "too short" in reason
+    # Duration is still reported in the error path so operators can
+    # see how far off the recording was.
+    assert duration > 0
+
+
+def test_inspect_wav_handles_missing_file(tmp_path: Path) -> None:
+    _duration, reason = inspect_wav(tmp_path / "missing.wav")
+    assert reason is not None
+    assert "unreadable" in reason
+
+
+def test_scan_directory_classifies_and_collects(tmp_path: Path) -> None:
+    _write_wav(tmp_path / "positive-001.wav", 2.0)
+    _write_wav(tmp_path / "negative-001.wav", 2.0)
+    _write_wav(tmp_path / "silence-001.wav", 2.0)
+    # Subdirectory: rglob picks it up.
+    _write_wav(tmp_path / "nested" / "positive-002.wav", 2.0)
+    # Unknown prefix → goes to invalid.
+    _write_wav(tmp_path / "random-001.wav", 2.0)
+    # Wrong shape → goes to invalid.
+    _write_stereo_wav(tmp_path / "negative-bad.wav", 2.0)
+
+    result = scan_directory(tmp_path)
+    assert len(result.recordings) == 4
+    assert result.label_counts == {"positive": 2, "negative": 1, "silence": 1}
+    assert len(result.invalid) == 2
+    invalid_names = {inv.path.name for inv in result.invalid}
+    assert invalid_names == {"random-001.wav", "negative-bad.wav"}
+
+
+def test_scan_directory_returns_empty_on_no_matches(tmp_path: Path) -> None:
+    result = scan_directory(tmp_path)
+    assert result.recordings == []
+    assert result.invalid == []
+
+
+def _mk_recordings(counts: dict[str, int]) -> list[Recording]:
+    out: list[Recording] = []
+    for label, n in counts.items():
+        for i in range(n):
+            out.append(
+                Recording(
+                    path=Path(f"{label}-{i:03d}.wav"),
+                    label=label,  # type: ignore[arg-type]
+                    duration_seconds=2.0,
+                )
+            )
+    return out
+
+
+def test_split_recordings_is_deterministic_for_same_seed() -> None:
+    recordings = _mk_recordings({"positive": 50, "negative": 200})
+    a = split_recordings(recordings, seed=42)
+    b = split_recordings(recordings, seed=42)
+    assert [r.path for r in a.train] == [r.path for r in b.train]
+    assert [r.path for r in a.val] == [r.path for r in b.val]
+    assert [r.path for r in a.test] == [r.path for r in b.test]
+
+
+def test_split_recordings_changes_with_seed() -> None:
+    recordings = _mk_recordings({"positive": 50, "negative": 200})
+    a = split_recordings(recordings, seed=1)
+    b = split_recordings(recordings, seed=2)
+    assert [r.path for r in a.train] != [r.path for r in b.train]
+
+
+def test_split_recordings_stratifies_per_label() -> None:
+    # Skewed bucket sizes — 50 positive, 200 negative, 10 silence.
+    # The val/test fractions of 0.15 each should pull ~7-8 positives
+    # AND ~30 negatives AND ~1-2 silences, not just "15% of the
+    # whole pool" which would crowd silence out entirely.
+    recordings = _mk_recordings({"positive": 50, "negative": 200, "silence": 10})
+    splits = split_recordings(recordings, val_fraction=0.15, test_fraction=0.15)
+    total = len(splits.train) + len(splits.val) + len(splits.test)
+    assert total == 260
+    # Each split contains at least one of every label (stratification).
+    train_labels = {r.label for r in splits.train}
+    val_labels = {r.label for r in splits.val}
+    test_labels = {r.label for r in splits.test}
+    assert train_labels == {"positive", "negative", "silence"}
+    assert val_labels == {"positive", "negative", "silence"}
+    assert test_labels == {"positive", "negative", "silence"}
+
+
+def test_split_recordings_rejects_oversized_fractions() -> None:
+    recordings = _mk_recordings({"positive": 10})
+    with pytest.raises(ValueError, match="leave no train data"):
+        split_recordings(recordings, val_fraction=0.6, test_fraction=0.5)
+
+
+def test_summarize_splits_counts_per_label() -> None:
+    recordings = _mk_recordings({"positive": 10, "negative": 40})
+    splits = split_recordings(recordings, val_fraction=0.1, test_fraction=0.1)
+    summary = summarize_splits(splits)
+    # Sum across all splits == original counts.
+    total_positive = sum(s.get("positive", 0) for s in summary.values())
+    total_negative = sum(s.get("negative", 0) for s in summary.values())
+    assert total_positive == 10
+    assert total_negative == 40
+
+
+def test_write_manifest_round_trips_to_json(tmp_path: Path) -> None:
+    base = tmp_path / "samples"
+    base.mkdir()
+    recordings = _mk_recordings({"positive": 6, "negative": 6})
+    # Point each path at a real file under base so to_manifest_entry's
+    # relative_to call lands somewhere reasonable.
+    placed: list[Recording] = []
+    for r in recordings:
+        target = base / r.path.name
+        _write_wav(target, 2.0)
+        placed.append(Recording(path=target, label=r.label, duration_seconds=r.duration_seconds))
+    splits = split_recordings(placed, val_fraction=0.0, test_fraction=0.0)
+
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(splits, manifest_path, base=base, split_seed=42)
+
+    loaded = json.loads(manifest_path.read_text())
+    assert loaded["schema_version"] == 1
+    assert loaded["split_seed"] == 42
+    # All entries landed in train (val/test fractions were zero).
+    assert len(loaded["splits"]["train"]) == 12
+    # Paths are relative to base, not absolute.
+    assert all("/" not in entry["path"] for entry in loaded["splits"]["train"])
+    # Summary mirrors split counts.
+    assert loaded["summary"]["train"] == {"positive": 6, "negative": 6}
+
+
+def test_invalid_recording_dataclass_roundtrips() -> None:
+    inv = InvalidRecording(path=Path("/x.wav"), reason="bad")
+    assert inv.path == Path("/x.wav")
+    assert inv.reason == "bad"


### PR DESCRIPTION
## Summary

Closes the next step in Arc F: now that `kws-record` (#534) captures samples, `kws-build-dataset` turns a directory of them into a deterministic train/val/test manifest the trainer can consume.

- **CLI**: `uv run kws-build-dataset --input samples/ --output manifest.json` — walks the input dir (rglob), classifies by filename prefix, validates WAV shape, splits stratified per label.
- **Stratified split**: per-label hold-out so a small `silence` bucket isn't crowded out of validation by a much larger `negative` one. `--seed` (default 42) makes re-runs against the same input bit-stable.
- **Validation**: rejects wrong sample rate (16 kHz only), stereo, mismatched sample width, clips < 0.5 s. Rejections land in an `invalid` list rather than being silently dropped. `--strict` exits non-zero on any rejection.
- **Filename → label**: `positive-*`, `negative-*`, `silence-*`, and `noise-*` (alias for negative). Case-insensitive.

## Manifest shape

```json
{
  "schema_version": 1,
  "split_seed": 42,
  "splits": {
    "train": [{"path": "positive-001.wav", "label": "positive", "duration_seconds": 5.0}],
    "val": [...],
    "test": [...]
  },
  "summary": {"train": {"positive": 35, "negative": 140}, "val": {...}, "test": {...}}
}
```

Paths are relative to `--input` so the manifest can move alongside the sample directory across hosts.

## Test plan

- [x] `uv run pytest` — 34 passed (16 recorder + 18 dataset)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — clean
- [x] Smoke test: 23 synthesised WAVs (8 positive + 12 negative + 3 silence) → manifest with 70/15/15 stratified split + JSON inspection