### PR TITLE
fix(net): stop PUT /settings wiping omitted optional config blocks

### DIFF
--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -818,11 +818,14 @@ fn requires_reboot(prev: &stackchan_net::Config, new: &stackchan_net::Config) ->
     false
 }
 
-/// `PUT /settings` — full replace, atomic SD writeback. Returns
-/// `{"reboot_required": <bool>}` where `<bool>` reflects whether any
-/// changed field can only take effect on the next boot (mDNS
-/// hostname, SNTP, tracker tuning) — Wi-Fi creds and audio still
-/// apply immediately via the existing signal paths.
+/// `PUT /settings` — block-level merge, atomic SD writeback. Blocks
+/// present in the body replace wholesale; optional blocks omitted
+/// from the body keep their currently-persisted values (a trimmed
+/// curl body must not wipe tracker calibration or ESP-NOW keys).
+/// Returns `{"reboot_required": <bool>}` where `<bool>` reflects
+/// whether any changed field can only take effect on the next boot
+/// (mDNS hostname, SNTP, tracker tuning) — Wi-Fi creds and audio
+/// still apply immediately via the existing signal paths.
 ///
 /// On a change to `wifi.ssid` or `wifi.psk` (compared against the
 /// current `CONFIG_SNAPSHOT`), signals [`WIFI_RECONFIG`] so the
