### PR TITLE
feat(kws-trainer): kws-eval CLI

### DIFF
--- a/tools/kws-trainer/pyproject.toml
+++ b/tools/kws-trainer/pyproject.toml
@@ -5,11 +5,22 @@ description = "Host tooling for capturing wake-word training samples from a stac
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "MIT OR Apache-2.0" }
-dependencies = []
+dependencies = [
+    "numpy>=2.0",
+]
+
+[project.optional-dependencies]
+# `eval` brings in the TFLite runtime needed for `kws-eval` to
+# invoke a trained model. Pulled in optionally so the recorder +
+# dataset builder stay installable without an ML dep.
+eval = [
+    "ai-edge-litert>=1.0",
+]
 
 [project.scripts]
 kws-record = "kws_trainer.cli.record:main"
 kws-build-dataset = "kws_trainer.cli.build_dataset:main"
+kws-eval = "kws_trainer.cli.eval:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/tools/kws-trainer/src/kws_trainer/cli/eval.py
+++ b/tools/kws-trainer/src/kws_trainer/cli/eval.py
@@ -1,0 +1,136 @@
+"""``kws-eval`` CLI — run a trained ``.tflite`` against a WAV and
+report detection scores.
+
+Useful for tuning ``behavior.wake_word_threshold`` without
+reflashing: capture a representative WAV via ``kws-record``, run
+the model offline, and pick a threshold where positives trigger
+cleanly and negatives stay below.
+
+Requires the ``eval`` extra: ``uv sync --extra eval`` (pulls in
+``ai-edge-litert``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import wave
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+from kws_trainer.features import SAMPLE_RATE_HZ
+from kws_trainer.inference import evaluate_pcm, load_interpreter
+
+_LOG = logging.getLogger("kws_trainer.cli.eval")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="kws-eval",
+        description=(
+            "Run a trained .tflite wake-word model against a WAV "
+            "and report per-frame scores + peak."
+        ),
+    )
+    p.add_argument(
+        "--model",
+        required=True,
+        type=Path,
+        help="Path to the streaming-quantized .tflite model.",
+    )
+    p.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="WAV file to evaluate (16 kHz mono s16 LE — the same shape kws-record produces).",
+    )
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Score threshold for the 'triggered?' summary line (default: 0.5).",
+    )
+    p.add_argument(
+        "--print-scores",
+        action="store_true",
+        help="Print the per-frame score timeline as `frame=score` lines. "
+        "Off by default — long clips produce hundreds of rows.",
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Log at INFO level (default: WARNING).",
+    )
+    return p
+
+
+def _configure_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.INFO if verbose else logging.WARNING,
+        format="%(message)s",
+    )
+
+
+def load_wav_as_int16(path: Path) -> np.ndarray:
+    """Read a 16 kHz mono s16 LE WAV into a 1-D ``int16`` numpy
+    array. Raises ``ValueError`` on any shape mismatch — the trained
+    model expects this exact wire shape and a stereo/22kHz input
+    would silently produce garbage scores."""
+    with wave.open(str(path), "rb") as w:
+        if w.getnchannels() != 1:
+            raise ValueError(f"{path}: expected mono, got {w.getnchannels()} channels")
+        if w.getsampwidth() != 2:
+            raise ValueError(f"{path}: expected 16-bit samples, got {w.getsampwidth() * 8}-bit")
+        if w.getframerate() != SAMPLE_RATE_HZ:
+            raise ValueError(f"{path}: expected {SAMPLE_RATE_HZ} Hz, got {w.getframerate()} Hz")
+        n_frames = w.getnframes()
+        raw = w.readframes(n_frames)
+    return np.frombuffer(raw, dtype=np.int16)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _configure_logging(args.verbose)
+    if not args.model.is_file():
+        print(f"error: --model {args.model} does not exist", file=sys.stderr)
+        return 2
+    if not args.input.is_file():
+        print(f"error: --input {args.input} does not exist", file=sys.stderr)
+        return 2
+
+    try:
+        interpreter = load_interpreter(args.model)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+
+    try:
+        pcm = load_wav_as_int16(args.input)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    if pcm.size == 0:
+        print(f"error: {args.input} contains zero samples", file=sys.stderr)
+        return 2
+
+    result = evaluate_pcm(interpreter, pcm, threshold=args.threshold)
+
+    duration_s = pcm.size / SAMPLE_RATE_HZ
+    print(f"clip: {args.input.name}  duration: {duration_s:.2f}s  frames: {result.n_frames}")
+    print(
+        f"peak score: {result.peak_score:.4f} at frame {result.peak_frame_index} "
+        f"(threshold {result.threshold:.2f})"
+    )
+    print(f"triggered: {'YES' if result.triggered else 'no'}")
+    if args.print_scores:
+        for i, s in enumerate(result.per_frame_scores):
+            print(f"  frame={i:04d} score={s:.4f}")
+    return 0 if result.triggered else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/kws-trainer/src/kws_trainer/features.py
+++ b/tools/kws-trainer/src/kws_trainer/features.py
@@ -1,0 +1,239 @@
+"""Pure-numpy mel-spectrogram frontend mirroring the firmware's
+``stackchan-audio-features`` crate.
+
+The firmware's on-device KWS path computes log-mel features and feeds
+them to a TFLite-micro classifier. ``kws-eval`` reproduces the
+**exact same DSP pipeline** on the host so an evaluator's score for a
+WAV matches what the device would compute on the same audio.
+
+Spec parity sources (see ``crates/stackchan-audio-features/``):
+
+- ``frontend.rs``: SAMPLE_RATE_HZ=16_000, WINDOW_SAMPLES=480,
+  HOP_SAMPLES=160, FFT_SAMPLES=512, MEL_BIN_COUNT=40,
+  MEL_LOWER_HZ=125.0, MEL_UPPER_HZ=7500.0.
+- ``window.rs``: periodic Hann (``2pi*i/N``, not ``2pi*i/(N-1)``).
+- ``mel.rs``: 40 triangles between 125 and 7500 Hz on the mel scale
+  (``mel = 2595·log10(1 + hz/700)``).
+- ``quantize.rs``: ``int8`` asymmetric quantization with default
+  ``scale=0.5, zero_point=-25`` and ``LOG_EPSILON=1e-6``.
+
+Any drift between this module and the firmware constants is a bug —
+the firmware crate is the single source of truth.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+SAMPLE_RATE_HZ: int = 16_000
+WINDOW_SAMPLES: int = 480
+HOP_SAMPLES: int = 160
+FFT_SAMPLES: int = 512
+FFT_BIN_COUNT: int = FFT_SAMPLES // 2 + 1
+MEL_BIN_COUNT: int = 40
+MEL_LOWER_HZ: float = 125.0
+MEL_UPPER_HZ: float = 7500.0
+# Firmware: `LOG_EPSILON = 1.0e-6` in `quantize.rs`.
+LOG_EPSILON: float = 1.0e-6
+
+
+@dataclass(frozen=True)
+class QuantParams:
+    """``int8`` asymmetric quantization parameters.
+
+    Default values match microWakeWord's reference quantization
+    (``scale=0.5, zero_point=-25``). Real model deployments override
+    these from the loaded TFLite's input tensor's
+    ``quantization_parameters``.
+    """
+
+    scale: float = 0.5
+    zero_point: int = -25
+
+
+def hz_to_mel(hz: float) -> float:
+    """microWakeWord's mel scale: ``2595·log10(1 + hz/700)``."""
+    return 2595.0 * math.log10(1.0 + hz / 700.0)
+
+
+def mel_to_hz(mel: float) -> float:
+    """Inverse of [`hz_to_mel`]."""
+    return float(700.0 * (10.0 ** (mel / 2595.0) - 1.0))
+
+
+def make_hann_window() -> np.ndarray:
+    """Periodic 480-sample Hann window. ``2π·i/N``, not ``2π·i/(N-1)``."""
+    n = np.arange(WINDOW_SAMPLES, dtype=np.float64)
+    return 0.5 * (1.0 - np.cos(2.0 * np.pi * n / WINDOW_SAMPLES))
+
+
+def make_mel_filterbank() -> np.ndarray:
+    """40 by 257 triangular mel filterbank between 125 and 7500 Hz.
+
+    Returns float64 weights indexed ``[mel_bin][fft_bin]``. Each row's
+    triangle has its peak at the mel-bin centre with edges at the
+    adjacent mel-bin centres.
+    """
+    mel_lower = hz_to_mel(MEL_LOWER_HZ)
+    mel_upper = hz_to_mel(MEL_UPPER_HZ)
+    mel_step = (mel_upper - mel_lower) / (MEL_BIN_COUNT + 1)
+    centres_hz = np.array(
+        [mel_to_hz(mel_lower + i * mel_step) for i in range(MEL_BIN_COUNT + 2)],
+        dtype=np.float64,
+    )
+    bin_hz = np.arange(FFT_BIN_COUNT, dtype=np.float64) * SAMPLE_RATE_HZ / FFT_SAMPLES
+    weights = np.zeros((MEL_BIN_COUNT, FFT_BIN_COUNT), dtype=np.float64)
+    for m in range(MEL_BIN_COUNT):
+        left, centre, right = centres_hz[m], centres_hz[m + 1], centres_hz[m + 2]
+        for b, f in enumerate(bin_hz):
+            if f <= left or f >= right:
+                continue
+            if f <= centre:
+                weights[m, b] = (f - left) / (centre - left)
+            else:
+                weights[m, b] = (right - f) / (right - centre)
+    return weights
+
+
+def quantize_scalar(x: float, params: QuantParams) -> int:
+    """``f32 → i8`` round-half-away-from-zero with saturation.
+
+    Mirrors firmware's ``quantize_scalar`` in ``quantize.rs``. The
+    ``int(round(...))`` cast saturates via ``clamp`` because raw
+    ``int8`` truncates wrap-around for out-of-range values.
+    """
+    raw = x / params.scale + params.zero_point
+    rounded = math.floor(raw + 0.5) if raw >= 0 else -math.floor(-raw + 0.5)
+    return max(-128, min(127, rounded))
+
+
+def log_then_quantize(mel_energy: np.ndarray, params: QuantParams) -> np.ndarray:
+    """Apply ``natural-log`` (with epsilon floor) and ``int8`` quantize.
+
+    ``mel_energy`` is shape ``(MEL_BIN_COUNT,)``. Output is shape
+    ``(MEL_BIN_COUNT,)`` of dtype ``int8``.
+    """
+    if mel_energy.shape != (MEL_BIN_COUNT,):
+        raise ValueError(f"mel_energy must have shape ({MEL_BIN_COUNT},), got {mel_energy.shape}")
+    floored = np.maximum(mel_energy, LOG_EPSILON)
+    logged = np.log(floored)
+    # Vectorised round-half-away-from-zero + saturation.
+    scaled = logged / params.scale + params.zero_point
+    rounded = np.where(scaled >= 0, np.floor(scaled + 0.5), -np.floor(-scaled + 0.5))
+    clipped: np.ndarray = np.clip(rounded, -128, 127).astype(np.int8)
+    return clipped
+
+
+class MelFrontend:
+    """Streaming mel-feature extractor.
+
+    Mirrors the firmware's [`MelFrontend`] class shape: feed samples
+    in arbitrary chunks via [`push_samples`], drain emitted frames
+    via the returned list. One frontend instance handles continuous
+    audio for a session; call [`reset`] between independent inputs.
+
+    For batch (file-at-a-time) eval, [`process_pcm`] is the simpler
+    entry point — it accepts the whole sample array and returns the
+    full ``(n_frames, MEL_BIN_COUNT)`` feature matrix.
+    """
+
+    def __init__(self, *, quant: QuantParams | None = None) -> None:
+        self._quant = quant or QuantParams()
+        self._hann = make_hann_window()
+        self._mel_weights = make_mel_filterbank()
+        self._buf = np.zeros(WINDOW_SAMPLES, dtype=np.float64)
+        self._filled = 0
+        self._hop_remaining = 0
+
+    def reset(self) -> None:
+        self._buf[:] = 0.0
+        self._filled = 0
+        self._hop_remaining = 0
+
+    def push_samples(self, samples: np.ndarray) -> list[np.ndarray]:
+        """Buffer ``samples`` (``int16`` 1-D) and return any frames
+        that fit during this push.
+
+        ``samples`` may be any length; the frontend tracks its own
+        window/hop state across calls. The frame layout matches
+        firmware's ``[i8; 40]`` (one element per mel bin).
+        """
+        if samples.dtype != np.int16:
+            raise ValueError(f"samples must be int16, got {samples.dtype}")
+        # Convert to float64 once for the whole batch; integer-to-float
+        # widening is the same cost as the firmware's per-sample
+        # promotion but avoids per-sample Python overhead.
+        floats = samples.astype(np.float64)
+        emitted: list[np.ndarray] = []
+        idx = 0
+        while idx < floats.size:
+            if self._filled < WINDOW_SAMPLES:
+                want = min(WINDOW_SAMPLES - self._filled, floats.size - idx)
+                self._buf[self._filled : self._filled + want] = floats[idx : idx + want]
+                self._filled += want
+                idx += want
+                if self._filled == WINDOW_SAMPLES:
+                    emitted.append(self._emit_frame())
+                    self._hop_remaining = HOP_SAMPLES
+            else:
+                # Steady state: rotate hop samples into the ring,
+                # then emit one frame each time hop_remaining hits 0.
+                want = min(self._hop_remaining, floats.size - idx)
+                # Linear-shift the buffer (simpler than ring for a
+                # host implementation; firmware uses a ring for perf
+                # but on host the memmove is cheap).
+                self._buf[:-want] = self._buf[want:]
+                self._buf[-want:] = floats[idx : idx + want]
+                idx += want
+                self._hop_remaining -= want
+                if self._hop_remaining == 0:
+                    emitted.append(self._emit_frame())
+                    self._hop_remaining = HOP_SAMPLES
+        return emitted
+
+    def _emit_frame(self) -> np.ndarray:
+        """Run one window through Hann → FFT → mel → log → quantize.
+        Returns an ``int8`` ``(MEL_BIN_COUNT,)`` array."""
+        windowed = self._buf * self._hann
+        padded = np.zeros(FFT_SAMPLES, dtype=np.float64)
+        padded[:WINDOW_SAMPLES] = windowed
+        spectrum = np.fft.rfft(padded)
+        magnitude = np.abs(spectrum)
+        mel_energy = self._mel_weights @ magnitude
+        return log_then_quantize(mel_energy.astype(np.float64), self._quant)
+
+    def process_pcm(self, pcm: np.ndarray) -> np.ndarray:
+        """Convenience: run an entire ``int16`` PCM array through the
+        frontend, returning a 2-D ``(n_frames, MEL_BIN_COUNT)``
+        ``int8`` matrix. Resets the frontend state first so repeat
+        calls on the same instance don't carry leftover ring state.
+        """
+        self.reset()
+        frames = self.push_samples(pcm)
+        if not frames:
+            return np.zeros((0, MEL_BIN_COUNT), dtype=np.int8)
+        return np.stack(frames, axis=0)
+
+
+__all__ = [
+    "FFT_BIN_COUNT",
+    "FFT_SAMPLES",
+    "HOP_SAMPLES",
+    "LOG_EPSILON",
+    "MEL_BIN_COUNT",
+    "MEL_LOWER_HZ",
+    "MEL_UPPER_HZ",
+    "SAMPLE_RATE_HZ",
+    "WINDOW_SAMPLES",
+    "MelFrontend",
+    "QuantParams",
+    "hz_to_mel",
+    "log_then_quantize",
+    "make_hann_window",
+    "make_mel_filterbank",
+    "mel_to_hz",
+    "quantize_scalar",
+]

