### PR TITLE
feat(firmware): dynamic SD-SPI clock rate (400 kHz init -> 25 MHz data)

### DIFF
--- a/crates/stackchan-firmware/src/sd_spi.rs
+++ b/crates/stackchan-firmware/src/sd_spi.rs
@@ -31,12 +31,53 @@
 #![allow(unsafe_code)]
 
 use core::cell::RefCell;
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 use esp_hal::Blocking;
-use esp_hal::spi::master::Spi;
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::{Config as SpiConfig, Spi};
+use esp_hal::time::Rate;
+
+/// LCD's SPI2 SCK rate, set at LCD bring-up in `main.rs`. Must match
+/// the `Rate::from_mhz(40)` in `crates/stackchan-firmware/src/main.rs`
+/// — we restore the bus to this rate at the end of every SD
+/// transaction so subsequent LCD `RefCellDevice` blits see the bus at
+/// the right speed. A mismatch here doesn't fail to compile; it just
+/// silently slows the LCD on every frame.
+const LCD_SCK_HZ: u32 = 40_000_000;
+
+/// SD-card SCK rate during init (CMD0 / CMD8 / ACMD41 / CMD58
+/// negotiation). The SD spec mandates ≤ 400 kHz before the card
+/// enters data state; running faster causes the init handshake to
+/// drop bits and `embedded-sdmmc` to spin in its retry loop at
+/// `sdcard::mod::424`. Confirmed against `SanDisk` High Endurance 32 GB.
+const SD_INIT_HZ: u32 = 400_000;
+
+/// SD-card SCK rate after init succeeds. 25 MHz is "default speed"
+/// per the SD spec — every SD card is required to support it in SPI
+/// mode. `Storage::mount` flips to this via [`set_data_rate`] once
+/// `SdCard::num_bytes()` confirms the card has entered data state.
+const SD_DATA_HZ: u32 = 25_000_000;
+
+/// SD-side SCK rate applied at the start of every SD transaction.
+/// Starts at [`SD_INIT_HZ`]; bumped to [`SD_DATA_HZ`] by
+/// [`set_data_rate`] once init has succeeded. Atomic so the
+/// `Storage::mount` path can mutate it without holding a `&mut` to
+/// an `SdSpiDevice` that `embedded-sdmmc`'s `SdCard` has consumed.
+static SD_SCK_HZ: AtomicU32 = AtomicU32::new(SD_INIT_HZ);
+
+/// Bump the SD-side SCK rate from init speed to data speed.
+///
+/// Called by `Storage::mount` after the SD card has finished
+/// CMD0/CMD8/ACMD41 negotiation and `num_bytes()` has confirmed the
+/// card is in data state. Until this point, every transaction runs at
+/// [`SD_INIT_HZ`] (400 kHz) so the init protocol can converge.
+pub fn set_data_rate() {
+    SD_SCK_HZ.store(SD_DATA_HZ, Ordering::Relaxed);
+}
 
 /// `GPIO_ENABLE1_W1TS_REG` — write `1` to set output-enable bits for
 /// pins 32–48. ESP32-S3 TRM, chapter 5.
@@ -137,6 +178,18 @@ where
         // `crates/stackchan-firmware/src/main.rs` (LCD path).
         let mut bus = self.bus.borrow_mut();
 
+        // Drop the SCK to an SD-compatible rate for the duration of
+        // this transaction. The LCD runs the bus at 40 MHz, which is
+        // 100× the SD spec's init ceiling — leaving the bus that fast
+        // makes some cards (e.g. SanDisk High Endurance 32 GB) fail
+        // CMD0/ACMD41 negotiation. We restore the LCD rate at the end
+        // of the transaction so the next LCD frame doesn't see a
+        // slowed bus.
+        let sd_cfg = SpiConfig::default()
+            .with_frequency(Rate::from_hz(SD_SCK_HZ.load(Ordering::Relaxed)))
+            .with_mode(SpiMode::_0);
+        bus.apply_config(&sd_cfg).map_err(|_| SdSpiError::Spi)?;
+
         // Switch GPIO35 from "LCD DC output" to "SD MISO input" before
         // pulling CS low. Pin floats; the SPI peripheral's MISO matrix
         // signal reads the externally-driven level from the SD card.
@@ -186,6 +239,15 @@ where
         // LCD transaction reuses the bus.
         set_gpio35_oe_high();
 
-        result.and(cs_result)
+        // Restore the LCD's SCK rate before releasing the bus borrow,
+        // regardless of inner success. The LCD's `RefCellDevice` does
+        // not re-apply its config on every transaction, so leaving the
+        // bus at SD speed would silently slow every subsequent frame.
+        let lcd_cfg = SpiConfig::default()
+            .with_frequency(Rate::from_hz(LCD_SCK_HZ))
+            .with_mode(SpiMode::_0);
+        let restore = bus.apply_config(&lcd_cfg).map_err(|_| SdSpiError::Spi);
+
+        result.and(cs_result).and(restore)
     }
 }

