### PR TITLE
fix: address post-merge Greptile findings on kws-eval + voice docs

### DIFF
--- a/docs/voice.md
+++ b/docs/voice.md
@@ -137,7 +137,7 @@ Set `tts_provider` in the sidecar's `.env`:
 
 | Provider | Setup cost | Voice quality | Per-call cost |
 |---|---|---|---|
-| `espeak_ng` *(default)* | Install `espeak-ng` binary (`apt install espeak-ng` / `brew install espeak`). No model file, no API key. | Robotic — intentionally so. The desk-toy aesthetic. | Free, local. |
+| `espeak_ng` *(default)* | Install `espeak-ng` binary (`apt install espeak-ng` / `brew install espeak-ng`). No model file, no API key. | Robotic — intentionally so. The desk-toy aesthetic. | Free, local. |
 | `piper` | Install `piper` binary + download an ONNX voice model + JSON metadata. ~50 MB per voice. | Competent neural. The middle option — much clearer than espeak-ng without an API bill. | Free, local. |
 | `elevenlabs` | Set `ELEVENLABS_API_KEY` + (optionally) `elevenlabs_voice_id`. **Requires the Starter tier ($5/mo) or higher** — the free tier returns MP3 only, and the sidecar asks for raw PCM at 16 kHz so the firmware skips an MP3 decoder. | Human-grade. Indistinguishable from a recording. | Cloud API; per-character billing. |
 
