### PR TITLE
refactor(sidecar): tidy TTS providers + guard /v1/audio with bearer

### DIFF
--- a/sidecar/src/stackchan_sidecar/app.py
+++ b/sidecar/src/stackchan_sidecar/app.py
@@ -133,7 +133,7 @@ def create_app(
             "providers": {"stt": "ready", "llm": "ready"},
         }
 
-    @app.get("/v1/audio/{token}")
+    @app.get("/v1/audio/{token}", dependencies=[Depends(verify_bearer)])
     async def audio_endpoint(token: str) -> Response:
         # Streams the cached PCM the firmware fetches after a /v1/listen
         # reply. Tokens are opaque per-request handles minted in the

--- a/sidecar/src/stackchan_sidecar/tts/__init__.py
+++ b/sidecar/src/stackchan_sidecar/tts/__init__.py
@@ -1,25 +1,18 @@
 """Text-to-speech providers for the sidecar voice-agent reply path.
 
-Every provider emits **raw 16 kHz mono s16 little-endian PCM** so the
-firmware's `AUDIO_TX_QUEUE` can consume it without any transcode. The
-wire contract between sidecar and firmware is:
+Wire contract:
 
-1. ``POST /v1/listen`` LLM-reply path includes ``"audio_url":
-   "/v1/audio/<token>"`` when synthesis succeeded, or
-   ``"audio_url": null`` when it failed (graceful degradation —
-   text + emotion still ship).
-2. Firmware ``GET /v1/audio/<token>`` returns the cached PCM as
-   ``Transfer-Encoding: chunked`` so playback can start on the
-   first chunk.
+1. ``POST /v1/listen`` includes ``"audio_url": "/v1/audio/<token>"``
+   on synthesis success or ``"audio_url": null`` on failure (text +
+   emotion still ship).
+2. Firmware ``GET /v1/audio/<token>`` returns the cached PCM as one
+   ``Content-Length``-framed response body, 16 kHz mono s16 LE.
+   Replies are short enough (≲ a few hundred KiB) that streaming
+   doesn't materially change first-sample latency on the LAN.
 
-Token lifetime is bounded by the in-memory audio cache (TTL +
-capacity, see ``audio_cache.py``); the firmware is expected to fetch
-within a few seconds.
-
-This package's public surface is the [`TTSProvider`] protocol and the
-three concrete providers ([`EspeakProvider`], [`PiperProvider`],
-[`ElevenLabsProvider`]). [`TTSError`] is the canonical failure type;
-callers catch it and fall back to ``audio_url: null``.
+Token lifetime is bounded by the [`AudioCache`] (TTL + capacity).
+Public surface: the [`TTSProvider`] protocol and concrete providers
+under this package. [`TTSError`] is the canonical failure type.
 """
 
 from __future__ import annotations

--- a/sidecar/src/stackchan_sidecar/tts/_audio.py
+++ b/sidecar/src/stackchan_sidecar/tts/_audio.py
@@ -1,28 +1,16 @@
 """Shared audio post-processing for subprocess-driven TTS providers.
 
-Both [`EspeakProvider`] and [`PiperProvider`] shell out to a binary
-that writes a WAV file at the model's native sample rate (22050 Hz for
-both, in practice), then read that WAV back as raw bytes and convert
-it to the firmware's wire format: **16 kHz mono s16 little-endian PCM**.
-
-The two paths share three concerns:
-
-1. WAV parse + sanity check (16-bit sample width, non-empty payload).
-2. Multi-channel → mono via per-frame mean (both providers are mono
-   in practice; the guard is cheap and future-proofs us against a
-   provider that defaults to stereo).
-3. Sample-rate resample to 16 kHz via linear interpolation on
-   NumPy arrays.
-
-Linear interpolation is "good enough" for a robot-voice desk toy.
-A more demanding application would reach for polyphase resampling
-(`scipy.signal.resample_poly`, `libsoxr`); for this product, the
-quality gap is invisible next to the model itself.
+WAV-to-PCM transcode (16-bit width check, multi-channel → mono via
+per-frame mean, linear resample to 16 kHz) plus a small subprocess
+helper that runs a binary writing a WAV file and reads it back.
 """
 
 from __future__ import annotations
 
