### PR TITLE
fix(firmware): retry servo-power enable + GET /hardware/status diagnostic

### DIFF
--- a/crates/stackchan-firmware/src/board.rs
+++ b/crates/stackchan-firmware/src/board.rs
@@ -89,6 +89,14 @@ const SERVO_POWER_SETTLE_MS: u64 = 200;
 /// the rail — see `device_specs.md`.
 const PY32_SERVO_POWER_PIN: u8 = 0;
 
+/// Boot attempts to raise the servo-power pin before giving up. The
+/// failure mode covered is a transient I²C glitch on the cold-boot bus
+/// (same class as the AXP2101 retry); a dead rail MOSFET or absent PY32
+/// just costs `(N-1) × SERVO_POWER_SETTLE_MS` extra boot latency before
+/// the non-fatal give-up. Kept low so a genuinely-missing co-processor
+/// never stalls boot for long.
+const SERVO_POWER_MAX_ATTEMPTS: u8 = 3;
+
 /// Retry delay between failed AXP2101 init attempts. Covers transient
 /// I²C glitches during cold boot.
 const PMIC_RETRY_MS: u64 = 500;
@@ -168,8 +176,14 @@ pub async fn bringup(
         Err(e) => defmt::panic!("AW9523 init failed: {}", defmt::Debug2Format(&e)),
     }
 
-    enable_servo_power(&mut i2c).await;
-    Timer::after(Duration::from_millis(SERVO_POWER_SETTLE_MS)).await;
+    let servo_power = enable_servo_power(&mut i2c).await;
+    if servo_power.enabled {
+        Timer::after(Duration::from_millis(SERVO_POWER_SETTLE_MS)).await;
+        crate::servo_power::record(crate::servo_power::ServoPowerStatus {
+            settled: true,
+            ..servo_power
+        });
+    }
 
     // Park the I²C0 bus in a shared-bus mutex. Any post-boot consumer
     // (touch, future RTC / IMU) gets its own cheap-to-create
@@ -232,7 +246,8 @@ pub async fn bringup(
     }
 }
 
-/// Drive the PY32's servo-power pin HIGH via the `py32` crate.
+/// Drive the PY32's servo-power pin HIGH via the `py32` crate, retrying
+/// transient I²C failures up to [`SERVO_POWER_MAX_ATTEMPTS`].
 ///
 /// Uses [`py32::Py32::configure_output_pin`], which does read-modify-
 /// write on the direction / pull-up / output registers. That's a change
