### PR TITLE
feat(config): pin default palette + face geometry in boot config

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1270,7 +1270,7 @@ async fn main(spawner: Spawner) -> ! {
             // SD-backed runtime store. Tolerant of a missing /
             // malformed file: any failure leaves the cache (and the
             // signal fan-out below) at variant defaults.
-            let runtime = stackchan_firmware::runtime_store::load_into_cache().await;
+            let runtime = stackchan_firmware::runtime_store::load_into_cache(&cfg.appearance).await;
             net::http::PALETTE_SIGNAL.signal(runtime.palette);
             net::http::MOOD_SIGNAL.signal(runtime.mood);
             net::http::FACE_GEOMETRY_SIGNAL.signal(runtime.face_geometry);

--- a/crates/stackchan-firmware/src/runtime_store.rs
+++ b/crates/stackchan-firmware/src/runtime_store.rs
@@ -180,13 +180,15 @@ pub fn set_cache(state: RuntimeState) {
 /// regardless of disk state. Returns the loaded (or default) state
 /// so the caller can fan it out to `PALETTE_SIGNAL` / `MOOD_SIGNAL`
 /// before the render task starts.
-pub async fn load_into_cache() -> RuntimeState {
+pub async fn load_into_cache(appearance: &stackchan_net::config::AppearanceConfig) -> RuntimeState {
     let raw = crate::storage::with_storage(crate::storage::FirmwareStorage::read_runtime).await;
     let state = match raw {
         Some(Ok(Some(text))) => parse(&text),
         Some(Ok(None)) => {
-            defmt::info!("runtime store: no /sd/RUNTIME.RON yet — using defaults");
-            RuntimeState::default()
+            defmt::info!(
+                "runtime store: no /sd/RUNTIME.RON yet — seeding from boot config appearance"
+            );
+            seed_from_appearance(appearance)
         }
         Some(Err(e)) => {
             defmt::warn!(
@@ -197,11 +199,24 @@ pub async fn load_into_cache() -> RuntimeState {
         }
         None => {
             defmt::info!("runtime store: no SD mounted — runtime state is non-persistent");
-            RuntimeState::default()
+            seed_from_appearance(appearance)
         }
     };
     set_cache(state);
     state
+}
+
+/// Build the first-boot runtime state from the boot config's pinned
+/// appearance. Empty / unknown wire strings resolve to the variant
+/// default — the same fallback [`parse`] applies to an unknown enum
+/// value on disk. Only palette + `face_geometry` are pinnable; mood and
+/// head offsets keep their defaults until an operator sets them.
+fn seed_from_appearance(appearance: &stackchan_net::config::AppearanceConfig) -> RuntimeState {
+    RuntimeState {
+        palette: Palette::from_wire_str(&appearance.palette).unwrap_or_default(),
+        face_geometry: FaceGeometry::from_wire_str(&appearance.face_geometry).unwrap_or_default(),
+        ..RuntimeState::default()
+    }
 }
 
 /// Update the palette field and persist the cache.
@@ -284,6 +299,7 @@ async fn persist() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn default_state_round_trips() {
@@ -367,5 +383,31 @@ mod tests {
     fn parse_empty_yields_defaults() {
         let s = parse("");
         assert_eq!(s, RuntimeState::default());
+    }
+
+    #[test]
+    fn seed_resolves_boot_appearance_wire_strings() {
+        let appearance = stackchan_net::config::AppearanceConfig {
+            palette: "cute".to_string(),
+            face_geometry: "chibi".to_string(),
+        };
+        let seeded = seed_from_appearance(&appearance);
+        assert_eq!(seeded.palette, Palette::Cute);
+        assert_eq!(seeded.face_geometry, FaceGeometry::Chibi);
+        // Unpinnable axes keep their defaults.
+        assert_eq!(seeded.mood, Mood::default());
+        assert_eq!(seeded.head_offsets, RuntimeState::default().head_offsets);
+    }
+
+    #[test]
+    fn seed_falls_back_to_default_on_empty_or_unknown() {
+        let empty = seed_from_appearance(&stackchan_net::config::AppearanceConfig::default());
+        assert_eq!(empty, RuntimeState::default());
+        let unknown = seed_from_appearance(&stackchan_net::config::AppearanceConfig {
+            palette: "rainbow".to_string(),
+            face_geometry: "compact".to_string(),
+        });
+        assert_eq!(unknown.palette, Palette::default());
+        assert_eq!(unknown.face_geometry, FaceGeometry::default());
     }
 }

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -22,8 +22,8 @@ use core::fmt::Write as _;
 
 use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{
-    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
-    TrackerSettings, WifiConfig, validate_for_disk,
+    AppearanceConfig, AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig,
+    TimeConfig, TrackerSettings, WifiConfig, validate_for_disk,
 };
 use crate::error::ConfigError;
 
@@ -184,6 +184,15 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     );
     out.push_str("    ),\n");
 
+    out.push_str("    appearance: (\n");
+    push_field(&mut out, "        palette", &config.appearance.palette);
+    push_field(
+        &mut out,
+        "        face_geometry",
+        &config.appearance.face_geometry,
+    );
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -235,6 +244,7 @@ impl<'a> Parser<'a> {
         let mut tracker: Option<TrackerSettings> = None;
         let mut esp_now: Option<EspNowConfig> = None;
         let mut behavior: Option<BehaviorConfig> = None;
+        let mut appearance: Option<AppearanceConfig> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -294,6 +304,12 @@ impl<'a> Parser<'a> {
                     }
                     behavior = Some(self.parse_behavior()?);
                 }
+                "appearance" => {
+                    if appearance.is_some() {
+                        return Err(bare_err("duplicate top-level field", "appearance"));
+                    }
+                    appearance = Some(self.parse_appearance()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -316,6 +332,7 @@ impl<'a> Parser<'a> {
             tracker: tracker.unwrap_or_default(),
             esp_now: esp_now.unwrap_or_default(),
             behavior: behavior.unwrap_or_default(),
+            appearance: appearance.unwrap_or_default(),
         })
     }
 
@@ -814,6 +831,49 @@ impl<'a> Parser<'a> {
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
             wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
             persona_name: persona_name.unwrap_or_default(),
+        })
+    }
+
+    /// Parse the optional `appearance: (palette, face_geometry)`
+    /// block. Both inner fields are optional and default to the empty
+    /// "not pinned" string, mirroring [`crate::bare::Parser::parse_auth`].
+    fn parse_appearance(&mut self) -> Result<AppearanceConfig, ConfigError> {
+        self.expect_char('(')?;
+        let mut palette: Option<String> = None;
+        let mut face_geometry: Option<String> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            let value = self.parse_string()?;
+            match key {
+                "palette" => {
+                    if palette.is_some() {
+                        return Err(bare_err("duplicate appearance field", "palette"));
+                    }
+                    palette = Some(value);
+                }
+                "face_geometry" => {
+                    if face_geometry.is_some() {
+                        return Err(bare_err("duplicate appearance field", "face_geometry"));
+                    }
+                    face_geometry = Some(value);
+                }
+                other => return Err(bare_err("unknown appearance field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in appearance", ""));
+            }
+        }
+        Ok(AppearanceConfig {
+            palette: palette.unwrap_or_default(),
+            face_geometry: face_geometry.unwrap_or_default(),
         })
     }
 
@@ -1903,5 +1963,51 @@ mod tests {
             msg.contains("duplicate behavior field") && msg.contains("wake_word_enabled"),
             "got {msg}"
         );
+    }
+
+    #[test]
+    fn missing_appearance_block_defaults_to_empty() {
+        // SD cards written before the appearance block landed omit it
+        // entirely; the parser must fall back to empty wire strings.
+        let cfg = parse_ron_bare(FIXTURE).unwrap();
+        assert!(cfg.appearance.palette.is_empty());
+        assert!(cfg.appearance.face_geometry.is_empty());
+    }
+
+    #[test]
+    fn round_trips_with_appearance_block() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                appearance: ( palette: "dark", face_geometry: "wide" ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        assert_eq!(cfg.appearance.palette, "dark");
+        assert_eq!(cfg.appearance.face_geometry, "wide");
+        let rendered = render_ron_bare(&cfg).unwrap();
+        let reparsed = parse_ron_bare(&rendered).unwrap();
+        assert_eq!(cfg, reparsed);
+        #[cfg(feature = "parse")]
+        {
+            let via_serde = crate::parse_ron(&rendered).unwrap();
+            assert_eq!(cfg, via_serde);
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_appearance_field() {
+        let s = with_base(r#"appearance: ( palette: "cute", oops: "x" ),"#);
+        let msg = assert_bare_parse_err(&s);
+        assert!(msg.contains("unknown appearance field"), "got {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_palette_after_parse() {
+        let s = with_base(r#"appearance: ( palette: "rainbow" ),"#);
+        let err = parse_ron_bare(&s).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidPalette(_)), "got {err:?}");
     }
 }

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -20,8 +20,8 @@ use alloc::vec::Vec;
 use core::fmt::Write as _;
 
 use crate::config::{
-    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
-    TrackerSettings, WifiConfig, validate,
+    AppearanceConfig, AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig,
+    TimeConfig, TrackerSettings, WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -147,6 +147,7 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
             },
             ..new.behavior
         },
+        appearance: new.appearance,
     }
 }
 