+import subprocess
+import tempfile
 import wave
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import numpy as np
@@ -31,17 +19,49 @@ from .errors import TTSError
 from .protocol import PCM_SAMPLE_RATE_HZ, PCM_SAMPLE_WIDTH_BYTES
 
 
-def wav_to_pcm(wav_path: Path, *, provider: str) -> bytes:
-    """Read a WAV file written by a TTS subprocess and return raw
-    16 kHz mono s16 LE bytes.
+def synthesize_via_subprocess(
+    *,
+    provider: str,
+    argv_for_wav: Callable[[Path], Sequence[str]],
+    text: str,
+    timeout_seconds: float,
+) -> bytes:
+    """Run a TTS subprocess that writes a WAV file and return its
+    16 kHz mono s16 LE PCM bytes.
 
-    ``provider`` is folded into [`TTSError`] messages so a failure
-    in the espeak path doesn't blame piper (and vice versa).
-
-    Raises [`TTSError`] with stage ``"synthesize"`` for empty output
-    and ``"transcode"`` for everything else (unreadable WAV, wrong
-    sample width, pathologically short payload after resample).
+    ``argv_for_wav`` is called with the temp WAV path and returns the
+    full ``argv`` for ``subprocess.run`` (binary + flags). ``text`` is
+    piped through stdin so an LLM reply with quotes / backticks can't
+    break shell escaping.
     """
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        wav_path = Path(tmp.name)
+    try:
+        try:
+            subprocess.run(
+                argv_for_wav(wav_path),
+                input=text,
+                text=True,
+                check=True,
+                timeout=timeout_seconds,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise TTSError(
+                "synthesize",
+                f"{provider} exited {e.returncode}: {e.stderr.strip()[:120]}",
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise TTSError("synthesize", f"{provider} timed out") from e
+        return wav_to_pcm(wav_path, provider=provider)
+    finally:
+        wav_path.unlink(missing_ok=True)
+
+
+def wav_to_pcm(wav_path: Path, *, provider: str) -> bytes:
+    """Read a WAV written by a TTS subprocess and return 16 kHz mono
+    s16 LE bytes. ``provider`` is folded into [`TTSError`] messages
+    so the failing engine is identifiable in logs."""
     try:
         with wave.open(str(wav_path), "rb") as r:
             channels = r.getnchannels()
@@ -71,8 +91,7 @@ def wav_to_pcm(wav_path: Path, *, provider: str) -> bytes:
 def resample_and_downmix(frames: bytes, src_rate: int, channels: int) -> bytes:
     """Convert raw s16 LE frames at ``src_rate`` x ``channels`` to
     16 kHz mono s16 LE bytes. Pure NumPy; no audioop / scipy / libsoxr
-    dependency.
-    """
+    dependency."""
     samples = np.frombuffer(frames, dtype=np.int16)
     if channels > 1:
         samples = samples.reshape(-1, channels).mean(axis=1).astype(np.int16)

--- a/sidecar/src/stackchan_sidecar/tts/elevenlabs.py
+++ b/sidecar/src/stackchan_sidecar/tts/elevenlabs.py
@@ -1,25 +1,10 @@
 """ElevenLabs TTS provider.
 
-ElevenLabs is the cloud quality opt-in — a paid API call per
-synthesis, but produces voices indistinguishable from human
-recordings. Setup requires:
-
-1. An ``xi-api-key`` from elevenlabs.io.
-2. A voice id (``settings.elevenlabs_voice_id``) — either a built-in
-   like Rachel (``21m00Tcm4TlvDq8ikWAM``) or one cloned by the
-   operator.
-3. The Starter tier or higher; the free tier only emits MP3, and
-   this provider asks for raw PCM at 16 kHz so the firmware audio
-   pipeline doesn't need an MP3 decoder.
-
-If any of those are missing, [`synthesize`] raises [`TTSError`] with
-stage ``"setup"`` (api-key) or ``"synthesize"`` (HTTP 4xx/5xx) so
-the operator gets a clear log rather than a runtime guess about
-the failure.
-
-The endpoint returns raw 16 kHz mono s16 LE PCM directly — no WAV
-header, no transcode, no resample. That's the same wire shape the
-firmware audio cache stores, so we hand it through unchanged.
+Setup needs an ``xi-api-key``, a ``voice_id``, and a Starter-tier or
+higher account — the free tier only emits MP3, and this provider
+requests raw ``pcm_16000`` so the firmware audio pipeline doesn't
+need an MP3 decoder. The endpoint returns the wire-shape PCM
+unchanged.
 """
 
 from __future__ import annotations
