### PR TITLE
feat(firmware): surface agent-sidecar replies in event log, SSE snapshot, and dashboard

### DIFF
--- a/crates/stackchan-firmware/src/agent_sidecar.rs
+++ b/crates/stackchan-firmware/src/agent_sidecar.rs
@@ -24,7 +24,10 @@
 //!    of the network round-trip.
 //! 4. The sidecar's JSON reply
 //!    (`{"text":"...","emotion":"..."}`, OpenAI-Chat-Completions
-//!    -shaped projection) surfaces on the firmware toast band, and
+//!    -shaped projection) surfaces on the firmware toast band, in
+//!    the [`crate::event_log`] ring (`GET /events`), and as the
+//!    `last_reply` field of the avatar snapshot (`GET /state` +
+//!    SSE), and
 //!    any `emotion` tag fires a [`RemoteCommand::SetEmotion`] so
 //!    the avatar mirrors the agent's mood. The `SetEmotion` handler in
 //!    [`stackchan_core::modifiers::RemoteCommandModifier`] clears
@@ -362,7 +365,7 @@ pub async fn agent_sidecar_task(
         // and emit a misleading "sidecar unreachable" toast.
         if !matches!(link.get().await, WifiLinkState::Connected) {
             defmt::warn!("agent-sidecar: link not Connected after capture; skipping POST");
-            toast_warn("sidecar: link down");
+            surface_failure("sidecar: link down", "link down");
             signal_failure_emotion();
             continue;
         }
@@ -526,10 +529,13 @@ async fn capture_window(
 }
 
 /// Apply the [`post_pcm`] result: surface a toast in every branch,
-/// fire [`RemoteCommand::SetEmotion`] with the tagged emotion on a
-/// successful reply, and fall back to either [`ExitThinking`] (success
-/// with no emotion tag) or a brief Sad face (POST failed, timeout) so
-/// the avatar's visible state always matches what just happened.
+/// record the outcome into the event log + avatar snapshot (the
+/// toast overlay is opt-in and defaults off, so those are the
+/// always-on surfaces), fire [`RemoteCommand::SetEmotion`] with the
+/// tagged emotion on a successful reply, and fall back to either
+/// [`ExitThinking`] (success with no emotion tag) or a brief Sad
+/// face (POST failed, timeout) so the avatar's visible state always
+/// matches what just happened.
 ///
 /// [`ExitThinking`]: stackchan_core::input::RemoteCommand::ExitThinking
 fn apply_outcome(outcome: Result<Result<SidecarReply, PostError>, embassy_time::TimeoutError>) {
@@ -542,6 +548,13 @@ fn apply_outcome(outcome: Result<Result<SidecarReply, PostError>, embassy_time::
                 reply.audio_url.as_deref().unwrap_or("<none>"),
             );
             toast_info(reply.text.as_str());
+            // `record` truncates at the event log's message cap on a
+            // char boundary; the snapshot keeps a longer prefix.
+            crate::event_log::record(
+                crate::event_log::Kind::Control,
+                &alloc::format!("reply: {}", reply.text.as_str()),
+            );
+            crate::net::snapshot::update_last_reply(true, reply.text.as_str());
             if let Some(e) = reply.emotion {
                 enqueue_remote_command(RemoteCommand::SetEmotion {
                     emotion: e,
@@ -558,7 +571,7 @@ fn apply_outcome(outcome: Result<Result<SidecarReply, PostError>, embassy_time::
         }
         Ok(Err(e)) => {
             defmt::warn!("agent-sidecar: POST failed ({:?})", e);
-            toast_warn("sidecar: post failed");
+            surface_failure("sidecar: post failed", "post failed");
             signal_failure_emotion();
         }
         Err(_) => {
@@ -566,10 +579,23 @@ fn apply_outcome(outcome: Result<Result<SidecarReply, PostError>, embassy_time::
                 "agent-sidecar: POST timed out after {=u64}ms",
                 REQUEST_TIMEOUT_MS
             );
-            toast_warn("sidecar: timed out");
+            surface_failure("sidecar: timed out", "timed out");
             signal_failure_emotion();
         }
     }
+}
+
+/// Surface one sidecar failure on every operator channel: warn toast
+/// (opt-in overlay), event-log ring (`GET /events`), and the
+/// `last_reply` snapshot field (`GET /state` + SSE) with `ok: false`.
+///
+/// `toast_msg` carries the `sidecar:` prefix for the toast band and
+/// event log; `reason` is the bare failure tag the dashboard's
+/// Listen panel renders next to its own "failed" label.
+fn surface_failure(toast_msg: &str, reason: &str) {
+    toast_warn(toast_msg);
+    crate::event_log::record(crate::event_log::Kind::Warn, toast_msg);
+    crate::net::snapshot::update_last_reply(false, reason);
 }
 
 /// Brief face-level reaction to a sidecar failure path. Fires a

--- a/crates/stackchan-firmware/src/net/respond.rs
+++ b/crates/stackchan-firmware/src/net/respond.rs
@@ -107,6 +107,10 @@ pub(super) fn state_body(s: AvatarSnapshot) -> String {
     let decorator = s
         .decorator
         .map_or_else(|| String::from("null"), |d| format!("\"{}\"", d.wire_str()));
+    let last_reply = s.last_reply.map_or_else(
+        || String::from("null"),
+        |r| format!("{{\"ok\":{},\"text\":\"{}\"}}", r.ok, json_escape(r.text())),
+    );
     format!(
         "{{\
 \"emotion\":\"{emotion}\",\
@@ -118,7 +122,8 @@ pub(super) fn state_body(s: AvatarSnapshot) -> String {
 \"battery\":{{\"percent\":{pct},\"voltage_mv\":{mv}}},\
 \"wifi\":{{\"connected\":{connected},\"ip\":{ip}}},\
 \"audio\":{{\"volume_pct\":{volume_pct},\"muted\":{muted}}},\
-\"camera_mode\":{camera_mode}\
+\"camera_mode\":{camera_mode},\
+\"last_reply\":{last_reply}\
 }}\n",
         emotion = s.emotion.wire_str(),
         mood = s.mood.wire_str(),
@@ -268,8 +273,9 @@ pub(super) fn events_body() -> String {
 }
 
 /// Minimal JSON string escaper — backslash, quote, and control bytes
-/// get the `\\uNNNN` form. Event messages are firmware-controlled (no
-/// user input lands here unredacted) so this stays simple.
+/// get the `\\uNNNN` form. Quote/backslash/control coverage is the
+/// full set JSON string safety needs, so remote-sourced text (the
+/// sidecar reply in `last_reply`) is safe through here too.
 pub(super) fn json_escape(s: &str) -> String {
     use core::fmt::Write as _;
     let mut out = String::with_capacity(s.len());

--- a/crates/stackchan-firmware/src/net/respond.rs
+++ b/crates/stackchan-firmware/src/net/respond.rs
@@ -109,7 +109,14 @@ pub(super) fn state_body(s: AvatarSnapshot) -> String {
         .map_or_else(|| String::from("null"), |d| format!("\"{}\"", d.wire_str()));
     let last_reply = s.last_reply.map_or_else(
         || String::from("null"),
-        |r| format!("{{\"ok\":{},\"text\":\"{}\"}}", r.ok, json_escape(r.text())),
+        |r| {
+            format!(
+                "{{\"ok\":{},\"seq\":{},\"text\":\"{}\"}}",
+                r.ok,
+                r.seq,
+                json_escape(r.text())
+            )
+        },
     );
     format!(
         "{{\

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -36,6 +36,56 @@ pub struct WifiSnapshot {
     pub ip: Option<Ipv4Addr>,
 }
 
+/// Byte cap for the last sidecar reply text mirrored into the
+/// snapshot. Longer replies truncate at a char boundary — the
+/// dashboard shows a one-liner, and the full text still lands in
+/// the defmt log.
+pub const REPLY_MAX: usize = 128;
+
+/// Outcome of the most recent agent-sidecar exchange — published by
+/// [`crate::agent_sidecar`] after each listen→reply round-trip.
+///
+/// Fixed `[u8; N]` + length instead of `heapless::String` so
+/// [`AvatarSnapshot`] stays `Copy` (it lives in a `Cell` and rides
+/// the SSE pubsub by value).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplySnapshot {
+    /// `true` when the sidecar returned a reply; `false` on any
+    /// failure path (link down, POST failed, timeout).
+    pub ok: bool,
+    /// Valid byte length of `buf`. Always `<= REPLY_MAX` and always
+    /// on a UTF-8 char boundary.
+    len: usize,
+    /// UTF-8 text bytes. `buf[len..]` stays zeroed so the derived
+    /// equality over the whole array matches text equality.
+    buf: [u8; REPLY_MAX],
+}
+
+impl ReplySnapshot {
+    /// Build from a reply (or failure-reason) string, truncating at
+    /// the last char boundary that fits [`REPLY_MAX`].
+    #[must_use]
+    pub fn new(ok: bool, text: &str) -> Self {
+        let mut buf = [0_u8; REPLY_MAX];
+        let mut len = 0;
+        for ch in text.chars() {
+            let ch_len = ch.len_utf8();
+            if len + ch_len > REPLY_MAX {
+                break;
+            }
+            ch.encode_utf8(&mut buf[len..]);
+            len += ch_len;
+        }
+        Self { ok, len, buf }
+    }
+
+    /// The stored text.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        core::str::from_utf8(&self.buf[..self.len]).unwrap_or("")
+    }
+}
+
 /// Composite avatar state surfaced via `GET /state`.
 ///
 /// Only `PartialEq` (not `Eq`) because `head_pose` carries `f32`s.
@@ -76,6 +126,9 @@ pub struct AvatarSnapshot {
     /// `entity.face.geometry`; HTTP `POST /face-geometry` and MCP
     /// `set_face_geometry` update this through `FACE_GEOMETRY_SIGNAL`.
     pub face_geometry: FaceGeometry,
+    /// Outcome of the most recent agent-sidecar exchange, or `None`
+    /// before the first listen→reply round-trip resolves.
+    pub last_reply: Option<ReplySnapshot>,
 }
 
 impl AvatarSnapshot {
@@ -106,6 +159,7 @@ impl AvatarSnapshot {
             && self.decorator == other.decorator
             && self.mood == other.mood
             && self.face_geometry == other.face_geometry
+            && self.last_reply == other.last_reply
     }
 }
 
@@ -122,6 +176,7 @@ impl Default for AvatarSnapshot {
             decorator: None,
             mood: Mood::Neutral,
             face_geometry: FaceGeometry::Default,
+            last_reply: None,
         }
     }
 }
@@ -149,6 +204,7 @@ pub static AVATAR_SNAPSHOT: Mutex<CriticalSectionRawMutex, core::cell::Cell<Avat
         decorator: None,
         mood: Mood::Neutral,
         face_geometry: FaceGeometry::Default,
+        last_reply: None,
     }));
 
 /// Replace the avatar/head fields. Called per render tick.
@@ -202,6 +258,17 @@ pub fn update_audio(audio: AudioConfig) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
         s.audio = audio;
+        cell.set(s);
+    });
+}
+
+/// Replace the last-reply field. Called by the agent-sidecar task
+/// after each listen round-trip resolves (reply or failure) so
+/// `GET /state` and the SSE stream surface the outcome.
+pub fn update_last_reply(ok: bool, text: &str) {
+    AVATAR_SNAPSHOT.lock(|cell| {
+        let mut s = cell.get();
+        s.last_reply = Some(ReplySnapshot::new(ok, text));
         cell.set(s);
     });
 }

