### PR TITLE
feat(voice): VoiceVox config surface + host-side WAV decode helpers

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -766,6 +766,8 @@ async fn handle_get_settings_backup(socket: &mut TcpSocket<'_>) -> Result<(), Ht
 /// - `behavior.agent_sidecar_url` / `agent_sidecar_token` /
 ///   `persona_name` (agent sidecar task args at spawn)
 /// - `behavior.follower_leader_hostname` (follower task arg at spawn)
+/// - `behavior.voicevox_url` / `voicevox_speaker_id` (`VoiceVox`
+///   synthesis task args at spawn)
 ///
 /// Future work that wants any of these to apply live needs both a
 /// signal channel from this handler AND a snapshot re-read in the
@@ -796,6 +798,8 @@ fn requires_reboot(prev: &stackchan_net::Config, new: &stackchan_net::Config) ->
         || b_prev.agent_sidecar_token != b_new.agent_sidecar_token
         || b_prev.follower_leader_hostname != b_new.follower_leader_hostname
         || b_prev.persona_name != b_new.persona_name
+        || b_prev.voicevox_url != b_new.voicevox_url
+        || b_prev.voicevox_speaker_id != b_new.voicevox_speaker_id
     {
         return true;
     }

--- a/crates/stackchan-net/src/bare.rs
+++ b/crates/stackchan-net/src/bare.rs
@@ -182,6 +182,16 @@ pub fn render_ron_bare(config: &Config) -> Result<String, ConfigError> {
         "        persona_name",
         &config.behavior.persona_name,
     );
+    push_field(
+        &mut out,
+        "        voicevox_url",
+        &config.behavior.voicevox_url,
+    );
+    let _ = writeln!(
+        out,
+        "        voicevox_speaker_id: {},",
+        config.behavior.voicevox_speaker_id
+    );
     out.push_str("    ),\n");
 
     out.push_str("    head: (\n");
@@ -773,6 +783,8 @@ impl<'a> Parser<'a> {
         let mut wake_word_threshold: Option<i8> = None;
         let mut wake_word_arena_kib: Option<u32> = None;
         let mut persona_name: Option<String> = None;
+        let mut voicevox_url: Option<String> = None;
+        let mut voicevox_speaker_id: Option<u16> = None;
         loop {
             self.skip_ws_and_comments();
             if self.try_consume_char(')') {
@@ -873,6 +885,18 @@ impl<'a> Parser<'a> {
                     }
                     persona_name = Some(self.parse_string()?);
                 }
+                "voicevox_url" => {
+                    if voicevox_url.is_some() {
+                        return Err(bare_err("duplicate behavior field", "voicevox_url"));
+                    }
+                    voicevox_url = Some(self.parse_string()?);
+                }
+                "voicevox_speaker_id" => {
+                    if voicevox_speaker_id.is_some() {
+                        return Err(bare_err("duplicate behavior field", "voicevox_speaker_id"));
+                    }
+                    voicevox_speaker_id = Some(self.parse_u16()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws_and_comments();
@@ -894,6 +918,8 @@ impl<'a> Parser<'a> {
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
             wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
             persona_name: persona_name.unwrap_or_default(),
+            voicevox_url: voicevox_url.unwrap_or_default(),
+            voicevox_speaker_id: voicevox_speaker_id.unwrap_or(1),
         })
     }
 
@@ -976,6 +1002,26 @@ impl<'a> Parser<'a> {
         let parsed: u32 = digits
             .parse()
             .map_err(|_| bare_err("not a u32 literal", digits))?;
+        self.input = rest;
+        Ok(parsed)
+    }
+
+    /// Parse a contiguous run of decimal digits as `u16`. Used for
+    /// `behavior.voicevox_speaker_id`. Digits past `u16::MAX` land on
+    /// `BareParse` rather than wrapping silently.
+    fn parse_u16(&mut self) -> Result<u16, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected unsigned integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: u16 = digits
+            .parse()
+            .map_err(|_| bare_err("u16 literal out of range", digits))?;
         self.input = rest;
         Ok(parsed)
     }

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -308,6 +308,13 @@ pub fn render_settings_json(config: &Config, redact_secrets: bool) -> Result<Str
     );
     out.push(',');
     push_string_field(&mut out, "persona_name", &config.behavior.persona_name);
+    out.push(',');
+    push_string_field(&mut out, "voicevox_url", &config.behavior.voicevox_url);
+    let _ = write!(
+        out,
+        ",\"voicevox_speaker_id\":{}",
+        config.behavior.voicevox_speaker_id
+    );
     out.push_str("},\"head\":{");
     let _ = write!(
         out,
@@ -895,6 +902,8 @@ impl<'a> Parser<'a> {
         let mut wake_word_threshold: Option<i8> = None;
         let mut wake_word_arena_kib: Option<u32> = None;
         let mut persona_name: Option<String> = None;
+        let mut voicevox_url: Option<String> = None;
+        let mut voicevox_speaker_id: Option<u16> = None;
         loop {
             self.skip_ws();
             if self.try_consume_char('}') {
@@ -995,6 +1004,18 @@ impl<'a> Parser<'a> {
                     }
                     persona_name = Some(self.parse_string()?);
                 }
+                "voicevox_url" => {
+                    if voicevox_url.is_some() {
+                        return Err(bare_err("duplicate behavior field", "voicevox_url"));
+                    }
+                    voicevox_url = Some(self.parse_string()?);
+                }
+                "voicevox_speaker_id" => {
+                    if voicevox_speaker_id.is_some() {
+                        return Err(bare_err("duplicate behavior field", "voicevox_speaker_id"));
+                    }
+                    voicevox_speaker_id = Some(self.parse_u16()?);
+                }
                 other => return Err(bare_err("unknown behavior field", other)),
             }
             self.skip_ws();
@@ -1016,6 +1037,8 @@ impl<'a> Parser<'a> {
             wake_word_threshold: wake_word_threshold.unwrap_or(100),
             wake_word_arena_kib: wake_word_arena_kib.unwrap_or(64),
             persona_name: persona_name.unwrap_or_default(),
+            voicevox_url: voicevox_url.unwrap_or_default(),
+            voicevox_speaker_id: voicevox_speaker_id.unwrap_or(1),
         })
     }
 
@@ -1149,6 +1172,26 @@ impl<'a> Parser<'a> {
         let parsed: u32 = digits
             .parse()
             .map_err(|_| bare_err("not a u32 literal", digits))?;
+        self.input = rest;
+        Ok(parsed)
+    }
+
+    /// Parse a contiguous run of decimal digits as `u16`. Used for
+    /// `behavior.voicevox_speaker_id`. Digits past `u16::MAX` land on
+    /// `BareParse`.
+    fn parse_u16(&mut self) -> Result<u16, ConfigError> {
+        let bytes = self.input.as_bytes();
+        let mut end = 0;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if end == 0 {
+            return Err(bare_err("expected unsigned integer", ""));
+        }
+        let (digits, rest) = self.input.split_at(end);
+        let parsed: u16 = digits
+            .parse()
+            .map_err(|_| bare_err("u16 literal out of range", digits))?;
         self.input = rest;
         Ok(parsed)
     }
@@ -1338,6 +1381,8 @@ mod tests {
                 wake_word_threshold: 95,
                 wake_word_arena_kib: 96,
                 persona_name: "desk-buddy".to_string(),
+                voicevox_url: "http://192.168.1.50:50021".to_string(),
+                voicevox_speaker_id: 3,
             },
             head: HeadTrim {
                 pan_trim_deg: -1.5,
@@ -1894,6 +1939,8 @@ mod tests {
                 wake_word_threshold: -32,
                 wake_word_arena_kib: 128,
                 persona_name: "desk-buddy".to_string(),
+                voicevox_url: "http://192.168.100.200:50021".to_string(),
+                voicevox_speaker_id: u16::MAX,
             },
             head: HeadTrim {
                 pan_trim_deg: 90.0,
@@ -1980,6 +2027,43 @@ mod tests {
             "mdns":{"hostname":"x"},
             "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
             "behavior":{"wake_word_threshold":200}
+        }"#;
+        let err = parse_settings_json(input).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn voicevox_fields_round_trip_custom_values() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "behavior":{"voicevox_url":"http://10.0.0.5:50021","voicevox_speaker_id":8}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert_eq!(parsed.behavior.voicevox_url, "http://10.0.0.5:50021");
+        assert_eq!(parsed.behavior.voicevox_speaker_id, 8);
+    }
+
+    #[test]
+    fn voicevox_fields_default_when_absent() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}
+        }"#;
+        let parsed = parse_settings_json(input).unwrap();
+        assert!(parsed.behavior.voicevox_url.is_empty());
+        assert_eq!(parsed.behavior.voicevox_speaker_id, 1);
+    }
+
+    #[test]
+    fn voicevox_speaker_id_rejects_out_of_range() {
+        let input = r#"{
+            "wifi":{"ssid":"a","psk":"b","country":"US"},
+            "mdns":{"hostname":"x"},
+            "time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},
+            "behavior":{"voicevox_speaker_id":70000}
         }"#;
         let err = parse_settings_json(input).unwrap_err();
         assert!(matches!(err, ConfigError::BareParse(_)), "got {err:?}");

