### PR TITLE
feat(firmware): reassemble fragmented BluFi frames

### DIFF
--- a/crates/stackchan-firmware/src/ble/server.rs
+++ b/crates/stackchan-firmware/src/ble/server.rs
@@ -629,6 +629,12 @@ impl WriteHandles {
 /// the device only persists once a `ControlSubtype::ConnectToAp`
 /// control frame lands. Dropped at the end of `gatt_events_task` so
 /// the staged PSK never outlives the connection.
+///
+/// A single in-flight fragment chain (`reasm` + `reasm_subtype`) is
+/// tracked at a time — the official provisioning app sends one
+/// credential per chain. The buffer is reset on completion, on a
+/// subtype switch mid-chain, and (by virtue of per-connection
+/// construction) on disconnect.
 struct BluFiSession {
     /// `SendStaSsid` payload, decoded as UTF-8. Empty until the
     /// central sends one. Overwritten on each new `SendStaSsid`.
@@ -656,6 +662,28 @@ struct BluFiSession {
     /// when both `Connecting` and `Disconnected` upstream states map
     /// to `NotConnected`.
     last_reported: Option<blufi::WifiConnState>,
+    /// Accumulated content of the in-flight fragment chain. Capacity
+    /// is [`PROV_PSK_CAP`] — the larger of the two staged caps — so a
+    /// chain that claims more is rejected structurally. Empty when no
+    /// chain is in flight.
+    reasm: HVec<u8, PROV_PSK_CAP>,
+    /// Data subtype of the in-flight fragment chain, or `None` when no
+    /// chain is in flight. A frame for a different subtype resets the
+    /// buffer before accumulating.
+    reasm_subtype: Option<u8>,
+}
+
+/// Outcome of feeding one fragment into a [`BluFiSession`] chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FragmentState {
+    /// The accumulated content has reached the declared total length;
+    /// the buffer holds the complete payload, ready to stage.
+    Complete,
+    /// More fragments are expected before the chain completes.
+    NeedMore,
+    /// The chain was rejected (over-cap or buffer overflow) and the
+    /// buffer has been reset.
+    Aborted,
 }
 
 impl BluFiSession {
@@ -668,6 +696,56 @@ impl BluFiSession {
             outbound_seq: 0,
             watch_link: false,
             last_reported: None,
+            reasm: HVec::new(),
+            reasm_subtype: None,
+        }
+    }
+
+    /// Clear the in-flight fragment chain.
+    fn reset_reasm(&mut self) {
+        self.reasm.clear();
+        self.reasm_subtype = None;
+    }
+
+    /// Feed one fragment's content into the chain for `subtype`.
+    ///
+    /// `total_len` is the chain's declared full content length (from
+    /// the fragmented frame's prefix); `content` is this frame's
+    /// slice. Starting or continuing a chain for a different subtype
+    /// resets the buffer first — only one chain is tracked at a time.
+    ///
+    /// Returns [`FragmentState::Aborted`] (and resets) when the chain
+    /// would exceed [`PROV_PSK_CAP`] or the buffer overflows;
+    /// [`FragmentState::Complete`] once the accumulated length reaches
+    /// `total_len`; otherwise [`FragmentState::NeedMore`].
+    fn push_fragment(&mut self, subtype: u8, total_len: usize, content: &[u8]) -> FragmentState {
+        if self.reasm_subtype != Some(subtype) {
+            self.reset_reasm();
+            self.reasm_subtype = Some(subtype);
+        }
+        if total_len > PROV_PSK_CAP {
+            defmt::warn!(
+                "ble: blufi fragment chain too long (total={=usize} > {=usize}); resetting",
+                total_len,
+                PROV_PSK_CAP
+            );
+            self.reset_reasm();
+            return FragmentState::Aborted;
+        }
+        if self.reasm.extend_from_slice(content).is_err() {
+            defmt::warn!(
+                "ble: blufi fragment buffer overflow (have={=usize} + {=usize}B > {=usize}); resetting",
+                self.reasm.len(),
+                content.len(),
+                PROV_PSK_CAP
+            );
+            self.reset_reasm();
+            return FragmentState::Aborted;
+        }
+        if self.reasm.len() >= total_len {
+            FragmentState::Complete
+        } else {
+            FragmentState::NeedMore
         }
     }
 
@@ -705,10 +783,9 @@ enum WriteAction {
     /// Signal the camera task to persist the latest frame to
     /// `/sd/CAPTURE.565`.
     CameraCapture,
-    /// Surface a parsed `BluFi` frame in defmt. The provisioning state
-    /// machine (SSID/password accumulation, commit on
-    /// `ControlSubtype::ConnectToAp`) lands in a follow-up; this
-    /// slice proves the GATT plumbing.
+    /// Hand a parsed `BluFi` frame to [`handle_blufi_frame`] — the
+    /// provisioning state machine (SSID/password accumulation +
+    /// fragment reassembly, commit on `ControlSubtype::ConnectToAp`).
     BluFiFrame(blufi::Frame),
     /// Raw bytes from the desktop NUS RX characteristic. Fed into the
     /// per-connection [`DesktopSession`] which handles line framing
@@ -1028,9 +1105,9 @@ const fn att_error_for_blufi(err: blufi::ParseError) -> AttErrorCode {
         blufi::ParseError::Truncated | blufi::ParseError::BadDataLength => {
             AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH
         }
-        blufi::ParseError::BadCrc | blufi::ParseError::UnknownType => {
-            AttErrorCode::VALUE_NOT_ALLOWED
-        }
+        blufi::ParseError::BadCrc
+        | blufi::ParseError::UnknownType
+        | blufi::ParseError::FragmentTooShort => AttErrorCode::VALUE_NOT_ALLOWED,
     }
 }
 
@@ -1080,9 +1157,8 @@ async fn apply_write_action<P: PacketPool>(
 }
 
 /// Surface a parsed `BluFi` frame in defmt — type, subtype, sequence,
-/// frame-control flags, and data length. No state mutation: the
-/// SSID/password accumulator and the `ControlSubtype::ConnectToAp`
-/// commit path land in a follow-up.
+/// frame-control flags, and data length. No state mutation; the
+/// dispatch + accumulation happens in [`handle_blufi_frame`].
 fn log_blufi_frame(frame: &blufi::Frame) {
     let kind = match frame.frame_type {
         blufi::Type::Control => "control",
@@ -1109,56 +1185,140 @@ fn log_blufi_frame(frame: &blufi::Frame) {
 /// `GetWifiStatus` notify a reply frame on the `BluFi` notify
 /// characteristic. Unhandled subtypes fall through with a log.
 ///
-/// Fragmented frames are rejected with a warn. The `BluFi` protocol
-/// allows large payloads to be split across multiple application-
-/// layer frames via the `FC_FRAGMENT` bit, and the GATT handler
-/// owns reassembly per `stackchan_net::blufi`'s module contract.
-/// Until reassembly lands, staging only the trailing fragment of a
-/// multi-frame `SendStaSsid` / `SendStaPassword` would silently
-/// commit a truncated network name or passphrase — the auth gate
-/// would happily accept it because the bytes are still valid UTF-8.
-/// Rejecting cleanly here keeps the session state coherent.
+/// `SendStaSsid` / `SendStaPassword` Data frames are run through the
+/// fragment reassembler (see [`handle_blufi_credential`]) so a large
+/// SSID or passphrase split across `FC_FRAGMENT` frames is staged
+/// whole rather than truncated. Fragmented frames of any other
+/// subtype — and any fragmented+encrypted frame, whose content is
+/// ciphertext that can't be reassembled until the deferred AES-CCM
+/// layer lands — are dropped with a warn, matching the parser's
+/// encrypted-CRC-deferral posture.
 async fn handle_blufi_frame<P: PacketPool>(
     server: &StackchanServer<'_>,
     conn: &GattConnection<'_, '_, P>,
     session: &mut BluFiSession,
     frame: blufi::Frame,
 ) {
-    if frame.fragmented {
-        defmt::warn!(
-            "ble: blufi fragmented frame (subtype={=u8:02x} seq={=u8}); \
-             reassembly not implemented — dropping",
-            frame.subtype,
-            frame.sequence,
-        );
-        return;
-    }
     match frame.frame_type {
-        blufi::Type::Control => match frame.control_subtype() {
-            Some(blufi::ControlSubtype::SetWifiOpMode) => {
-                if let Some(&byte) = frame.data.first() {
-                    session.op_mode = Some(byte);
-                    defmt::info!("ble: blufi op_mode set ({=u8})", byte);
-                } else {
-                    defmt::warn!("ble: blufi op_mode payload empty; ignoring");
+        blufi::Type::Control => {
+            if frame.fragmented {
+                warn_drop_fragment(&frame);
+                return;
+            }
+            match frame.control_subtype() {
+                Some(blufi::ControlSubtype::SetWifiOpMode) => {
+                    if let Some(&byte) = frame.data.first() {
+                        session.op_mode = Some(byte);
+                        defmt::info!("ble: blufi op_mode set ({=u8})", byte);
+                    } else {
+                        defmt::warn!("ble: blufi op_mode payload empty; ignoring");
+                    }
+                }
+                Some(blufi::ControlSubtype::ConnectToAp) => {
+                    commit_blufi_provisioning(server, conn, session).await;
+                }
+                Some(blufi::ControlSubtype::GetVersion) => {
+                    reply_blufi_version(server, conn, session).await;
+                }
+                Some(blufi::ControlSubtype::GetWifiStatus) => {
+                    reply_blufi_wifi_status(server, conn, session).await;
+                }
+                _ => {}
+            }
+        }
+        blufi::Type::Data => match frame.data_subtype() {
+            Some(sub @ (blufi::DataSubtype::SendStaSsid | blufi::DataSubtype::SendStaPassword)) => {
+                handle_blufi_credential(session, sub, &frame);
+            }
+            _ => {
+                if frame.fragmented {
+                    warn_drop_fragment(&frame);
                 }
             }
-            Some(blufi::ControlSubtype::ConnectToAp) => {
-                commit_blufi_provisioning(server, conn, session).await;
-            }
-            Some(blufi::ControlSubtype::GetVersion) => {
-                reply_blufi_version(server, conn, session).await;
-            }
-            Some(blufi::ControlSubtype::GetWifiStatus) => {
-                reply_blufi_wifi_status(server, conn, session).await;
-            }
-            _ => {}
         },
-        blufi::Type::Data => match frame.data_subtype() {
-            Some(blufi::DataSubtype::SendStaSsid) => stage_blufi_ssid(session, &frame.data),
-            Some(blufi::DataSubtype::SendStaPassword) => stage_blufi_psk(session, &frame.data),
-            _ => {}
-        },
+    }
+}
+
+/// Drop a fragmented frame we don't reassemble, logging why.
+fn warn_drop_fragment(frame: &blufi::Frame) {
+    defmt::warn!(
+        "ble: blufi fragmented frame not reassembled (subtype={=u8:02x} seq={=u8} encrypted={=bool}); dropping",
+        frame.subtype,
+        frame.sequence,
+        frame.encrypted,
+    );
+}
+
+/// Feed one `SendStaSsid` / `SendStaPassword` frame through the
+/// reassembler and stage the credential once the chain completes.
+///
+/// A fragmented frame carries a 2-byte total-content-length prefix
+/// ([`blufi::fragment_content`]); its content is accumulated. A
+/// non-fragmented frame is the terminating fragment when a chain for
+/// the same subtype is in flight (its data is appended verbatim —
+/// no prefix), or a standalone single-fragment credential otherwise.
+/// Either way, on completion the assembled bytes go to the matching
+/// `stage_blufi_*` helper and the buffer resets.
+///
+/// Fragmented+encrypted frames are dropped: reassembling ciphertext
+/// is meaningless without the deferred AES-CCM layer, and staging it
+/// as an SSID/PSK would corrupt the credential.
+fn handle_blufi_credential(
+    session: &mut BluFiSession,
+    subtype: blufi::DataSubtype,
+    frame: &blufi::Frame,
+) {
+    if frame.fragmented {
+        if frame.encrypted {
+            warn_drop_fragment(frame);
+            return;
+        }
+        let frag = match blufi::fragment_content(frame) {
+            Ok(frag) => frag,
+            Err(e) => {
+                defmt::warn!(
+                    "ble: blufi fragment prefix malformed ({}); dropping",
+                    defmt::Debug2Format(&e)
+                );
+                return;
+            }
+        };
+        match session.push_fragment(frame.subtype, frag.total_len as usize, frag.content) {
+            FragmentState::Complete => stage_blufi_credential(session, subtype),
+            FragmentState::NeedMore | FragmentState::Aborted => {}
+        }
+        return;
+    }
+
+    if session.reasm_subtype == Some(frame.subtype) {
+        // Terminating fragment: its data carries no length prefix, so
+        // append verbatim. The total_len from the chain's opening
+        // fragment already bounds the buffer; pass it through so an
+        // overflow still aborts cleanly.
+        let total_len = session.reasm.len() + frame.data.len();
+        match session.push_fragment(frame.subtype, total_len, &frame.data) {
+            FragmentState::Complete => stage_blufi_credential(session, subtype),
+            FragmentState::NeedMore | FragmentState::Aborted => {}
+        }
+        return;
+    }
+
+    match subtype {
+        blufi::DataSubtype::SendStaSsid => stage_blufi_ssid(session, &frame.data),
+        blufi::DataSubtype::SendStaPassword => stage_blufi_psk(session, &frame.data),
+        _ => {}
+    }
+}
+
+/// Stage the just-completed reassembly buffer as the SSID or PSK,
+/// then clear the chain.
+fn stage_blufi_credential(session: &mut BluFiSession, subtype: blufi::DataSubtype) {
+    let assembled = core::mem::take(&mut session.reasm);
+    session.reasm_subtype = None;
+    match subtype {
+        blufi::DataSubtype::SendStaSsid => stage_blufi_ssid(session, &assembled),
+        blufi::DataSubtype::SendStaPassword => stage_blufi_psk(session, &assembled),
+        _ => {}
     }
 }
 

--- a/crates/stackchan-net/src/blufi.rs
+++ b/crates/stackchan-net/src/blufi.rs
@@ -34,10 +34,12 @@
 //!   Operators relying on link-layer encryption from BLE LE
 //!   Secure Connections get a comparable security posture; full
 //!   BluFi crypto is a follow-up.
-//! - Fragment reassembly. The `Fragment follows` FrameControl bit
-//!   is parsed and surfaced as [`Frame::fragmented`]; the
-//!   higher-level GATT handler is responsible for buffering
-//!   continuations.
+//! - Fragment reassembly *state*. The `Fragment follows`
+//!   FrameControl bit is parsed and surfaced as
+//!   [`Frame::fragmented`]; [`fragment_content`] is the stateless
+//!   helper that strips a fragmented frame's leading
+//!   total-content-length prefix. The accumulation buffer lives in
+//!   the GATT handler, which owns per-chain state.
 //! - GATT integration. The [`SERVICE_UUID`] / [`WRITE_CHAR_UUID`]
 //!   / [`NOTIFY_CHAR_UUID`] `u16` constants are exported for code
 //!   paths that consume UUIDs at runtime — service-discovery filters,
@@ -357,6 +359,11 @@ pub enum ParseError {
     /// them as `Data` would hide a malformed or future-format
     /// frame from the GATT handler.
     UnknownType,
+    /// A frame with `FC_FRAGMENT` set carried fewer than the two
+    /// bytes its leading total-content-length prefix needs. A
+    /// conformant central always prefixes a fragmented frame's data
+    /// with that `u16`, so a sub-2-byte payload is malformed.
+    FragmentTooShort,
 }
 
 /// Parse one BluFi frame from `buf`.
@@ -424,6 +431,49 @@ pub fn parse_frame(buf: &[u8]) -> Result<Frame, ParseError> {
         data,
         fragmented: frame_control & FC_FRAGMENT != 0,
         encrypted,
+    })
+}
+
+/// A fragmented frame's payload, split into its declared total
+/// content length and the content bytes this frame contributes.
+///
+/// See [`fragment_content`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FragmentContent<'a> {
+    /// Total length of the fully-reassembled content across the
+    /// whole fragment chain, taken from this frame's leading `u16`
+    /// little-endian prefix. The receiver uses it to size its
+    /// staging buffer and to know when the chain is complete.
+    pub total_len: u16,
+    /// This frame's slice of the content, borrowed from
+    /// [`Frame::data`] with the 2-byte prefix removed.
+    pub content: &'a [u8],
+}
+
+/// Strip a fragmented frame's leading total-content-length prefix.
+///
+/// Per the BluFi spec, every frame with `FC_FRAGMENT` set carries
+/// `[total_content_length: u16 little-endian][content…]` in its
+/// Data field; `content` is `Data Length - 2` bytes. The
+/// *terminating* frame in a chain has `FC_FRAGMENT` clear and
+/// carries **no** prefix — its data is the final content slice
+/// verbatim, so this helper must not be called on it.
+///
+/// This is stateless: it reads one frame and returns its prefix +
+/// content. Accumulating slices across the chain until the running
+/// length reaches `total_len` is the GATT handler's job.
+///
+/// # Errors
+///
+/// Returns [`ParseError::FragmentTooShort`] when `frame.data` holds
+/// fewer than the two bytes the prefix needs.
+pub fn fragment_content(frame: &Frame) -> Result<FragmentContent<'_>, ParseError> {
+    let Some((prefix, content)) = frame.data.split_first_chunk::<2>() else {
+        return Err(ParseError::FragmentTooShort);
+    };
+    Ok(FragmentContent {
+        total_len: u16::from_le_bytes(*prefix),
+        content,
     })
 }
 
@@ -641,6 +691,62 @@ mod tests {
         let parsed = parse_frame(&buf).unwrap();
         assert!(parsed.fragmented);
         assert!(parsed.encrypted);
+    }
+
+    #[test]
+    fn fragment_content_splits_le_prefix_from_content() {
+        // A fragmented SendStaSsid frame whose data is
+        // [total_len_lo, total_len_hi, content…]. total_len = 0x0140
+        // (320) — bigger than this frame's slice, as expected mid-chain.
+        let mut buf = build_frame(
+            Type::Data,
+            DataSubtype::SendStaSsid as u8,
+            0,
+            &[0x40, 0x01, b'a', b'b', b'c'],
+        )
+        .unwrap();
+        buf[1] |= FC_FRAGMENT;
+        let frame = parse_frame(&buf).unwrap();
+        let frag = fragment_content(&frame).unwrap();
+        assert_eq!(frag.total_len, 0x0140);
+        assert_eq!(frag.content, b"abc");
+    }
+
+    #[test]
+    fn fragment_content_rejects_data_under_two_bytes() {
+        let mut buf = build_frame(Type::Data, DataSubtype::SendStaSsid as u8, 0, &[0x07]).unwrap();
+        buf[1] |= FC_FRAGMENT;
+        let frame = parse_frame(&buf).unwrap();
+        assert_eq!(fragment_content(&frame), Err(ParseError::FragmentTooShort));
+    }
+
+    #[test]
+    fn fragmented_then_terminating_frame_round_trips() {
+        // Two-frame chain reassembling "hello-world-network" (19 bytes).
+        // Frame A: fragmented, prefix = total_len, carries "hello-world".
+        // Frame B: terminating (FC_FRAGMENT clear, no prefix), carries
+        // "-network".
+        let payload = b"hello-world-network";
+        let total_len = u16::try_from(payload.len()).unwrap();
+        let head = &payload[..11];
+        let tail = &payload[11..];
+
+        let mut a_data = total_len.to_le_bytes().to_vec();
+        a_data.extend_from_slice(head);
+        let mut a_buf =
+            build_frame(Type::Data, DataSubtype::SendStaSsid as u8, 0, &a_data).unwrap();
+        a_buf[1] |= FC_FRAGMENT;
+        let frame_a = parse_frame(&a_buf).unwrap();
+        let frag_a = fragment_content(&frame_a).unwrap();
+
+        let b_buf = build_frame(Type::Data, DataSubtype::SendStaSsid as u8, 1, tail).unwrap();
+        let frame_b = parse_frame(&b_buf).unwrap();
+        assert!(!frame_b.fragmented);
+
+        let mut assembled = frag_a.content.to_vec();
+        assembled.extend_from_slice(&frame_b.data);
+        assert_eq!(assembled, payload);
+        assert_eq!(assembled.len(), frag_a.total_len as usize);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Added a stateless `fragment_content` helper + `ParseError::FragmentTooShort` and a `FragmentContent` struct to the `stackchan-net` BluFi codec, keeping the codec pure per its layering contract (3 new unit tests).
- In firmware, added a bounded reassembly buffer (`PROV_PSK_CAP=64`) + active-subtype tracking to the per-connection `BluFiSession`, plus a `FragmentState` state machine (`push_fragment` with over-cap/overflow abort, no `unwrap`/`expect`).
- Rewired `handle_blufi_frame` to accumulate `SendStaSsid`/`SendStaPassword` fragments (fragmented frames carry a u16 LE total-length prefix; the prefix-less non-fragmented frame is treated as the terminating fragment) and stage the assembled credential on completion.
- Fragmented control/other-data and fragmented+encrypted frames are warn-dropped; `att_error_for_blufi` updated for the new variant and stale follow-up doc comments refreshed.

## Test plan
- Host gate `just check` — PASS (clean fmt/clippy, all tests including the 3 new blufi codec tests).
- Firmware gate `just clippy-firmware` — PASS with `-D warnings` (no warnings).
- End-to-end >253-byte credential provisioning via the official ESP BLE Provisioning app on hardware is a manual follow-up not coverable in this environment.

Greptile: please review.