@@ -306,6 +307,10 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     );
     out.push(',');
     push_string_field(&mut out, "persona_name", &config.behavior.persona_name);
+    out.push_str("},\"appearance\":{");
+    push_string_field(&mut out, "palette", &config.appearance.palette);
+    out.push(',');
+    push_string_field(&mut out, "face_geometry", &config.appearance.face_geometry);
     out.push_str("}}");
     Ok(out)
 }
@@ -364,6 +369,7 @@ impl<'a> Parser<'a> {
         let mut tracker: Option<TrackerSettings> = None;
         let mut esp_now: Option<EspNowConfig> = None;
         let mut behavior: Option<BehaviorConfig> = None;
+        let mut appearance: Option<AppearanceConfig> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -422,6 +428,12 @@ impl<'a> Parser<'a> {
                     }
                     behavior = Some(self.parse_behavior()?);
                 }
+                "appearance" => {
+                    if appearance.is_some() {
+                        return Err(bare_err("duplicate top-level field", "appearance"));
+                    }
+                    appearance = Some(self.parse_appearance()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -442,6 +454,7 @@ impl<'a> Parser<'a> {
             tracker: tracker.unwrap_or_default(),
             esp_now: esp_now.unwrap_or_default(),
             behavior: behavior.unwrap_or_default(),
+            appearance: appearance.unwrap_or_default(),
         })
     }
 