@@ -34,17 +19,14 @@ from .protocol import PCM_SAMPLE_RATE_HZ, TTSResult
 _LOG = logging.getLogger("stackchan_sidecar.tts.elevenlabs")
 
 _ENDPOINT_TEMPLATE = "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
-# `eleven_turbo_v2_5` is the latency-optimised model — ~70 % cheaper
-# than the multilingual flagship and fast enough for a desk toy.
-# Operators can swap it for `eleven_multilingual_v2` if they need
+# Latency-optimised model. Swap for `eleven_multilingual_v2` for
 # non-English voices.
 _DEFAULT_MODEL = "eleven_turbo_v2_5"
 _DEFAULT_TIMEOUT_S = 30.0
 
 
 class ElevenLabsProvider:
-    """Provider that POSTs to ElevenLabs' text-to-speech REST endpoint
-    and asks for raw 16 kHz mono s16 LE PCM in the response body."""
+    """POSTs to ElevenLabs and asks for raw 16 kHz mono s16 LE PCM."""
 
     name: str = "elevenlabs"
 

--- a/sidecar/src/stackchan_sidecar/tts/errors.py
+++ b/sidecar/src/stackchan_sidecar/tts/errors.py
@@ -1,4 +1,4 @@
-"""Canonical TTS failure type. Catch-and-convert at the /v1/listen
+"""Canonical TTS failure type. Catch-and-convert at the ``/v1/listen``
 boundary so a TTS outage degrades to ``audio_url: null`` instead of
 taking down the whole reply path."""
 
@@ -6,17 +6,12 @@ from __future__ import annotations
 
 
 class TTSError(Exception):
-    """Raised by a [`TTSProvider`] when synthesis can't produce
-    well-shaped PCM. Carries a short slug usable in logs / error
-    envelopes; the underlying exception (if any) is the ``__cause__``.
+    """Synthesis couldn't produce well-shaped PCM.
 
-    Stage is one of:
-    - ``"setup"`` — provider couldn't initialise (missing binary,
-      missing model file, missing API key)
-    - ``"synthesize"`` — provider's synthesis call failed (subprocess
-      crash, HTTP 5xx, timeout, empty output)
-    - ``"transcode"`` — bytes returned but the resample / format
-      conversion to 16 kHz mono s16 LE failed
+    ``stage`` is one of ``"setup"`` (missing binary / model / key),
+    ``"synthesize"`` (subprocess or HTTP failure, empty output), or
+    ``"transcode"`` (resample / format conversion failed). The
+    underlying exception (if any) is the ``__cause__``.
     """
 
     def __init__(self, stage: str, detail: str) -> None:

--- a/sidecar/src/stackchan_sidecar/tts/espeak.py
+++ b/sidecar/src/stackchan_sidecar/tts/espeak.py
@@ -1,12 +1,8 @@
 """eSpeak-NG TTS provider.
 
-The always-available fallback — ships in 2 MB on any Linux/macOS host,
-no API key, no model file. Synthesis is a subprocess call to the
-``espeak-ng`` binary, which writes a WAV file we strip down to raw PCM
-via the shared [`wav_to_pcm`] helper.
-
-The robot-voice aesthetic is intentional; if an operator wants quality
-they pick Piper or ElevenLabs.
+Always-available fallback — subprocess call to ``espeak-ng`` writes a
+WAV; the shared transcoder produces 16 kHz mono s16 LE PCM. No API
+key, no model file.
 """
 
 from __future__ import annotations
@@ -14,31 +10,24 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
-import subprocess
-import tempfile
 from pathlib import Path
 
-from ._audio import wav_to_pcm
+from ._audio import synthesize_via_subprocess
 from .errors import TTSError
 from .protocol import TTSResult
 
 _LOG = logging.getLogger("stackchan_sidecar.tts.espeak")
 
