### PR TITLE
fix: clear clippy 1.97 lints blocking host CI

### DIFF
--- a/crates/stackchan-core/src/modifiers/head_from_body_gesture.rs
+++ b/crates/stackchan-core/src/modifiers/head_from_body_gesture.rs
@@ -372,7 +372,7 @@ mod tests {
         // Sweep a few timestamps; pan magnitude is always 1.
         for ms in [0u64, 1, 2, 3, 100, 12_345, 999_999] {
             let (pan, _) = random_signs(Instant::from_millis(ms));
-            assert!(pan.abs() == 1.0);
+            assert_eq!(pan.abs(), 1.0);
         }
     }
 

--- a/crates/stackchan-net/src/esp_now.rs
+++ b/crates/stackchan-net/src/esp_now.rs
@@ -457,7 +457,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_too_short() {
-        let buf = [b'S', b'T', b'K'];
+        let buf = *b"STK";
         assert_eq!(decode(&buf), Err(DecodeError::TooShort));
     }
 


### PR DESCRIPTION
## Summary
- CI installs unpinned stable Rust; the 1.97 release added `clippy::byte_char_slices` and `clippy::manual_assert_eq` to the default warn set, which `-D warnings` promotes to errors — the Host job now fails on every PR regardless of its diff (see dependabot #601/#602, failing in files their diffs don't touch).
- `crates/stackchan-net/src/esp_now.rs`: `[b'S', b'T', b'K']` → `*b"STK"` (test fixture).
- `crates/stackchan-core/src/modifiers/head_from_body_gesture.rs`: `assert!(pan.abs() == 1.0)` → `assert_eq!(pan.abs(), 1.0)` (test assertion).
- `crash_latch.rs`'s `assert!(a == b)` is untouched: it's a compile-time `const _: ()` assertion where `assert_eq!` isn't usable, and clippy 1.97 correctly doesn't flag it.

## Test plan
- [x] `rustup run stable cargo clippy --workspace --exclude stackchan-firmware --exclude esp-tflite-micro-sys --all-features --all-targets -- -D warnings` clean on 1.97 locally (same invocation as CI)
- [x] `just check` green (fmt + clippy + host tests + doctests)
- Test-only changes; no firmware or runtime surface touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Host CI breakage on Rust 1.97 by addressing new Clippy lints in tests, restoring a clean run with `-D warnings`. No runtime changes.

- **Bug Fixes**
  - `crates/stackchan-net/src/esp_now.rs` tests: replace `[b'S', b'T', b'K']` with `*b"STK"` to satisfy `clippy::byte_char_slices`.
  - `crates/stackchan-core/src/modifiers/head_from_body_gesture.rs` tests: change `assert!(pan.abs() == 1.0)` to `assert_eq!(pan.abs(), 1.0)` for `clippy::manual_assert_eq`.

<sup>Written for commit 05184b470d35ad29114ab1ed00c7187d8a0111a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/stackchan-kai/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

