### PR TITLE
feat(web): surface motion, sleep/wake, palette, and behavior-flag controls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,9 @@ import { Emotion } from "./components/Emotion";
 import { Listen } from "./components/Listen";
 import { Mood } from "./components/Mood";
 import { FaceGeometry } from "./components/FaceGeometry";
+import { Palette } from "./components/Palette";
+import { BehaviorFlags } from "./components/BehaviorFlags";
+import { Gestures } from "./components/Gestures";
 import { LookAt } from "./components/LookAt";
 import { Audio } from "./components/Audio";
 import { Camera } from "./components/Camera";
@@ -189,10 +192,13 @@ export function App() {
                 <Emotion />
                 <Mood />
                 <FaceGeometry />
+                <Palette />
+                <BehaviorFlags />
               </Match>
               <Match when={section() === "motion"}>
                 <PageHead title="Motion" />
                 <LookAt />
+                <Gestures />
                 <Calibration />
               </Match>
               <Match when={section() === "voice"}>

--- a/web/src/components/Appearance.tsx
+++ b/web/src/components/Appearance.tsx
@@ -99,8 +99,9 @@ export function Appearance() {
         <small>
           These are BOOT defaults: they seed the runtime store only on first
           boot (when <code>RUNTIME.RON</code> is absent). A later live change via
-          the Behavior page (POST /palette / POST /face-geometry) persists to
-          the runtime store and wins on subsequent boots. Leave a field as
+          the Behavior page's Palette and Face cards (POST /palette /
+          POST /face-geometry) persists to the runtime store and wins on
+          subsequent boots. Leave a field as
           <code>(not pinned)</code> to fall back to the firmware default.
         </small>
       </form>

--- a/web/src/components/BehaviorFlags.tsx
+++ b/web/src/components/BehaviorFlags.tsx
@@ -1,0 +1,116 @@
+import { For, Show, createSignal, onMount } from "solid-js";
+import { authedFetch } from "../auth";
+import { showToast } from "../store";
+import type { Settings as SettingsType } from "../types";
+
+// Field vocabulary mirrors `BehaviorFlagUpdate` in
+// `crates/stackchan-net/src/http_command.rs` — the four booleans
+// POST /behavior accepts. Reboot-only fields (wake_word_*) stay
+// behind PUT /settings on the System page.
+const FLAGS = [
+  { field: "soliloquy_enabled", label: "Soliloquy" },
+  { field: "hourly_chime_enabled", label: "Hourly chime" },
+  { field: "battery_icon_enabled", label: "Battery icon" },
+  { field: "toast_overlay_enabled", label: "Toast overlay" },
+] as const;
+
+type FlagField = (typeof FLAGS)[number]["field"];
+type FlagState = Record<FlagField, boolean>;
+
+export function BehaviorFlags() {
+  const [flags, setFlags] = createSignal<FlagState | null>(null);
+
+  const load = async () => {
+    try {
+      const res = await fetch("/settings");
+      if (!res.ok) {
+        if (res.status === 503) {
+          showToast("behavior flags unavailable (no SD card)", true);
+        } else {
+          showToast(`GET /settings: ${res.status}`, true);
+        }
+        return;
+      }
+      const c = (await res.json()) as SettingsType;
+      setFlags({
+        soliloquy_enabled: c.behavior.soliloquy_enabled,
+        hourly_chime_enabled: c.behavior.hourly_chime_enabled,
+        battery_icon_enabled: c.behavior.battery_icon_enabled,
+        toast_overlay_enabled: c.behavior.toast_overlay_enabled,
+      });
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  onMount(load);
+
+  const toggle = async (field: FlagField, value: boolean): Promise<boolean> => {
+    try {
+      const res = await authedFetch("/behavior", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ field, value }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`${res.status}: ${text || res.statusText}`);
+      }
+      setFlags((curr) => (curr ? { ...curr, [field]: value } : curr));
+      const reply = (await res.json().catch(() => ({}))) as { reboot_required?: boolean };
+      showToast(
+        reply.reboot_required
+          ? `${field} → ${value ? "on" : "off"} — reboot to apply`
+          : `${field} → ${value ? "on" : "off"}`,
+      );
+      return true;
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+      return false;
+    }
+  };
+
+  return (
+    <section>
+      <h2>Flags</h2>
+      <Show
+        when={flags()}
+        fallback={
+          <small>
+            Flags unavailable — GET /settings failed (no SD card?).{" "}
+            <button type="button" onClick={() => void load()}>
+              Retry
+            </button>
+          </small>
+        }
+      >
+        {(f) => (
+          <div class="btn-row">
+            <For each={FLAGS}>
+              {({ field, label }) => (
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={f()[field]}
+                    onChange={(e) => {
+                      const el = e.currentTarget;
+                      void toggle(field, el.checked).then((ok) => {
+                        if (!ok) el.checked = f()[field];
+                      });
+                    }}
+                  />
+                  {label}
+                </label>
+              )}
+            </For>
+          </div>
+        )}
+      </Show>
+      <small>
+        Each toggle persists one boolean to <code>STACKCHAN.RON</code> via POST /behavior. The
+        consuming task captures its flag at boot, so changes take effect on the next reboot —
+        the firmware replies <code>reboot_required</code> to make that explicit.
+      </small>
+    </section>
+  );
+}

--- a/web/src/components/BehaviorFlags.tsx
+++ b/web/src/components/BehaviorFlags.tsx
@@ -19,11 +19,14 @@ type FlagState = Record<FlagField, boolean>;
 
 export function BehaviorFlags() {
   const [flags, setFlags] = createSignal<FlagState | null>(null);
+  const [loadFailed, setLoadFailed] = createSignal(false);
 
   const load = async () => {
+    setLoadFailed(false);
     try {
       const res = await fetch("/settings");
       if (!res.ok) {
+        setLoadFailed(true);
         if (res.status === 503) {
           showToast("behavior flags unavailable (no SD card)", true);
         } else {
@@ -39,6 +42,7 @@ export function BehaviorFlags() {
         toast_overlay_enabled: c.behavior.toast_overlay_enabled,
       });
     } catch (e) {
+      setLoadFailed(true);
       showToast(e instanceof Error ? e.message : String(e), true);
     }
   };
@@ -76,12 +80,14 @@ export function BehaviorFlags() {
       <Show
         when={flags()}
         fallback={
-          <small>
-            Flags unavailable — GET /settings failed (no SD card?).{" "}
-            <button type="button" onClick={() => void load()}>
-              Retry
-            </button>
-          </small>
+          <Show when={loadFailed()} fallback={<small>Loading…</small>}>
+            <small>
+              Flags unavailable — GET /settings failed (no SD card?).{" "}
+              <button type="button" onClick={() => void load()}>
+                Retry
+              </button>
+            </small>
+          </Show>
         }
       >
         {(f) => (

--- a/web/src/components/Gestures.tsx
+++ b/web/src/components/Gestures.tsx
@@ -1,0 +1,52 @@
+import { For } from "solid-js";
+import { postJson } from "../auth";
+import { showToast } from "../store";
+
+// Wire-string vocabulary mirrors `NamedMotion::wire_str` in
+// `crates/stackchan-core/src/motion.rs`.
+const MOTIONS = ["greet", "nod", "shake", "laugh"] as const;
+
+export function Gestures() {
+  const send = async (motion: string) => {
+    try {
+      await postJson("/motion", { motion });
+      showToast(`motion → ${motion}`);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  const power = async (path: "/sleep" | "/wake") => {
+    try {
+      await postJson(path, null);
+      showToast(path === "/sleep" ? "sleeping" : "awake");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Gestures</h2>
+      <div class="btn-row">
+        <For each={MOTIONS}>
+          {(name) => (
+            <button onClick={() => void send(name)} data-motion={name}>
+              {name.charAt(0).toUpperCase() + name.slice(1)}
+            </button>
+          )}
+        </For>
+      </div>
+      <h3>Sleep</h3>
+      <div class="btn-row">
+        <button onClick={() => void power("/sleep")}>Sleep</button>
+        <button onClick={() => void power("/wake")}>Wake</button>
+      </div>
+      <small>
+        Gestures play a baked one-shot head + emotion script through the dance player. Sleep
+        drops the eyes shut, head limp, LED ring dark, and audio TX paused; wake via the Wake
+        button, any touch, or the power-key short-press. Runtime-only — sleep resets on reboot.
+      </small>
+    </section>
+  );
+}

--- a/web/src/components/Palette.tsx
+++ b/web/src/components/Palette.tsx
@@ -1,0 +1,46 @@
+import { For, createSignal } from "solid-js";
+import { postJson } from "../auth";
+import { showToast } from "../store";
+
+// Wire-string vocabulary mirrors `Palette::wire_str` in
+// `crates/stackchan-core/src/palette.rs`.
+const PALETTES = ["default", "dark", "cute", "dog"] as const;
+
+export function Palette() {
+  // The avatar snapshot doesn't carry the active palette, so highlight
+  // the last selection sent from this tab only.
+  const [selected, setSelected] = createSignal<string | null>(null);
+
+  const send = async (palette: string) => {
+    try {
+      await postJson("/palette", { palette });
+      setSelected(palette);
+      showToast(`palette → ${palette}`);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e), true);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Palette</h2>
+      <div class="btn-row">
+        <For each={PALETTES}>
+          {(name) => (
+            <button
+              onClick={() => void send(name)}
+              style={selected() === name ? "border-color:var(--accent)" : ""}
+              data-palette={name}
+            >
+              {name.charAt(0).toUpperCase() + name.slice(1)}
+            </button>
+          )}
+        </For>
+      </div>
+      <small>
+        Swaps the avatar's skin / eye / mouth colours at runtime. Persists across reboots via the
+        runtime store and wins over the System page's boot appearance pin.
+      </small>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- **Gestures card** (Motion page): greet/nod/shake/laugh buttons via `POST /motion` (`{"motion": ...}`, vocabulary mirrors `NamedMotion::wire_str`), plus Sleep/Wake buttons (`POST /sleep` / `POST /wake`).
- **Palette card** (Behavior page): runtime palette swap via `POST /palette` (default/dark/cute/dog), matching the Mood/FaceGeometry button-row idiom. Highlights the last selection sent from this tab — the avatar snapshot doesn't carry the active palette.
- **Flags card** (Behavior page): the four `POST /behavior` booleans (soliloquy, hourly chime, battery icon, toast overlay) as checkboxes loaded from `GET /settings`; `reboot_required` replies surface as a "reboot to apply" toast, failed toggles revert. `wake_word_enabled` is deliberately absent — the handler rejects it (reboot-only, stays behind `PUT /settings`).
- `Appearance.tsx` comment updated: it pointed operators at a live-palette control that didn't exist; now it names the new Palette card.

These v0.2.0 features (named gestures, sleep mode, runtime palette, behavior flags) were previously curl/MCP-only.

## Test plan
- [x] `just web-build` (tsc + vite; bundle 91.3 kB / 27.7 kB gz)
- [x] `just check` green
- [ ] On-device browser smoke after next firmware flash embeds the new bundle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced gesture, sleep/wake, palette, and behavior-flag controls in the web dashboard so you can trigger actions and tweak behavior at runtime without curl/MCP. Adds a proper loading state and clearer errors for flags.

- **New Features**
  - Motion – Gestures card: greet/nod/shake/laugh via POST /motion; Sleep/Wake via POST /sleep and POST /wake.
  - Behavior – Palette card: swap palette (default/dark/cute/dog) via POST /palette; highlights last choice from this tab.
  - Behavior – Flags card: toggle soliloquy, hourly chime, battery icon, toast overlay; loads from GET /settings, persists via POST /behavior; shows “reboot to apply” on reboot_required; reverts on failure; `wake_word_enabled` excluded (reboot-only via PUT /settings).

- **Bug Fixes**
  - Flags card shows a Loading state instead of a false failure while GET /settings is in flight, and surfaces 503 “no SD card” errors.

<sup>Written for commit a7144d89f4912374557b0ab7cd17ca4838d64ab9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/stackchan-kai/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