-# espeak-ng's default voice & rate. The voice selector controls
-# language/accent; the rate selector controls words-per-minute.
 # `175 wpm` is the espeak-ng default; comfortable for a desk toy.
 _DEFAULT_VOICE = "en"
 _DEFAULT_WPM = 175
 
 
 class EspeakProvider:
-    """Provider that shells out to ``espeak-ng`` and post-processes
-    the resulting WAV into 16 kHz mono PCM.
+    """Shells out to ``espeak-ng`` and transcodes the resulting WAV.
 
-    Construction probes for the binary in PATH; if missing,
-    [`synthesize`] raises [`TTSError`] with stage ``"setup"`` on the
-    first call. Probe is lazy so a sidecar that uses ElevenLabs or
-    Piper as its real provider doesn't need espeak-ng installed.
+    Construction probes for the binary lazily so a sidecar that runs
+    a different provider doesn't need espeak-ng installed.
     """
 
     name: str = "espeak_ng"
@@ -53,45 +42,19 @@ class EspeakProvider:
             raise TTSError("setup", "espeak-ng binary not found in PATH")
         if not text.strip():
             raise TTSError("synthesize", "empty text")
-        # Subprocess runs to completion in a thread so the FastAPI event
-        # loop stays responsive. Synthesis is fast enough (< 200 ms for
-        # toast-band-length text) that streaming isn't worth the
-        # complexity for this provider.
         return await asyncio.to_thread(self._synthesize_sync, binary, text)
 
     def _synthesize_sync(self, binary: str, text: str) -> TTSResult:
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-            wav_path = Path(tmp.name)
-        try:
-            try:
-                # `--stdin` reads the text from stdin, dodging shell-escape
-                # gotchas if the LLM reply contains quotes or backticks.
-                subprocess.run(
-                    [
-                        binary,
-                        "--stdin",
-                        "-v",
-                        self._voice,
-                        "-s",
-                        str(self._wpm),
-                        "-w",
-                        str(wav_path),
-                    ],
-                    input=text,
-                    text=True,
-                    check=True,
-                    timeout=10.0,
-                    capture_output=True,
-                )
-            except subprocess.CalledProcessError as e:
-                raise TTSError(
-                    "synthesize",
-                    f"espeak-ng exited {e.returncode}: {e.stderr.strip()[:120]}",
-                ) from e
-            except subprocess.TimeoutExpired as e:
-                raise TTSError("synthesize", "espeak-ng timed out") from e
-            pcm = wav_to_pcm(wav_path, provider="espeak-ng")
-            _LOG.debug("espeak-ng synthesized %d bytes", len(pcm))
-            return TTSResult(pcm=pcm, provider=self.name, voice=self._voice)
-        finally:
-            wav_path.unlink(missing_ok=True)
+        # `--stdin` reads the text from stdin, dodging shell-escape
+        # gotchas if the LLM reply contains quotes or backticks.
+        def argv(wav: Path) -> list[str]:
+            return [binary, "--stdin", "-v", self._voice, "-s", str(self._wpm), "-w", str(wav)]
+
+        pcm = synthesize_via_subprocess(
+            provider="espeak-ng",
+            argv_for_wav=argv,
+            text=text,
+            timeout_seconds=10.0,
+        )
+        _LOG.debug("espeak-ng synthesized %d bytes", len(pcm))
+        return TTSResult(pcm=pcm, provider=self.name, voice=self._voice)

--- a/sidecar/src/stackchan_sidecar/tts/piper.py
+++ b/sidecar/src/stackchan_sidecar/tts/piper.py
@@ -1,20 +1,9 @@
 """Piper TTS provider.
 