--- a/crates/stackchan-firmware/src/net/snapshot.rs
+++ b/crates/stackchan-firmware/src/net/snapshot.rs
@@ -53,6 +53,14 @@ pub struct ReplySnapshot {
     /// `true` when the sidecar returned a reply; `false` on any
     /// failure path (link down, POST failed, timeout).
     pub ok: bool,
+    /// Monotonic per-boot exchange counter, starting at 1. Freshness
+    /// marker: a repeated byte-identical outcome ("Yes." twice, two
+    /// `timed out`s, or two long replies sharing a truncated
+    /// [`REPLY_MAX`] prefix) would otherwise compare equal, suppress
+    /// the SSE publish, and leave the dashboard with no sign the
+    /// second exchange completed. Participates in derived equality so
+    /// every round-trip pushes.
+    pub seq: u32,
     /// Valid byte length of `buf`. Always `<= REPLY_MAX` and always
     /// on a UTF-8 char boundary.
     len: usize,
@@ -65,7 +73,7 @@ impl ReplySnapshot {
     /// Build from a reply (or failure-reason) string, truncating at
     /// the last char boundary that fits [`REPLY_MAX`].
     #[must_use]
-    pub fn new(ok: bool, text: &str) -> Self {
+    pub fn new(ok: bool, seq: u32, text: &str) -> Self {
         let mut buf = [0_u8; REPLY_MAX];
         let mut len = 0;
         for ch in text.chars() {
@@ -76,7 +84,7 @@ impl ReplySnapshot {
             ch.encode_utf8(&mut buf[len..]);
             len += ch_len;
         }
-        Self { ok, len, buf }
+        Self { ok, seq, len, buf }
     }
 
     /// The stored text.
@@ -262,13 +270,18 @@ pub fn update_audio(audio: AudioConfig) {
     });
 }
 
-/// Replace the last-reply field. Called by the agent-sidecar task
-/// after each listen round-trip resolves (reply or failure) so
-/// `GET /state` and the SSE stream surface the outcome.
+/// Replace the last-reply field.
+///
+/// Called by the agent-sidecar task after each listen round-trip
+/// resolves (reply or failure) so `GET /state` and the SSE stream
+/// surface the outcome. The `seq` counter derives from the previous
+/// entry under the same critical section, so concurrent callers
+/// can't mint duplicate values.
 pub fn update_last_reply(ok: bool, text: &str) {
     AVATAR_SNAPSHOT.lock(|cell| {
         let mut s = cell.get();
-        s.last_reply = Some(ReplySnapshot::new(ok, text));
+        let seq = s.last_reply.map_or(1, |prev| prev.seq.wrapping_add(1));
+        s.last_reply = Some(ReplySnapshot::new(ok, seq, text));
         cell.set(s);
     });
 }

--- a/docs/http.md
+++ b/docs/http.md
@@ -65,13 +65,16 @@ $ curl http://stackchan.local/state
  "battery":{"percent":78,"voltage_mv":3920},
  "wifi":{"connected":true,"ip":"192.168.1.42"},
  "audio":{"volume_pct":50,"muted":false},
- "last_reply":{"ok":true,"text":"Sure! Let me check."}}
+ "last_reply":{"ok":true,"seq":3,"text":"Sure! Let me check."}}
 ```
 
 `last_reply` is the outcome of the most recent agent-sidecar
 listen round-trip (`null` before the first one): `ok` is `false`
 on a failure, with the reason in `text`. Text is capped at 128
-bytes, truncated at a char boundary.
+bytes, truncated at a char boundary. `seq` is a per-boot monotonic
+exchange counter — it increments on every round-trip, so a repeated
+byte-identical outcome still registers as a snapshot change (and an
+SSE push) instead of being deduplicated away.
 
 `GET /state/stream` opens a Server-Sent Events stream. The server
 emits an initial event on connect, then one event per change. Idle

--- a/docs/http.md
+++ b/docs/http.md
@@ -23,7 +23,7 @@ beats pulling a full HTTP framework into the firmware target.
 |--------|------------------|-----------------------------------------------------|
 | GET    | `/`              | Operator dashboard (HTML + JS, embedded in firmware) |
 | GET    | `/health`        | Uptime, firmware version, free heap                  |
-| GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi, audio |
+| GET    | `/state`         | Snapshot JSON: emotion, head pose, battery, Wi-Fi, audio, last sidecar reply |
 | GET    | `/sensors`       | Live IMU / ambient / audio-RMS / body-touch sample   |
 | GET    | `/sensor-history` | Rolling 60-second window of one-per-second sensor snapshots, oldest first |
 | GET    | `/hardware/status` | Boot-time servo-power-rail health (servo-power only, not a full hardware rollup) |
@@ -64,8 +64,14 @@ $ curl http://stackchan.local/state
  "head_actual":{"pan_deg":0.10,"tilt_deg":-0.20},
  "battery":{"percent":78,"voltage_mv":3920},
  "wifi":{"connected":true,"ip":"192.168.1.42"},
- "audio":{"volume_pct":50,"muted":false}}
+ "audio":{"volume_pct":50,"muted":false},
+ "last_reply":{"ok":true,"text":"Sure! Let me check."}}
 ```