--- a/crates/stackchan-net/src/config.rs
+++ b/crates/stackchan-net/src/config.rs
@@ -502,6 +502,22 @@ pub struct BehaviorConfig {
     /// The sidecar still validates per-request — this is defence in
     /// depth at the firmware boundary.
     pub persona_name: String,
+    /// HTTP base URL of a self-hosted `VoiceVox` (or API-compatible)
+    /// TTS engine, as `"http://ip:port"`. Empty disables the
+    /// `VoiceVox` synthesis task. When set, the firmware drives the
+    /// engine's two-step `/audio_query` → `/synthesis` protocol to
+    /// turn dynamic speech text into PCM and enqueues it on the audio
+    /// TX path. Hostname-only URLs are not resolved — use a raw IPv4
+    /// literal (mirrors `agent_sidecar_url`). The wire format lives in
+    /// [`stackchan_tts::voicevox`](../../stackchan-tts/src/voicevox.rs).
+    pub voicevox_url: String,
+    /// `VoiceVox` engine speaker (voice) ID. The engine ships a
+    /// catalogue of numbered voices — `1` (Zundamon "ノーマル") is the
+    /// common default; query the engine's `GET /speakers` for the full
+    /// list. Ignored when `voicevox_url` is empty. Any `u16` is a
+    /// valid wire value; the engine rejects unknown IDs at synthesis
+    /// time, so there's no config-side range gate.
+    pub voicevox_speaker_id: u16,
 }
 
 impl Default for BehaviorConfig {
@@ -520,9 +536,17 @@ impl Default for BehaviorConfig {
             wake_word_threshold: 100,
             wake_word_arena_kib: 64,
             persona_name: String::new(),
+            voicevox_url: String::new(),
+            voicevox_speaker_id: DEFAULT_VOICEVOX_SPEAKER_ID,
         }
     }
 }