@@ -246,21 +261,64 @@ pub async fn bringup(
 /// lend the bus via a mutable borrow and drop the `Py32` handle at
 /// end of scope, releasing the borrow for the shared-bus wrapper.
 ///
-/// Failures are logged at `warn` and the function returns; the servo
-/// bus will still initialise but `ping_servo` will time out, which is
-/// the already-handled path for "servos missing".
-async fn enable_servo_power(i2c: &mut I2c<'static, esp_hal::Async>) {
-    let mut py = py32::Py32::new(i2c);
-    match py.configure_output_pin(PY32_SERVO_POWER_PIN, true).await {
-        Ok(()) => defmt::info!(
-            "PY32: servo power enabled (pin {=u8} HIGH)",
-            PY32_SERVO_POWER_PIN
-        ),
-        Err(e) => defmt::warn!(
-            "PY32: servo-power enable incomplete ({}) — servos may stay unpowered",
-            defmt::Debug2Format(&e)
-        ),
+/// On exhausting all attempts the failure is logged at `warn`, recorded
+/// to the event ring for LAN read-out, and the function returns
+/// `enabled: false`; the servo bus still initialises but `ping_servo`
+/// will time out, which is the already-handled "servos missing" path.
+/// The returned status is mirrored to [`crate::servo_power`] for
+/// `GET /hardware/status` regardless of outcome.
+async fn enable_servo_power(
+    i2c: &mut I2c<'static, esp_hal::Async>,
+) -> crate::servo_power::ServoPowerStatus {
+    let mut last_err = None;
+    for attempt in 1..=SERVO_POWER_MAX_ATTEMPTS {
+        let mut py = py32::Py32::new(&mut *i2c);
+        match py.configure_output_pin(PY32_SERVO_POWER_PIN, true).await {
+            Ok(()) => {
+                defmt::info!(
+                    "PY32: servo power enabled (pin {=u8} HIGH, attempt {=u8}/{=u8})",
+                    PY32_SERVO_POWER_PIN,
+                    attempt,
+                    SERVO_POWER_MAX_ATTEMPTS
+                );
+                let status = crate::servo_power::ServoPowerStatus {
+                    enabled: true,
+                    attempts: attempt,
+                    settled: false,
+                };
+                crate::servo_power::record(status);
+                return status;
+            }
+            Err(e) => {
+                defmt::warn!(
+                    "PY32: servo-power enable failed (attempt {=u8}/{=u8}): {}",
+                    attempt,
+                    SERVO_POWER_MAX_ATTEMPTS,
+                    defmt::Debug2Format(&e)
+                );
+                last_err = Some(e);
+                if attempt < SERVO_POWER_MAX_ATTEMPTS {
+                    Timer::after(Duration::from_millis(SERVO_POWER_SETTLE_MS)).await;
+                }
+            }
+        }
     }
+    defmt::warn!(
+        "PY32: servo-power enable incomplete after {=u8} attempts ({}) — servos may stay unpowered",
+        SERVO_POWER_MAX_ATTEMPTS,
+        defmt::Debug2Format(&last_err)
+    );
+    crate::event_log::record(
+        crate::event_log::Kind::Warn,
+        "servo power enable failed — head unpowered",
+    );
+    let status = crate::servo_power::ServoPowerStatus {
+        enabled: false,
+        attempts: SERVO_POWER_MAX_ATTEMPTS,
+        settled: false,
+    };
+    crate::servo_power::record(status);
+    status
 }
 
 /// Probe one `SCServo` ID and log the outcome. 10 ms is well past the

--- a/crates/stackchan-firmware/src/lib.rs
+++ b/crates/stackchan-firmware/src/lib.rs
@@ -46,6 +46,7 @@ pub mod reminders;
 pub mod runtime_store;
 pub mod sd_spi;
 pub mod sensor_history;
+pub mod servo_power;
 pub mod sleep;
 pub mod storage;
 pub mod toast;

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -23,6 +23,9 @@
 //!   per entry, plus an `age_secs` for each.
 //! - `GET /tasks` — watchdog channel health: per-task heartbeat
 //!   delta in the last window + a `stale` flag.
+//! - `GET /hardware/status` — boot-time servo-power-rail health:
+//!   whether the PY32 enable succeeded, attempt count, settle flag.
+//!   Field-debugging aid for a head that won't move.
 //! - `GET /events` — recent operator-visible events (lifecycle,
 //!   control actions, warnings) from a bounded RAM ring.
 //! - `POST /emotion` — JSON `{"emotion": "...", "hold_ms": ...}`.
@@ -147,8 +150,9 @@ use stackchan_net::http_parse::{
 };
 
 use super::respond::{
-    HttpError, events_body, health_body, sensor_history_body, sensors_body, state_body, tasks_body,
-    write_dashboard, write_json, write_no_content, write_status_for_error, write_text,
+    HttpError, events_body, hardware_status_body, health_body, sensor_history_body, sensors_body,
+    state_body, tasks_body, write_dashboard, write_json, write_no_content, write_status_for_error,
+    write_text,
 };
 use super::snapshot::{self, AvatarSnapshot};
 use super::wifi::{LINK_READY, WIFI_RECONFIG, WifiCreds};
@@ -468,6 +472,14 @@ async fn serve_one(socket: &mut TcpSocket<'_>) -> Result<(), HttpError> {
                 socket,
                 200,
                 &tasks_body(crate::watchdog::read_tasks_snapshot()),
+            )
+            .await
+        }
+        ("GET", "/hardware/status") => {
+            write_json(
+                socket,
+                200,
+                &hardware_status_body(crate::servo_power::read_status()),
             )
             .await
         }

--- a/crates/stackchan-firmware/src/net/respond.rs
+++ b/crates/stackchan-firmware/src/net/respond.rs
@@ -233,6 +233,18 @@ pub(super) fn tasks_body(s: crate::watchdog::TasksSnapshot) -> String {
     out
 }
 
+/// Serialise the `/hardware/status` body — servo-power-rail health.
+///
+/// Scoped to the boot-time servo-power gate only (not a full hardware
+/// rollup); the `servo_power` envelope leaves room to grow without a
+/// breaking shape change.
+pub(super) fn hardware_status_body(s: crate::servo_power::ServoPowerStatus) -> String {
+    format!(
+        "{{\"servo_power\":{{\"enabled\":{},\"attempts\":{},\"settled\":{}}}}}\n",
+        s.enabled, s.attempts, s.settled
+    )
+}
+
 /// Serialise the `/events` body — recent ring entries, oldest first.
 pub(super) fn events_body() -> String {
     use crate::event_log;

--- a/crates/stackchan-firmware/src/servo_power.rs
+++ b/crates/stackchan-firmware/src/servo_power.rs
@@ -1,0 +1,62 @@
+//! Boot-time servo-power-rail status, mirrored for HTTP read-out.
+//!
+//! [`board::bringup`](crate::board) drives the PY32's servo-power gate
+//! HIGH at boot. That step is non-fatal: a failure leaves the rail off
+//! and the head unpowered, but the firmware still boots a working face.
+//! The only on-device evidence of the failure is a one-shot defmt
+//! `warn` — gone after the next reset, and invisible to an operator
+//! debugging over the LAN.
+//!
+//! This module records the outcome of the rail-enable attempt into a
+//! single mirror static so `GET /hardware/status` can report whether
+//! the servos are powered without re-touching the I²C bus. Mirrors the
+//! `watchdog::TASKS_SNAPSHOT` read-side pattern.
+
+use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+/// Outcome of the boot-time servo-power-rail enable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServoPowerStatus {
+    /// Whether the rail-enable write to the PY32 ultimately succeeded.
+    /// `false` means the head is unpowered — `ping_servo` will time out
+    /// and commanded poses produce no motion.
+    pub enabled: bool,
+    /// Number of enable attempts made (1 on first-try success, up to
+    /// the boot retry cap on failure).
+    pub attempts: u8,
+    /// Whether the post-enable settle delay completed. Distinguishes a
+    /// rail that came up cleanly from one whose enable returned `Ok`
+    /// but never finished settling (only `false` before boot reaches
+    /// the settle step).
+    pub settled: bool,
+}
+
+impl ServoPowerStatus {
+    /// Pre-boot placeholder: rail not yet enabled. Distinguishable from
+    /// a real failure by `attempts == 0`.
+    const fn empty() -> Self {
+        Self {
+            enabled: false,
+            attempts: 0,
+            settled: false,
+        }
+    }
+}
+
+/// Read-side mirror of the boot-time enable outcome. Written once by
+/// [`record`] during `board::bringup`; read by the HTTP
+/// `GET /hardware/status` handler.
+static SERVO_POWER_STATUS: Mutex<CriticalSectionRawMutex, core::cell::Cell<ServoPowerStatus>> =
+    Mutex::new(core::cell::Cell::new(ServoPowerStatus::empty()));
+
+/// Cheap snapshot read for the HTTP `GET /hardware/status` handler.
+#[must_use]
+pub fn read_status() -> ServoPowerStatus {
+    SERVO_POWER_STATUS.lock(core::cell::Cell::get)
+}
+
+/// Record the outcome of the boot-time servo-power-rail enable.
+pub(crate) fn record(status: ServoPowerStatus) {
+    SERVO_POWER_STATUS.lock(|cell| cell.set(status));
+}

--- a/docs/http.md
+++ b/docs/http.md
@@ -26,6 +26,7 @@ beats pulling a full HTTP framework into the firmware target.
 | GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi, audio |
 | GET    | `/sensors`       | Live IMU / ambient / audio-RMS / body-touch sample   |
 | GET    | `/sensor-history` | Rolling 60-second window of one-per-second sensor snapshots, oldest first |
+| GET    | `/hardware/status` | Boot-time servo-power-rail health (servo-power only, not a full hardware rollup) |
 | GET    | `/camera/snapshot` | Most recent `/sd/CAPTURE.565` frame as raw QVGA RGB565 BE |
 | GET    | `/state/stream`  | Server-Sent Events stream of state changes          |
 | GET    | `/state/ws`      | WebSocket stream of state changes (RFC 6455)        |
@@ -105,6 +106,33 @@ accepts the handshake, sends the initial snapshot, then pushes
 text frames whenever the snapshot changes. Client-sent frames
 are ignored; binary frames, fragmentation, and per-frame
 masking are out of scope for this v1.
+
+## Hardware status
+
+`GET /hardware/status` reports the outcome of the boot-time
+servo-power-rail enable. The firmware drives a PY32 co-processor pin
+HIGH to gate the servo rail MOSFET; if that I²C write fails (retried a
+few times at boot), the head is left unpowered while the rest of the
+device boots normally. Reach for this route when a head won't move —
+it distinguishes "rail never came up" from "servos present but stuck".
+
+```
+$ curl http://stackchan.local/hardware/status
+{"servo_power":{"enabled":true,"attempts":1,"settled":true}}
+```
+
+| Field         | Type | Notes                                                        |
+|---------------|------|--------------------------------------------------------------|
+| `enabled`     | bool | Whether the rail-enable write ultimately succeeded.          |
+| `attempts`    | u8   | Enable attempts made (`0` before boot reaches the step).     |
+| `settled`     | bool | Whether the post-enable settle delay completed.              |
+
+`enabled:false` means the PY32 write never succeeded — `ping_servo`
+times out at boot and commanded poses produce no motion. A boot-time
+failure is also recorded to the event ring (`GET /events`, `warn`
+kind), but that ring is volatile and drains on reset, so the status
+here is the durable-until-reset read-out. Scope is servo-power only,
+not a full PMU / SD / sensor rollup.
 
 ## Manual control
 


### PR DESCRIPTION
## Summary
- `board.rs::enable_servo_power` now retries the PY32 `configure_output_pin` write up to `SERVO_POWER_MAX_ATTEMPTS` (3), with a `SERVO_POWER_SETTLE_MS` (200 ms) delay between failed attempts. Idempotent RMW, so retry is safe.
- On exhaustion the path stays non-fatal: logs a `warn`, records a `Kind::Warn` event-ring entry ("servo power enable failed — head unpowered"), and reports `enabled:false` — never blocks boot, no panic.
- New `servo_power` module mirrors the boot outcome into a `Mutex<CriticalSectionRawMutex, Cell<ServoPowerStatus>>` static (faithful to the `watchdog::TASKS_SNAPSHOT` read-side pattern); `read_status()` pub, `record()` pub(crate).
- New `GET /hardware/status` route returns `{"servo_power":{"enabled":bool,"attempts":u8,"settled":bool}}` — durable-until-reset read-out for field-debugging a head that won't move. Scoped to servo-power only (envelope leaves room to grow), documented in `docs/http.md`.
- Web dashboard intentionally not touched this PR (deferred per blueprint).

## Test plan
- `just check` (host: fmt + workspace clippy + host tests) — green.
- `source ~/export-esp.sh && just clippy-firmware` (strict clippy, `-D warnings`) — green (~6m31s).
- No `unwrap`/`expect` added; no `unsafe`.
- On-device verification still needed: confirm `GET /hardware/status` returns `enabled:true,attempts:1,settled:true` on a healthy boot, and that a forced PY32 write failure surfaces `enabled:false` plus a `warn` entry in `GET /events`.

Greptile: please review.