@@ -941,6 +954,49 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parse the optional `"appearance"` object. Both fields default
+    /// to the empty "not pinned" string so a body that pre-dates the
+    /// block round-trips cleanly.
+    fn parse_appearance(&mut self) -> Result<AppearanceConfig, ConfigError> {
+        self.expect_char('{')?;
+        let mut palette: Option<String> = None;
+        let mut face_geometry: Option<String> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            let value = self.parse_string()?;
+            match key.as_str() {
+                "palette" => {
+                    if palette.is_some() {
+                        return Err(bare_err("duplicate appearance field", "palette"));
+                    }
+                    palette = Some(value);
+                }
+                "face_geometry" => {
+                    if face_geometry.is_some() {
+                        return Err(bare_err("duplicate appearance field", "face_geometry"));
+                    }
+                    face_geometry = Some(value);
+                }
+                other => return Err(bare_err("unknown appearance field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in appearance", ""));
+            }
+        }
+        Ok(AppearanceConfig {
+            palette: palette.unwrap_or_default(),
+            face_geometry: face_geometry.unwrap_or_default(),
+        })
+    }
+
     /// Parse `null` or a decimal `u8`. The JSON wire form for an
     /// `Option<u8>` — null = `None`, integer = `Some(n)`. Used for
     /// `esp_now.channel`.
@@ -1217,6 +1273,10 @@ mod tests {
                 wake_word_threshold: 95,
                 wake_word_arena_kib: 96,
                 persona_name: "desk-buddy".to_string(),
+            },
+            appearance: AppearanceConfig {
+                palette: "cute".to_string(),
+                face_geometry: "chibi".to_string(),
             },
         }
     }