+
+`last_reply` is the outcome of the most recent agent-sidecar
+listen round-trip (`null` before the first one): `ok` is `false`
+on a failure, with the reason in `text`. Text is capped at 128
+bytes, truncated at a char boundary.
 
 `GET /state/stream` opens a Server-Sent Events stream. The server
 emits an initial event on connect, then one event per change. Idle

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -118,7 +118,7 @@ returns:
 
 | Field     | Required | Notes                                                                                |
 |-----------|----------|--------------------------------------------------------------------------------------|
-| `text`    | yes      | Assistant reply. Surfaced on the firmware toast band (truncated to 32 chars).        |
+| `text`    | yes      | Assistant reply. Surfaced on the firmware toast band (truncated to 32 chars), recorded in the event log (`GET /events`, 64 bytes), and mirrored into the `last_reply` field of `GET /state` / the SSE stream (128 bytes). |
 | `emotion` | no       | One of `neutral` / `happy` / `sleepy` / `surprised` / `sad` / `angry`. Fires a 2.5 s `SetEmotion` hold. Unknown values are ignored. |
 
 Response status must be `2xx`. Anything else (4xx, 5xx) is treated
@@ -141,8 +141,10 @@ are unavoidable, wrap or pre-substitute them on the sidecar side.
 
 ## Failure surface
 