+
+/// Default `VoiceVox` speaker ID — Zundamon "ノーマル". Mirrors
+/// `stackchan_tts::DEFAULT_VOICEVOX_SPEAKER_ID`; kept as a local
+/// literal so the config schema doesn't take a dependency on the TTS
+/// crate for one constant.
+const DEFAULT_VOICEVOX_SPEAKER_ID: u16 = 1;
 
 /// Time / SNTP configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1293,6 +1317,25 @@ mod tests {
         let c = Config::default();
         assert!(c.appearance.palette.is_empty());
         assert!(c.appearance.face_geometry.is_empty());
+    }
+
+    #[test]
+    fn default_behavior_has_voicevox_disabled() {
+        let c = Config::default();
+        assert!(
+            c.behavior.voicevox_url.is_empty(),
+            "empty URL = VoiceVox task disabled"
+        );
+        assert_eq!(c.behavior.voicevox_speaker_id, DEFAULT_VOICEVOX_SPEAKER_ID);
+    }
+
+    #[test]
+    fn validate_accepts_voicevox_config() {
+        let mut c = Config::default();
+        c.wifi.ssid = "x".to_string();
+        c.behavior.voicevox_url = "http://192.168.1.50:50021".to_string();
+        c.behavior.voicevox_speaker_id = 3;
+        assert!(validate(&c).is_ok());
     }
 
     #[test]