@@ -830,31 +833,31 @@ fn requires_reboot(prev: &stackchan_net::Config, new: &stackchan_net::Config) ->
 /// Operators changing the AP from the dashboard now see a brief
 /// link blip rather than needing to power-cycle the device.
 async fn handle_put_settings(socket: &mut TcpSocket<'_>, body: &str) -> Result<(), HttpError> {
-    let parsed_config = match stackchan_net::parse_settings_json(body) {
-        Ok(c) => c,
-        Err(e) => {
-            defmt::warn!(
-                "http: PUT /settings parse failed ({})",
-                defmt::Debug2Format(&e)
-            );
-            let body = format!("invalid request body: {e:?}\n");
-            return write_text(socket, 400, &body).await;
-        }
-    };
-    // Substitute the `***` redaction sentinel for the persisted PSK
-    // and token so a dashboard form that submits unchanged secrets
-    // doesn't clobber them. With no current snapshot (the brief
-    // pre-storage-mount window), preserving against the default
-    // empty values is a no-op — the parsed body wins.
-    //
     // Track whether the snapshot was actually populated so the
     // reboot-required diff doesn't compare against a synthesized
     // default (which would falsely flag every first-boot PUT as
     // requiring reboot just because the new value differs from the
-    // struct default).
+    // struct default). With no current snapshot (the brief
+    // pre-storage-mount window), both the omitted-block fill and the
+    // sentinel merge run against defaults — the parsed body wins.
     let prior_snapshot = crate::storage::CONFIG_SNAPSHOT.lock().await.clone();
     let had_prior_snapshot = prior_snapshot.is_some();
     let snapshot_for_merge = prior_snapshot.unwrap_or_default();
+    let parsed_config =
+        match stackchan_net::parse_settings_json_with_current(body, &snapshot_for_merge) {
+            Ok(c) => c,
+            Err(e) => {
+                defmt::warn!(
+                    "http: PUT /settings parse failed ({})",
+                    defmt::Debug2Format(&e)
+                );
+                let body = format!("invalid request body: {e:?}\n");
+                return write_text(socket, 400, &body).await;
+            }
+        };
+    // Substitute the `***` redaction sentinel for the persisted PSK
+    // and token so a dashboard form that submits unchanged secrets
+    // doesn't clobber them.
     let new_config = stackchan_net::merge_settings_with_current(parsed_config, &snapshot_for_merge);
     let write_result =
         crate::storage::with_storage(|storage| storage.write_config(&new_config)).await;

--- a/crates/stackchan-firmware/src/net/http.rs
+++ b/crates/stackchan-firmware/src/net/http.rs
@@ -103,7 +103,9 @@
 //! - `GET /settings/backup` — same payload UNREDACTED. The single
 //!   auth-gated GET (every other GET stays open) — returning real
 //!   secrets is what makes the backup usable for restore via PUT.
-//! - `PUT /settings` — full-replace [`stackchan_net::Config`] body.
+//! - `PUT /settings` — [`stackchan_net::Config`] body; omitted
+//!   optional blocks keep their persisted values, present blocks
+//!   replace wholesale.
 //!   Validates, writes back atomically to `/sd/STACKCHAN.RON`, and
 //!   responds `{"reboot_required": <bool>}`. Wi-Fi creds reconnect
 //!   immediately via [`super::wifi::WIFI_RECONFIG`] and audio

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -69,8 +69,31 @@ pub const ESP_NOW_KEY_REDACTED: &str = "***";
 /// the shared [`validate`] gate so out-of-range values surface the
 /// same `Invalid*` variants as [`crate::parse_ron`].
 pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
+    parse_settings_json_with_current(input, &Config::default())
+}
+
+/// Like [`parse_settings_json`], but optional blocks absent from the
+/// body keep their values from `current` instead of resetting to
+/// struct defaults.
+///
+/// This is the `PUT /settings` entry point: a hand-trimmed body that
+/// omits `tracker` or `esp_now` must not silently erase dialled-in
+/// calibration or pairing keys on a 200 response. Blocks present in
+/// the body still replace wholesale; [`merge_settings_with_current`]
+/// remains the separate, field-level sentinel pass for redacted
+/// secrets.
+///
+/// # Errors
+///
+/// Same surface as [`parse_settings_json`]; [`validate`] runs on the
+/// merged result so a body that only validates together with the
+/// preserved blocks still gets the full gate.
+pub fn parse_settings_json_with_current(
+    input: &str,
+    current: &Config,
+) -> Result<Config, ConfigError> {
     let mut p = Parser::new(input);
-    let config = p.parse_config()?;
+    let config = p.parse_config(current)?;
     p.skip_ws();
     if !p.input.is_empty() {
         return Err(bare_err("trailing data after object", ""));
@@ -379,7 +402,7 @@ impl<'a> Parser<'a> {
                   Splitting per field would scatter the duplicate/missing-field bookkeeping \
                   for no readability gain."
     )]
-    fn parse_config(&mut self) -> Result<Config, ConfigError> {
+    fn parse_config(&mut self, current: &Config) -> Result<Config, ConfigError> {
         self.skip_ws();
         self.expect_char('{')?;
         let mut wifi: Option<WifiConfig> = None;
@@ -473,17 +496,19 @@ impl<'a> Parser<'a> {
             wifi: wifi.ok_or_else(|| bare_err("missing field 'wifi'", ""))?,
             mdns: mdns.ok_or_else(|| bare_err("missing field 'mdns'", ""))?,
             time: time.ok_or_else(|| bare_err("missing field 'time'", ""))?,
-            // `auth`, `audio`, `tracker` are optional for migration:
-            // bodies emitted before each block landed don't have them,
-            // and the defaults match the firmware's prior hard-coded
-            // behaviour.
-            auth: auth.unwrap_or_default(),
-            audio: audio.unwrap_or_default(),
-            tracker: tracker.unwrap_or_default(),
-            esp_now: esp_now.unwrap_or_default(),
-            behavior: behavior.unwrap_or_default(),
-            head: head.unwrap_or_default(),
-            appearance: appearance.unwrap_or_default(),
+            // The remaining blocks are optional for migration (bodies
+            // emitted before each block landed don't have them) and
+            // fall back to `current`: struct defaults via
+            // `parse_settings_json`, the live snapshot via
+            // `parse_settings_json_with_current` so an omitted block
+            // never wipes persisted state.
+            auth: auth.unwrap_or_else(|| current.auth.clone()),
+            audio: audio.unwrap_or(current.audio),
+            tracker: tracker.unwrap_or(current.tracker),
+            esp_now: esp_now.unwrap_or_else(|| current.esp_now.clone()),
+            behavior: behavior.unwrap_or_else(|| current.behavior.clone()),
+            head: head.unwrap_or(current.head),
+            appearance: appearance.unwrap_or_else(|| current.appearance.clone()),
         })
     }
 
@@ -1530,6 +1555,50 @@ mod tests {
         let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
         let parsed = parse_settings_json(input).unwrap();
         assert_eq!(parsed.auth.token, "");
+    }
+
+    #[test]
+    fn omitted_blocks_keep_current_values() {
+        // A trimmed PUT body carrying only the required blocks must
+        // not reset dialled-in state: tracker calibration, ESP-NOW
+        // keys, head trim, behavior, appearance, audio, and the auth
+        // token all survive from `current`.
+        let current = full_config();
+        let input = r#"{"wifi":{"ssid":"newnet","psk":"newkey","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let parsed = parse_settings_json_with_current(input, &current).unwrap();
+        assert_eq!(parsed.wifi.ssid, "newnet");
+        assert_eq!(parsed.auth, current.auth);
+        assert_eq!(parsed.audio, current.audio);
+        assert_eq!(parsed.tracker, current.tracker);
+        assert_eq!(parsed.esp_now, current.esp_now);
+        assert_eq!(parsed.behavior, current.behavior);
+        assert_eq!(parsed.head, current.head);
+        assert_eq!(parsed.appearance, current.appearance);
+    }
+
+    #[test]
+    fn present_block_replaces_current_wholesale() {
+        // A block that IS in the body replaces the current one field
+        // for field — omission is the only preserve mechanism at this
+        // layer (secret sentinels merge downstream).
+        let current = full_config();
+        let input = r#"{"wifi":{"ssid":"a","psk":"b","country":"US"},"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]},"head":{"pan_trim_deg":2.0,"tilt_trim_deg":0.0}}"#;
+        let parsed = parse_settings_json_with_current(input, &current).unwrap();
+        assert!((parsed.head.pan_trim_deg - 2.0).abs() < f32::EPSILON);
+        assert!((parsed.head.tilt_trim_deg - 0.0).abs() < f32::EPSILON);
+        assert_eq!(parsed.tracker, current.tracker);
+    }
+
+    #[test]
+    fn required_blocks_never_fall_back_to_current() {
+        // Only the optional blocks fill from `current` — omitting
+        // `wifi` is still a hard parse error even with a
+        // fully-populated fallback config.
+        let current = full_config();
+        let input =
+            r#"{"mdns":{"hostname":"x"},"time":{"tz":"UTC","sntp_servers":["pool.ntp.org"]}}"#;
+        let err = parse_settings_json_with_current(input, &current).unwrap_err();
+        assert!(matches!(err, ConfigError::BareParse(_)));
     }
 
     #[test]

--- a/crates/stackchan-net/src/bare_json.rs
+++ b/crates/stackchan-net/src/bare_json.rs
@@ -64,10 +64,12 @@ pub const ESP_NOW_KEY_REDACTED: &str = "***";
 /// # Errors
 ///
 /// Returns [`ConfigError::BareParse`] on any structural mismatch
-/// (missing field, unknown key, bad string escape, runaway literal,
-/// or `wifi.psk` set to the [`PSK_REDACTED`] sentinel), then runs
-/// the shared [`validate`] gate so out-of-range values surface the
-/// same `Invalid*` variants as [`crate::parse_ron`].
+/// (missing field, unknown key, bad string escape, runaway
+/// literal), then runs the shared [`validate`] gate so out-of-range
+/// values surface the same `Invalid*` variants as
+/// [`crate::parse_ron`]. A [`PSK_REDACTED`] sentinel is *not* an
+/// error — it parses through for [`merge_settings_with_current`] to
+/// substitute downstream.
 pub fn parse_settings_json(input: &str) -> Result<Config, ConfigError> {
     parse_settings_json_with_current(input, &Config::default())
 }

--- a/crates/stackchan-net/src/lib.rs
+++ b/crates/stackchan-net/src/lib.rs
@@ -64,7 +64,10 @@ pub mod mdns_pose;
 pub mod ota;
 
 pub use bare::{parse_ron_bare, render_ron_bare};
-pub use bare_json::{merge_settings_with_current, parse_settings_json, render_settings_json};
+pub use bare_json::{
+    merge_settings_with_current, parse_settings_json, parse_settings_json_with_current,
+    render_settings_json,
+};
 pub use config::{
     AppearanceConfig, AuthConfig, BehaviorConfig, Config, EspNowConfig, HeadTrim, MdnsConfig,
     TimeConfig, WifiConfig, parse_mac, tz_offset_minutes, validate,

--- a/docs/http.md
+++ b/docs/http.md
@@ -404,16 +404,18 @@ the rest of the body back from `GET /settings` unchanged — the
 `***` sentinels for `wifi.psk` and `auth.token` will be merged
 against the persisted values rather than clobbering them.
 
-Unlike the redacted secrets, the `appearance` and `head` blocks have
-no preserve-on-echo sentinel: an omitted block parses to its default
-(empty appearance / compile-time head trim) and overwrites the
-persisted value. Callers **must** round-trip both blocks from
-`GET /settings` or they reset the operator's pinned boot appearance
-and per-unit head trim. The dashboard handles this for you — the
-System page's Boot appearance panel edits `appearance`, and the
-Settings form carries `appearance` + `head` through every save.
+Block-level merge: the required `wifi` / `mdns` / `time` blocks must
+always be present, but any optional block (`auth`, `audio`,
+`tracker`, `esp_now`, `behavior`, `head`, `appearance`) omitted from
+the body keeps its currently-persisted value — a trimmed curl body
+that only carries the required blocks can't wipe tracker
+calibration, ESP-NOW keys, or per-unit head trim. A block that *is*
+present replaces the persisted one wholesale, so partial edits
+within a block still need the other fields of that block echoed back
+from `GET /settings`. The dashboard does this for every block it
+binds fields from.
 
-Full-replace. The server validates the body via
+The server validates the merged config via
 `stackchan_net::validate` (rejects empty SSID, invalid country code,
 invalid hostname, empty SNTP list) and then writes back atomically:
 the new config goes to `/sd/STACKCHAN.NEW`, gets copied onto

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -64,9 +64,10 @@ export function Settings() {
       // edited elsewhere (Calibration, the Appearance panel, POST /palette,
       // POST /face-geometry, hand-edited STACKCHAN.RON, operator-set
       // wake_word/chime flags, ESP-NOW peer config) survive a save through
-      // this form. The PUT parser defaults any omitted block to its zero
-      // value, so a block left out here is silently wiped — only the keys
-      // this form binds may be overwritten, everything else round-trips.
+      // this form. The PUT handler preserves fully-omitted blocks, but a
+      // block this form sends is replaced wholesale — so any block with
+      // even one bound key must be merged against `fresh` here to keep
+      // its unbound keys round-tripping.
       const body: SettingsType = {
         wifi: { ssid: ssid(), psk: psk(), country: country().toUpperCase() },
         mdns: { hostname: hostname() },


### PR DESCRIPTION
## Summary
- `parse_settings_json` finalized every optional block (`auth`, `audio`, `tracker`, `esp_now`, `behavior`, `head`, `appearance`) with `unwrap_or_default()` when absent from the body, so a hand-trimmed `PUT /settings` silently erased tracker calibration, ESP-NOW pairing keys, sidecar config, and per-unit head trim — returning 200 with no warning. The dashboard even documented the hazard in a comment and worked around it with merge-against-fresh discipline.
- New `parse_settings_json_with_current(input, &current)`: optional blocks absent from the body keep their values from `current`; present blocks still replace wholesale; required blocks (`wifi`/`mdns`/`time`) still hard-error when absent. `validate` runs on the merged result. `parse_settings_json` delegates with `Config::default()`, so legacy/migration semantics (and all ~40 existing tests) are unchanged.
- `handle_put_settings` now takes the `CONFIG_SNAPSHOT` clone *before* parsing and feeds it as the fallback; the `***` secret-sentinel merge is unchanged and stays downstream.
- Docs updated: `docs/http.md` PUT section rewritten for block-merge semantics (the old text *required* callers to round-trip `head`/`appearance` or lose them); `Settings.tsx` comment updated — the form's merge-against-fresh is still needed for partial-block edits, just no longer for whole-block survival.

## Test plan
- [x] New host tests: omitted blocks keep current values (all seven), present block replaces wholesale, required blocks never fall back
- [x] `just check` green (fmt + clippy 1.97 + 66 host test suites)
- [x] `just check-firmware` + `just clippy-firmware` green (esp toolchain)
- [ ] On-device curl smoke (trimmed PUT body → GET confirms tracker/esp_now survive) — not yet run; host-side semantics fully covered by unit tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PUT /settings so omitted optional blocks keep existing values instead of resetting. Prevents accidental loss of tracker calibration, ESP‑NOW keys, head trim, and other preserved settings.

- **Bug Fixes**
  - Added `parse_settings_json_with_current(input, &current)` in `stackchan-net`: omitted optional blocks fall back to `current`; present blocks replace; required `wifi`/`mdns`/`time` still error if missing.
  - Updated firmware `handle_put_settings` to snapshot config before parsing and pass it as the fallback.
  - Kept legacy behavior via `parse_settings_json` delegating to defaults; parser now accepts `***` without error and merges secrets downstream.
  - Docs: clarified block-merge semantics and that redacted `***` isn’t a parse error; updated `Settings.tsx` guidance for within-block merges.
  - Added tests for omitted-block preserve, present-block replace, and required-block errors.

<sup>Written for commit 167bfa5ddba7172f53e7502091564dda88cc6d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/stackchan-kai/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

