### PR TITLE
feat(web): surface boot appearance + stop wiping appearance/head on save

### DIFF
--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -1838,6 +1838,38 @@ mod tests {
     }
 
     #[test]
+    fn omitted_appearance_and_head_blocks_reset_to_default() {
+        // The parser defaults any omitted top-level block to its zero
+        // value and `merge_settings_with_current` takes `head` /
+        // `appearance` from `new` verbatim — neither block carries a
+        // redaction sentinel. A PUT body that drops these blocks
+        // therefore wipes a pinned boot appearance / head trim. This
+        // pins that contract so the dashboard (and any other client)
+        // is forced to round-trip both blocks; the regression this
+        // guards is a form that omits them.
+        let current = full_config();
+        let body = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let parsed = parse_settings_json(body).unwrap();
+        let merged = merge_settings_with_current(parsed, &current);
+        assert_eq!(merged.appearance, AppearanceConfig::default());
+        assert_eq!(merged.head, HeadTrim::default());
+    }
+
+    #[test]
+    fn echoed_appearance_and_head_survive_merge() {
+        // The dashboard's fix: a PUT body that carries the appearance
+        // and head blocks read from GET /settings round-trips them
+        // untouched through parse + merge, even when other fields change.
+        let current = full_config();
+        let rendered = render_settings_json(&current, true).unwrap();
+        let mut parsed = parse_settings_json(&rendered).unwrap();
+        parsed.wifi.ssid = "different".to_string();
+        let merged = merge_settings_with_current(parsed, &current);
+        assert_eq!(merged.appearance, current.appearance);
+        assert_eq!(merged.head, current.head);
+    }
+
+    #[test]
     fn render_uses_psk_redacted_constant() {
         // Pin: the sentinel string emitted by render is the same
         // string parse rejects.

--- a/docs/http.md
+++ b/docs/http.md
@@ -376,6 +376,15 @@ the rest of the body back from `GET /settings` unchanged — the
 `***` sentinels for `wifi.psk` and `auth.token` will be merged
 against the persisted values rather than clobbering them.
 
+Unlike the redacted secrets, the `appearance` and `head` blocks have
+no preserve-on-echo sentinel: an omitted block parses to its default
+(empty appearance / compile-time head trim) and overwrites the
+persisted value. Callers **must** round-trip both blocks from
+`GET /settings` or they reset the operator's pinned boot appearance
+and per-unit head trim. The dashboard handles this for you — the
+System page's Boot appearance panel edits `appearance`, and the
+Settings form carries `appearance` + `head` through every save.
+
 Full-replace. The server validates the body via
 `stackchan_net::validate` (rejects empty SSID, invalid country code,
 invalid hostname, empty SNTP list) and then writes back atomically:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { Events } from "./components/Events";
 import { Recovery } from "./components/Recovery";
 import { Sensors } from "./components/Sensors";
 import { Settings } from "./components/Settings";
+import { Appearance } from "./components/Appearance";
 import { Pair } from "./components/Pair";
 import { Speak } from "./components/Speak";
 import { TaskHealth } from "./components/TaskHealth";
@@ -214,6 +215,7 @@ export function App() {
               <Match when={section() === "system"}>
                 <PageHead title="System" />
                 <Settings />
+                <Appearance />
                 <Recovery />
               </Match>
             </Switch>

--- a/web/src/components/Appearance.tsx
+++ b/web/src/components/Appearance.tsx
@@ -1,0 +1,109 @@
+import { createSignal, onMount } from "solid-js";
+import { authedFetch } from "../auth";
+import { showToast } from "../store";
+import type { Settings as SettingsType } from "../types";
+
+// Wire-string vocabularies mirror `Palette::wire_str` and
+// `FaceGeometry::wire_str` in `crates/stackchan-core/src/{palette,face}.rs`.
+// The empty string is the "(not pinned)" sentinel the firmware reads as
+// "fall back to the variant default".
+const PALETTES = ["", "default", "dark", "cute", "dog"] as const;
+const GEOMETRIES = ["", "default", "chibi", "wide", "sleepy"] as const;
+
+const label = (v: string) => (v === "" ? "(not pinned)" : v);
+
+export function Appearance() {
+  const [palette, setPalette] = createSignal("");
+  const [geometry, setGeometry] = createSignal("");
+
+  const load = async () => {
+    try {
+      const res = await fetch("/settings");
+      if (!res.ok) {
+        if (res.status === 503) {
+          showToast("settings unavailable (no SD card)", true);
+        } else {
+          showToast(`GET /settings: ${res.status}`, true);
+        }
+        return;
+      }
+      const c = (await res.json()) as SettingsType;
+      setPalette(c.appearance.palette);
+      setGeometry(c.appearance.face_geometry);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  onMount(load);
+
+  const submit = async (ev: Event) => {
+    ev.preventDefault();
+    try {
+      // Re-fetch before PUT and overwrite only the appearance block, so a
+      // concurrent save through the Settings form (or a hand-edit) isn't
+      // clobbered — same merge-against-fresh discipline as Settings.tsx.
+      const freshRes = await fetch("/settings");
+      if (!freshRes.ok) {
+        if (freshRes.status === 503) {
+          throw new Error("settings unavailable (no SD card)");
+        }
+        throw new Error(`GET /settings: ${freshRes.status}`);
+      }
+      const fresh = (await freshRes.json()) as SettingsType;
+      const body: SettingsType = {
+        ...fresh,
+        appearance: { palette: palette(), face_geometry: geometry() },
+      };
+      const res = await authedFetch("/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${text || res.statusText}`);
+      }
+      showToast("saved — boot appearance applies on next reboot");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Boot appearance</h2>
+      <form class="grid" onSubmit={submit}>
+        <label>
+          Palette
+          <select value={palette()} onChange={(e) => setPalette(e.currentTarget.value)}>
+            {PALETTES.map((p) => (
+              <option value={p}>{label(p)}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Face geometry
+          <select value={geometry()} onChange={(e) => setGeometry(e.currentTarget.value)}>
+            {GEOMETRIES.map((g) => (
+              <option value={g}>{label(g)}</option>
+            ))}
+          </select>
+        </label>
+        <div class="btn-row">
+          <button type="submit">Save</button>
+          <button type="button" onClick={load}>
+            Reload
+          </button>
+        </div>
+        <small>
+          These are BOOT defaults: they seed the runtime store only on first
+          boot (when <code>RUNTIME.RON</code> is absent). A later live change via
+          the Behavior page (POST /palette / POST /face-geometry) persists to
+          the runtime store and wins on subsequent boots. Leave a field as
+          <code>(not pinned)</code> to fall back to the firmware default.
+        </small>
+      </form>
+    </section>
+  );
+}

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -59,11 +59,14 @@ export function Settings() {
       }
       const fresh = (await freshRes.json()) as SettingsType;
       const audio = snapshot()?.audio ?? fresh.audio;
-      // Spread `fresh.behavior` / `fresh.esp_now` / `fresh.tracker` so
-      // fields edited elsewhere (Calibration, hand-edited STACKCHAN.RON,
-      // operator-set wake_word/chime flags, ESP-NOW peer config) survive
-      // a save through this form. Only the keys this form binds get
-      // overwritten; everything else round-trips untouched.
+      // Carry through `fresh.tracker` / `fresh.esp_now` / `fresh.head` /
+      // `fresh.appearance` and the unbound `behavior` keys so fields
+      // edited elsewhere (Calibration, the Appearance panel, POST /palette,
+      // POST /face-geometry, hand-edited STACKCHAN.RON, operator-set
+      // wake_word/chime flags, ESP-NOW peer config) survive a save through
+      // this form. The PUT parser defaults any omitted block to its zero
+      // value, so a block left out here is silently wiped — only the keys
+      // this form binds may be overwritten, everything else round-trips.
       const body: SettingsType = {
         wifi: { ssid: ssid(), psk: psk(), country: country().toUpperCase() },
         mdns: { hostname: hostname() },
@@ -83,6 +86,8 @@ export function Settings() {
           agent_sidecar_url: sidecarUrl(),
           agent_sidecar_token: sidecarToken(),
         },
+        head: fresh.head,
+        appearance: fresh.appearance,
       };
       const newToken = body.auth.token;
       const res = await authedFetch("/settings", {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -65,6 +65,25 @@ export type Settings = {
   tracker: Tracker;
   esp_now: EspNow;
   behavior: Behavior;
+  head: HeadTrim;
+  appearance: Appearance;
+};
+
+// Per-unit head zero-point trim, applied at boot. Mirrors the
+// `head` block emitted by `render_settings_json` in
+// `crates/stackchan-net/src/bare_json.rs`.
+export type HeadTrim = {
+  pan_trim_deg: number;
+  tilt_trim_deg: number;
+};
+
+// Boot-pinned default appearance. Empty strings mean "not pinned" —
+// the firmware falls back to the variant default. Wire vocabularies
+// mirror `Palette::wire_str` / `FaceGeometry::wire_str` in
+// `crates/stackchan-core/src/{palette,face}.rs`.
+export type Appearance = {
+  palette: string;
+  face_geometry: string;
 };
 
 export type EspNow = {


### PR DESCRIPTION
## Summary
- Fix silent data-loss: the Settings form built its PUT /settings body without the `appearance` and `head` blocks, and the firmware parser defaults omitted blocks to their zero value, so every save wiped the operator's pinned boot palette/geometry and per-unit head trim.
- Add `appearance` and `head` to the TS `Settings` type so `tsc` enforces them at every construction site, and round-trip both blocks through the Settings submit.
- Add a System-page "Boot appearance" panel (palette + face-geometry dropdowns with a "(not pinned)" `""` sentinel option) seeded from GET /settings.
- Add two `bare_json.rs` regression tests (omission resets to default; echoed blocks survive merge) and document the round-trip contract in `docs/http.md`.

## Test plan
- `just check` (fmt + workspace clippy + host tests) — green; both new `bare_json` tests pass.
- Web typecheck (`tsc --noEmit`) / build — green.
- No firmware Rust crates touched, so the firmware gate was not required.
- On-device: verify a Settings save no longer clears a pinned boot palette/geometry or head trim, and that the new Boot appearance panel reflects GET /settings.

Greptile: please review.