@@ -218,7 +218,15 @@ behavior: (
 - `wake_word_threshold` — int8 score above which the firmware treats
   the model output as a positive detection. Lower values (≈80)
   increase sensitivity at the cost of false positives; higher values
-  (≈115) tighten it. Tune per model.
+  (≈115) tighten it. Tune per model. `kws-eval` reports the model's
+  *dequantized* output (float in `[0.0, 1.0]`) while the firmware
+  compares against the *raw* int8. Convert by inverting the model's
+  output quantization: `wake_word_threshold = round(float_score /
+  output_scale) + output_zero_point`. For the canonical microWakeWord
+  output quant (`scale=1/255, zero_point=-128`), a `kws-eval` peak of
+  `0.89` maps to `~99`; `0.95` maps to `~114`. Check your model's
+  exact quant via the TFLite Python API if the canonical values
+  don't apply.
 - `wake_word_arena_kib` — size of the TFLM tensor arena in KiB.
   The microWakeWord v2 family declares 17–26 KiB nominal; `64` leaves
   headroom for the TFLM planner's scratch space. Bump if a custom

--- a/tools/kws-trainer/src/kws_trainer/inference.py
+++ b/tools/kws-trainer/src/kws_trainer/inference.py
@@ -17,14 +17,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 
 from .features import MEL_BIN_COUNT, MelFrontend, QuantParams
-
-if TYPE_CHECKING:
-    pass
 
 _LOG = logging.getLogger("kws_trainer.inference")
 
@@ -71,6 +68,44 @@ def load_interpreter(model_path: Path) -> Any:
     return interpreter
 
 
+@dataclass(frozen=True)
+class ModelIO:
+    """Snapshot of the interpreter's input/output tensor details.
+
+    Reading these from the TFLite C API is cheap individually but
+    adds up when called once per 10 ms frame on a multi-minute clip.
+    Hoist out of the hot loop and pass through to [`run_frame`].
+    """
+
+    input_index: int
+    input_shape: tuple[int, ...]
+    input_dtype: Any
+    output_index: int
+    output_dtype: Any
+    output_scale: float
+    output_zero_point: int
+
+
+def read_model_io(interpreter: Any) -> ModelIO:
+    """Pull tensor metadata + output quantization from the
+    interpreter once so the per-frame loop can pass it through
+    without re-crossing the TFLite boundary."""
+    inp = interpreter.get_input_details()[0]
+    out = interpreter.get_output_details()[0]
+    out_quant = out.get("quantization_parameters", {})
+    out_scales = out_quant.get("scales", [])
+    out_zps = out_quant.get("zero_points", [])
+    return ModelIO(
+        input_index=int(inp["index"]),
+        input_shape=tuple(int(d) for d in inp["shape"]),
+        input_dtype=inp["dtype"],
+        output_index=int(out["index"]),
+        output_dtype=out["dtype"],
+        output_scale=float(out_scales[0]) if len(out_scales) > 0 else 1.0,
+        output_zero_point=int(out_zps[0]) if len(out_zps) > 0 else 0,
+    )
+
+
 def input_quant_params(interpreter: Any) -> QuantParams:
     """Read the model's input-tensor quantization parameters.
 
@@ -81,40 +116,36 @@ def input_quant_params(interpreter: Any) -> QuantParams:
     """
     details = interpreter.get_input_details()[0]
     quant = details.get("quantization_parameters", {})
-    scales = quant.get("scales", []) or [0.5]
-    zero_points = quant.get("zero_points", []) or [-25]
-    scale = float(scales[0]) if len(scales) else 0.5
-    zero_point = int(zero_points[0]) if len(zero_points) else -25
+    scales = quant.get("scales", [])
+    zero_points = quant.get("zero_points", [])
+    # `if len(...) > 0` rather than `or [default]`: a numpy array
+    # containing a single 0 (legitimate `zero_point=0` from a model
+    # with symmetric quantization) is falsy under Python's `or`
+    # truthiness, which silently shifts every feature by the
+    # firmware-default 25 quantization steps and corrupts scores.
+    scale = float(scales[0]) if len(scales) > 0 else 0.5
+    zero_point = int(zero_points[0]) if len(zero_points) > 0 else -25
     return QuantParams(scale=scale, zero_point=zero_point)
 
 
-def run_frame(interpreter: Any, frame: np.ndarray) -> float:
+def run_frame(interpreter: Any, frame: np.ndarray, io: ModelIO | None = None) -> float:
     """Feed one ``(MEL_BIN_COUNT,)`` ``int8`` frame to the model and
     return the scalar score (float in ``[0, 1]``).
 
-    The input tensor's shape is taken from the model — typically
-    ``(1, 40, 1)`` for streaming MixConv models. Dequantization
-    of the output uses the output tensor's own scale/zero_point.
+    ``io`` is the cached tensor metadata from [`read_model_io`]. The
+    optional default makes single-frame ad-hoc usage work without a
+    pre-call setup step; batch loops should hoist [`read_model_io`]
+    out and pass the result in to avoid per-frame TFLite-boundary
+    crossings.
     """
-    input_details = interpreter.get_input_details()[0]
-    output_details = interpreter.get_output_details()[0]
-    target_shape = tuple(int(d) for d in input_details["shape"])
-    # Most microWakeWord streaming models expect shape (1, 40, 1).
-    # Reshape via broadcasting so the function works for any
-    # consistent leading singleton.
-    reshaped = frame.reshape(target_shape).astype(input_details["dtype"])
-    interpreter.set_tensor(input_details["index"], reshaped)
+    if io is None:
+        io = read_model_io(interpreter)
+    reshaped = frame.reshape(io.input_shape).astype(io.input_dtype)
+    interpreter.set_tensor(io.input_index, reshaped)
     interpreter.invoke()
-    raw = interpreter.get_tensor(output_details["index"])
-    # Dequantize int8 outputs to float using the output tensor's
-    # quantization parameters; float outputs pass through unchanged.
-    if output_details["dtype"] == np.int8:
-        out_quant = output_details.get("quantization_parameters", {})
-        scales = out_quant.get("scales", [1.0])
-        zps = out_quant.get("zero_points", [0])
-        scale = float(scales[0])
-        zp = int(zps[0])
-        score = float(scale * (int(raw.flatten()[0]) - zp))
+    raw = interpreter.get_tensor(io.output_index)
+    if io.output_dtype == np.int8:
+        score = float(io.output_scale * (int(raw.flatten()[0]) - io.output_zero_point))
     else:
         score = float(raw.flatten()[0])
     return score
@@ -134,6 +165,7 @@ def evaluate_pcm(
     with a non-default ``scale`` doesn't see misaligned features.
     """
     quant = input_quant_params(interpreter)
+    io = read_model_io(interpreter)
     frontend = MelFrontend(quant=quant)
     feature_matrix = frontend.process_pcm(pcm)
     scores: list[float] = []
@@ -142,7 +174,7 @@ def evaluate_pcm(
     for i, frame in enumerate(feature_matrix):
         if frame.shape != (MEL_BIN_COUNT,):
             raise ValueError(f"frame {i}: expected shape ({MEL_BIN_COUNT},), got {frame.shape}")
-        score = run_frame(interpreter, frame)
+        score = run_frame(interpreter, frame, io)
         scores.append(score)
         if score > peak_score:
             peak_score = score
@@ -166,8 +198,10 @@ def evaluate_pcm(
 
 __all__ = [
     "InferenceResult",
+    "ModelIO",
     "evaluate_pcm",
     "input_quant_params",
     "load_interpreter",
+    "read_model_io",
     "run_frame",
 ]

--- a/tools/kws-trainer/tests/test_inference.py
+++ b/tools/kws-trainer/tests/test_inference.py
@@ -99,6 +99,18 @@ def test_input_quant_params_reads_from_interpreter() -> None:
     assert q.zero_point == 10
 
 
+def test_input_quant_params_respects_zero_point_of_zero() -> None:
+    # Greptile P1 regression: a Python `or` fallback on the numpy
+    # quant arrays silently turned `zero_point=0` (a legitimate
+    # symmetric-quant value) into the firmware default `-25`, because
+    # `bool(np.array([0]))` is `False`. The fix uses explicit
+    # `if len(arr) > 0` guards — verified here.
+    interp = _FakeInterpreter(input_scale=0.25, input_zero_point=0)
+    q = input_quant_params(interp)
+    assert q.scale == pytest.approx(0.25)
+    assert q.zero_point == 0
+
+
 def test_input_quant_params_falls_back_when_empty() -> None:
     class _NoQuantInterpreter(_FakeInterpreter):
         def get_input_details(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

The merge train cleared #541 (kws-eval) and #542 (voice docs) on Greptile-status SUCCESS — but Greptile's findings land as **inline comments**, not check failures, so the train didn't gate on them. Four findings (2 × P1 + 2 × P2) are now on main; this PR addresses all of them.

## kws-eval — \`tools/kws-trainer/src/kws_trainer/inference.py\`

- **P1 correctness:** \`input_quant_params\` used \`scales = quant.get(\"scales\", []) or [0.5]\` to fall back on empty arrays. \`np.array([0])\` is falsy under Python truthiness, so a model with \`zero_point=0\` (symmetric quantization) silently fell back to the firmware default \`-25\` — shifting every feature 25 quantization steps and producing wrong scores. Replace \`or [default]\` with explicit \`if len(arr) > 0 else default\` guards. Regression test pins it.
- **P2 perf:** \`run_frame\` called \`get_input_details\` + \`get_output_details\` on every invocation. Extract a \`ModelIO\` dataclass once via \`read_model_io\` and pass it through. Meaningful on multi-minute clips at one call per 10 ms frame.
- **P2 dead code:** drop the empty \`if TYPE_CHECKING: pass\` block.

## voice docs — \`docs/voice.md\`

- **P1 docs bug:** \`brew install espeak\` installs an older unrelated package. Fix to \`brew install espeak-ng\`.
- **P2 operator UX:** kws-eval reports dequantized float scores while \`wake_word_threshold\` takes raw int8 — the docs pointed at kws-eval for threshold tuning without telling operators how to translate. Add the inverse-quantization formula (\`round(float_score / output_scale) + output_zero_point\`) plus the canonical microWakeWord values worked through (0.89 → ~99, 0.95 → ~114).

## Test plan

- [x] \`uv run pytest\` — 61 passed (one new regression test for the zero_point=0 case)
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy .\` — clean