@@ -1765,6 +1825,10 @@ mod tests {
                 wake_word_threshold: -32,
                 wake_word_arena_kib: 128,
                 persona_name: "desk-buddy".to_string(),
+            },
+            appearance: AppearanceConfig {
+                palette: "dog".to_string(),
+                face_geometry: "sleepy".to_string(),
             },
         };
         let rendered = render_settings_json(&config, false).unwrap();

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -62,6 +62,41 @@ pub struct Config {
     /// the canonical modifier stack at all times).
     #[cfg_attr(feature = "parse", serde(default))]
     pub behavior: BehaviorConfig,
+    /// Default appearance the operator can pin in the boot config:
+    /// the colour palette and face-geometry preset. Seeds the runtime
+    /// store only on first boot (when `/sd/RUNTIME.RON` is absent); a
+    /// later operator change via `POST /palette` / `POST /face-geometry`
+    /// persists to `RUNTIME.RON` and wins on subsequent boots.
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub appearance: AppearanceConfig,
+}
+
+/// Default appearance pinned in the boot config.
+///
+/// Both fields are wire strings rather than the `stackchan-core`
+/// enums: that crate has no `serde` dependency, and the string form
+/// mirrors how `RUNTIME.RON` round-trips the same values via
+/// `Palette::wire_str` / `FaceGeometry::wire_str`. An empty string
+/// means "not pinned" — the firmware falls back to the variant
+/// default, exactly like an unknown value would.
+///
+/// Default: both empty. A missing `appearance:` block reproduces the
+/// firmware's pre-runtime-config behaviour (neutral palette + default
+/// geometry).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct AppearanceConfig {
+    /// Lowercase palette wire name (`"default"`, `"dark"`, `"cute"`,
+    /// `"dog"`). Empty = not pinned. A non-empty value that doesn't
+    /// parse via `stackchan_core::Palette::from_wire_str` is rejected
+    /// by [`validate`].
+    pub palette: String,
+    /// Lowercase face-geometry wire name (`"default"`, `"chibi"`,
+    /// `"wide"`, `"sleepy"`). Empty = not pinned. A non-empty value
+    /// that doesn't parse via
+    /// `stackchan_core::FaceGeometry::from_wire_str` is rejected by
+    /// [`validate`].
+    pub face_geometry: String,
 }
 
 /// Wi-Fi station credentials.
@@ -631,6 +666,7 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
     }
     validate_agent_sidecar_token(&config.behavior.agent_sidecar_token)?;
     validate_persona_name(&config.behavior.persona_name)?;
+    validate_appearance(&config.appearance)?;
     Ok(())
 }
 
@@ -742,6 +778,26 @@ fn validate_persona_name(name: &str) -> Result<(), ConfigError> {
         || name.contains("..")
     {
         return Err(ConfigError::PersonaNameInvalidChars);
+    }
+    Ok(())
+}
+
+/// Reject a pinned appearance whose non-empty wire string doesn't
+/// parse back into the `stackchan-core` enum.
+///
+/// Empty short-circuits — that's the "not pinned" marker the firmware
+/// resolves to the variant default. A non-empty unknown string would
+/// otherwise silently fall back to the default at boot, hiding the
+/// operator's typo; rejecting at validation surfaces it on the
+/// `PUT /settings` write instead.
+fn validate_appearance(a: &AppearanceConfig) -> Result<(), ConfigError> {
+    if !a.palette.is_empty() && stackchan_core::Palette::from_wire_str(&a.palette).is_none() {
+        return Err(ConfigError::InvalidPalette(a.palette.clone()));
+    }
+    if !a.face_geometry.is_empty()
+        && stackchan_core::FaceGeometry::from_wire_str(&a.face_geometry).is_none()
+    {
+        return Err(ConfigError::InvalidFaceGeometry(a.face_geometry.clone()));
     }
     Ok(())
 }