-Every error path surfaces a toast so the operator sees the
-failure without an attached monitor:
+Every error path surfaces a toast, a warn-kind event-log entry
+with the same text, and a `last_reply` snapshot update with
+`"ok": false`, so the operator sees the failure without an
+attached monitor:
 
 | Toast text             | Cause                                                       |
 |------------------------|-------------------------------------------------------------|

--- a/web/src/components/Listen.tsx
+++ b/web/src/components/Listen.tsx
@@ -1,11 +1,14 @@
+import { Show } from "solid-js";
 import { postJson } from "../auth";
-import { showToast } from "../store";
+import { showToast, snapshot } from "../store";
 
 /// Default listen window in milliseconds — matches
 /// `DEFAULT_LISTEN_DURATION_MS` in `stackchan-net::http_command`.
 const DEFAULT_DURATION_MS = 3_000;
 
 export function Listen() {
+  const reply = () => snapshot()?.last_reply ?? null;
+
   const open = async () => {
     try {
       await postJson("/listen", { duration_ms: DEFAULT_DURATION_MS });
@@ -23,10 +26,18 @@ export function Listen() {
           Listen for 3s
         </button>
       </div>
+      <Show when={reply()}>
+        {(r) => (
+          <div class={r().ok ? "listen-reply" : "listen-reply listen-reply-bad"}>
+            <span class="listen-reply-label">{r().ok ? "reply" : "failed"}</span>
+            <span class="listen-reply-text">{r().text}</span>
+          </div>
+        )}
+      </Show>
       <small>
         Opens a 3-second listen window: arms the Ear decorator, sets Attention::Listening, and
-        plays the wake-chirp. Wake-word detection ships in a follow-up — for now this is the
-        push-to-talk equivalent for the avatar's listening pose.
+        plays the wake-chirp. When an agent sidecar is configured, the reply lands here live via
+        the state stream.
       </small>
     </section>
   );

--- a/web/src/components/Listen.tsx
+++ b/web/src/components/Listen.tsx
@@ -29,7 +29,9 @@ export function Listen() {
       <Show when={reply()}>
         {(r) => (
           <div class={r().ok ? "listen-reply" : "listen-reply listen-reply-bad"}>
-            <span class="listen-reply-label">{r().ok ? "reply" : "failed"}</span>
+            <span class="listen-reply-label">
+              {r().ok ? "reply" : "failed"} #{r().seq}
+            </span>
             <span class="listen-reply-text">{r().text}</span>
           </div>
         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -901,6 +901,37 @@ small {
   word-break: break-word;
 }
 
+/* ─── Listen reply ────────────────────────────────────────────── */
+
+.listen-reply {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.listen-reply-label {
+  flex: none;
+  font: 600 var(--text-xs) / 1 var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--ok);
+}
+
+.listen-reply-bad .listen-reply-label {
+  color: var(--bad);
+}
+
+.listen-reply-text {
+  font: var(--text-sm) / var(--leading-base) var(--font-mono);
+  color: var(--fg);
+  word-break: break-word;
+}
+
 /* ─── Toast (stack) ─────────────────────────────────────────────── */
 
 .toast-stack {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -18,6 +18,13 @@ export type AudioState = {
   muted: boolean;
 };
 
+// Outcome of the most recent agent-sidecar listen round-trip.
+// `ok: false` carries the failure reason in `text`.
+export type LastReply = {
+  ok: boolean;
+  text: string;
+};
+
 export type AvatarSnapshot = {
   emotion: string;
   mood: string;
@@ -29,6 +36,7 @@ export type AvatarSnapshot = {
   wifi: WifiSnapshot;
   audio: AudioState;
   camera_mode: boolean;
+  last_reply: LastReply | null;
 };
 
 export type Tracker = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -19,9 +19,12 @@ export type AudioState = {
 };
 
 // Outcome of the most recent agent-sidecar listen round-trip.
-// `ok: false` carries the failure reason in `text`.
+// `ok: false` carries the failure reason in `text`. `seq` is a
+// per-boot monotonic exchange counter — the freshness marker that
+// makes a repeated identical reply distinguishable from silence.
 export type LastReply = {
   ok: boolean;
+  seq: number;
   text: string;
 };
 


### PR DESCRIPTION
## Summary
- Sidecar replies were invisible by default: the only surface was the toast overlay, which is opt-in and defaults off. A fresh install with a configured sidecar got replies shown nowhere but defmt logs.
- **Event log**: successful replies record as `Kind::Control` (`reply: <text>`, truncated at the existing 64-byte cap on a char boundary); the three failure paths (link down / post failed / timed out) record as `Kind::Warn` via a new `surface_failure` helper that fans out to toast + event log + snapshot. Deliberately avoids `record_fmt` — heapless `write_fmt` is all-or-nothing, so a long reply would have logged just `"reply: "`.
- **SSE snapshot**: `AvatarSnapshot` is `Copy`, so the reply rides a new fixed-buffer `ReplySnapshot { ok, len, buf: [u8; 128] }` (char-boundary truncation, zeroed tail so derived `Eq` is text equality), wired into the snapshot's change detection. ~0.5 KiB SRAM across the snapshot statics.
- **Wire**: `state_body` emits `"last_reply":{"ok":bool,"text":"..."}|null` through the existing `json_escape` (remote-sourced text is escaped; the helper's stale "firmware-controlled only" comment updated). Flows to `GET /state`, SSE, and WebSocket identically.
- **Dashboard**: `Listen.tsx` shows the reply (or failure) live from the snapshot store. No App.tsx churn.
- Docs: `docs/http.md` + `docs/sidecar.md` updated for the new field.

## Test plan
- [x] `just check`, `just web-build`, `just check-firmware`, `just clippy-firmware` all green (re-run after rebase onto current main)
- [ ] On-device: listen round-trip then curl `/state` + `/events` — **blocked: CoreS3 not currently connected**; flag stays on-device-unverified until the next flash session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface agent-sidecar replies and failures by default across the event log, `GET /state`/SSE, and the dashboard Listen panel. Add a per-boot `seq` so identical outcomes still publish and show up.

- **New Features**
  - Event log: log replies as Control (`reply: <text>`, 64-byte cap) and failures as Warn (link down, post failed, timed out).
  - State/SSE/WS: add `last_reply` to snapshot (`{"ok":bool,"seq":u32,"text":string}` or `null`), 128-byte char-safe cap.
  - Dashboard: Listen panel shows the latest reply or failure with a visible exchange counter via the snapshot stream.
  - Wire/API: `GET /state` now includes `last_reply` with `ok`, `seq`, and `text`; JSON escaping safely handles remote-sourced text.
  - Docs: updated `docs/http.md` and `docs/sidecar.md` for the new field and failure surface.

<sup>Written for commit 55029a6c99695402585214ecd1ae99000936eba8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/stackchan-kai/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

