### PR TITLE
fix(firmware): route SPI2 MISO to GPIO35 so the SD card mounts

### DIFF
--- a/crates/stackchan-firmware/src/main.rs
+++ b/crates/stackchan-firmware/src/main.rs
@@ -55,7 +55,7 @@ use embedded_hal_bus::spi::RefCellDevice;
 use esp_hal::{
     Blocking,
     clock::CpuClock,
-    gpio::{Level, Output, OutputConfig},
+    gpio::{Flex, InputSignal, Level, Output, OutputConfig},
     rng::Rng,
     spi::{
         Mode as SpiMode,
@@ -156,7 +156,7 @@ type LcdDisplay = mipidsi::Display<
     SpiInterface<
         'static,
         RefCellDevice<'static, Spi<'static, Blocking>, Output<'static>, Delay>,
-        Output<'static>,
+        Flex<'static>,
     >,
     ILI9342CRgb565,
     NoResetPin,
@@ -1142,7 +1142,19 @@ async fn main(spawner: Spawner) -> ! {
         Err(e) => defmt::panic!("SPI2 config rejected: {}", defmt::Debug2Format(&e)),
     };
     let cs = Output::new(peripherals.GPIO3, Level::High, OutputConfig::default());
-    let dc = Output::new(peripherals.GPIO35, Level::Low, OutputConfig::default());
+    // GPIO35 is dual-purpose on CoreS3: LCD DC (output) AND SD-card MISO
+    // (input) share this one physical pin. A `Flex` drives DC for the LCD
+    // while keeping its input buffer live so the SPI2 peripheral can sample
+    // the SD card; `sd_spi` toggles the output-enable per SD transaction so
+    // the card can drive the line. The FSPIQ→GPIO35 matrix route below is the
+    // other half: without it SPI2 reads an unconnected input (0x00) and SD
+    // card init spins forever in embedded-sdmmc's CMD0 loop.
+    let mut dc = Flex::new(peripherals.GPIO35);
+    dc.apply_output_config(&OutputConfig::default());
+    dc.set_output_enable(true);
+    dc.set_input_enable(true);
+    dc.set_low();
+    InputSignal::FSPIQ.connect_to(&dc);
 
     // SPI2 is shared territory on CoreS3: LCD + SD card both sit on
     // SCK=GPIO36 + MOSI=GPIO37, and SD MISO is wired to GPIO35 — the

--- a/crates/stackchan-firmware/src/sd_spi.rs
+++ b/crates/stackchan-firmware/src/sd_spi.rs
@@ -12,12 +12,18 @@
 //! - **CS LOW (LCD)** → OE on  → GPIO35 drives DC value (output)
 //! - **CS LOW (SD)**  → OE off → GPIO35 floats; SPI MISO reads it (input)
 //!
-//! The fancier alternative — splitting the pin via `peripheral_input`
-//! / `OutputSignal::connect_to` — relies on `#[doc(hidden)]` esp-hal
-//! 1.0 surfaces (tracked in esp-rs/esp-hal#2876, currently blocked).
-//! A direct register write to `GPIO_ENABLE1_W1TS_REG` /
-//! `GPIO_ENABLE1_W1TC_REG` is what M5GFX actually does and is the
-//! pattern this module follows.
+//! This is only half the story. For the SPI2 peripheral to *read*
+//! GPIO35, its `FSPIQ` (MISO) input signal must be routed to the pin in
+//! the GPIO matrix and the pin's input buffer kept live — done once at
+//! LCD bring-up in `main.rs` via `InputSignal::FSPIQ.connect_to(&dc)` on
+//! a `Flex` GPIO35. Without that route the OE flip below floats the pin
+//! but the peripheral reads an unconnected input (`0x00`), and SD card
+//! init spins forever in `embedded-sdmmc`'s CMD0 loop. The OE flip
+//! (this module) and the FSPIQ route (`main.rs`) are both required.
+//!
+//! The OE flip itself is a direct register write to
+//! `GPIO_ENABLE1_W1TS_REG` / `GPIO_ENABLE1_W1TC_REG` — what M5GFX does
+//! and the pattern this module follows.
 
 // Direct register access for the GPIO35 OE flip. The unsafe surface is
 // two `core::ptr::write_volatile` calls in `set_dc_drive_*` below, both


### PR DESCRIPTION
## Summary

- #552 added the per-transaction output-enable flip on GPIO35 (the pin CoreS3 shares between LCD DC and SD MISO) but never connected SPI2's `FSPIQ` (MISO) **input** signal to the pin in the GPIO matrix. The peripheral therefore read an unconnected input (`0x00`), `embedded-sdmmc` spun in its `CMD0` retry loop, and the card init failed with `CardInit` — the SD never mounted.
- Make GPIO35 a `Flex` with its input buffer kept live, and route `FSPIQ` to it via the supported `InputSignal::FSPIQ.connect_to(&dc)`. `sd_spi`'s OE flip still hands the line to the card during reads. Both halves (OE flip + MISO route) are now present; updated the `sd_spi` module doc and the `LcdDisplay` type alias accordingly.

## Test plan

- `just check-firmware` — clean (exit 0).
- `just clippy-firmware` (`-D warnings`) — clean (exit 0).
- **On-device (M5Stack CoreS3, brand-new SD card inserted):** flashed `--release` and watched the defmt boot log:
  - `Got response: 0` retries: **51 → 1** (one normal init retry, then success).
  - `SD: mount failed (CardInit)` — **gone**.
  - Now: `SD: read /sd/STACKCHAN.RON failed (FileNotFound); using defaults` (card mounts; config file simply absent on the blank card), `runtime store: ... seeding from boot config`, `ble: bonds: 0 persisted bond(s) registered` (was "no SD mounted; bonds disabled").
  - `ILI9342C ready` + `render task: 33 ms tick` + `boot complete` — LCD still renders fine through the `Flex` DC pin; no panic.

Greptile: please review.