--- a/crates/stackchan-tts/README.md
+++ b/crates/stackchan-tts/README.md
@@ -35,12 +35,14 @@ queue element type the firmware audio router pulls from.
   catalog entries. Renders non-verbal SFX from compile-time sine-cycle
   tables, and verbal phrases from `include_bytes!`-embedded raw PCM
   under `assets/<locale>/<phrase>.pcm`.
-- [`VoiceVoxBackend`] — wire-format + WAV-parsing scaffolding for
+- [`VoiceVoxBackend`] — wire-format + WAV-decode scaffolding for
   self-hosted [`VoiceVox`] (and API-compatible engines like
-  [`AivisSpeech`]). [`SpeechBackend::render`] is currently
-  [`RenderError::BackendUnavailable`] until the async HTTP fetcher
-  task lands on the firmware side; the URL builders and WAV parser
-  are host-testable today.
+  [`AivisSpeech`]). [`SpeechBackend::render`] stays
+  [`RenderError::BackendUnavailable`]: the two async `embassy-net`
+  round-trips run in a dedicated firmware task, not in the
+  synchronous `render`. The host-testable helpers that task drives —
+  URL builders, the audio-query rate override, the WAV parser, and
+  the WAV→`Vec<i16>` decode — are usable today.
 - [`LipSync`] + [`Viseme`] re-exports from `stackchan-core::lipsync`
   so backends and the firmware audio task share one envelope shape.
 
@@ -91,18 +93,27 @@ returns a WAV file. This module ships:
 
 - [`audio_query_path`] / [`synthesis_path`] — URL builders (paths +
   query strings). Caller wraps in a full URL.
+- [`with_output_sampling_rate`] — rewrites the `outputSamplingRate`
+  field in the step-1 audio-query JSON before it becomes the step-2
+  body, so the engine renders at the rate the firmware I²S path can
+  play (16 kHz on the CoreS3) instead of `VoiceVox`'s 24 kHz default.
+  This avoids an on-device resampler; without it `parse_wav` rejects
+  the synthesis response as a rate mismatch.
 - [`VoiceVoxConfig`] — `host` + `port` + `speaker_id` settings.
   Defaults: port `50_021`, speaker `1` (Zundamon "ノーマル").
 - [`parse_wav`] / [`WavHeader`] / [`WavError`] — RIFF-chunk WAV
   parser that locates the PCM payload inside a synthesis response.
+- [`wav_to_samples`] — composes [`parse_wav`] with a little-endian
+  `i16` decode of the located `data` chunk, yielding an owned
+  `Vec<i16>` ready to wrap in a [`BufferedSource`].
 - [`BufferedSource`] — [`AudioSource`] that wraps a `Vec<i16>` of
   decoded samples, suitable for handing back from a future async
   fetcher task.
 
 The async fetcher itself lives in the firmware crate and isn't
 shipped yet, so [`VoiceVoxBackend::render`] returns
-[`RenderError::BackendUnavailable`]. The URL builders + WAV parser
-are exercised by host tests today.
+[`RenderError::BackendUnavailable`]. Every host-side helper it will
+drive is exercised by unit tests today.
 
 ## Gotchas
 
@@ -152,6 +163,8 @@ are exercised by host tests today.
 [`VoiceVoxConfig`]: src/voicevox.rs
 [`audio_query_path`]: src/voicevox.rs
 [`synthesis_path`]: src/voicevox.rs
+[`with_output_sampling_rate`]: src/voicevox.rs
+[`wav_to_samples`]: src/voicevox.rs
 [`parse_wav`]: src/voicevox.rs
 [`WavHeader`]: src/voicevox.rs
 [`WavError`]: src/voicevox.rs

--- a/crates/stackchan-tts/src/lib.rs
+++ b/crates/stackchan-tts/src/lib.rs
@@ -49,6 +49,7 @@ pub use source::AudioSource;
 pub use voicevox::{
     BufferedSource, DEFAULT_VOICEVOX_PORT, DEFAULT_VOICEVOX_SPEAKER_ID, VoiceVoxBackend,
     VoiceVoxConfig, WavError, WavHeader, audio_query_path, parse_wav, synthesis_path,
+    wav_to_samples, with_output_sampling_rate,
 };
 // Re-export lip-sync types from core; they live there because the
 // `Perception` layer carries them as a per-frame field.