@@ -1120,6 +1176,48 @@ mod tests {
         c.esp_now.channel = Some(6);
         c.esp_now.tx_rate_hz = 5;
         assert!(validate(&c).is_ok());
+    }
+
+    #[test]
+    fn default_config_has_empty_appearance() {
+        let c = Config::default();
+        assert!(c.appearance.palette.is_empty());
+        assert!(c.appearance.face_geometry.is_empty());
+    }
+
+    #[test]
+    fn validate_accepts_empty_appearance() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        assert!(validate(&c).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_known_appearance_wire_strings() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.appearance.palette = "cute".to_string();
+        c.appearance.face_geometry = "chibi".to_string();
+        assert!(validate(&c).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_palette() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.appearance.palette = "rainbow".to_string();
+        assert!(matches!(validate(&c), Err(ConfigError::InvalidPalette(_))));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_face_geometry() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.appearance.face_geometry = "compact".to_string();
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidFaceGeometry(_))
+        ));
     }
 
     #[test]

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -180,4 +180,20 @@ pub enum ConfigError {
     /// the field name so the operator can fix the right line.
     #[error("{0} contains the redaction sentinel \"***\" on disk — supply the real value")]
     RedactionSentinelOnDisk(&'static str),
+
+    /// `appearance.palette` was non-empty but didn't parse via
+    /// `stackchan_core::Palette::from_wire_str`. The boot config pins a
+    /// default look by wire name (`"default"`, `"dark"`, `"cute"`,
+    /// `"dog"`); an unknown value would silently fall back to the
+    /// variant default at boot, so reject it at load with the offending
+    /// string.
+    #[error("appearance.palette is not a known palette: {0:?}")]
+    InvalidPalette(String),
+
+    /// `appearance.face_geometry` was non-empty but didn't parse via
+    /// `stackchan_core::FaceGeometry::from_wire_str`. Same rationale as
+    /// [`Self::InvalidPalette`]: an unknown preset name would silently
+    /// fall back rather than surface the operator's typo.
+    #[error("appearance.face_geometry is not a known preset: {0:?}")]
+    InvalidFaceGeometry(String),
 }

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -66,8 +66,8 @@ pub mod ota;
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
 pub use config::{
-    AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig,
-    parse_mac, tz_offset_minutes, validate,
+    AppearanceConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
+    WifiConfig, parse_mac, tz_offset_minutes, validate,
 };
 #[cfg(feature = "parse")]
 pub use config::{parse_ron, render_ron};

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -111,6 +111,8 @@ RON config parse + validation. Host crate; firmware wraps with `Debug2Format` fo
 - `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
 - `EmptySntpServer(usize)` — a `time.sntp_servers` entry was empty / whitespace-only. The `usize` carries the offending index. Caught at parse time so the firmware's "try in order" loop doesn't burn its full per-server timeout on an unresolvable hostname before falling back.
 - `InvalidVolumePct(u8)` — `audio.volume_pct` was outside `0..=100`. The wire format is a percentile; the firmware maps it linearly across the AW88298 dB range. The `u8` carries the offending value.
+- `InvalidPalette(String)` — `appearance.palette` was non-empty but didn't parse via `Palette::from_wire_str` (`"default"` / `"dark"` / `"cute"` / `"dog"`). Empty is allowed (= not pinned). Rejected so an unknown name surfaces on load instead of silently falling back to the default.
+- `InvalidFaceGeometry(String)` — `appearance.face_geometry` was non-empty but didn't parse via `FaceGeometry::from_wire_str` (`"default"` / `"chibi"` / `"wide"` / `"sleepy"`). Same empty-allowed / reject-unknown rationale as `InvalidPalette`.
 
 ### `stackchan_tts::RenderError`
 Speech-backend rendering. Returned from `SpeechBackend::render` when a

--- a/docs/http.md
+++ b/docs/http.md
@@ -306,8 +306,20 @@ $ curl http://stackchan.local/settings
  "auth":{"token":"***"},
  "audio":{"volume_pct":50,"muted":false},
  "tracker":{"fov_h_deg":62.0,"fov_v_deg":49.0,"target_smoothing_alpha":1.0,
-            "flip_x":false,"flip_y":false}}
+            "flip_x":false,"flip_y":false},
+ "appearance":{"palette":"","face_geometry":""}}
 ```
+
+`appearance` pins a default look in the boot config: `palette`
+(`default` / `dark` / `cute` / `dog`) and `face_geometry`
+(`default` / `chibi` / `wide` / `sleepy`). Both default to an empty
+string, meaning "not pinned" — the firmware falls back to the
+neutral palette and default geometry. A non-empty value that isn't a
+known wire name is rejected on load. The appearance block is a
+**first-boot seed only**: it populates `/sd/RUNTIME.RON` when that
+file is absent, but once an operator changes the look at runtime via
+`POST /palette` / `POST /face-geometry`, `RUNTIME.RON` exists and wins
+on subsequent boots.
 
 `tracker` carries the operator-tunable subset of the firmware
 tracker config: physical lens FOV (`fov_h_deg` / `fov_v_deg`),


### PR DESCRIPTION
## Summary
- Added an optional `appearance` block (`palette` + `face_geometry` wire strings) to the `STACKCHAN.RON` boot schema, completing the v1.0 RON-configurable-appearance promise.
- Threaded the field through all four serializer surfaces: serde struct + `validate` in `config.rs`, the bare RON parser/renderer in `bare.rs`, JSON parse/render/merge in `bare_json.rs`, and the re-export in `lib.rs`; added two new `ConfigError` variants.
- Firmware (`runtime_store.rs`) seeds the palette/face_geometry cache from `cfg.appearance` only when `/sd/RUNTIME.RON` is absent — a default seed, not an override, so a later runtime change still wins.
- Empty/unknown wire strings fall back to the variant default; a non-empty unknown value is rejected by `validate`. Docs updated in `http.md` + `errors.md`.

## Test plan
- `just check` — host gate green (521 net tests pass).
- `cargo test -p stackchan-net` — 521 + 16 pass; round-trip, empty/known/unknown, and pre-block back-compat covered.
- `just clippy-firmware` (`cargo +esp clippy --release -- -D warnings`) — no warnings.
- On-device: firmware first-boot seeding path (RUNTIME.RON absent) not exercised on hardware in this PR.

Greptile: please review.
