### PR TITLE
fix(core): allow suboptimal_flops on mouth-audio smoothing lerp

### DIFF
--- a/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
+++ b/crates/stackchan-core/src/modifiers/mouth_from_audio.rs
@@ -198,7 +198,12 @@ impl Modifier for MouthFromAudio {
         )]
         let dt_ms_f32 = dt_ms as f32;
         let alpha = one_minus_exp_approx(dt_ms_f32 / tau_ms);
-        self.current += (target - self.current) * alpha;
+        #[allow(
+            clippy::suboptimal_flops,
+            reason = "no_std Xtensa lacks f32::mul_add; libm::fmaf is heavier than the savings"
+        )]
+        let next = self.current + (target - self.current) * alpha;
+        self.current = next;
         entity.face.mouth.mouth_open = clamp_unit(self.current);
     }
 }


### PR DESCRIPTION
## Summary

Rust 1.96.0's clippy promoted `clippy::suboptimal_flops` to fire on the single-pole IIR smoothing step in `mouth_from_audio.rs`, which broke the **Host (core + sim + drivers)** CI gate on `main`. Because that gate is red on `main`, every open PR inherits the failure — all four open dependabot PRs (#586, #585, #584, #551) are blocked solely by this.

Clippy suggests `f32::mul_add`, but that lowers to `libm::fmaf` on the no_std Xtensa target — exactly the dependency this module is engineered to avoid (it sits beside the libm-free `one_minus_exp_approx` approximation). This matches the standing decision already documented in `head_from_attention` and `lost_target_search`, so the fix `#[allow]`s the lint with the same rationale rather than taking clippy's suggestion.

## Test plan
- `just check` — fmt + workspace clippy (`-D warnings`) + host tests all green locally
- `cargo clippy -p stackchan-core --all-targets --all-features -- -D warnings` passes