--- a/crates/stackchan-tts/src/voicevox.rs
+++ b/crates/stackchan-tts/src/voicevox.rs
@@ -17,25 +17,28 @@
 //! 2. `POST /synthesis?speaker=<id>` with the audio-query JSON as the
 //!    body → returns a WAV file (RIFF + PCM data chunk).
 //!
-//! The firmware doesn't need to understand the audio-query JSON; it
-//! just round-trips the bytes from step 1 into step 2. This module
-//! ships the URL builders for both steps and a WAV parser that finds
-//! the PCM payload inside the synthesis response.
+//! The firmware mostly round-trips the audio-query JSON from step 1
+//! into step 2, but first rewrites its `outputSamplingRate` field via
+//! [`with_output_sampling_rate`] so the engine renders at a rate the
+//! I²S path can play without an on-device resampler. This module
+//! ships the URL builders for both steps, the rate-override rewrite,
+//! a WAV parser that finds the PCM payload inside the synthesis
+//! response, and [`wav_to_samples`] to decode that payload into an
+//! owned `Vec<i16>`.
 //!
-//! ## Why host-only for now
+//! ## Why the backend stays host-only
 //!
 //! [`SpeechBackend::render`] is synchronous (`fn render(&self, ...)`),
-//! but HTTP I/O on this firmware target is async (`embassy-net`). The
-//! end-to-end path therefore needs:
-//!
-//! 1. An async firmware task that fetches the WAV into a `Vec<i16>`.
-//! 2. A `VoiceVoxBackend` whose `render` returns a [`BufferedSource`]
-//!    wrapping that `Vec`.
-//!
-//! Step 2 is in this module (host-testable, no firmware deps); step 1
-//! lives in the firmware crate and ships in a follow-up PR. Until
-//! then, [`VoiceVoxBackend::render`] returns
-//! [`crate::RenderError::BackendUnavailable`].
+//! but HTTP I/O on this firmware target is async (`embassy-net`), so
+//! `render` cannot itself perform the two synthesis round-trips. The
+//! end-to-end path instead runs in a dedicated async firmware task
+//! that fetches + decodes the WAV (reusing this module's host-tested
+//! [`with_output_sampling_rate`] / [`wav_to_samples`] helpers) and
+//! enqueues a [`BufferedSource`] directly onto the audio TX queue.
+//! That task lives in the firmware crate and ships in a follow-up PR;
+//! until then [`VoiceVoxBackend::render`] returns
+//! [`crate::RenderError::BackendUnavailable`] (the backend is a config
+//! carrier + `can_handle` gate, not the synthesis driver).
 //!
 //! [`AivisSpeech`]: https://github.com/Aivis-Project/AivisSpeech-Engine
 //! [`AudioSource`]: crate::AudioSource
@@ -129,6 +132,49 @@ fn percent_encode(input: &str) -> String {
             out.push(HEX[(byte & 0xF) as usize] as char);
         }
     }
+    out
+}
+
+/// JSON key in the `/audio_query` response that controls the
+/// synthesis output sample rate. The engine populates it with its
+/// own default (24 000 Hz); rewriting it before the `/synthesis` POST
+/// is how the firmware asks for a rate it can play without an
+/// on-device resampler.
+const OUTPUT_SAMPLING_RATE_KEY: &str = "\"outputSamplingRate\":";
+
+/// Rewrite the `outputSamplingRate` value in an `/audio_query` JSON
+/// body so `/synthesis` returns PCM at `target_rate_hz`.
+///
+/// `VoiceVox` defaults to 24 kHz, but the firmware I²S path (and the
+/// [`parse_wav`] rate gate) are wired for a single rate. Asking the
+/// engine to render at that rate up front keeps the firmware free of
+/// a resampler. The audio-query JSON always carries an
+/// `outputSamplingRate` field, so this is a targeted numeric rewrite
+/// rather than a full JSON reparse — cheap enough for the embedded
+/// path and host-testable in isolation.
+///
+/// Returns the rewritten JSON. If the key is absent (a
+/// non-`VoiceVox` engine, or a future schema change) the input is
+/// returned unchanged — the engine then falls back to its own
+/// default rate, which [`parse_wav`] rejects loudly downstream rather
+/// than silently mis-playing.
+#[must_use]
+pub fn with_output_sampling_rate(audio_query_json: &str, target_rate_hz: u32) -> String {
+    let Some(key_at) = audio_query_json.find(OUTPUT_SAMPLING_RATE_KEY) else {
+        return String::from(audio_query_json);
+    };
+    let value_start = key_at + OUTPUT_SAMPLING_RATE_KEY.len();
+    let value_len = audio_query_json[value_start..]
+        .bytes()
+        .take_while(u8::is_ascii_digit)
+        .count();
+    if value_len == 0 {
+        return String::from(audio_query_json);
+    }
+    let mut out = String::with_capacity(audio_query_json.len() + 8);
+    out.push_str(&audio_query_json[..value_start]);
+    let _ = core::fmt::Write::write_fmt(&mut out, format_args!("{target_rate_hz}"));
+    out.push_str(&audio_query_json[value_start + value_len..]);
     out
 }
 