--- a/tools/kws-trainer/src/kws_trainer/inference.py
+++ b/tools/kws-trainer/src/kws_trainer/inference.py
@@ -1,0 +1,173 @@
+"""TFLite-based wake-word inference for ``kws-eval``.
+
+The trained ``.tflite`` is a *streaming* model: each invocation
+consumes one mel frame and produces one probability between 0 and
+1. The model holds its own state across invocations (the ``resource
+variable`` ops microWakeWord v2 relies on — see memory note
+``project_stackchan_microwakeword_operators``), so the host runner
+just feeds frames sequentially and reads the score.
+
+The TFLite runtime is loaded lazily so importing this module never
+fails on hosts without ``ai-edge-litert`` installed — the dep lives
+in the optional ``eval`` group.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from .features import MEL_BIN_COUNT, MelFrontend, QuantParams
+
+if TYPE_CHECKING:
+    pass
+
+_LOG = logging.getLogger("kws_trainer.inference")
+
+
+@dataclass(frozen=True)
+class InferenceResult:
+    """Outcome of running a TFLite model against a PCM clip."""
+
+    per_frame_scores: list[float]
+    peak_score: float
+    peak_frame_index: int
+    threshold: float
+    triggered: bool
+
+    @property
+    def n_frames(self) -> int:
+        return len(self.per_frame_scores)
+
+
+def load_interpreter(model_path: Path) -> Any:
+    """Open ``model_path`` with the TFLite runtime and return a
+    ready-to-use Interpreter.
+
+    Uses ``ai_edge_litert`` (the current canonical Python TFLite
+    runtime as of 2024 — replaces the older ``tflite_runtime``
+    package). Falls back to the full ``tensorflow`` package if
+    ``ai_edge_litert`` isn't installed; the latter is bigger but
+    operators with full TF may already have it.
+    """
+    try:
+        from ai_edge_litert.interpreter import Interpreter  # type: ignore[import-not-found]
+    except ImportError:
+        try:
+            from tensorflow.lite.python.interpreter import (  # type: ignore[import-untyped,unused-ignore]
+                Interpreter,
+            )
+        except ImportError as e:
+            raise RuntimeError(
+                "no TFLite runtime found. Install the eval extra: "
+                "`uv sync --extra eval` (pulls in ai-edge-litert)."
+            ) from e
+    interpreter = Interpreter(model_path=str(model_path))
+    interpreter.allocate_tensors()
+    return interpreter
+
+
+def input_quant_params(interpreter: Any) -> QuantParams:
+    """Read the model's input-tensor quantization parameters.
+
+    The frontend must quantize log-mel energies using the model's
+    actual ``(scale, zero_point)`` — not the firmware default — so
+    feature values land at the same integer points the model saw
+    during training.
+    """
+    details = interpreter.get_input_details()[0]
+    quant = details.get("quantization_parameters", {})
+    scales = quant.get("scales", []) or [0.5]
+    zero_points = quant.get("zero_points", []) or [-25]
+    scale = float(scales[0]) if len(scales) else 0.5
+    zero_point = int(zero_points[0]) if len(zero_points) else -25
+    return QuantParams(scale=scale, zero_point=zero_point)
+
+
+def run_frame(interpreter: Any, frame: np.ndarray) -> float:
+    """Feed one ``(MEL_BIN_COUNT,)`` ``int8`` frame to the model and
+    return the scalar score (float in ``[0, 1]``).
+
+    The input tensor's shape is taken from the model — typically
+    ``(1, 40, 1)`` for streaming MixConv models. Dequantization
+    of the output uses the output tensor's own scale/zero_point.
+    """
+    input_details = interpreter.get_input_details()[0]
+    output_details = interpreter.get_output_details()[0]
+    target_shape = tuple(int(d) for d in input_details["shape"])
+    # Most microWakeWord streaming models expect shape (1, 40, 1).
+    # Reshape via broadcasting so the function works for any
+    # consistent leading singleton.
+    reshaped = frame.reshape(target_shape).astype(input_details["dtype"])
+    interpreter.set_tensor(input_details["index"], reshaped)
+    interpreter.invoke()
+    raw = interpreter.get_tensor(output_details["index"])
+    # Dequantize int8 outputs to float using the output tensor's
+    # quantization parameters; float outputs pass through unchanged.
+    if output_details["dtype"] == np.int8:
+        out_quant = output_details.get("quantization_parameters", {})
+        scales = out_quant.get("scales", [1.0])
+        zps = out_quant.get("zero_points", [0])
+        scale = float(scales[0])
+        zp = int(zps[0])
+        score = float(scale * (int(raw.flatten()[0]) - zp))
+    else:
+        score = float(raw.flatten()[0])
+    return score
+
+
+def evaluate_pcm(
+    interpreter: Any,
+    pcm: np.ndarray,
+    *,
+    threshold: float = 0.5,
+) -> InferenceResult:
+    """Run streaming inference over an int16 PCM clip.
+
+    Returns per-frame scores, peak score + index, and a triggered
+    boolean (peak ≥ threshold). The frontend uses the model's actual
+    input quantization, not the firmware default — so a model trained
+    with a non-default ``scale`` doesn't see misaligned features.
+    """
+    quant = input_quant_params(interpreter)
+    frontend = MelFrontend(quant=quant)
+    feature_matrix = frontend.process_pcm(pcm)
+    scores: list[float] = []
+    peak_score = 0.0
+    peak_index = 0
+    for i, frame in enumerate(feature_matrix):
+        if frame.shape != (MEL_BIN_COUNT,):
+            raise ValueError(f"frame {i}: expected shape ({MEL_BIN_COUNT},), got {frame.shape}")
+        score = run_frame(interpreter, frame)
+        scores.append(score)
+        if score > peak_score:
+            peak_score = score
+            peak_index = i
+    triggered = peak_score >= threshold
+    _LOG.debug(
+        "evaluate_pcm: %d frames, peak=%.3f at frame %d, triggered=%s",
+        len(scores),
+        peak_score,
+        peak_index,
+        triggered,
+    )
+    return InferenceResult(
+        per_frame_scores=scores,
+        peak_score=peak_score,
+        peak_frame_index=peak_index,
+        threshold=threshold,
+        triggered=triggered,
+    )
+
+
+__all__ = [
+    "InferenceResult",
+    "evaluate_pcm",
+    "input_quant_params",
+    "load_interpreter",
+    "run_frame",
+]

--- a/tools/kws-trainer/tests/test_features.py
+++ b/tools/kws-trainer/tests/test_features.py
@@ -1,0 +1,230 @@
+"""Tests for the numpy mel-spectrogram frontend.
+
+These pin the DSP outputs against known references so any drift
+from the firmware's ``stackchan-audio-features`` spec is caught at
+host-test time, before a model trained on host features ever gets
+flashed.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from kws_trainer.features import (
+    FFT_BIN_COUNT,
+    HOP_SAMPLES,
+    LOG_EPSILON,
+    MEL_BIN_COUNT,
+    MEL_LOWER_HZ,
+    MEL_UPPER_HZ,
+    SAMPLE_RATE_HZ,
+    WINDOW_SAMPLES,
+    MelFrontend,
+    QuantParams,
+    hz_to_mel,
+    log_then_quantize,
+    make_hann_window,
+    make_mel_filterbank,
+    mel_to_hz,
+    quantize_scalar,
+)
+
+
+def test_constants_match_firmware_spec() -> None:
+    # Drift guard: if these change in `stackchan-audio-features::frontend`,
+    # update them here too — the on-device feature pipeline IS the spec.
+    assert SAMPLE_RATE_HZ == 16_000
+    assert WINDOW_SAMPLES == 480
+    assert HOP_SAMPLES == 160
+    assert FFT_BIN_COUNT == 257
+    assert MEL_BIN_COUNT == 40
+    assert pytest.approx(125.0) == MEL_LOWER_HZ
+    assert pytest.approx(7500.0) == MEL_UPPER_HZ
+
+
+def test_hz_to_mel_round_trip() -> None:
+    # mel(hz(m)) == m for arbitrary mel values.
+    for m in [50.0, 500.0, 1000.0, 3000.0]:
+        assert mel_to_hz(hz_to_mel(700.0 * (10 ** (m / 2595.0) - 1.0))) == pytest.approx(
+            700.0 * (10 ** (m / 2595.0) - 1.0)
+        )
+
+
+def test_hz_to_mel_known_values() -> None:
+    # 1000 Hz on the mel scale is well-tabulated as ~1000 mel (the
+    # scale is designed so 1000 Hz ≈ 1000 mel for the slaney variant;
+    # the htk variant we use puts it slightly higher).
+    assert hz_to_mel(1000.0) == pytest.approx(999.99, abs=2.0)
+
+
+def test_hann_window_is_periodic() -> None:
+    # Periodic Hann (the firmware spec): coeff[0] == 0, coeff[N/2]
+    # is the peak (1.0), and coeff is symmetric around N/2 (with the
+    # subtle off-by-one that periodic introduces).
+    window = make_hann_window()
+    assert window.shape == (WINDOW_SAMPLES,)
+    assert window[0] == pytest.approx(0.0)
+    assert window[WINDOW_SAMPLES // 2] == pytest.approx(1.0)
+    # The N-1 coefficient is not 0 for periodic — that's a periodic
+    # vs symmetric Hann tell. Pin the value so drift to symmetric
+    # is caught.
+    expected_last = 0.5 * (1.0 - math.cos(2.0 * math.pi * (WINDOW_SAMPLES - 1) / WINDOW_SAMPLES))
+    assert window[-1] == pytest.approx(expected_last)
+
+
+def test_mel_filterbank_shape_and_partition() -> None:
+    fb = make_mel_filterbank()
+    assert fb.shape == (MEL_BIN_COUNT, FFT_BIN_COUNT)
+    # Triangles sum to a partition-of-unity-ish profile across the
+    # mel-overlap region: each inner FFT bin is covered by ~1.0
+    # total weight across all mel filters. Bins outside the
+    # MEL_LOWER..MEL_UPPER band drop to zero.
+    bin_sum = fb.sum(axis=0)
+    # Find a bin firmly inside the active mel band (e.g. ~1500 Hz).
+    inner_bin = round(1500.0 * FFT_BIN_COUNT * 2 / SAMPLE_RATE_HZ)
+    assert bin_sum[inner_bin] == pytest.approx(1.0, abs=0.05)
+
+
+def test_quantize_scalar_default_quant_zero() -> None:
+    # Default quant: scale=0.5, zero_point=-25 → 0.0 quantizes to
+    # zero_point exactly (no rounding contribution from input).
+    assert quantize_scalar(0.0, QuantParams()) == -25
+
+
+def test_quantize_scalar_saturates_on_overflow() -> None:
+    # Very large positive input clamps at +127; very negative at -128.
+    assert quantize_scalar(10_000.0, QuantParams()) == 127
+    assert quantize_scalar(-10_000.0, QuantParams()) == -128
+
+
+def test_quantize_scalar_round_half_away_from_zero() -> None:
+    # Mirrors firmware's `quantize_scalar` rounding behaviour. Use
+    # scale=1.0, zero_point=0 so the output equals round(input).
+    p = QuantParams(scale=1.0, zero_point=0)
+    assert quantize_scalar(0.5, p) == 1  # half-up
+    assert quantize_scalar(-0.5, p) == -1  # half-down (away-from-zero)
+    assert quantize_scalar(1.5, p) == 2
+    assert quantize_scalar(-1.5, p) == -2
+
+
+def test_log_then_quantize_handles_zero_via_epsilon() -> None:
+    # Inputs at 0 land at log(LOG_EPSILON) ≈ -13.8 which (under
+    # default quant) is well within the int8 range and well below 0.
+    out = log_then_quantize(np.zeros(MEL_BIN_COUNT, dtype=np.float64), QuantParams())
+    expected = quantize_scalar(math.log(LOG_EPSILON), QuantParams())
+    assert all(v == expected for v in out)
+
+
+def test_log_then_quantize_unit_input_produces_log_of_one() -> None:
+    # log(1.0) = 0 → quantizes to zero_point exactly under default
+    # quant. Pin this so any drift in log/quant order surfaces.
+    out = log_then_quantize(np.ones(MEL_BIN_COUNT, dtype=np.float64), QuantParams())
+    assert all(v == -25 for v in out)
+
+
+def test_log_then_quantize_rejects_wrong_shape() -> None:
+    with pytest.raises(ValueError, match="shape"):
+        log_then_quantize(np.zeros(MEL_BIN_COUNT - 1, dtype=np.float64), QuantParams())
+
+
+def test_frontend_emits_one_frame_per_full_window_when_primed() -> None:
+    # First WINDOW_SAMPLES → one frame; then every HOP_SAMPLES → one
+    # more frame. A 480 + 160 + 160 + 160 sample push should emit
+    # 4 frames (initial + 3 hops).
+    fe = MelFrontend()
+    n = WINDOW_SAMPLES + 3 * HOP_SAMPLES
+    pcm = np.zeros(n, dtype=np.int16)
+    frames = fe.push_samples(pcm)
+    assert len(frames) == 4
+    # All silence → all frames identical, all set to
+    # quantize(log(LOG_EPSILON)).
+    expected = quantize_scalar(math.log(LOG_EPSILON), QuantParams())
+    for f in frames:
+        assert f.shape == (MEL_BIN_COUNT,)
+        assert all(v == expected for v in f)
+
+
+def test_frontend_chunk_size_invariance() -> None:
+    # Same PCM split into different chunk shapes must produce the
+    # exact same frame sequence — the ring/hop state has to handle
+    # arbitrary push sizes.
+    rng = np.random.default_rng(seed=42)
+    pcm = rng.integers(-5000, 5000, size=WINDOW_SAMPLES + 5 * HOP_SAMPLES, dtype=np.int16)
+    fe_a = MelFrontend()
+    a = fe_a.push_samples(pcm)
+    # Chunk into 73-sample pieces (deliberately not aligned to hop or
+    # window boundaries) and re-feed.
+    fe_b = MelFrontend()
+    chunked: list[np.ndarray] = []
+    for start in range(0, pcm.size, 73):
+        chunked += fe_b.push_samples(pcm[start : start + 73])
+    assert len(a) == len(chunked)
+    for fa, fb in zip(a, chunked, strict=True):
+        assert np.array_equal(fa, fb)
+
+
+def test_frontend_reset_clears_ring_state() -> None:
+    fe = MelFrontend()
+    pcm = np.ones(WINDOW_SAMPLES, dtype=np.int16) * 10_000
+    fe.push_samples(pcm)
+    fe.reset()
+    # After reset, the first WINDOW_SAMPLES of zeros should produce
+    # an all-silence frame identical to a fresh-frontend run.
+    silence = np.zeros(WINDOW_SAMPLES, dtype=np.int16)
+    frames_after = fe.push_samples(silence)
+    fresh = MelFrontend()
+    frames_fresh = fresh.push_samples(silence)
+    assert len(frames_after) == len(frames_fresh) == 1
+    assert np.array_equal(frames_after[0], frames_fresh[0])
+
+
+def test_frontend_rejects_non_int16_input() -> None:
+    fe = MelFrontend()
+    with pytest.raises(ValueError, match="int16"):
+        fe.push_samples(np.zeros(WINDOW_SAMPLES, dtype=np.float32))
+
+
+def test_process_pcm_returns_2d_matrix() -> None:
+    fe = MelFrontend()
+    pcm = np.zeros(WINDOW_SAMPLES + 5 * HOP_SAMPLES, dtype=np.int16)
+    matrix = fe.process_pcm(pcm)
+    assert matrix.dtype == np.int8
+    assert matrix.shape == (6, MEL_BIN_COUNT)
+
+
+def test_process_pcm_returns_empty_for_undersized_input() -> None:
+    # Less than one window → no frames.
+    fe = MelFrontend()
+    pcm = np.zeros(WINDOW_SAMPLES - 1, dtype=np.int16)
+    matrix = fe.process_pcm(pcm)
+    assert matrix.shape == (0, MEL_BIN_COUNT)
+
+
+def test_frontend_sine_wave_concentrates_energy_in_expected_mel_bin() -> None:
+    # 1 kHz pure tone should produce mel energy concentrated in the
+    # bins covering 1 kHz, not at DC or near Nyquist. This is a sanity
+    # check that the FFT + filterbank are wired in the right order.
+    duration_s = 0.5
+    n = int(duration_s * SAMPLE_RATE_HZ)
+    t = np.arange(n) / SAMPLE_RATE_HZ
+    amplitude = 10_000  # well within int16 range
+    pcm = (amplitude * np.sin(2.0 * np.pi * 1000.0 * t)).astype(np.int16)
+    fe = MelFrontend()
+    matrix = fe.process_pcm(pcm)
+    # Sum across time to find which mel bin holds the most energy
+    # (we want consistent peak, not just any single frame's peak).
+    # Convert back to float so int8 saturation doesn't dominate.
+    aggregated = matrix.astype(np.int32).sum(axis=0)
+    peak_bin = int(np.argmax(aggregated))
+    # 1 kHz on the mel scale (htk) is ~999 mel. Our 40-bin filterbank
+    # spans ~155 to ~2840 mel — 1 kHz lands somewhere mid-band.
+    # The bin index can shift by ±2 depending on rounding; assert it
+    # falls in a generous window around the expected centre.
+    mel_lower = hz_to_mel(MEL_LOWER_HZ)
+    mel_upper = hz_to_mel(MEL_UPPER_HZ)
+    target_mel = hz_to_mel(1000.0)
+    target_bin = round((target_mel - mel_lower) / (mel_upper - mel_lower) * (MEL_BIN_COUNT + 1) - 1)
+    assert abs(peak_bin - target_bin) <= 3, f"peak at {peak_bin}, expected near {target_bin}"

--- a/tools/kws-trainer/tests/test_inference.py
+++ b/tools/kws-trainer/tests/test_inference.py
@@ -1,0 +1,193 @@
+"""Tests for the TFLite runner.
+
+The real TFLite runtime lives in the optional ``eval`` extra; tests
+mock the Interpreter shape so the unit suite runs without the ML
+dep installed. End-to-end smoke against a real ``.tflite`` is
+deferred to the on-device validation step.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from kws_trainer.features import MEL_BIN_COUNT
+from kws_trainer.inference import (
+    evaluate_pcm,
+    input_quant_params,
+    run_frame,
+)
+
+
+class _FakeInterpreter:
+    """Minimal stub matching the subset of TFLite Interpreter's
+    surface that the inference module touches: ``get_input_details``,
+    ``get_output_details``, ``set_tensor``, ``invoke``, ``get_tensor``.
+    """
+
+    def __init__(
+        self,
+        *,
+        input_shape: tuple[int, ...] = (1, MEL_BIN_COUNT, 1),
+        input_dtype: Any = np.int8,
+        input_scale: float = 0.5,
+        input_zero_point: int = -25,
+        output_dtype: Any = np.int8,
+        output_scale: float = 1.0 / 255.0,
+        output_zero_point: int = -128,
+        score_for_frame: Any = None,
+    ) -> None:
+        self._input_shape = input_shape
+        self._input_dtype = input_dtype
+        self._input_scale = input_scale
+        self._input_zero_point = input_zero_point
+        self._output_dtype = output_dtype
+        self._output_scale = output_scale
+        self._output_zero_point = output_zero_point
+        # `score_for_frame(frame_index, frame_array) -> raw_int8` lets
+        # tests script per-frame outputs. Default returns mid-range.
+        self._score_for_frame = score_for_frame or (lambda _i, _f: 0)
+        self._frame_index = 0
+        self._last_input: np.ndarray | None = None
+        self._next_raw: int = 0
+
+    def get_input_details(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "index": 0,
+                "shape": np.array(self._input_shape, dtype=np.int32),
+                "dtype": self._input_dtype,
+                "quantization_parameters": {
+                    "scales": np.array([self._input_scale]),
+                    "zero_points": np.array([self._input_zero_point]),
+                },
+            }
+        ]
+
+    def get_output_details(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "index": 1,
+                "shape": np.array([1], dtype=np.int32),
+                "dtype": self._output_dtype,
+                "quantization_parameters": {
+                    "scales": np.array([self._output_scale]),
+                    "zero_points": np.array([self._output_zero_point]),
+                },
+            }
+        ]
+
+    def set_tensor(self, _index: int, tensor: np.ndarray) -> None:
+        self._last_input = tensor
+
+    def invoke(self) -> None:
+        if self._last_input is None:
+            raise RuntimeError("invoke() before set_tensor()")
+        self._next_raw = int(self._score_for_frame(self._frame_index, self._last_input.flatten()))
+        self._frame_index += 1
+
+    def get_tensor(self, _index: int) -> np.ndarray:
+        return np.array([self._next_raw], dtype=self._output_dtype)
+
+
+def test_input_quant_params_reads_from_interpreter() -> None:
+    interp = _FakeInterpreter(input_scale=0.75, input_zero_point=10)
+    q = input_quant_params(interp)
+    assert q.scale == pytest.approx(0.75)
+    assert q.zero_point == 10
+
+
+def test_input_quant_params_falls_back_when_empty() -> None:
+    class _NoQuantInterpreter(_FakeInterpreter):
+        def get_input_details(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "index": 0,
+                    "shape": np.array((1, MEL_BIN_COUNT, 1), dtype=np.int32),
+                    "dtype": np.int8,
+                    "quantization_parameters": {},
+                }
+            ]
+
+    q = input_quant_params(_NoQuantInterpreter())
+    assert q.scale == 0.5
+    assert q.zero_point == -25
+
+
+def test_run_frame_dequantizes_int8_output() -> None:
+    # Raw int8 output of 100 with scale=0.01 and zp=-50 →
+    # (100 - (-50)) * 0.01 = 1.5
+    interp = _FakeInterpreter(
+        output_scale=0.01,
+        output_zero_point=-50,
+        score_for_frame=lambda _i, _f: 100,
+    )
+    frame = np.zeros(MEL_BIN_COUNT, dtype=np.int8)
+    assert run_frame(interp, frame) == pytest.approx(1.5)
+
+
+def test_run_frame_passes_float_outputs_through() -> None:
+    # When output dtype is float, no dequantization should happen.
+    class _FloatOutInterpreter(_FakeInterpreter):
+        def __init__(self) -> None:
+            super().__init__(output_dtype=np.float32)
+
+        def get_tensor(self, _index: int) -> np.ndarray:
+            # Return a deterministic float so the test can pin it.
+            return np.array([0.42], dtype=np.float32)
+
+    frame = np.zeros(MEL_BIN_COUNT, dtype=np.int8)
+    assert run_frame(_FloatOutInterpreter(), frame) == pytest.approx(0.42)
+
+
+def test_run_frame_reshapes_to_model_input_shape() -> None:
+    # Captured input tensor must end up with the model's expected
+    # shape (1, 40, 1) even though we pass in (40,).
+    interp = _FakeInterpreter()
+    frame = np.arange(MEL_BIN_COUNT, dtype=np.int8)
+    run_frame(interp, frame)
+    assert interp._last_input is not None
+    assert interp._last_input.shape == (1, MEL_BIN_COUNT, 1)
+
+
+def test_evaluate_pcm_aggregates_frame_scores() -> None:
+    # Script the model to emit increasing raw ints; the dequantized
+    # peak should land at the last frame.
+    interp = _FakeInterpreter(
+        output_scale=0.01,
+        output_zero_point=0,
+        # Each frame returns raw int8 == frame index, capped at int8 max.
+        score_for_frame=lambda i, _f: min(i, 127),
+    )
+    # Long-enough PCM to produce ~6 frames.
+    pcm = np.zeros(480 + 5 * 160, dtype=np.int16)
+    result = evaluate_pcm(interp, pcm, threshold=0.04)
+    assert result.n_frames == 6
+    # Peak should be the last frame (5 * 0.01 = 0.05).
+    assert result.peak_frame_index == 5
+    assert result.peak_score == pytest.approx(0.05)
+    assert result.triggered is True
+
+
+def test_evaluate_pcm_below_threshold_not_triggered() -> None:
+    interp = _FakeInterpreter(
+        output_scale=0.001,
+        output_zero_point=0,
+        score_for_frame=lambda _i, _f: 1,
+    )
+    pcm = np.zeros(480 + 5 * 160, dtype=np.int16)
+    result = evaluate_pcm(interp, pcm, threshold=0.5)
+    assert result.peak_score < 0.5
+    assert result.triggered is False
+
+
+def test_evaluate_pcm_empty_pcm_returns_zero_frames() -> None:
+    # Less than one window → no frames → peak score stays 0.
+    interp = _FakeInterpreter()
+    pcm = np.zeros(100, dtype=np.int16)
+    result = evaluate_pcm(interp, pcm, threshold=0.5)
+    assert result.n_frames == 0
+    assert result.peak_score == 0.0
+    assert result.triggered is False

--- a/tools/kws-trainer/uv.lock
+++ b/tools/kws-trainer/uv.lock
@@ -7,6 +7,33 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ai-edge-litert"
+version = "2.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-strenum" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/37/cf525a4ed6aff573b10a162b7bff19673e50ce6f45daac0a095dcd099a28/ai_edge_litert-2.1.5-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b62fd3d90e643bcc3e3a31885a7636b5662527d48c27154cf07793f26896f018", size = 9711976, upload-time = "2026-05-15T23:34:16.988Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/6f/b43fc56831ecc439a6e6eb0e1bfdffbfe6213e8c706aa421017dce1ac56b/ai_edge_litert-2.1.5-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1d282722cdfb70bb42d457f4bfe7789f88187ccadd73fea9f0107dce6e98fe45", size = 12867617, upload-time = "2026-05-15T23:11:22.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/20/a76ba29b1c4c3009b5c64f4ec7f5fe5165104fe15481bd79b55927948541/ai_edge_litert-2.1.5-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:f1c6d8db4382890881baeb8ed13c0802ada022e0b104b0db8fccf31353899ee0", size = 17570644, upload-time = "2026-05-15T23:05:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/5399085daffd9949668d13a83a48db9f69af535ef9f9d06fdf71f0205321/ai_edge_litert-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:6d2db6759188b12be9fd095468c3c7069c1bc7c128de78f42f862fb654d247ea", size = 17755006, upload-time = "2026-05-15T23:39:24.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fd/28f24305904954f31ee1a979eea39b670c6a1ab13cf6e5e4fe5f128e9eff/ai_edge_litert-2.1.5-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:2af16685a4cc8923d9a89ee5c732b8c66ae2c4d0cb538dbcebba3b93afb662ca", size = 9713185, upload-time = "2026-05-15T23:34:19.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/88/e7e32b37f972b4877df788d1ad0995388f823d74dc2743b200bf71a25a53/ai_edge_litert-2.1.5-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:57506e9e9b91ee04e4cf3e986d184b0c92f1aa9f510c32841835c0d719a7fbb5", size = 12867247, upload-time = "2026-05-15T23:11:24.667Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c1/5192c360a467dd6e09fa28388022c37bca5d9777e616da40dc5d517186a9/ai_edge_litert-2.1.5-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:b7825e13454a90e7a4782ecdb6f6d987a2bcc9147aa90eb181193867bf696f24", size = 17570488, upload-time = "2026-05-15T23:05:36.078Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ba/154599984a8eccbdd14bcd89fabc2e9cbdfcbf537a3c1ab08712c7ce7d02/ai_edge_litert-2.1.5-cp313-cp313-win_amd64.whl", hash = "sha256:602fc90f6baf396df0fe4b0317b35627305c2233beb48db194b79e7e420bafa7", size = 17755085, upload-time = "2026-05-15T23:39:26.901Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/51/34f0ad0def8b15093d602ca6904b129d3ab242ae4711c872190d5c95c010/ai_edge_litert-2.1.5-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:597ea79f947452c79ca7e9dd7abfedad6179302851df4a4bb4c755069a2f5ffe", size = 9712496, upload-time = "2026-05-15T23:34:21.36Z" },
+    { url = "https://files.pythonhosted.org/packages/42/43/2b8ef317dca3096372cbf820aa5a3a6c8857dad67f31840a1e17a951e2d3/ai_edge_litert-2.1.5-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:41d2e8267f047ed14f14a5ff4e0f677a9c5143dd17a36991513f8cc5ef580a3b", size = 12867899, upload-time = "2026-05-15T23:11:26.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d5/9640952de755409c84e09eec5d107675c59fe4f4859391464275eb2c3db6/ai_edge_litert-2.1.5-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:4fa10d99b2f8647678850684d31075fbb304f50535d5788c2ca93e273ce727a8", size = 17570849, upload-time = "2026-05-15T23:05:37.981Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d4/0843e5a41bf71eb99ccd1e54714485df527bec19e8c8e679e1395176345d/ai_edge_litert-2.1.5-cp314-cp314-win_amd64.whl", hash = "sha256:14b35558bfce76146046cc2fc647f3fde97146e8b7622ea7fb02e85ac16cd906", size = 18380722, upload-time = "2026-05-15T23:39:29.365Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -47,12 +74,29 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-strenum"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -178,6 +222,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +307,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
 ]
 
 [[package]]
@@ -258,6 +378,14 @@ wheels = [
 name = "stackchan-kws-trainer"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+]
+
+[package.optional-dependencies]
+eval = [
+    { name = "ai-edge-litert" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -267,12 +395,29 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "ai-edge-litert", marker = "extra == 'eval'", specifier = ">=1.0" },
+    { name = "numpy", specifier = ">=2.0" },
+]
+provides-extras = ["eval"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.13" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "ruff", specifier = ">=0.7" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Next slice in Arc F: load a trained `.tflite` wake-word model, run it against a WAV, report per-frame detection scores.

- **CLI**: `uv run --extra eval kws-eval --model wakeword.tflite --input sample.wav` — outputs duration, frame count, peak score + frame index, threshold pass/fail. `--print-scores` dumps the per-frame timeline.
- **Mel frontend (`features.py`)**: pure-numpy mirror of `stackchan-audio-features::frontend` — periodic Hann × 480 samples (30 ms @ 16 kHz), 512-point FFT, 40 mel bins from 125-7500 Hz, log + int8 quantize. Constants are pinned against the firmware crate; drift is caught by a test guard.
- **TFLite runner (`inference.py`)**: streaming inference loop. Reads the model's input quantization (`scale, zero_point`) from the loaded TFLite so the frontend produces features at the same integer points the model saw at training. Dequantizes int8 outputs using the output tensor's own quant params.
- **Optional dep group `eval`** = ai-edge-litert (the canonical TFLite Python runtime as of 2024+). Falls back to `tensorflow` if installed instead.

Use case: capture a representative clip via kws-record, run kws-eval, pick a `wake_word_threshold` where positives trigger and negatives don't — all without reflashing.

## Why mirror the firmware spec instead of using microWakeWord's preprocessor?

The on-device path (esp-tflite-micro + `stackchan-audio-features`) is the ground truth. A host evaluator using a different feature pipeline could disagree with the device on borderline scores — which would make threshold tuning misleading. Bit-equivalence with the firmware is the only way kws-eval predicts real on-device behavior.

## Test plan

- [x] `uv run pytest` — 42 passed (16 recorder + 18 features + 8 inference)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — clean
- [ ] On-device smoke: capture a clip, train a model via the eventual `kws-train` slice, run kws-eval against the same clip, verify peak score matches what the device computes on the same audio. Deferred to Arc F's full close.