### PR TITLE
feat(firmware): head pan/tilt trim as boot-config override

### DIFF
--- a/crates/stackchan-firmware/src/head.rs
+++ b/crates/stackchan-firmware/src/head.rs
@@ -25,10 +25,14 @@
 //!
 //! ## Calibration
 //!
-//! `PAN_TRIM_DEG` / `TILT_TRIM_DEG` are per-unit const trims applied at
-//! the driver edge: `commanded_pos = POSITION_CENTER + direction *
-//! (pose.axis + axis_trim) * POSITION_PER_DEGREE`. Rebuild after
-//! physical trim.
+//! [`PAN_TRIM_DEG`] / [`TILT_TRIM_DEG`] are the per-unit trim defaults
+//! applied at the driver edge: `commanded_pos = POSITION_CENTER +
+//! direction * (pose.axis + axis_trim) * POSITION_PER_DEGREE`. They are
+//! the compile-time fallback; [`ScsHead`] carries the live trim as
+//! runtime fields seeded from the boot config (`head.pan_trim_deg` /
+//! `head.tilt_trim_deg` in `STACKCHAN.RON`) via [`ScsHead::set_trims`],
+//! so a unit can be re-calibrated over `PUT /settings` without a
+//! reflash. A cold boot with no SD card falls back to the consts.
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, with_timeout};
@@ -104,12 +108,14 @@ pub static HEAD_POSE_ACTUAL_SIGNAL: Signal<CriticalSectionRawMutex, Pose> = Sign
 
 /// Operator-supplied head zero-point correction.
 ///
-/// Layered on top of the compile-time [`PAN_TRIM_DEG`] /
-/// [`TILT_TRIM_DEG`]: the const trims absorb the per-unit servo
-/// encoder offset (a hardware property of the assembled module);
+/// Layered on top of the per-unit head trim ([`PAN_TRIM_DEG`] /
+/// [`TILT_TRIM_DEG`], overridable from the boot config via
+/// [`ScsHead::set_trims`]): the trim absorbs the per-unit servo
+/// encoder offset (a durable property of the assembled module);
 /// `OFFSETS` absorbs day-of mounting / cabling differences that an
-/// operator wants to dial in without reflashing. Not yet enrolled in
-/// the SD-backed `RuntimeStore` — head offsets reset on reboot.
+/// operator wants to dial in live. These offsets persist in the
+/// SD-backed `RuntimeStore` (`/sd/RUNTIME.RON`) and are restored on
+/// boot; the trim persists separately in `/sd/STACKCHAN.RON`.
 pub static OFFSETS_SIGNAL: Signal<CriticalSectionRawMutex, HeadOffsets> = Signal::new();
 
 /// Operator-supplied head zero-point correction; latched in the head
@@ -184,18 +190,92 @@ mod head_offsets_tests {
     }
 }
 
