### PR TITLE
fix(firmware): revert trouble-host 0.7 bump (bt-hci version split breaks BLE)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # trouble-host >=0.7 moves to bt-hci 0.9, but esp-radio ~0.17 still
+      # ships a BleConnector built against bt-hci 0.6. The two Transport
+      # impls don't unify, so the firmware BLE bridge fails to compile until
+      # esp-radio (and esp-hal ~1.1) catch up. Pin to the 0.5.x line.
+      - dependency-name: "trouble-host"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,21 +613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bt-hci"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3c66fd0a41a3b3a5906847b1bf5516048ce083e24fa9341a0fa31d3b4cd73d"
-dependencies = [
- "btuuid",
- "defmt 1.1.0",
- "embassy-sync 0.8.0",
- "embedded-io 0.7.1",
- "embedded-io-async 0.7.0",
- "futures-intrusive",
- "heapless 0.9.2",
-]
-
-[[package]]
 name = "btuuid"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,7 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
 dependencies = [
  "allocator-api2 0.3.1",
- "bt-hci 0.6.0",
+ "bt-hci",
  "cfg-if",
  "defmt 1.1.0",
  "document-features",
@@ -5240,18 +5225,18 @@ dependencies = [
 
 [[package]]
 name = "trouble-host"
-version = "0.7.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9fe2be24000037431b036ba244cdb1d26f40e1719548553fb43c3fc62d496b"
+checksum = "2881b4859001fe1f48445145cda5149deac9110b1d707ec0a251b7ff6d8bdfa4"
 dependencies = [
  "aes",
- "bt-hci 0.9.0",
+ "bt-hci",
  "cmac",
  "defmt 1.1.0",
  "embassy-futures",
- "embassy-sync 0.8.0",
+ "embassy-sync 0.7.2",
  "embassy-time",
- "embedded-io 0.7.1",
+ "embedded-io 0.6.1",
  "futures",
  "heapless 0.9.2",
  "p256",
@@ -5265,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "trouble-host-macros"
-version = "0.5.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2562dc74f79ad12f7bf088da55c936d5eb1d022f2caac9849175326307a5eec1"
+checksum = "bcb85bec3a8393c22ca1a7c25c82c2d33689ab412f3487c492fd01a033ede7c2"
 dependencies = [
  "convert_case",
  "darling 0.20.11",

--- a/crates/stackchan-firmware/Cargo.toml
+++ b/crates/stackchan-firmware/Cargo.toml
@@ -122,7 +122,7 @@ esp-radio = { version = "~0.17", features = ["defmt", "esp32s3", "wifi", "ble", 
 # in `p256` + `aes` + `cmac` + `rand_chacha` (~50 KB code on this
 # target). Required for the BLE provisioning service to gate writes
 # behind a paired peer.
-trouble-host = { version = "0.7.0", default-features = false, features = ["defmt", "peripheral", "gatt", "derive", "default-packet-pool", "security"] }
+trouble-host = { version = "0.5.1", default-features = false, features = ["defmt", "peripheral", "gatt", "derive", "default-packet-pool", "security"] }
 # embassy-net's TCP / UDP / DHCPv4 stack on top of smoltcp. 0.9.x
 # pairs with esp-radio 0.18 (both ride the embassy-sync 0.7 line).
 embassy-net = { version = "0.9", features = ["defmt", "proto-ipv4", "tcp", "udp", "dhcpv4", "dns", "multicast", "medium-ethernet"] }


### PR DESCRIPTION
## Summary

Dependabot #593 bumped `trouble-host` 0.5.1 → 0.7.0 and was merged to `main`, breaking the **Firmware cross-check** CI job (and all firmware builds).

Root cause is a transitive-dependency version split, not adaptable firmware code:

- `esp-radio ~0.17` ships a `BleConnector` implementing `bt_hci::transport::Transport` from **bt-hci 0.6.0**
- `trouble-host 0.7.0` moved to **bt-hci 0.9.0**

Cargo links both `bt-hci` versions at once, so the two `Transport` / `FromHciBytesError` types never unify — producing the tell-tale `expected bt_hci::FromHciBytesError, found bt_hci::FromHciBytesError`. trouble-host 0.7 also broke its own API (`GAP_SERVICE_ATTRIBUTE_COUNT` removed, `Host` renamed, `HostResources` gained a 4th generic). None of this is fixable in firmware until `esp-radio` (and `esp-hal ~1.1`) adopt bt-hci 0.9 — the toolchain bump the Cargo.toml comments deliberately avoid.

## Changes

- Revert the trouble-host bump (`Cargo.toml` + `Cargo.lock` back to 0.5.1; lockfile collapses back to a single `bt-hci 0.6.0`).
- Add a Dependabot `ignore` for `trouble-host` minor/major updates so the broken bump stops being re-proposed weekly until the esp ecosystem aligns.

## Test plan

- [x] `just check-firmware` (cargo +esp check) — clean compile, exit 0
- [ ] CI green (host + firmware cross-check)