@@ -260,6 +306,34 @@ pub fn parse_wav(bytes: &[u8], expected_sample_rate_hz: u32) -> Result<WavHeader
     }
 
     Err(WavError::NoDataChunk)
+}
+
+/// Decode a synthesis WAV response into an owned PCM sample buffer.
+///
+/// Composes [`parse_wav`] (RIFF/format validation + rate gate) with a
+/// little-endian `i16` decode of the located `data` sub-chunk. The
+/// firmware calls this on the buffered HTTP response body, then wraps
+/// the result in a [`BufferedSource`] for the audio TX queue.
+///
+/// A trailing odd byte in the `data` chunk (a malformed WAV whose
+/// PCM payload isn't a whole number of samples) is dropped rather
+/// than rejected — the parser already validated 16-bit mono, so a
+/// dangling byte is engine noise, not a format error worth aborting
+/// playback over.
+///
+/// # Errors
+///
+/// Propagates every [`WavError`] [`parse_wav`] can return, including
+/// [`WavError::UnsupportedSampleRate`] when the engine ignored the
+/// [`with_output_sampling_rate`] override.
+pub fn wav_to_samples(bytes: &[u8], expected_rate_hz: u32) -> Result<Vec<i16>, WavError> {
+    let header = parse_wav(bytes, expected_rate_hz)?;
+    let pcm = &bytes[header.data_offset..header.data_offset + header.data_len];
+    let mut samples = Vec::with_capacity(header.sample_count());
+    for chunk in pcm.chunks_exact(2) {
+        samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
+    }
+    Ok(samples)
 }
 
 /// Parsed `fmt ` sub-chunk — just the fields we care about.
@@ -497,6 +571,51 @@ mod tests {
             parse_wav(&bytes, 16_000),
             Err(WavError::UnsupportedSampleRate(24_000))
         );
+    }
+
+    #[test]
+    fn wav_to_samples_round_trips_pcm() {
+        let samples = [0_i16, 1, -1, 32_767, -32_768, 12_345];
+        let bytes = build_test_wav(16_000, &samples);
+        let decoded = wav_to_samples(&bytes, 16_000).expect("valid wav should decode");
+        assert_eq!(decoded, samples);
+    }
+
+    #[test]
+    fn wav_to_samples_surfaces_sample_rate_mismatch() {
+        let bytes = build_test_wav(24_000, &[1, 2, 3]);
+        assert_eq!(
+            wav_to_samples(&bytes, 16_000),
+            Err(WavError::UnsupportedSampleRate(24_000))
+        );
+    }
+
+    #[test]
+    fn with_output_sampling_rate_rewrites_value() {
+        let json = "{\"accent_phrases\":[],\"outputSamplingRate\":24000,\"outputStereo\":false}";
+        let out = with_output_sampling_rate(json, 16_000);
+        assert_eq!(
+            out,
+            "{\"accent_phrases\":[],\"outputSamplingRate\":16000,\"outputStereo\":false}"
+        );
+    }
+
+    #[test]
+    fn with_output_sampling_rate_rewrites_when_value_is_last_field() {
+        let json = "{\"outputSamplingRate\":24000}";
+        assert_eq!(
+            with_output_sampling_rate(json, 16_000),
+            "{\"outputSamplingRate\":16000}"
+        );
+    }
+
+    #[test]
+    fn with_output_sampling_rate_passes_through_when_key_absent() {
+        // A non-VoiceVox engine or a future schema change without the
+        // key leaves the body untouched; the rate gate in parse_wav
+        // then surfaces any mismatch downstream.
+        let json = "{\"accent_phrases\":[]}";
+        assert_eq!(with_output_sampling_rate(json, 16_000), json);
     }
 
     #[test]

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -34,6 +34,9 @@ enough to warrant its own page (e.g. audio debug, sidecar), the
 | `wake_word_enabled` | bool | `false` | **reboot** | Runs on-device wake-word detection. Loads `/sd/WAKE_WORD.tflite` at boot; missing file parks the task. |
 | `wake_word_threshold` | i8 | `100` | **reboot** | Int8 detection cut-point. Bundled-model reference ≈ 0.95 confidence lands near 100. Lower = more sensitive. |
 | `wake_word_arena_kib` | u32 | `64` | **reboot** | TFLite Micro arena size in KiB. Allocated once at boot from PSRAM. Must be `>= 1`; `0` is rejected by validation. |