-Piper is a fast, local, neural TTS that runs from a model file on
-CPU — no API key, no GPU. Voice quality is "competent neural" rather
-than "indistinguishable from human", which is the right spot for a
-desk toy: clearer than espeak-ng's robot voice, no per-utterance
-network cost or rate limit.
-
-Setup is *not* zero-touch: the operator must install the
-``piper`` binary and download an ONNX voice model + JSON metadata
-(both `.onnx` and `.onnx.json` must sit side-by-side). Without those,
-``PiperProvider`` raises [`TTSError`] with stage ``"setup"`` on the
-first synthesis call.
-
-Wire shape is identical to espeak-ng: subprocess writes a 22050 Hz
-mono s16 WAV, we transcode to 16 kHz mono s16 LE PCM via the shared
-[`wav_to_pcm`] helper.
+Local neural TTS via the ``piper`` binary plus an ONNX voice model
+(``<model>.onnx`` plus the side-car ``<model>.onnx.json``). Subprocess
+writes a 22050 Hz mono s16 WAV; the shared transcoder produces
+16 kHz mono s16 LE PCM.
 """
 
 from __future__ import annotations
@@ -22,11 +11,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
-import subprocess
-import tempfile
 from pathlib import Path
 
-from ._audio import wav_to_pcm
+from ._audio import synthesize_via_subprocess
 from .errors import TTSError
 from .protocol import TTSResult
 
@@ -34,14 +21,12 @@ _LOG = logging.getLogger("stackchan_sidecar.tts.piper")
 
 
 class PiperProvider:
-    """Provider that shells out to ``piper`` and post-processes the
-    resulting WAV into 16 kHz mono PCM.
+    """Shells out to ``piper`` and transcodes the resulting WAV.
 
-    The model path is supplied at construction; ``piper`` will look
-    for ``<model_path>.json`` automatically (the voice's metadata),
-    so callers only pass the ``.onnx`` path. ``speaker_id`` selects
-    one of the speakers in a multi-speaker model; for single-speaker
-    models it is ignored.
+    ``model_path`` is the ``.onnx`` file; ``piper`` looks for the
+    accompanying ``.onnx.json`` automatically. ``speaker_id`` selects
+    one of the speakers in a multi-speaker model; ignored for
+    single-speaker models.
     """
 
     name: str = "piper"
@@ -55,49 +40,25 @@ class PiperProvider:
         if binary is None:
             raise TTSError("setup", "piper binary not found in PATH")
         if not self._model_path.is_file():
-            raise TTSError(
-                "setup",
-                f"piper model not found at {self._model_path}",
-            )
+            raise TTSError("setup", f"piper model not found at {self._model_path}")
         if not text.strip():
             raise TTSError("synthesize", "empty text")
         return await asyncio.to_thread(self._synthesize_sync, binary, text)
 
     def _synthesize_sync(self, binary: str, text: str) -> TTSResult:
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-            wav_path = Path(tmp.name)
-        try:
-            args = [
-                binary,
-                "--model",
-                str(self._model_path),
-                "--output_file",
-                str(wav_path),
-            ]
+        def argv(wav: Path) -> list[str]:
+            base = [binary, "--model", str(self._model_path), "--output_file", str(wav)]
             if self._speaker_id is not None:
-                args += ["--speaker", str(self._speaker_id)]
-            try:
-                subprocess.run(
-                    args,
-                    input=text,
-                    text=True,
-                    check=True,
-                    # Neural inference can be slow on cold CPU; give it
-                    # enough runway for a long-ish reply but bound it
-                    # so a hung process doesn't pin the request.
-                    timeout=30.0,
-                    capture_output=True,
-                )
-            except subprocess.CalledProcessError as e:
-                raise TTSError(
-                    "synthesize",
-                    f"piper exited {e.returncode}: {e.stderr.strip()[:120]}",
-                ) from e
-            except subprocess.TimeoutExpired as e:
-                raise TTSError("synthesize", "piper timed out") from e
-            pcm = wav_to_pcm(wav_path, provider="piper")
-            _LOG.debug("piper synthesized %d bytes", len(pcm))
-            voice = self._model_path.stem
-            return TTSResult(pcm=pcm, provider=self.name, voice=voice)
-        finally:
-            wav_path.unlink(missing_ok=True)
+                base += ["--speaker", str(self._speaker_id)]
+            return base
+
+        # Neural inference can be slow on cold CPU; the 30 s ceiling
+        # bounds a hung process without truncating a typical reply.
+        pcm = synthesize_via_subprocess(
+            provider="piper",
+            argv_for_wav=argv,
+            text=text,
+            timeout_seconds=30.0,
+        )
+        _LOG.debug("piper synthesized %d bytes", len(pcm))
+        return TTSResult(pcm=pcm, provider=self.name, voice=self._model_path.stem)

