### PR TITLE
chore(deps): pin esp-alloc to the 0.9.x line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
       - dependency-name: "trouble-host"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
+      # esp-alloc >=0.10 depends on esp-sync 0.3, while esp-rtos 0.2 and
+      # esp-hal ~1.0 still pull esp-sync 0.1. Both copies land in the tree and
+      # the 0.3 one gets no chip feature, so its build script aborts with
+      # "Expected exactly one of the following features to be enabled".
+      # Pin to the 0.9.x line until the esp-hal ~1.1 bump.
+      - dependency-name: "esp-alloc"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot #633 (esp-alloc 0.9.0 to 0.11.0) fails the xtensa-esp32s3-none-elf cross-check:

```
error: failed to run custom build command for `esp-sync v0.3.0`
  Error: "Expected exactly one of the following features to be enabled: esp32, ... esp32s3"
```

esp-alloc 0.9 depends on `esp-sync ^0.1.0`; 0.11 moves to `esp-sync ^0.3.0`. esp-rtos 0.2.0 still requires `esp-alloc ^0.9.0` and `esp-sync ^0.1.0` on `esp-hal ^1.0.0`, so bumping esp-alloc alone puts two semver-incompatible esp-sync copies in the tree. esp-hal sets `esp32s3` on the 0.1 copy, nothing sets it on the 0.3 copy, and its build script aborts.

No feature flag resolves this. It needs esp-rtos and esp-hal to move to the 1.1 line together, the same wider toolchain bump already blocking esp-radio and trouble-host.

Ignores esp-alloc minor and major updates, mirroring the existing trouble-host rule. Patch updates still come through.

Closes #633

https://claude.ai/code/session_01NTHGYvaZT18aS8mfj1v9m1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `esp-alloc` to the 0.9.x line in Dependabot so automated minor/major updates stop breaking the xtensa build.

`esp-alloc` 0.10+ pulls in `esp-sync` 0.3, while `esp-rtos` 0.2 and `esp-hal` ~1.0 still use `esp-sync` 0.1, causing the 0.3 copy to fail its build script without a chip feature. This mirrors the existing `trouble-host` pin; patch updates for `esp-alloc` still come through.

<sup>Written for commit 43817379e4ac18ea456081431e7f3dcfab7e5849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andymai/stackchan-kai/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