+#[cfg(test)]
+mod trim_tests {
+    use super::*;
+    use scservo::Scservo;
+
+    /// A `Write` sink that drops everything — enough to construct an
+    /// `ScsHead` so the trim-field accessors can be exercised on host.
+    struct NullWrite;
+
+    impl embedded_io_async::ErrorType for NullWrite {
+        type Error = core::convert::Infallible;
+    }
+
+    impl Write for NullWrite {
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+            Ok(buf.len())
+        }
+    }
+
+    #[test]
+    fn position_for_uses_supplied_trim() {
+        let neutral = ScsHead::<NullWrite>::position_for(0.0, 0.0, PAN_DIRECTION);
+        let trimmed = ScsHead::<NullWrite>::position_for(0.0, 10.0, PAN_DIRECTION);
+        let direct = ScsHead::<NullWrite>::position_for(10.0, 0.0, PAN_DIRECTION);
+        assert_eq!(trimmed, direct);
+        assert_ne!(trimmed, neutral);
+    }
+
+    #[test]
+    fn deg_for_inverts_position_for_with_trim() {
+        let trim = 49.0;
+        let pos = ScsHead::<NullWrite>::position_for(12.0, trim, TILT_DIRECTION);
+        let back = ScsHead::<NullWrite>::deg_for(pos, trim, TILT_DIRECTION);
+        assert!((back - 12.0).abs() < 1.0, "round-trip drift: {back}");
+    }
+
+    #[test]
+    fn new_seeds_compile_default_trims() {
+        let head = ScsHead::new(Scservo::new(NullWrite));
+        assert!((head.pan_trim_deg - PAN_TRIM_DEG).abs() < f32::EPSILON);
+        assert!((head.tilt_trim_deg - TILT_TRIM_DEG).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn set_trims_overrides_defaults() {
+        let mut head = ScsHead::new(Scservo::new(NullWrite));
+        head.set_trims(2.0, 45.0);
+        assert!((head.pan_trim_deg - 2.0).abs() < f32::EPSILON);
+        assert!((head.tilt_trim_deg - 45.0).abs() < f32::EPSILON);
+    }
+}
+
 /// Feetech SCServo-backed head driver.
 pub struct ScsHead<W> {
     /// Underlying `SCServo` protocol driver on the UART bus.
     bus: Scservo<W>,
+    /// Per-unit pan trim in degrees, seeded from [`PAN_TRIM_DEG`] and
+    /// overridable from the boot config via [`Self::set_trims`].
+    pan_trim_deg: f32,
+    /// Per-unit tilt trim in degrees, seeded from [`TILT_TRIM_DEG`] and
+    /// overridable from the boot config via [`Self::set_trims`].
+    tilt_trim_deg: f32,
 }
 
 impl<W: Write> ScsHead<W> {
-    /// Wrap an [`Scservo`] bus driver. The caller is responsible for
-    /// configuring the UART baud rate (1 Mbaud for SCS defaults).
+    /// Wrap an [`Scservo`] bus driver, seeding the per-unit trims to the
+    /// compile-time [`PAN_TRIM_DEG`] / [`TILT_TRIM_DEG`] defaults. The
+    /// caller is responsible for configuring the UART baud rate
+    /// (1 Mbaud for SCS defaults). Use [`Self::set_trims`] to apply a
+    /// boot-config override once the SD config is loaded.
     #[must_use]
     pub const fn new(bus: Scservo<W>) -> Self {
-        Self { bus }
+        Self {
+            bus,
+            pan_trim_deg: PAN_TRIM_DEG,
+            tilt_trim_deg: TILT_TRIM_DEG,
+        }
+    }
+
+    /// Override the per-unit pan / tilt trims from the boot config.
+    /// Applied after construction (and after the boot-nod gesture) once
+    /// `/sd/STACKCHAN.RON` has been parsed; takes effect on the next
+    /// `set_pose` / `read_pose`.
+    pub const fn set_trims(&mut self, pan_trim_deg: f32, tilt_trim_deg: f32) {
+        self.pan_trim_deg = pan_trim_deg;
+        self.tilt_trim_deg = tilt_trim_deg;
     }
 
     /// Borrow the wrapped bus mutably. Needed by firmware `main` to
@@ -269,8 +349,8 @@ impl<U: Read + Write> ScsHead<U> {
     pub async fn read_pose(&mut self) -> Result<Pose, scservo::Error<U::Error>> {
         let pan_pos = self.bus.read_position(YAW_SERVO_ID).await?;
         let tilt_pos = self.bus.read_position(PITCH_SERVO_ID).await?;
-        let pan_deg = Self::deg_for(pan_pos, PAN_TRIM_DEG, PAN_DIRECTION);
-        let tilt_deg = Self::deg_for(tilt_pos, TILT_TRIM_DEG, TILT_DIRECTION);
+        let pan_deg = Self::deg_for(pan_pos, self.pan_trim_deg, PAN_DIRECTION);
+        let tilt_deg = Self::deg_for(tilt_pos, self.tilt_trim_deg, TILT_DIRECTION);
         Ok(Pose::new(pan_deg, tilt_deg))
     }
 }
@@ -279,8 +359,8 @@ impl<U: Read + Write> HeadDriver for ScsHead<U> {
     type Error = scservo::Error<U::Error>;
 
     async fn set_pose(&mut self, pose: Pose, _now: Instant) -> Result<(), Self::Error> {
-        let pan_pos = Self::position_for(pose.pan_deg, PAN_TRIM_DEG, PAN_DIRECTION);
-        let tilt_pos = Self::position_for(pose.tilt_deg, TILT_TRIM_DEG, TILT_DIRECTION);
+        let pan_pos = Self::position_for(pose.pan_deg, self.pan_trim_deg, PAN_DIRECTION);
+        let tilt_pos = Self::position_for(pose.tilt_deg, self.tilt_trim_deg, TILT_DIRECTION);
         self.bus
             .write_position(YAW_SERVO_ID, pan_pos, MOVE_TIME_MS, MOVE_SPEED)
             .await?;

--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -1114,7 +1114,7 @@ async fn main(spawner: Spawner) -> ! {
     );
 
     let mut delay = Delay;
-    let board_io = board::bringup(
+    let mut board_io = board::bringup(
         peripherals.I2C0,
         peripherals.UART1,
         peripherals.GPIO12,
@@ -1671,6 +1671,19 @@ async fn main(spawner: Spawner) -> ! {
     )) {
         defmt::panic!("spawn render_task failed: {}", defmt::Debug2Format(&e));
     }
+    // Seed the per-unit head trim from the boot config before the head
+    // task takes ownership of the driver. The boot-nod in `bringup` ran
+    // with the compile-time defaults; from here the live trim overrides
+    // them. No SD / no config block leaves the compile-time defaults in
+    // place (offline-first).
+    board_io
+        .head
+        .set_trims(net_config.head.pan_trim_deg, net_config.head.tilt_trim_deg);
+    defmt::info!(
+        "head trim: pan={=f32}° tilt={=f32}° (boot config)",
+        net_config.head.pan_trim_deg,
+        net_config.head.tilt_trim_deg,
+    );
     if let Err(e) = spawner.spawn(head_task(board_io.head)) {
         defmt::panic!("spawn head_task failed: {}", defmt::Debug2Format(&e));
     }

--- a/crates/stackchan-net/README.md
+++ b/crates/stackchan-net/README.md
@@ -54,6 +54,7 @@ runs.
         wake_word_threshold: 100,
         wake_word_arena_kib: 64,
     ),
+    head: ( pan_trim_deg: 0.0, tilt_trim_deg: 49.0 ),
 )
 ```
 

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -22,8 +22,8 @@ use core::fmt::Write as _;
 
 use crate::bare_json::TOKEN_REDACTED;
 use crate::config::{
-    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
-    TrackerSettings, WifiConfig, validate_for_disk,
+    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, HeadTrim, MdnsConfig,
+    TimeConfig, TrackerSettings, WifiConfig, validate_for_disk,
 };
 use crate::error::ConfigError;
 
@@ -184,6 +184,11 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
     );
     out.push_str("    ),\n");
 
+    out.push_str("    head: (\n");
+    let _ = writeln!(out, "        pan_trim_deg: {},", config.head.pan_trim_deg);
+    let _ = writeln!(out, "        tilt_trim_deg: {},", config.head.tilt_trim_deg);
+    out.push_str("    ),\n");
+
     out.push_str(")\n");
     Ok(out)
 }
@@ -235,6 +240,7 @@ impl<'a> Parser<'a> {
         let mut tracker: Option<TrackerSettings> = None;
         let mut esp_now: Option<EspNowConfig> = None;
         let mut behavior: Option<BehaviorConfig> = None;
+        let mut head: Option<HeadTrim> = None;
 
         loop {
             self.skip_ws_and_comments();
@@ -294,6 +300,12 @@ impl<'a> Parser<'a> {
                     }
                     behavior = Some(self.parse_behavior()?);
                 }
+                "head" => {
+                    if head.is_some() {
+                        return Err(bare_err("duplicate top-level field", "head"));
+                    }
+                    head = Some(self.parse_head()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws_and_comments();
@@ -316,6 +328,7 @@ impl<'a> Parser<'a> {
             tracker: tracker.unwrap_or_default(),
             esp_now: esp_now.unwrap_or_default(),
             behavior: behavior.unwrap_or_default(),
+            head: head.unwrap_or_default(),
         })
     }
 
@@ -598,6 +611,50 @@ impl<'a> Parser<'a> {
             target_smoothing_alpha: alpha.unwrap_or(defaults.target_smoothing_alpha),
             flip_x: flip_x.unwrap_or(defaults.flip_x),
             flip_y: flip_y.unwrap_or(defaults.flip_y),
+        })
+    }
+
+    /// Parse the `head: (...)` block. Both fields are optional;
+    /// missing fields fall back to [`HeadTrim::DEFAULT`] so a SD card
+    /// written before this block existed reproduces the firmware's
+    /// compile-time trim behaviour exactly.
+    fn parse_head(&mut self) -> Result<HeadTrim, ConfigError> {
+        self.expect_char('(')?;
+        let mut pan_trim: Option<f32> = None;
+        let mut tilt_trim: Option<f32> = None;
+        loop {
+            self.skip_ws_and_comments();
+            if self.try_consume_char(')') {
+                break;
+            }
+            let key = self.read_ident()?;
+            self.skip_ws_and_comments();
+            self.expect_char(':')?;
+            self.skip_ws_and_comments();
+            match key {
+                "pan_trim_deg" => {
+                    if pan_trim.is_some() {
+                        return Err(bare_err("duplicate head field", "pan_trim_deg"));
+                    }
+                    pan_trim = Some(self.parse_f32()?);
+                }
+                "tilt_trim_deg" => {
+                    if tilt_trim.is_some() {
+                        return Err(bare_err("duplicate head field", "tilt_trim_deg"));
+                    }
+                    tilt_trim = Some(self.parse_f32()?);
+                }
+                other => return Err(bare_err("unknown head field", other)),
+            }
+            self.skip_ws_and_comments();
+            if !self.try_consume_char(',') && !self.peek_eq(')') {
+                return Err(bare_err("expected ',' or ')' in head", ""));
+            }
+        }
+        let defaults = HeadTrim::DEFAULT;
+        Ok(HeadTrim {
+            pan_trim_deg: pan_trim.unwrap_or(defaults.pan_trim_deg),
+            tilt_trim_deg: tilt_trim.unwrap_or(defaults.tilt_trim_deg),
         })
     }
 
@@ -1902,6 +1959,88 @@ mod tests {
         assert!(
             msg.contains("duplicate behavior field") && msg.contains("wake_word_enabled"),
             "got {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_head_block_defaults_to_compile_trim() {
+        // Forward-compat: an SD card written before the head block
+        // landed omits `head:` entirely. The parser must fall back to
+        // HeadTrim::DEFAULT so a firmware bump reproduces the old
+        // compile-time trim behaviour rather than zeroing the tilt.
+        let cfg = parse_ron_bare(FIXTURE).unwrap();
+        assert_eq!(cfg.head, HeadTrim::DEFAULT);
+    }
+
+    #[test]
+    fn parses_head_block_with_explicit_values() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                head: ( pan_trim_deg: -2.5, tilt_trim_deg: 47.0 ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        assert!((cfg.head.pan_trim_deg - (-2.5)).abs() < f32::EPSILON);
+        assert!((cfg.head.tilt_trim_deg - 47.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn round_trips_with_head_block() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                head: ( pan_trim_deg: 1.5, tilt_trim_deg: 50.0 ),
+            )
+        "#;
+        let cfg = parse_ron_bare(s).unwrap();
+        let rendered = render_ron_bare(&cfg).unwrap();
+        let reparsed = parse_ron_bare(&rendered).unwrap();
+        assert_eq!(cfg, reparsed);
+    }
+
+    #[test]
+    fn rejects_unknown_head_field() {
+        let s = with_base(r"head: ( pan_trim_deg: 0.0, oops: 1 ),");
+        let msg = assert_bare_parse_err(&s);
+        assert!(msg.contains("unknown head field"), "got {msg}");
+    }
+
+    #[test]
+    fn rejects_duplicate_head_field() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                head: ( pan_trim_deg: 0.0, pan_trim_deg: 1.0 ),
+            )
+        "#;
+        let msg = assert_bare_parse_err(s);
+        assert!(
+            msg.contains("duplicate head field") && msg.contains("pan_trim_deg"),
+            "got {msg}"
+        );
+    }
+
+    #[test]
+    fn head_trim_out_of_range_fails_validate() {
+        let s = r#"
+            (
+                wifi: ( ssid: "n", psk: "p", country: "US" ),
+                mdns: ( hostname: "h" ),
+                time: ( tz: "UTC", sntp_servers: ["pool.ntp.org"] ),
+                head: ( pan_trim_deg: 0.0, tilt_trim_deg: 491.0 ),
+            )
+        "#;
+        let err = parse_ron_bare(s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidHeadTrim(_)),
+            "got {err:?}"
         );
     }
 }

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -20,8 +20,8 @@ use alloc::vec::Vec;
 use core::fmt::Write as _;
 
 use crate::config::{
-    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig,
-    TrackerSettings, WifiConfig, validate,
+    AudioConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, HeadTrim, MdnsConfig,
+    TimeConfig, TrackerSettings, WifiConfig, validate,
 };
 use crate::error::ConfigError;
 
@@ -95,8 +95,8 @@ pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
 /// overwrites.
 ///
 /// Fields the wire format doesn't redact (`ssid`, `country`,
-/// `mdns.hostname`, `time.*`, `audio.*`, `tracker.*`) pass through
-/// from `new` unchanged.
+/// `mdns.hostname`, `time.*`, `audio.*`, `tracker.*`, `head.*`) pass
+/// through from `new` unchanged.
 #[must_use]
 pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
     Config {
@@ -147,6 +147,7 @@ pub fn merge_settings_with_current(new: Config, current: &Config) -> Config {
             },
             ..new.behavior
         },
+        head: new.head,
     }
 }
 
@@ -306,6 +307,13 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     );
     out.push(',');
     push_string_field(&mut out, "persona_name", &config.behavior.persona_name);
+    out.push_str("},\"head\":{");
+    let _ = write!(
+        out,
+        "\"pan_trim_deg\":{pan:?},\"tilt_trim_deg\":{tilt:?}",
+        pan = config.head.pan_trim_deg,
+        tilt = config.head.tilt_trim_deg,
+    );
     out.push_str("}}");
     Ok(out)
 }
@@ -364,6 +372,7 @@ impl<'a> Parser<'a> {
         let mut tracker: Option<TrackerSettings> = None;
         let mut esp_now: Option<EspNowConfig> = None;
         let mut behavior: Option<BehaviorConfig> = None;
+        let mut head: Option<HeadTrim> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -422,6 +431,12 @@ impl<'a> Parser<'a> {
                     }
                     behavior = Some(self.parse_behavior()?);
                 }
+                "head" => {
+                    if head.is_some() {
+                        return Err(bare_err("duplicate top-level field", "head"));
+                    }
+                    head = Some(self.parse_head()?);
+                }
                 other => return Err(bare_err("unknown top-level field", other)),
             }
             self.skip_ws();
@@ -442,6 +457,7 @@ impl<'a> Parser<'a> {
             tracker: tracker.unwrap_or_default(),
             esp_now: esp_now.unwrap_or_default(),
             behavior: behavior.unwrap_or_default(),
+            head: head.unwrap_or_default(),
         })
     }
 
@@ -722,6 +738,49 @@ impl<'a> Parser<'a> {
             target_smoothing_alpha: alpha.unwrap_or(defaults.target_smoothing_alpha),
             flip_x: flip_x.unwrap_or(defaults.flip_x),
             flip_y: flip_y.unwrap_or(defaults.flip_y),
+        })
+    }
+
+    /// Parse the `"head": { ... }` block. Both fields are optional on
+    /// the wire; missing fields fall back to [`HeadTrim::DEFAULT`].
+    /// Range validation lives in the `validate` pass after parse.
+    fn parse_head(&mut self) -> Result<HeadTrim, ConfigError> {
+        self.expect_char('{')?;
+        let mut pan_trim: Option<f32> = None;
+        let mut tilt_trim: Option<f32> = None;
+        loop {
+            self.skip_ws();
+            if self.try_consume_char('}') {
+                break;
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            self.expect_char(':')?;
+            self.skip_ws();
+            match key.as_str() {
+                "pan_trim_deg" => {
+                    if pan_trim.is_some() {
+                        return Err(bare_err("duplicate head field", "pan_trim_deg"));
+                    }
+                    pan_trim = Some(self.parse_f32()?);
+                }
+                "tilt_trim_deg" => {
+                    if tilt_trim.is_some() {
+                        return Err(bare_err("duplicate head field", "tilt_trim_deg"));
+                    }
+                    tilt_trim = Some(self.parse_f32()?);
+                }
+                other => return Err(bare_err("unknown head field", other)),
+            }
+            self.skip_ws();
+            if !self.try_consume_char(',') && !self.peek_eq('}') {
+                return Err(bare_err("expected ',' or '}' in head", ""));
+            }
+        }
+        let defaults = HeadTrim::DEFAULT;
+        Ok(HeadTrim {
+            pan_trim_deg: pan_trim.unwrap_or(defaults.pan_trim_deg),
+            tilt_trim_deg: tilt_trim.unwrap_or(defaults.tilt_trim_deg),
         })
     }
 
@@ -1217,6 +1276,10 @@ mod tests {
                 wake_word_threshold: 95,
                 wake_word_arena_kib: 96,
                 persona_name: "desk-buddy".to_string(),
+            },
+            head: HeadTrim {
+                pan_trim_deg: -1.5,
+                tilt_trim_deg: 47.5,
             },
         }
     }
@@ -1766,6 +1829,10 @@ mod tests {
                 wake_word_arena_kib: 128,
                 persona_name: "desk-buddy".to_string(),
             },
+            head: HeadTrim {
+                pan_trim_deg: 90.0,
+                tilt_trim_deg: -90.0,
+            },
         };
         let rendered = render_settings_json(&config, false).unwrap();
         assert!(
@@ -2086,6 +2153,58 @@ mod tests {
         let s = with_base(r#","behavior":{"soliloquy_enabled":true,"soliloquy_enabled":false}"#);
         let msg = assert_bare_parse_err(&s);
         assert!(msg.contains("duplicate behavior field"), "got {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_head_field() {
+        let s = with_base(r#","head":{"pan_trim_deg":0.0,"oops":1}"#);
+        let msg = assert_bare_parse_err(&s);
+        assert!(msg.contains("unknown head field"), "got {msg}");
+    }
+
+    #[test]
+    fn rejects_duplicate_head_field() {
+        let s = with_base(r#","head":{"pan_trim_deg":0.0,"pan_trim_deg":1.0}"#);
+        let msg = assert_bare_parse_err(&s);
+        assert!(msg.contains("duplicate head field"), "got {msg}");
+    }
+
+    #[test]
+    fn missing_head_block_defaults_to_compile_trim() {
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.head, HeadTrim::DEFAULT);
+    }
+
+    #[test]
+    fn head_block_round_trips_through_render_then_parse() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "head":{"pan_trim_deg":-2.5,"tilt_trim_deg":47.0}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert!((parsed.head.pan_trim_deg - (-2.5)).abs() < f32::EPSILON);
+        assert!((parsed.head.tilt_trim_deg - 47.0).abs() < f32::EPSILON);
+        let rendered = render_settings_json(&parsed, false).unwrap();
+        let reparsed = parse_settings_json(&rendered).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn merge_preserves_head_block() {
+        let current = full_config();
+        let new = Config {
+            head: HeadTrim {
+                pan_trim_deg: 3.0,
+                tilt_trim_deg: 51.0,
+            },
+            ..current.clone()
+        };
+        let merged = merge_settings_with_current(new, &current);
+        assert!((merged.head.pan_trim_deg - 3.0).abs() < f32::EPSILON);
+        assert!((merged.head.tilt_trim_deg - 51.0).abs() < f32::EPSILON);
     }
 
     // ============================================================

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -62,6 +62,14 @@ pub struct Config {
     /// the canonical modifier stack at all times).
     #[cfg_attr(feature = "parse", serde(default))]
     pub behavior: BehaviorConfig,
+    /// Per-unit head zero-point trim. Boot-time override of the
+    /// firmware's compile-time `PAN_TRIM_DEG` / `TILT_TRIM_DEG`
+    /// defaults; seeded into the `SCServo` driver at construction.
+    /// Changes via `PUT /settings` take effect on the next boot
+    /// (mirrors the tracker / audio-init pattern). Distinct from the
+    /// per-session operator offsets set via `POST /head/offsets`.
+    #[cfg_attr(feature = "parse", serde(default))]
+    pub head: HeadTrim,
 }
 
 /// Wi-Fi station credentials.
@@ -206,6 +214,52 @@ impl TrackerSettings {
 }
 
 impl Default for TrackerSettings {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+/// Per-unit head zero-point trim, in degrees.
+///
+/// These absorb the per-physical-unit servo encoder offset (a fixed
+/// property of the assembled module — the pitch encoder zero sits well
+/// below physical horizontal) and rarely change after a unit is
+/// calibrated. The firmware applies them at the driver edge inside the
+/// `SCServo` head:
+/// `commanded_pos = CENTER + direction * (pose.axis + axis_trim) * per_deg`.
+///
+/// This is deliberately a separate layer from the per-session operator
+/// offsets set via `POST /head/offsets`: those are applied in the head
+/// task on top of the modifier-commanded pose and dialed in for day-of
+/// mounting differences. The trim is the durable per-unit zero.
+///
+/// The defaults below MUST stay in sync with `PAN_TRIM_DEG` /
+/// `TILT_TRIM_DEG` in `crates/stackchan-firmware/src/head.rs` — those
+/// firmware consts are the canonical fallback the device uses on a
+/// cold boot with no SD card, so a missing `head:` block reproduces
+/// the firmware's compile-time behaviour exactly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "parse", derive(Serialize, Deserialize))]
+pub struct HeadTrim {
+    /// Pan (yaw) trim in degrees. Positive = head points rightward at
+    /// commanded NEUTRAL.
+    pub pan_trim_deg: f32,
+    /// Tilt (pitch) trim in degrees. Positive = head aims up at
+    /// NEUTRAL. ~49° on the reference unit (encoder offset + anti-droop
+    /// bias).
+    pub tilt_trim_deg: f32,
+}
+
+impl HeadTrim {
+    /// Const-evaluable default mirroring the firmware's `PAN_TRIM_DEG`
+    /// / `TILT_TRIM_DEG` compile-time consts.
+    pub const DEFAULT: Self = Self {
+        pan_trim_deg: 0.0,
+        tilt_trim_deg: 49.0,
+    };
+}
+
+impl Default for HeadTrim {
     fn default() -> Self {
         Self::DEFAULT
     }
@@ -625,6 +679,12 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
             config.tracker.target_smoothing_alpha,
         ));
     }
+    if !is_valid_head_trim(config.head.pan_trim_deg) {
+        return Err(ConfigError::InvalidHeadTrim(config.head.pan_trim_deg));
+    }
+    if !is_valid_head_trim(config.head.tilt_trim_deg) {
+        return Err(ConfigError::InvalidHeadTrim(config.head.tilt_trim_deg));
+    }
     validate_esp_now(&config.esp_now)?;
     if config.behavior.wake_word_arena_kib == 0 {
         return Err(ConfigError::InvalidWakeWordArenaKib);
@@ -863,6 +923,16 @@ fn is_valid_fov_deg(deg: f32) -> bool {
     deg.is_finite() && deg > 0.0 && deg <= 180.0
 }
 
+/// True iff `deg` is a finite value within `[-90.0, 90.0]`. A head
+/// trim is a small per-unit zero-point correction; the real tilt
+/// encoder offset on the reference unit is ~49°, so the range stays
+/// wide enough to accept it while still catching a fat-fingered value
+/// (a stray `490.0` or a `NaN`) before it reaches the servo math,
+/// where `position_for` would otherwise clamp it silently to a rail.
+fn is_valid_head_trim(deg: f32) -> bool {
+    deg.is_finite() && (-90.0..=90.0).contains(&deg)
+}
+
 /// True iff `alpha` is a finite value in `[0.05, 1.0]`. Lower than
 /// 0.05 effectively freezes the published target for tens of seconds,
 /// which is a UX bug; higher than 1.0 has no defined meaning for an
@@ -917,6 +987,46 @@ mod tests {
         assert_eq!(c.time.sntp_servers, vec!["pool.ntp.org".to_string()]);
         assert_eq!(c.audio.volume_pct, 50);
         assert!(!c.audio.muted);
+        assert_eq!(c.head, HeadTrim::DEFAULT);
+    }
+
+    #[test]
+    fn head_trim_default_matches_compile_consts() {
+        // These literals MUST track PAN_TRIM_DEG / TILT_TRIM_DEG in
+        // crates/stackchan-firmware/src/head.rs — the firmware uses
+        // its own consts as the no-SD cold-boot fallback.
+        assert!((HeadTrim::DEFAULT.pan_trim_deg - 0.0).abs() < f32::EPSILON);
+        assert!((HeadTrim::DEFAULT.tilt_trim_deg - 49.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn validate_rejects_nan_head_trim() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.head.pan_trim_deg = f32::NAN;
+        assert!(matches!(validate(&c), Err(ConfigError::InvalidHeadTrim(_))));
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_head_trim() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.head.tilt_trim_deg = 490.0;
+        assert!(matches!(
+            validate(&c),
+            Err(ConfigError::InvalidHeadTrim(490.0))
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_head_trim_at_typical_offset() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.head = HeadTrim {
+            pan_trim_deg: -3.0,
+            tilt_trim_deg: 49.0,
+        };
+        assert!(validate(&c).is_ok());
     }
 
     #[test]

--- a/crates/stackchan-net/src/error.rs
+++ b/crates/stackchan-net/src/error.rs
@@ -91,6 +91,14 @@ pub enum ConfigError {
     #[error("tracker.target_smoothing_alpha must be in [0.05, 1.0]; got {0}")]
     InvalidSmoothingAlpha(f32),
 
+    /// `head.pan_trim_deg` or `head.tilt_trim_deg` was non-finite or
+    /// outside `[-90.0, 90.0]`. A head trim is a small per-unit
+    /// zero-point correction; values past that range can't be physical
+    /// and would clamp to a servo rail. The carried `f32` is the
+    /// offending value.
+    #[error("head trim must be a finite value in [-90.0, 90.0]; got {0}")]
+    InvalidHeadTrim(f32),
+
     /// Hand-rolled bare parser failure (firmware-side path that
     /// avoids `serde + ron`). Carries a short reason string in lieu
     /// of `ron`'s line/col `SpannedError` — the firmware logs this

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -66,7 +66,7 @@ pub mod ota;
 pub use bare::{parse_ron_bare, render_ron_bare};
 pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
 pub use config::{
-    AuthConfig, BehaviorConfig, Config, EspNowConfig, MdnsConfig, TimeConfig, WifiConfig,
+    AuthConfig, BehaviorConfig, Config, EspNowConfig, HeadTrim, MdnsConfig, TimeConfig, WifiConfig,
     parse_mac, tz_offset_minutes, validate,
 };
 #[cfg(feature = "parse")]

--- a/crates/stackchan-net/tests/fixtures/full.ron
+++ b/crates/stackchan-net/tests/fixtures/full.ron
@@ -17,4 +17,8 @@
             "pool.ntp.org",
         ],
     ),
+    head: (
+        pan_trim_deg: -3.0,
+        tilt_trim_deg: 47.5,
+    ),
 )

--- a/crates/stackchan-net/tests/golden_config.rs
+++ b/crates/stackchan-net/tests/golden_config.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::unwrap_used, clippy::panic, missing_docs)]
 
-use stackchan_net::{Config, ConfigError, parse_ron, render_ron};
+use stackchan_net::{Config, ConfigError, HeadTrim, parse_ron, render_ron};
 
 const MINIMAL_RON: &str = include_str!("fixtures/minimal.ron");
 const FULL_RON: &str = include_str!("fixtures/full.ron");
@@ -45,6 +45,13 @@ fn parses_full_fixture() {
             "time.cloudflare.com".to_string(),
             "pool.ntp.org".to_string(),
         ]
+    );
+    assert_eq!(
+        cfg.head,
+        HeadTrim {
+            pan_trim_deg: -3.0,
+            tilt_trim_deg: 47.5,
+        }
     );
 }
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -111,6 +111,7 @@ RON config parse + validation. Host crate; firmware wraps with `Debug2Format` fo
 - `NoSntpServers` — `time.sntp_servers` empty. Firmware needs at least one candidate.
 - `EmptySntpServer(usize)` — a `time.sntp_servers` entry was empty / whitespace-only. The `usize` carries the offending index. Caught at parse time so the firmware's "try in order" loop doesn't burn its full per-server timeout on an unresolvable hostname before falling back.
 - `InvalidVolumePct(u8)` — `audio.volume_pct` was outside `0..=100`. The wire format is a percentile; the firmware maps it linearly across the AW88298 dB range. The `u8` carries the offending value.
+- `InvalidHeadTrim(f32)` — `head.pan_trim_deg` or `head.tilt_trim_deg` was non-finite or outside `[-90.0, 90.0]`. The trim is a small per-unit zero-point correction (the reference unit's tilt encoder offset is ~49°); a value past that range can't be physical and would clamp to a servo rail. The `f32` carries the offending value.
 
 ### `stackchan_tts::RenderError`
 Speech-backend rendering. Returned from `SpeechBackend::render` when a

--- a/docs/http.md
+++ b/docs/http.md
@@ -306,7 +306,8 @@ $ curl http://stackchan.local/settings
  "auth":{"token":"***"},
  "audio":{"volume_pct":50,"muted":false},
  "tracker":{"fov_h_deg":62.0,"fov_v_deg":49.0,"target_smoothing_alpha":1.0,
-            "flip_x":false,"flip_y":false}}
+            "flip_x":false,"flip_y":false},
+ "head":{"pan_trim_deg":0.0,"tilt_trim_deg":49.0}}
 ```
 
 `tracker` carries the operator-tunable subset of the firmware
@@ -316,6 +317,17 @@ EMA smoothing on the published target (`target_smoothing_alpha`,
 orientation flips for non-standard mountings. Algorithm tuning
 (P-gain, block thresholds, dead zones) stays compile-time. Changes
 take effect on next boot — same as `mdns.hostname` / `time.*`.
+
+`head` carries the per-unit zero-point trim seeded into the SCServo
+driver at boot: `pan_trim_deg` / `tilt_trim_deg` are added to every
+commanded pose at the driver edge to absorb the assembled module's
+servo encoder offset (the tilt encoder zero sits well below physical
+horizontal, ~49° on the reference unit). This is the durable per-unit
+calibration; it is distinct from the per-session `POST /head/offsets`
+correction, which is applied on top and resets on reboot. Both default
+to the firmware's compile-time `PAN_TRIM_DEG` / `TILT_TRIM_DEG` when the
+`head` block is absent. Range: `[-90.0, 90.0]`. Changes take effect on
+next boot — same as `tracker.*`.
 
 `wifi.psk` and a non-empty `auth.token` are redacted to `***`.
 On `PUT /settings`, the server treats either sentinel as **"keep
@@ -337,7 +349,8 @@ $ curl -X PUT http://stackchan.local/settings \
             "auth":{"token":"s3cret"},
             "audio":{"volume_pct":50,"muted":false},
             "tracker":{"fov_h_deg":62.0,"fov_v_deg":49.0,"target_smoothing_alpha":1.0,
-                       "flip_x":false,"flip_y":false}}'
+                       "flip_x":false,"flip_y":false},
+            "head":{"pan_trim_deg":0.0,"tilt_trim_deg":49.0}}'
 {"reboot_required":true}
 ```
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -324,7 +324,7 @@ commanded pose at the driver edge to absorb the assembled module's
 servo encoder offset (the tilt encoder zero sits well below physical
 horizontal, ~49° on the reference unit). This is the durable per-unit
 calibration; it is distinct from the per-session `POST /head/offsets`
-correction, which is applied on top and resets on reboot. Both default
+correction, which is applied on top and persisted to `/sd/RUNTIME.RON`. Both default
 to the firmware's compile-time `PAN_TRIM_DEG` / `TILT_TRIM_DEG` when the
 `head` block is absent. Range: `[-90.0, 90.0]`. Changes take effect on
 next boot — same as `tracker.*`.


### PR DESCRIPTION
## Summary
- Add a per-unit head pan/tilt trim as a boot-config override of the firmware's compile-time `PAN_TRIM_DEG` / `TILT_TRIM_DEG` defaults. New `HeadTrim` block in `stackchan_net::Config` (`pan_trim_deg` / `tilt_trim_deg`), `HeadTrim::DEFAULT` = 0.0 / 49.0 mirroring the consts, `serde(default)` so a missing `head:` block is forward-compatible.
- Validate via `is_valid_head_trim` (finite, `[-90, 90]`) + new `ConfigError::InvalidHeadTrim(f32)`. Wired through all three Config (de)serializers in lockstep: `config.rs` (serde + validate), `bare.rs` (hand-rolled RON), `bare_json.rs` (hand-rolled JSON, incl. merge passthrough).
- `ScsHead` carries runtime `pan_trim_deg` / `tilt_trim_deg` seeded from the consts in `new`, with a `set_trims` const setter; `position_for` / `deg_for` read the fields. Consts stay as the canonical cold-boot fallback. `main.rs` applies the boot-config trim after the SD config snapshot loads and before `head_task` spawns (boot-nod still uses defaults; no SD => defaults preserved, offline-first).
- Keep the trim (per-unit zero, `STACKCHAN.RON`) separate from operator `HeadOffsets` (per-session, `RUNTIME.RON`) — two distinct correction layers. No dedicated `POST /head/trim` route; `PUT /settings` already covers host-side calibration and trim takes effect on reboot.
- Docs: `docs/http.md` GET/PUT `/settings` examples + `head` block paragraph; `stackchan-net/README.md` example RON; `docs/errors.md` ConfigError catalog entry for `InvalidHeadTrim`.

## Test plan
- `just check` (host fmt + clippy + tests) — green. New host tests in `stackchan-net`: default-matches-consts, NaN / out-of-range rejection, typical-offset acceptance; `bare.rs` + `bare_json.rs` each get missing-block forward-compat, explicit-values parse, render->reparse identity, unknown-field, duplicate-field, out-of-range validate, and (json) merge-preserves-head. `full.ron` golden fixture now carries an explicit head block asserted in `parses_full_fixture`, so the serde `parse_ron` path also exercises a non-default trim.
- `just clippy-firmware` (esp toolchain) — green. `head.rs` + `main.rs` compile under strict clippy. `head.rs` `trim_tests` module is documentation-only (firmware `#[cfg(test)]` is not executed by either gate).
- No hardware flashing performed. On-device verification still needed: confirm a real `STACKCHAN.RON` head trim is applied at boot and that the boot-nod gesture (which uses compile defaults) looks correct.

## Review status (draft)
Opened as a draft. The two pre-merge blocking items have been **resolved** in this PR:
1. ~~`docs/errors.md` not updated for `InvalidHeadTrim`~~ — fixed (catalog entry added, per the catalog's own same-PR rule).
2. ~~Firmware clippy gate unverified~~ — `source ~/export-esp.sh && just clippy-firmware` run and green.

Remaining for reviewers:
- Greptile review (authoritative reviewer) has not yet run on this branch.
- Human sign-off, especially on the on-device behavior noted in the test plan.

Greptile: please review.