+| `persona_name` | string | empty | live | Persona slug advertised to the sidecar via `X-Persona-Name`. Empty leaves the header off (sidecar default persona). ≤ 64 bytes, no control chars / path separators. |
+| `voicevox_url` | URL | empty | **reboot** | HTTP base URL (`http://ip:port`) of a self-hosted VoiceVox / API-compatible TTS engine. Empty disables the synthesis task. IPv4-literal only — no DNS. See [voice](voice). |
+| `voicevox_speaker_id` | u16 | `1` | **reboot** | VoiceVox speaker (voice) ID. `1` is Zundamon "ノーマル"; query the engine's `GET /speakers` for the catalogue. Ignored when `voicevox_url` is empty. |
 
 Reboot semantics: every field marked **live** takes effect on the
 next render frame (`PUT /settings` immediately signals the relevant

--- a/docs/voice-voicevox.md
+++ b/docs/voice-voicevox.md
@@ -1,0 +1,97 @@
+---
+title: VoiceVox — self-hosted TTS engine
+---
+
+# VoiceVox TTS
+
+[VoiceVox](https://voicevox.hiroshiba.jp/) is a self-hostable Japanese
+TTS engine. The firmware can drive it directly over HTTP to turn
+dynamic speech text into spoken audio, separate from the
+[sidecar](sidecar.md) path (which owns STT + LLM). API-compatible
+engines such as
+[AivisSpeech](https://github.com/Aivis-Project/AivisSpeech-Engine)
+speak the same wire format and work the same way.
+
+This page covers running the engine and pointing the firmware at it.
+The wire format (URL builders, the audio-query rate override, and the
+WAV decoder) lives in
+[`stackchan-tts::voicevox`](../crates/stackchan-tts/src/voicevox.rs);
+the firmware synthesis task that fetches and enqueues audio ships in a
+follow-up — until then `voicevox_url` is parsed and persisted but the
+on-device fetch path is not yet wired.
+
+## Run the engine
+
+The upstream Docker image listens on port `50021`:
+
+```sh
+docker run --rm -p 50021:50021 voicevox/voicevox_engine:cpu-latest
+```
+
+Confirm it answers on the LAN IP the avatar will reach (not
+`localhost` — the firmware connects from another host):
+
+```sh
+curl -s http://192.168.1.50:50021/speakers | head -c 200
+```
+
+## Point the firmware at it
+
+Set `behavior.voicevox_url` (and optionally
+`behavior.voicevox_speaker_id`) in `STACKCHAN.RON`:
+
+```ron
+behavior: (
+    voicevox_url: "http://192.168.1.50:50021",
+    voicevox_speaker_id: 1,
+    // ...other behavior flags...
+)
+```
+
+Empty (the default) disables the synthesis task. Both fields also
+round-trip through `PUT /settings`; see [behavior](behavior.md) for
+the full field table and reboot semantics.
+
+Hostnames are not resolved — use a raw IPv4 literal, same as
+`agent_sidecar_url`. DNS support is a future extension.
+
+`voicevox_speaker_id` selects the voice. `1` is Zundamon "ノーマル";
+the engine's `GET /speakers` lists the full catalogue with per-style
+IDs.
+
+## Sample rate: 16 kHz, not 24 kHz
+
+VoiceVox renders at 24 kHz by default, but the CoreS3 I²S output path
+plays a single fixed rate (16 kHz). The firmware therefore rewrites
+the `outputSamplingRate` field in the engine's audio-query response to
+16 000 before requesting synthesis, so no on-device resampler is
+needed. If the engine returns a different rate the WAV decoder rejects
+the response rather than playing it back at the wrong pitch.
+
+To reproduce the firmware's two-step request by hand:
+
+```sh
+ENGINE=http://192.168.1.50:50021
+# Step 1: audio query (prosody JSON), rewriting the output rate to 16 kHz.
+curl -s -X POST "$ENGINE/audio_query?speaker=1&text=こんにちは" \
+  | sed 's/"outputSamplingRate":[0-9]*/"outputSamplingRate":16000/' \
+  > query.json
+# Step 2: synthesis -> 16 kHz mono WAV.
+curl -s -X POST "$ENGINE/synthesis?speaker=1" \
+  -H 'Content-Type: application/json' --data @query.json -o out.wav
+```
+
+## Security
+
+Like the sidecar, the firmware speaks plain HTTP on the LAN — no TLS,
+no auth. VoiceVox upstream has no authentication of its own, so keep
+the engine on a trusted segment and don't expose port `50021` to the
+internet.
+
+## Related
+
+- [voice](voice.md) — the end-to-end wake-word + sidecar onboarding flow.
+- [behavior](behavior.md) — the `voicevox_url` / `voicevox_speaker_id`
+  config fields and reboot semantics.
+- [`stackchan-tts`](../crates/stackchan-tts/README.md) — the
+  `SpeechBackend` surface and the VoiceVox wire-format helpers.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -171,6 +171,9 @@ with `audio_url: null`. The firmware sees the null, skips the fetch
 step, and the reply appears on screen with no audio. Watch the
 sidecar logs for `TTSError(stage="...")` to diagnose.
 
+For a self-hosted Japanese TTS engine the firmware drives **directly**
+(no sidecar in the path), see [VoiceVox](voice-voicevox.md).
+
 ## Enable the wake word (optional)
 
 Wake-word detection is local-only — microWakeWord v2 streaming


### PR DESCRIPTION
## Summary
- Add `behavior.voicevox_url` + `behavior.voicevox_speaker_id` to the RON/JSON config schema across `stackchan-net` (`bare.rs` + `bare_json.rs`): parse, render, validate, and reboot-detection. Speaker-id defaults to 1, mirroring `stackchan_tts::DEFAULT_VOICEVOX_SPEAKER_ID`. `voicevox_url` is intentionally not validated, matching the existing `agent_sidecar_url` convention (VoiceVox has no auth, so no token field).
- Add two host-testable synthesis helpers in `stackchan-tts/src/voicevox.rs`: `with_output_sampling_rate` rewrites the audio-query rate to 16 kHz so synthesis matches the I2S path (resolving the 24kHz/16kHz mismatch without a resampler), and `wav_to_samples` decodes the synthesis WAV response into a `Vec<i16>`.
- `VoiceVoxBackend::render` stays `BackendUnavailable` by design: the two synthesis round-trips are async and belong in a dedicated firmware task. Touched one firmware file (`http.rs`) only for reboot-detection.
- Added 10 unit tests covering the parse/render/validate round-trips and the WAV decode/rate-rewrite helpers.

DEFERRED to a follow-up PR (hardware-gated, plus two open design decisions flagged in the blueprint for user input): the async firmware synthesis task and the producer/trigger surface (`RemoteCommand::SpeakText` route vs routing `SpeechContent::Dynamic`).

## Test plan
- `just check` (fmt + workspace clippy `-D warnings` + host tests): passes clean, no warnings.
- `just clippy-firmware` (strict firmware clippy; `http.rs` was touched): passes clean, no regression.
- `cargo doc` for `stackchan-tts` + `stackchan-net`: builds with no broken intra-doc links.
- No on-device verification needed for this slice — the firmware synthesis task lands in the follow-up PR.

Greptile: please review.