--- a/crates/stackchan-firmware/src/storage.rs
+++ b/crates/stackchan-firmware/src/storage.rs
@@ -23,10 +23,13 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 use embassy_time::Delay;
 use embedded_hal::digital::OutputPin;
+use embedded_hal::spi::SpiBus;
 use embedded_sdmmc::{Mode, SdCard, TimeSource, Timestamp, VolumeIdx, VolumeManager};
 use esp_hal::Blocking;
 use esp_hal::gpio::Output;
-use esp_hal::spi::master::Spi;
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::{Config as SpiConfig, Spi};
+use esp_hal::time::Rate;
 
 use crate::sd_spi::SdSpiDevice;
 
@@ -300,11 +303,42 @@ where
         bus: &'static RefCell<Spi<'static, Blocking>>,
         cs: CS,
     ) -> Result<Self, StorageError> {
+        // SD spec priming: ≥74 SCK pulses at ≤400 kHz with no CS
+        // asserted, before any command. embedded-sdmmc 0.9.0's
+        // `SdCard` doc comment leaves this to the caller (see
+        // `sdcard::mod::26-33`). Some cards (e.g. `SanDisk` High
+        // Endurance 32 GB) need it; without it, the card answers CMD0
+        // with `R1=0x00` ("not idle") instead of the expected `0x01`
+        // and the driver spins in its retry loop. We borrow the bus
+        // directly, drop SCK to 400 kHz, write 10 dummy bytes (80
+        // clocks > 74 required) with both LCD CS and SD CS deasserted
+        // HIGH, then restore the LCD rate before handing the bus to
+        // `SdCard::new`.
+        {
+            let mut spi = bus.borrow_mut();
+            let prime_cfg = SpiConfig::default()
+                .with_frequency(Rate::from_hz(400_000))
+                .with_mode(SpiMode::_0);
+            spi.apply_config(&prime_cfg)
+                .map_err(|_| StorageError::Spi)?;
+            <Spi<'static, Blocking> as SpiBus>::write(&mut spi, &[0xFFu8; 10])
+                .map_err(|_| StorageError::Spi)?;
+            let lcd_cfg = SpiConfig::default()
+                .with_frequency(Rate::from_mhz(40))
+                .with_mode(SpiMode::_0);
+            spi.apply_config(&lcd_cfg).map_err(|_| StorageError::Spi)?;
+        }
         let sd_device = SdSpiDevice::new(bus, cs, Delay);
         let sd_card = SdCard::new(sd_device, Delay);
         // Force card init by querying capacity. Returns once the SD
-        // has answered ACMD41 and entered the data state.
+        // has answered ACMD41 and entered the data state. The SD-side
+        // bus rate is held at 400 kHz init speed by `sd_spi` until
+        // this point — see `sd_spi::SD_INIT_HZ`.
         sd_card.num_bytes().map_err(|_| StorageError::CardInit)?;
+        // Card is in data state; bump the SD-side SCK to 25 MHz so
+        // subsequent reads/writes (config, bonds, camera capture,
+        // wake-word model) don't pay the init-speed penalty.
+        crate::sd_spi::set_data_rate();
         let mgr = VolumeManager::new(sd_card, EpochTime);
         // Probe FAT volume 0 and immediately drop the handle — we
         // re-open per call so callers don't have to thread lifetimes.


### PR DESCRIPTION
## Summary
- Drop the shared SPI2 bus to 400 kHz for SD init priming (>=74 clocks, CS deasserted) and the CMD0/CMD8/ACMD41/CMD58 handshake, where the SD spec mandates <=400 kHz.
- Bump the SD-side SCK to 25 MHz "default speed" once `SdCard::num_bytes()` confirms the card has entered data state, via a new `sd_spi::set_data_rate()` (`AtomicU32`-backed so `Storage::mount` can flip it without a `&mut` to the `SdSpiDevice` that `embedded-sdmmc` has consumed).
- Apply the SD rate per-transaction and restore the LCD's 40 MHz rate before releasing the bus borrow, so subsequent LCD blits aren't silently slowed (the LCD `RefCellDevice` doesn't re-apply its config each transaction).
- Motivation: some cards (SanDisk High Endurance 32 GB) fail CMD0/ACMD41 negotiation when the bus is left at the LCD's 40 MHz; the priming + init-speed path makes the handshake converge, and the data-speed bump avoids paying the 400 kHz penalty on every config/bond/camera/model read.

## Test plan
- `just check` (fmt + workspace clippy + host tests + doctests) — passed.
- `source ~/export-esp.sh && just clippy-firmware` (web build + strict `cargo +esp clippy --release -- -D warnings`) — passed.
- Needs on-device verification: this touches the SD boot/mount path and the shared LCD/SD SPI2 bus. Confirm clean boot + SD mount and that LCD frames render at full speed via `just fmr` on the CoreS3.

Greptile: please review.