--- a/sidecar/src/stackchan_sidecar/tts/protocol.py
+++ b/sidecar/src/stackchan_sidecar/tts/protocol.py
@@ -1,18 +1,13 @@
-"""Provider-agnostic TTS protocol.
-
-All providers return [`TTSResult`] — raw PCM bytes plus the sample
-rate and channel layout that produced them. The shared rate target
-is 16 kHz mono s16 LE so the firmware playback path can consume the
-bytes directly; providers whose engine emits something else
-resample down to 16 kHz before returning.
-"""
+"""Provider-agnostic TTS protocol. All providers return 16 kHz mono
+s16 LE PCM so the firmware playback path can consume the bytes
+directly."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
-# Target wire-rate. Matches the firmware's `AUDIO_TX_QUEUE` expectation
+# Matches the firmware's `AUDIO_TX_QUEUE` expectation
 # (see `crates/stackchan-firmware/src/audio.rs`).
 PCM_SAMPLE_RATE_HZ = 16_000
 PCM_CHANNELS = 1
@@ -21,13 +16,6 @@ PCM_SAMPLE_WIDTH_BYTES = 2
 
 @dataclass(frozen=True)
 class TTSResult:
-    """Output of one synthesis call.
-
-    ``pcm`` is the raw 16 kHz mono s16 LE bytes the firmware streams
-    into the AW88298 amp. ``provider`` and ``voice`` are surfaced in
-    logs so an operator can tell which engine made the noise.
-    """
-
     pcm: bytes
     provider: str
     voice: str
@@ -40,16 +28,10 @@ class TTSResult:
 
 @runtime_checkable
 class TTSProvider(Protocol):
-    """Async-friendly synthesis interface.
-
-    Implementations are expected to ``await`` rather than block; CPU-bound
-    engines (Piper, eSpeak-NG subprocess) bridge through
-    ``asyncio.to_thread``. Network providers (ElevenLabs) use ``httpx``
-    natively.
-
-    Failures raise [`stackchan_sidecar.tts.errors.TTSError`]; the
-    /v1/listen handler catches it and falls back to ``audio_url: null``.
-    """
+    """Async synthesis. CPU-bound engines bridge through
+    ``asyncio.to_thread``; network providers ``await`` natively.
+    Failures raise [`TTSError`]; ``/v1/listen`` catches and falls
+    back to ``audio_url: null``."""
 
     name: str
 

--- a/sidecar/tests/test_tts_app.py
+++ b/sidecar/tests/test_tts_app.py
@@ -92,7 +92,7 @@ def test_audio_endpoint_returns_cached_pcm(
         headers={**auth_headers, "Content-Type": _AUDIO_CT},
     )
     audio_url = r.json()["audio_url"]
-    audio_r = tts_client.get(audio_url)
+    audio_r = tts_client.get(audio_url, headers=auth_headers)
     assert audio_r.status_code == 200
     assert audio_r.content == fake_tts.pcm
     # Format header signals the firmware can stream straight in.
@@ -101,9 +101,18 @@ def test_audio_endpoint_returns_cached_pcm(
     assert audio_r.headers["x-audio-voice"] == "fake-voice"
 
 
-def test_audio_endpoint_404s_for_unknown_token(tts_client: TestClient) -> None:
-    r = tts_client.get("/v1/audio/deadbeefdeadbeefdeadbeefdeadbeef")
+def test_audio_endpoint_404s_for_unknown_token(
+    tts_client: TestClient, auth_headers: dict[str, str]
+) -> None:
+    r = tts_client.get("/v1/audio/deadbeefdeadbeefdeadbeefdeadbeef", headers=auth_headers)
     assert r.status_code == 404
+
+
+def test_audio_endpoint_401s_without_bearer(tts_client: TestClient) -> None:
+    # /v1/audio is a state-bearing endpoint; tokens have 128 bits of
+    # entropy but defense-in-depth still applies on a trusted LAN.
+    r = tts_client.get("/v1/audio/deadbeefdeadbeefdeadbeefdeadbeef")
+    assert r.status_code == 401
 
 
 def test_audio_endpoint_404s_after_ttl_expiry(
@@ -131,10 +140,10 @@ def test_audio_endpoint_404s_after_ttl_expiry(
         )
         audio_url = r.json()["audio_url"]
         # Immediate fetch hits.
-        assert c.get(audio_url).status_code == 200
+        assert c.get(audio_url, headers=auth_headers).status_code == 200
         # Past TTL — eviction on next access returns 404.
         now[0] += 10.0
-        assert c.get(audio_url).status_code == 404
+        assert c.get(audio_url, headers=auth_headers).status_code == 404
 
 
 def test_listen_null_audio_url_when_tts_fails(

--- a/sidecar/tests/test_tts_piper.py
+++ b/sidecar/tests/test_tts_piper.py
@@ -69,7 +69,7 @@ async def test_subprocess_failure_surfaces_as_synthesize_error(
     def fake_run(*_a: Any, **_kw: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.CalledProcessError(returncode=1, cmd=["piper"], stderr="model load failed")
 
-    monkeypatch.setattr("stackchan_sidecar.tts.piper.subprocess.run", fake_run)
+    monkeypatch.setattr("stackchan_sidecar.tts._audio.subprocess.run", fake_run)
     with pytest.raises(TTSError) as exc_info:
         await PiperProvider(model_path=fake_model).synthesize("hello")
     assert exc_info.value.stage == "synthesize"
@@ -87,7 +87,7 @@ async def test_subprocess_timeout_surfaces_as_synthesize_error(
     def fake_run(*_a: Any, **_kw: Any) -> subprocess.CompletedProcess[str]:
         raise subprocess.TimeoutExpired(cmd="piper", timeout=30.0)
 
-    monkeypatch.setattr("stackchan_sidecar.tts.piper.subprocess.run", fake_run)
+    monkeypatch.setattr("stackchan_sidecar.tts._audio.subprocess.run", fake_run)
     with pytest.raises(TTSError) as exc_info:
         await PiperProvider(model_path=fake_model).synthesize("hello")
     assert exc_info.value.stage == "synthesize"
@@ -111,7 +111,7 @@ async def test_speaker_id_passes_through_to_subprocess(
         # to read back).
         raise subprocess.CalledProcessError(returncode=0, cmd=args, stderr="")
 
-    monkeypatch.setattr("stackchan_sidecar.tts.piper.subprocess.run", fake_run)
+    monkeypatch.setattr("stackchan_sidecar.tts._audio.subprocess.run", fake_run)
     with pytest.raises(TTSError):
         await PiperProvider(model_path=fake_model, speaker_id=3).synthesize("hi")
     assert captured_args, "subprocess.run should have been called"


### PR DESCRIPTION
## Summary

Code-review + simplifier pass over the Arc A sidecar work (#535-#537).

**Three substantive changes:**

1. **P1 security — `/v1/audio/{token}` now requires the bearer.** Tokens have 128 bits of entropy from `secrets.token_hex(16)` so practical risk was low, but every other state-bearing endpoint (`/v1/listen`, `/v1/personas`, etc.) gates on `verify_bearer`. The firmware was already sending the bearer on the GET, so no wire-format change. New test `test_audio_endpoint_401s_without_bearer` pins it.

2. **Subprocess provider dedupe.** `espeak.py` and `piper.py` each open-coded the same temp-WAV + `subprocess.run` + error-stage mapping + cleanup boilerplate. Lifted into `synthesize_via_subprocess()` in `tts/_audio.py`. Both providers shrink ~95 → ~60 lines — argv builder + helper call. Behavior preserved.

3. **Docstring/comment trim.** Provider docs dropped AI-flavoured marketing prose ("indistinguishable from human recordings", "robot-voice aesthetic is intentional") + wire-contract recaps that duplicated the package docs.

**Wire-shape docstring fix:** The package docstring claimed `/v1/audio` returns the body "chunked so playback can start on the first chunk", but the route is a plain `Response` with Content-Length framing. Updated to match.

## Test plan

- [x] `uv run pytest` — 176 passed, 3 skipped (espeak-ng absent locally)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — clean